### PR TITLE
Implement config context commands

### DIFF
--- a/sdk/src/beta9/cli/config.py
+++ b/sdk/src/beta9/cli/config.py
@@ -1,6 +1,14 @@
 import click
+from rich.table import Column, Table, box
 
-from ..config import prompt_for_config_context
+from .. import terminal
+from ..config import (
+    DEFAULT_CONTEXT_NAME,
+    ConfigContext,
+    load_config,
+    prompt_for_config_context,
+    save_config,
+)
 from .extraclick import ClickManagementGroup
 
 
@@ -13,16 +21,69 @@ def management():
     pass
 
 
-@management.command(name="list")
+@management.command(
+    name="list",
+    help="Lists available contexts.",
+)
 def list_contexts():
-    pass
+    contexts = load_config()
+
+    table = Table(
+        Column("Name"),
+        Column("Host"),
+        Column("Port"),
+        box=box.SIMPLE,
+    )
+
+    for name, context in contexts.items():
+        table.add_row(
+            name,
+            context.gateway_host,
+            str(context.gateway_port),
+        )
+
+    terminal.print(table)
 
 
-@management.command(name="create")
+@management.command(
+    name="delete",
+    help="Delete a context.",
+)
+@click.option("--name", "-n", type=click.STRING, required=True)
+def delete_context(name: str):
+    contexts = load_config()
+
+    if name == DEFAULT_CONTEXT_NAME:
+        contexts[name] = ConfigContext()
+
+    elif name in contexts:
+        del contexts[name]
+
+    save_config(contexts)
+    terminal.print("Deleted context")
+
+
+@management.command(
+    name="create",
+    help="Create a new context.",
+)
 @click.option("--name", type=click.STRING, required=True)
 @click.option("--token", type=click.STRING)
 @click.option("--gateway-host", type=click.STRING)
 @click.option("--gateway-port", type=click.INT)
-@click.option("--gateway-http-port", type=click.INT)
 def create_context(**kwargs):
     prompt_for_config_context(**kwargs)
+
+
+@management.command(
+    name="select",
+    help="Set a context as the default. This will overwrite the default context.",
+)
+@click.option("--name", "-n", type=click.STRING, required=True)
+def select_context(name: str):
+    contexts = load_config()
+
+    if name in contexts:
+        contexts[DEFAULT_CONTEXT_NAME] = contexts[name]
+
+    save_config(contexts)

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -27,7 +27,6 @@ def write_test_config():
                 token = test-token
                 gateway_host = 0.0.0.0
                 gateway_port = 1993
-                gateway_http_port = 1994
                 """
             )
         )


### PR DESCRIPTION
- Add config list, delete, select subcommands
- When deleting the default context, only empty it, don't delete it entirely
- Show token as its typed/pasted

<img width="526" alt="image" src="https://github.com/beam-cloud/beta9/assets/4001122/c90685f7-ce8f-4ac1-8d8c-3699c6ce6165">
