### PR TITLE
Proxy tailscale traffic through custom client

### DIFF
--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -218,7 +218,7 @@ func (es *HttpEndpointService) getOrCreateEndpointInstance(stubId string, option
 
 	// Create endpoint instance to hold endpoint specific methods/fields
 	instance = &endpointInstance{
-		buffer: NewRequestBuffer(es.ctx, es.rdb, &stub.Workspace, stubId, requestBufferSize, es.containerRepo, stubConfig),
+		buffer: NewRequestBuffer(es.ctx, es.rdb, &stub.Workspace, stubId, requestBufferSize, es.containerRepo, stubConfig, es.tailscale, es.config.Tailscale),
 	}
 
 	// Create base autoscaled instance

--- a/pkg/providers/remote_config.go
+++ b/pkg/providers/remote_config.go
@@ -19,7 +19,6 @@ func GetRemoteConfig(baseConfig types.AppConfig, tailscale *network.Tailscale) (
 
 	// Overwrite certain config fields with tailscale hostnames
 	// TODO: figure out a more elegant to override these fields without hardcoding service names
-	// possibly, use proxy config values
 	remoteConfig := types.AppConfig{}
 	if err = json.Unmarshal(configBytes, &remoteConfig); err != nil {
 		return nil, err
@@ -29,6 +28,8 @@ func GetRemoteConfig(baseConfig types.AppConfig, tailscale *network.Tailscale) (
 	if err != nil {
 		return nil, err
 	}
+	remoteConfig.Database.Redis.Addrs[0] = redisHostname
+	remoteConfig.Database.Redis.InsecureSkipVerify = true
 
 	if baseConfig.Storage.Mode == storage.StorageModeJuiceFS {
 		juiceFsRedisHostname, err := tailscale.GetHostnameForService("juicefs-redis")
@@ -49,9 +50,6 @@ func GetRemoteConfig(baseConfig types.AppConfig, tailscale *network.Tailscale) (
 	if err != nil {
 		return nil, err
 	}
-
-	remoteConfig.Database.Redis.Addrs[0] = redisHostname
-	remoteConfig.Database.Redis.InsecureSkipVerify = true
 	remoteConfig.GatewayService.Host = strings.Split(gatewayGrpcHostname, ":")[0]
 
 	return &remoteConfig, nil


### PR DESCRIPTION
- Allow endpoints to work through tailscale
- Cache http clients to prevent re-establishing connections