### PR TITLE
Disable TLS termination for remote machine config

### DIFF
--- a/pkg/api/v1/machine.go
+++ b/pkg/api/v1/machine.go
@@ -75,6 +75,7 @@ func (g *MachineGroup) RegisterMachine(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Unable to lookup service: gateway-grpc")
 	}
 
+	remoteConfig.Database.Redis.EnableTLS = false
 	remoteConfig.Database.Redis.Addrs[0] = redisHostname
 	remoteConfig.GatewayService.Host = strings.Split(gatewayGrpcHostname, ":")[0]
 


### PR DESCRIPTION
[HOTFIX] Remote machines communicate through proxied endpoints, so redis TLS does not work out of the box - this disables it 