### PR TITLE
Improve shutdown and connection termination

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -22,3 +22,4 @@ venv
 .venv
 .k3d
 .python-version
+test

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -57,7 +57,7 @@ controllers:
         - |
           until nc -z redis-master.beta9 6379; do echo "Waiting on Redis..."; sleep 2; done;
           echo "All systems ready!"
-  
+
 persistence:
   images:
     enabled: true

--- a/internal/abstractions/volume/volume.go
+++ b/internal/abstractions/volume/volume.go
@@ -3,7 +3,6 @@ package volume
 import (
 	"context"
 	"errors"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -144,11 +143,8 @@ func (vs *GlobalVolumeService) CopyPathStream(stream pb.VolumeService_CopyPathSt
 
 		for {
 			request, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
 			if err != nil {
-				break
+				return
 			}
 
 			ch <- CopyPathContent{

--- a/internal/common/config.default.yaml
+++ b/internal/common/config.default.yaml
@@ -30,6 +30,7 @@ gateway:
   grpcPort: 1993
   maxRecvMsgSize: 1024
   maxSendMsgSize: 1024
+  shutdownTimeout: 180s
   http:
     port: 1994
     enablePrettyLogs: true
@@ -131,6 +132,7 @@ tailscale:
   debug: false
   hostName: headscale.internal
 proxy:
+  httpPort: 1989
   services:
   - name: redis
     localPort: 6379

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -75,11 +75,12 @@ type CORSConfig struct {
 }
 
 type GatewayServiceConfig struct {
-	Host           string     `key:"host" json:"host"`
-	GRPCPort       int        `key:"grpcPort" json:"grpc_port"`
-	MaxRecvMsgSize int        `key:"maxRecvMsgSize" json:"max_recv_msg_size"`
-	MaxSendMsgSize int        `key:"maxSendMsgSize" json:"max_send_msg_size"`
-	HTTP           HTTPConfig `key:"http" json:"http"`
+	Host            string        `key:"host" json:"host"`
+	GRPCPort        int           `key:"grpcPort" json:"grpc_port"`
+	MaxRecvMsgSize  int           `key:"maxRecvMsgSize" json:"max_recv_msg_size"`
+	MaxSendMsgSize  int           `key:"maxSendMsgSize" json:"max_send_msg_size"`
+	HTTP            HTTPConfig    `key:"http" json:"http"`
+	ShutdownTimeout time.Duration `key:"shutdownTimeout" json:"shutdown_timeout"`
 }
 
 type ImageServiceConfig struct {
@@ -270,6 +271,7 @@ type TailscaleConfig struct {
 }
 
 type ProxyConfig struct {
+	HTTPPort int               `key:"httpPort" json:"http_port"`
 	Services []InternalService `key:"services" json:"services"`
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -788,19 +788,18 @@ func (s *Worker) shutdown() error {
 
 	var errs error
 
-	worker, err := s.workerRepo.GetWorkerById(s.workerId)
-	if err != nil {
+	if worker, err := s.workerRepo.GetWorkerById(s.workerId); err != nil {
 		errs = errors.Join(errs, err)
-	}
-
-	err = s.workerRepo.RemoveWorker(worker)
-	if err != nil {
-		errs = errors.Join(errs, err)
+	} else if worker != nil {
+		err = s.workerRepo.RemoveWorker(worker)
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	s.cancel()
 
-	err = s.storage.Unmount(s.config.Storage.FilesystemPath)
+	err := s.storage.Unmount(s.config.Storage.FilesystemPath)
 	if err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to unmount storage: %v", err))
 	}

--- a/manifests/kustomize/components/beta9-gateway/deployment.yaml
+++ b/manifests/kustomize/components/beta9-gateway/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/name: beta9
     spec:
       automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 185
       initContainers:
       - name: wait-on-backends
         image: busybox
@@ -81,6 +82,8 @@ metadata:
   namespace: beta9
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: beta9-proxy
@@ -89,6 +92,16 @@ spec:
       labels:
         app: beta9-proxy
     spec:
+      terminationGracePeriodSeconds: 185
+      initContainers:
+      - name: wait-on-backends
+        image: busybox
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z redis-master.beta9 6379; do echo "Waiting on Redis..."; sleep 2; done;
+          echo "All systems ready!"
       containers:
       - name: proxy
         image: registry.localhost:5000/beta9-proxy:latest
@@ -96,6 +109,14 @@ spec:
         - /usr/local/bin/proxy
         securityContext:
           privileged: true
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          timeoutSeconds: 2
+          httpGet:
+            path: /ready
+            port: 1989
         resources:
           requests:
             cpu: 1000m


### PR DESCRIPTION
- Gateway: Use timeout on http shutdown
- Gateway: Use gracefulstop on grpc shutdown
- Gateway: Call cancel func at the end
- Gateway: Add termination grace period
- Proxy: Add http server for readiness probe
- Proxy: Stop accepting connections during shutdown (via readiness prob failure), but wait for active connections to finish
- Proxy: Add init container for local dev
- Proxy: Add readiness probe for local dev
- Proxy: Add termination grace period
- Proxy: Fix redis client name
- Worker: Collect all errors during shutdown and return them
- Worker: Call cancel func after remove worker from repo
- Worker: Remove calling cancel func again
- Worker: Close channels when Run() completes

Resolve BE-1356