### PR TITLE
Paginator Bugfix: Ensure Inclusion of Next Page Indicator in Results

### DIFF
--- a/pkg/repository/common/paginator.go
+++ b/pkg/repository/common/paginator.go
@@ -65,9 +65,9 @@ type SquirrelCursorPaginator[DBType any] struct {
 func getOperator(sortOrder string) string {
 	lowercaseSortOrder := strings.ToLower(sortOrder)
 	if lowercaseSortOrder == "asc" {
-		return ">"
+		return ">="
 	}
-	return "<"
+	return "<="
 }
 
 func EncodeCursor(cursor DatetimeCursor) string {
@@ -123,7 +123,6 @@ func Paginate[DBType any](settings SquirrelCursorPaginator[DBType], cursorString
 	}
 
 	sql, args, err := settings.SelectBuilder.ToSql()
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This implementation ensures that when retrieving paginated results, an additional result (+1) is included beyond the requested page size. For example, for a page size of 10, the pagination will actually retrieve 11 results. The extra result serves two purposes:

	1.	It confirms the presence of a subsequent page.
	2.	It provides a starting point for the next page of results.

This pull request ensures that the extra entry is consistently included in the next set of pagination results.
