### PR TITLE
Add elasticsearch config for remote config

### DIFF
--- a/pkg/network/resolve.go
+++ b/pkg/network/resolve.go
@@ -2,11 +2,14 @@ package network
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/types"
+	"tailscale.com/client/tailscale"
 )
 
 func ConnectToHost(ctx context.Context, host string, timeout time.Duration, tailscale *Tailscale, tsConfig types.TailscaleConfig) (net.Conn, error) {
@@ -26,4 +29,34 @@ func ConnectToHost(ctx context.Context, host string, timeout time.Duration, tail
 		return conn, err
 	}
 	return conn, nil
+}
+
+func ResolveTailscaleService(serviceName string, timeout time.Duration) (string, error) {
+	client := tailscale.LocalClient{}
+	interval := time.Second * 1
+	startTime := time.Now()
+
+	for time.Since(startTime) < timeout {
+		// Get the status from Tailscale
+		status, err := client.Status(context.Background())
+		if err != nil {
+			return "", err
+		}
+
+		// Iterate through the peers to find a matching service
+		for _, peer := range status.Peer {
+			if !peer.Online {
+				continue
+			}
+
+			if strings.Contains(peer.HostName, serviceName) {
+				log.Printf("Found tailscale service<%s> @ %s\n", serviceName, peer.HostName)
+				return peer.HostName, nil
+			}
+		}
+
+		time.Sleep(interval)
+	}
+
+	return "", fmt.Errorf("no valid service found for <%s>", serviceName)
 }

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -226,29 +226,43 @@ type ProviderConfig struct {
 	LambdaLabsConfig LambdaLabsProviderConfig `key:"lambda" json:"lambda"`
 }
 
+type ProviderAgentConfig struct {
+	ElasticSearch ElasticSearchConfig `key:"elasticSearch" json:"elastic_search"`
+}
+
+type ElasticSearchConfig struct {
+	Host       string `key:"host" json:"host"`
+	Port       string `key:"port" json:"port"`
+	HttpUser   string `key:"httpUser" json:"http_user"`
+	HttpPasswd string `key:"httpPasswd" json:"http_passwd"`
+}
+
 type EC2ProviderConfig struct {
-	AWSAccessKey string  `key:"awsAccessKey" json:"aws_access_key"`
-	AWSSecretKey string  `key:"awsSecretKey" json:"aws_secret_key"`
-	AWSRegion    string  `key:"awsRegion" json:"aws_region"`
-	AMI          string  `key:"ami" json:"ami"`
-	SubnetId     *string `key:"subnetId" json:"subnet_id"`
+	AWSAccessKey string              `key:"awsAccessKey" json:"aws_access_key"`
+	AWSSecretKey string              `key:"awsSecretKey" json:"aws_secret_key"`
+	AWSRegion    string              `key:"awsRegion" json:"aws_region"`
+	AMI          string              `key:"ami" json:"ami"`
+	SubnetId     *string             `key:"subnetId" json:"subnet_id"`
+	Agent        ProviderAgentConfig `key:"agent" json:"agent"`
 }
 
 type OCIProviderConfig struct {
-	Tenancy            string `key:"tenancy" json:"tenancy"`
-	UserId             string `key:"userId" json:"user_id"`
-	Region             string `key:"region" json:"region"`
-	FingerPrint        string `key:"fingerprint" json:"fingerprint"`
-	PrivateKey         string `key:"privateKey" json:"private_key"`
-	PrivateKeyPassword string `key:"privateKeyPassword" json:"private_key_password"`
-	CompartmentId      string `key:"compartmentId" json:"compartment_id"`
-	SubnetId           string `key:"subnetId" json:"subnet_id"`
-	AvailabilityDomain string `key:"availabilityDomain" json:"availability_domain"`
-	ImageId            string `key:"imageId" json:"image_id"`
+	Tenancy            string              `key:"tenancy" json:"tenancy"`
+	UserId             string              `key:"userId" json:"user_id"`
+	Region             string              `key:"region" json:"region"`
+	FingerPrint        string              `key:"fingerprint" json:"fingerprint"`
+	PrivateKey         string              `key:"privateKey" json:"private_key"`
+	PrivateKeyPassword string              `key:"privateKeyPassword" json:"private_key_password"`
+	CompartmentId      string              `key:"compartmentId" json:"compartment_id"`
+	SubnetId           string              `key:"subnetId" json:"subnet_id"`
+	AvailabilityDomain string              `key:"availabilityDomain" json:"availability_domain"`
+	ImageId            string              `key:"imageId" json:"image_id"`
+	Agent              ProviderAgentConfig `key:"agent" json:"agent"`
 }
 
 type LambdaLabsProviderConfig struct {
-	ApiKey string `key:"apiKey" json:"apiKey"`
+	ApiKey string              `key:"apiKey" json:"apiKey"`
+	Agent  ProviderAgentConfig `key:"agent" json:"agent"`
 }
 
 type MetricsCollector string
