### PR TITLE
Remove map check in redis lock

### DIFF
--- a/pkg/common/redis.go
+++ b/pkg/common/redis.go
@@ -21,7 +21,6 @@ var (
 	ErrChannelClosed    = errors.New("redis: channel closed")
 	ErrConnectionIssue  = errors.New("redis: connection issue")
 	ErrUnknownRedisMode = errors.New("redis: unknown mode")
-	ErrLockNotReleased  = errors.New("redislock: lock not released")
 )
 
 type RedisClient struct {
@@ -272,10 +271,6 @@ func NewRedisLock(client *RedisClient, opts ...RedisLockOption) *RedisLock {
 func (l *RedisLock) Acquire(ctx context.Context, key string, opts RedisLockOptions) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-
-	if _, ok := l.locks[key]; ok {
-		return ErrLockNotReleased
-	}
 
 	var retryStrategy redislock.RetryStrategy = nil
 	if opts.Retries > 0 {

--- a/pkg/common/redis_test.go
+++ b/pkg/common/redis_test.go
@@ -39,7 +39,7 @@ func TestRedisLock(t *testing.T) {
 	// Test acquiring lock again without releasing
 	err = lock.Acquire(context.Background(), key, opts)
 	assert.Error(t, err)
-	assert.Equal(t, "redislock: lock not released", err.Error())
+	assert.Equal(t, "redislock: not obtained", err.Error())
 
 	// Test releasing lock
 	err = lock.Release(key)


### PR DESCRIPTION
- Remove check to see if lock exists and instead rely on redislock retry system + mutex