### PR TITLE
Add init container to gateway controller

### DIFF
--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -47,20 +47,17 @@ controllers:
           tag: "{{ .Values.images.gateway.tag | default .Chart.AppVersion }}"
           pullPolicy: {{ .Values.images.gateway.pullPolicy | default "IfNotPresent" }}
         probes:
-          readiness: &readiness
+          readiness:
             enabled: true
             custom: true
-            spec: &readinessSpec
-              periodSeconds: 5
+            spec:
               failureThreshold: 3
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 2
               httpGet:
                 path: /api/v1/health
                 port: 1994
-          startup:
-            <<: *readiness
-            spec:
-              <<: *readinessSpec
-              failureThreshold: 30
         securityContext:
           privileged: true
 service:

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -20,6 +20,19 @@ controllers:
     rollingUpdate:
       unavailable:
       surge:
+    initContainers:
+      wait-on-backends:
+        image:
+          repository: busybox
+          tag: latest
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z postgresql.beta9 5432; do echo "Waiting on PostgreSQL..."; sleep 2; done;
+          until nc -z redis-master.beta9 6379; do echo "Waiting on Redis..."; sleep 2; done;
+          until nc -z juicefs-redis-master.beta9 6379; do echo "Waiting on Redis (JuiceFS)..."; sleep 2; done;
+          echo "All systems ready!"
 
 persistence:
   images:

--- a/manifests/kustomize/components/beta9-gateway/deployment.yaml
+++ b/manifests/kustomize/components/beta9-gateway/deployment.yaml
@@ -22,6 +22,17 @@ spec:
         app.kubernetes.io/name: beta9
     spec:
       automountServiceAccountToken: true
+      initContainers:
+      - name: wait-on-backends
+        image: busybox
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z postgresql.beta9 5432; do echo "Waiting on PostgreSQL..."; sleep 2; done;
+          until nc -z redis-master.beta9 6379; do echo "Waiting on Redis..."; sleep 2; done;
+          until nc -z juicefs-redis-master.beta9 6379; do echo "Waiting on Redis (JuiceFS)..."; sleep 2; done;
+          echo "All systems ready!"
       containers:
       - command:
         - /usr/local/bin/gateway
@@ -32,26 +43,18 @@ spec:
         name: main
         readinessProbe:
           failureThreshold: 3
-          httpGet:
-            path: /api/v1/health
-            port: 1994
           initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 2
+          httpGet:
+            path: /api/v1/health
+            port: 1994
         resources:
           limits:
             cpu: 4000m
             memory: 4Gi
         securityContext:
           privileged: true
-        startupProbe:
-          failureThreshold: 30
-          httpGet:
-            path: /api/v1/health
-            port: 1994
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 2
         volumeMounts:
         - mountPath: /etc/beta9
           name: config


### PR DESCRIPTION
Add an init container that prevents gateway from starting until postgres and both redis' are listening on their ports.

I also tested with building this into gateway and calling that logic in an init container. It was nice in that we could use our existing app config. However, I'm not sure if there's an appetite for having different entry points in gateway via flags so I didn't go with this solution. Could also build a separate binary, but that will add more weight to the image.

Here is what logs look like for both containers in the gateway pod now.
```
+ beta9-gateway-59bbf6bd84-mvwbr › wait-on-backends
beta9-gateway-59bbf6bd84-mvwbr wait-on-backends 02-10 14:05:53 Waiting on PostgreSQL...
beta9-gateway-59bbf6bd84-mvwbr wait-on-backends 02-10 14:05:57 Waiting on Redis...
beta9-gateway-59bbf6bd84-mvwbr wait-on-backends 02-10 14:06:00 Waiting on Redis...
beta9-gateway-59bbf6bd84-mvwbr wait-on-backends 02-10 14:06:03 Waiting on Redis...
beta9-gateway-59bbf6bd84-mvwbr wait-on-backends 02-10 14:06:06 All systems ready!
- beta9-gateway-59bbf6bd84-mvwbr › wait-on-backends
+ beta9-gateway-59bbf6bd84-mvwbr › main
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 goose: no migrations to run. current version: 1
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 Formatting JuiceFS filesystem with name: 'beta9-fs'
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 JuiceFS filesystem formatted: 'beta9-fs'
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 JuiceFS filesystem is being mounted to: '/data'
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 Gateway http server running @ 1994
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 Gateway grpc server running @ 1993
beta9-gateway-59bbf6bd84-mvwbr main 02-10 14:06:07 2024/02/10 19:06:07 Gateway metrics server running @ 9090
```

Resolve BE-1224