### PR TITLE
Allow CLI to be run as a module

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.29"
+version = "0.1.30"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/__main__.py
+++ b/sdk/src/beta9/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main.start()


### PR DESCRIPTION
- Add the ability to run the CLI with `python -m beta9` when beta9 is installed in activated Python environment.