### PR TITLE
Update Crusoe Cloud single-instance deployment

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,7 +2,7 @@
 
 # ----------------------------------------------
 # This script is used to setup the environment for Kubernetes development.
-# It installs kubectl, stern, helm, okteto, and k3d on the machine.
+# It installs kubectl, kustomize, stern, helm, okteto, and k3d on the machine.
 # It determines the operating system and architecture of the machine to download the appropriate binaries.
 # ----------------------------------------------
 
@@ -17,12 +17,17 @@ elif [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 k8s_version=$(curl -sSfL https://dl.k8s.io/release/stable.txt)
+kustomize_version="5.4.2"
 stern_version="1.28.0"
 helm_verision="3.14.0"
 
 echo "Installing kubectl"
 curl -sSfL "https://dl.k8s.io/release/${k8s_version}/bin/${os}/${arch}/kubectl" > /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
+
+echo "Installing kustomize"
+curl -sSfL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize_version}/kustomize_v${kustomize_version}_${os}_${arch}.tar.gz | tar -xz -C /usr/local/bin kustomize
+chmod +x /usr/local/bin/kustomize
 
 echo "Installing stern"
 curl -sSfL "https://github.com/stern/stern/releases/download/v${stern_version}/stern_${stern_version}_${os}_${arch}.tar.gz" | tar -xz -C /usr/local/bin stern

--- a/deploy/crusoe/README.md
+++ b/deploy/crusoe/README.md
@@ -8,20 +8,60 @@ This will help you run a single instance of Beta9 on [Crusoe Cloud](https://docs
 ## Prereqs
 
 1. Install terraform.
-1. Configure your Crusoe config ([docs](https://docs.crusoecloud.com/quickstart/installing-the-cli/index.html#configure-the-cli)).
+1. Install Crusoe CLI and setup your config ([docs](https://docs.crusoecloud.com/quickstart/installing-the-cli/index.html#configure-the-cli)).
 
 ## Getting started
 
-1. Find your project ID.
 1. Make a new SSH key, or point to an existing one.
 1. Create a `terraform.tfvars` file in this directory.
     ```
-    project_id    = "<uuid of your project>"
     ssh_key_path  = "~/.ssh/id_crusoecloud.pub"
     ```
 1. Apply your Terraform.
-
     ```sh
     terraform init
     terraform apply
     ```
+1. To monitor the setup, tail the logs over SSH
+    ```sh
+    ssh -i ~/.ssh/id_crusoecloud ubuntu@<instance-ip> 'tail -n+1 -f /var/log/user-data.log'
+    ```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_crusoe"></a> [crusoe](#requirement\_crusoe) | 0.5.18 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_crusoe"></a> [crusoe](#provider\_crusoe) | 0.5.18 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [crusoe_compute_instance.this](https://registry.terraform.io/providers/crusoecloud/crusoe/0.5.18/docs/resources/compute_instance) | resource |
+| [crusoe_storage_disk.data](https://registry.terraform.io/providers/crusoecloud/crusoe/0.5.18/docs/resources/storage_disk) | resource |
+| [crusoe_vpc_firewall_rule.ingress](https://registry.terraform.io/providers/crusoecloud/crusoe/0.5.18/docs/resources/vpc_firewall_rule) | resource |
+| [crusoe_vpc_networks.this](https://registry.terraform.io/providers/crusoecloud/crusoe/0.5.18/docs/data-sources/vpc_networks) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Type of instance to run. Run the CLI command to show a list of instance types.<pre>crusoe compute vms types</pre> | `string` | `"a100-80gb.1x"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Location to deploy your resources. Run the CLI command to show a list of locations.<pre>crusoe locations list</pre> | `string` | `"us-northcentral1-a"` | no |
+| <a name="input_ssh_key_path"></a> [ssh\_key\_path](#input\_ssh\_key\_path) | Path to your public SSH key. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_public_ipv4"></a> [public\_ipv4](#output\_public\_ipv4) | n/a |

--- a/deploy/crusoe/config.tf
+++ b/deploy/crusoe/config.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     crusoe = {
-      source  = "registry.terraform.io/crusoecloud/crusoe"
-      version = "0.5.3"
+      source  = "crusoecloud/crusoe"
+      version = "0.5.18"
     }
   }
 }

--- a/deploy/crusoe/main.tf
+++ b/deploy/crusoe/main.tf
@@ -4,23 +4,25 @@ locals {
 }
 
 resource "crusoe_compute_instance" "this" {
-  name       = local.name
-  image      = "ubuntu20.04-nvidia-pcie-docker:latest"
-  type       = var.instance_type
-  ssh_key    = local.ssh_key_content
-  location   = var.location
-  project_id = var.project_id
+  name     = local.name
+  image    = "ubuntu20.04-nvidia-pcie-docker:latest"
+  type     = var.instance_type
+  ssh_key  = local.ssh_key_content
+  location = var.location
 
   startup_script = <<-EOF
   #!/bin/bash
+
+  exec > >(tee -a /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+
   mkdir /data
   mkfs.ext4 /dev/vda
   mount -t ext4 /dev/vda /data
 
-  # cd /data
-  # git clone https://github.com/beam-cloud/beta9.git
-  # cd beta9
-  # make setup
+  cd /data
+  git clone https://github.com/beam-cloud/beta9.git
+  cd beta9
+  make setup
   EOF
 
   disks = [
@@ -35,10 +37,9 @@ resource "crusoe_compute_instance" "this" {
 }
 
 resource "crusoe_storage_disk" "data" {
-  name       = local.name
-  size       = "400GiB"
-  location   = var.location
-  project_id = var.project_id
+  name     = local.name
+  size     = "400GiB"
+  location = var.location
 }
 
 data "crusoe_vpc_networks" "this" {}

--- a/deploy/crusoe/variables.tf
+++ b/deploy/crusoe/variables.tf
@@ -1,20 +1,26 @@
-variable "project_id" {
-  description = "UUID of your project."
-  type        = string
-}
-
 variable "ssh_key_path" {
   description = "Path to your public SSH key."
   type        = string
 }
 
 variable "location" {
-  description = "Location to deploy your resources."
+  description = <<-EOF
+    Location to deploy your resources. Run the CLI command to show a list of locations.
+      ```
+      crusoe locations list
+      ```
+  EOF
   type        = string
   default     = "us-northcentral1-a"
 }
 
 variable "instance_type" {
-  type    = string
-  default = "a40.1x"
+  description = <<-EOF
+    Type of instance to run. Run the CLI command to show a list of instance types.
+      ```
+      crusoe compute vms types
+      ```
+  EOF
+  type        = string
+  default     = "a100-80gb.1x"
 }

--- a/hack/k3d.yaml
+++ b/hack/k3d.yaml
@@ -16,6 +16,9 @@ ports:
 - port: 9000:9000
   nodeFilters:
   - loadbalancer
+- port: 8008:8008
+  nodeFilters:
+  - loadbalancer
 
 volumes:
 - volume: $PWD/manifests/k3d:k3s-manifests-custom


### PR DESCRIPTION
- Update Crusoe Terraform provider to the latest to fix Project ID issues
- Update Crusoe deployment README and suffix `terrform-docs` output
- Improve Terraform variable descriptions by mentioning where to get the values from
- Uncomment cloud-init script so that beta9 is downloaded, built, and deployed automatically
- Send all cloud-init script logs to `/var/log/user-data.log` so setup can be observed
- Add kustomize to setup.sh so setup make target can install manifests
- Add port on k3d local setup for internal api development

Resolve BE-1444