@@ -296,8 +310,7 @@ type InternalService struct {
 }
 
 type FluentBitConfig struct {
-	Events  FluentBitEventConfig  `key:"events" json:"events"`
-	Outputs FluentBitOutputConfig `key:"outputs" json:"outputs"`
+	Events FluentBitEventConfig `key:"events" json:"events"`
 }
 
 type FluentBitEventConfig struct {
@@ -307,15 +320,4 @@ type FluentBitEventConfig struct {
 	IdleConnTimeout time.Duration `key:"idleConnTimeout" json:"idle_conn_timeout"`
 	DialTimeout     time.Duration `key:"dialTimeout" json:"dial_timeout"`
 	KeepAlive       time.Duration `key:"keepAlive" json:"keep_alive"`
-}
-
-type FluentBitOutputConfig struct {
-	ElasticSearch ElasticSearchConfig `key:"es" json:"es"`
-}
-
-type ElasticSearchConfig struct {
-	Host       string `key:"host" json:"host"`
-	Port       string `key:"port" json:"port"`
-	HttpUser   string `key:"httpUser" json:"http_user"`
-	HttpPasswd string `key:"httpPasswd" json:"http_passwd"`
 }

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -296,14 +296,26 @@ type InternalService struct {
 }
 
 type FluentBitConfig struct {
-	Events FluentBitEventConfig `key:"events"`
+	Events  FluentBitEventConfig  `key:"events" json:"events"`
+	Outputs FluentBitOutputConfig `key:"outputs" json:"outputs"`
 }
 
 type FluentBitEventConfig struct {
-	Endpoint        string        `key:"endpoint"`
-	MaxConns        int           `key:"maxConns"`
-	MaxIdleConns    int           `key:"maxIdleConns"`
-	IdleConnTimeout time.Duration `key:"idleConnTimeout"`
-	DialTimeout     time.Duration `key:"dialTimeout"`
-	KeepAlive       time.Duration `key:"keepAlive"`
+	Endpoint        string        `key:"endpoint" json:"endpoint"`
+	MaxConns        int           `key:"maxConns" json:"max_conns"`
+	MaxIdleConns    int           `key:"maxIdleConns" json:"max_idle_conns"`
+	IdleConnTimeout time.Duration `key:"idleConnTimeout" json:"idle_conn_timeout"`
+	DialTimeout     time.Duration `key:"dialTimeout" json:"dial_timeout"`
+	KeepAlive       time.Duration `key:"keepAlive" json:"keep_alive"`
+}
+
+type FluentBitOutputConfig struct {
+	ElasticSearch ElasticSearchConfig `key:"es" json:"es"`
+}
+
+type ElasticSearchConfig struct {
+	Host       string `key:"host" json:"host"`
+	Port       string `key:"port" json:"port"`
+	HttpUser   string `key:"httpUser" json:"http_user"`
+	HttpPasswd string `key:"httpPasswd" json:"http_passwd"`
 }


### PR DESCRIPTION
- Adds an optional ES output config to types/config.go for use in external providers
- Add dynamic tailscale service resolution func