### PR TITLE
Remove an unnecessary lock inside the RedisLock data struct

### DIFF
--- a/pkg/common/redis.go
+++ b/pkg/common/redis.go
@@ -269,9 +269,6 @@ func NewRedisLock(client *RedisClient, opts ...RedisLockOption) *RedisLock {
 }
 
 func (l *RedisLock) Acquire(ctx context.Context, key string, opts RedisLockOptions) error {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
 	var retryStrategy redislock.RetryStrategy = nil
 	if opts.Retries > 0 {
 		retryStrategy = redislock.LimitRetry(redislock.LinearBackoff(100*time.Millisecond), opts.Retries)


### PR DESCRIPTION
This lock was initially meant to protect the in memory lock dictionary that was removed. 
Since this redis lock is usually shared by an entire repository data struct (e.g ContainerRedisRepo), there is a possibility for causing deadlocks when that lock is nested within itself but for different keys.

example
```
cr.lock.Acquire(context.TODO(), common.RedisKeys.SomeKey...)
     ...
     cr.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerContainerLock(containerId)....)
     cr.lock.Releae(common.RedisKeys.SchedulerContainerLock(containerId))
     ...
cr.lock.Release(context.TODO(), common.RedisKeys.SomeKey...)
```