### PR TITLE
Cleanup active fuse mounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
+	github.com/hanwen/go-fuse/v2 v2.5.1
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/knadh/koanf/parsers/json v0.1.0
 	github.com/knadh/koanf/parsers/yaml v0.1.0
@@ -122,7 +123,6 @@ require (
 	github.com/google/nftables v0.1.1-0.20230115205135-9aa6fdf5a28c // indirect
 	github.com/gorilla/csrf v1.7.1 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
-	github.com/hanwen/go-fuse/v2 v2.5.1 // indirect
 	github.com/hdevalence/ed25519consensus v0.1.0 // indirect
 	github.com/illarion/gonotify v1.0.1 // indirect
 	github.com/insomniacslk/dhcp v0.0.0-20230908212754-65c27093e38a // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
 	github.com/beam-cloud/blobcache v0.0.0-20240512162245-f8b1aa1cad58
-	github.com/beam-cloud/clip v0.0.0-20240516163541-45e3dd1b74df
+	github.com/beam-cloud/clip v0.0.0-20240516191226-939bb7a25ea7
 	github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170
 	github.com/bsm/redislock v0.9.4
 	github.com/cloudevents/sdk-go/v2 v2.15.1

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/blobcache v0.0.0-20240512162245-f8b1aa1cad58 h1:b9Q6mxH5CMKh5XpYWiC0AX68ZygLHsPYl0cHvplbiVo=
 github.com/beam-cloud/blobcache v0.0.0-20240512162245-f8b1aa1cad58/go.mod h1:msZBPNo2uDlcvYA1+epdSRZVeN/89ML5BeiJy70bxjQ=
-github.com/beam-cloud/clip v0.0.0-20240516191226-939bb7a25ea7 h1:6n8OpIOJRxbTszJPRdloStGXYRSvuPEQlG3WflboyXI=
-github.com/beam-cloud/clip v0.0.0-20240516191226-939bb7a25ea7/go.mod h1:fD+s/BBWbUDzbX772ydDsLXkvXKzt6y+mzdTVmsAd30=
+github.com/beam-cloud/clip v0.0.0-20240516163541-45e3dd1b74df h1:gX4/QxYWVxM9BautIfWf1YFHsY3oVFLPvwLJmfSjNoQ=
+github.com/beam-cloud/clip v0.0.0-20240516163541-45e3dd1b74df/go.mod h1:fD+s/BBWbUDzbX772ydDsLXkvXKzt6y+mzdTVmsAd30=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/blobcache v0.0.0-20240512162245-f8b1aa1cad58 h1:b9Q6mxH5CMKh5XpYWiC0AX68ZygLHsPYl0cHvplbiVo=
 github.com/beam-cloud/blobcache v0.0.0-20240512162245-f8b1aa1cad58/go.mod h1:msZBPNo2uDlcvYA1+epdSRZVeN/89ML5BeiJy70bxjQ=
-github.com/beam-cloud/clip v0.0.0-20240516163541-45e3dd1b74df h1:gX4/QxYWVxM9BautIfWf1YFHsY3oVFLPvwLJmfSjNoQ=
-github.com/beam-cloud/clip v0.0.0-20240516163541-45e3dd1b74df/go.mod h1:fD+s/BBWbUDzbX772ydDsLXkvXKzt6y+mzdTVmsAd30=
+github.com/beam-cloud/clip v0.0.0-20240516191226-939bb7a25ea7 h1:6n8OpIOJRxbTszJPRdloStGXYRSvuPEQlG3WflboyXI=
+github.com/beam-cloud/clip v0.0.0-20240516191226-939bb7a25ea7/go.mod h1:fD+s/BBWbUDzbX772ydDsLXkvXKzt6y+mzdTVmsAd30=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
- Save fuse servers in safemap for later cleanup
- Clean up fuse servers by unmounting them when worker shuts down (assume server process may remain useful during lifecycle of the worker)