### PR TITLE
update metrics to sort keys/values before sending to prom

### DIFF
--- a/internal/repository/metrics/metrics_prometheus.go
+++ b/internal/repository/metrics/metrics_prometheus.go
@@ -247,7 +247,7 @@ func (pr *PrometheusMetricsRepository) getHistogramVec(opts prometheus.Histogram
 
 func (pr *PrometheusMetricsRepository) parseMetadata(metadata map[string]interface{}) (keys []string, values []string) {
 	keys = maps.Keys(metadata)
-	values = make([]string, 0, len(metadata))
+	values = []string{}
 	sort.Strings(keys)
 
 	for _, key := range keys {


### PR DESCRIPTION
Not sure how I like the sorting logic but the alternatively, we pass in a list of structs that look like 
```{key: string, value: interface{}}```
in the base MetricsRepo functions

