### PR TITLE
Add CLI release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         arch: [x86_64, arm64]
 
     steps:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,80 @@
+name: Build and release CLI
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      app_version:
+        description: Semantic version of release
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    if: startsWith(github.ref, 'refs/tags/cli-') || inputs.app_version != ''
+    environment: Release
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        arch: [x86_64, arm64]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set version
+        id: set-version
+        run: |
+          if [[ ! -z "${{ inputs.app_version }}" ]]; then
+            echo "app_version=${{ inputs.app_version }}" >> $GITHUB_OUTPUT
+          else
+            echo "app_version=${GITHUB_REF_NAME#sdk-}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Rust
+        uses: moonrepo/setup-rust@v1
+
+      - name: Setup PyApp
+        id: setup-pyapp
+        env:
+          PYAPP_VERSION: 0.22.0
+        run: |
+          curl -L -o pyapp.tar.gz https://github.com/ofek/pyapp/releases/download/v${PYAPP_VERSION}/source.tar.gz
+          tar -xzf pyapp.tar.gz
+          mv pyapp-v* pyapp-latest
+
+      - name: Build binary
+        id: build-binary
+        env:
+          PYAPP_PROJECT_NAME: "beta9"
+          PYAPP_PROJECT_VERSION: "${{ steps.set-version.outputs.app_version }}"
+          PYAPP_FULL_ISOLATION: "true"
+          PYAPP_DISTRIBUTION_EMBED: "true"
+        run: |
+          cd pyapp-latest
+
+          cargo build --release
+
+          mv target/release/pyapp ${PYAPP_PROJECT_NAME}
+
+          TAR_FILE_NAME=${PYAPP_PROJECT_NAME}-${PYAPP_PROJECT_VERSION}.tar.gz
+          tar -cvf ${TAR_FILE_NAME} ${PYAPP_PROJECT_NAME}
+          echo "tar_file_name=${TAR_FILE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Upload binary
+        uses: shallwefootball/s3-upload-action@master
+        id: upload-binary
+        with:
+          aws_key_id: "${{ secrets.TIGRIS_ACCESS_KEY }}"
+          aws_secret_access_key: "${{ secrets.TIGRIS_SECRET_KEY }}"
+          aws_bucket: "release.beam.cloud"
+          source_dir: "${{ steps.build-binary.outputs.tar_file_name }}"
+          destination_dir: "sdk"
+          endpoint: "https://fly.storage.tigris.dev"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -29,13 +29,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set version
-        id: set-version
+      - name: Set build info
+        id: set-build-info
         run: |
           if [[ ! -z "${{ inputs.app_version }}" ]]; then
             echo "app_version=${{ inputs.app_version }}" >> $GITHUB_OUTPUT
           else
             echo "app_version=${GITHUB_REF_NAME#sdk-}" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "${{ matrix.arch }}" == "arm64" ]]; then
+            echo "arch=arm64" >> $GITHUB_OUTPUT
+          else
+            echo "arch=amd64" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            echo "os_name=linux" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            echo "os_name=darwin" >> $GITHUB_OUTPUT
           fi
 
       - name: Setup Rust
@@ -54,7 +66,7 @@ jobs:
         id: build-binary
         env:
           PYAPP_PROJECT_NAME: "beta9"
-          PYAPP_PROJECT_VERSION: "${{ steps.set-version.outputs.app_version }}"
+          PYAPP_PROJECT_VERSION: "${{ steps.set-build-info.outputs.app_version }}"
           PYAPP_FULL_ISOLATION: "true"
           PYAPP_DISTRIBUTION_EMBED: "true"
         run: |
@@ -64,11 +76,19 @@ jobs:
 
           mv target/release/pyapp ${PYAPP_PROJECT_NAME}
 
-          TAR_FILE_NAME=${PYAPP_PROJECT_NAME}-${PYAPP_PROJECT_VERSION}.tar.gz
+          TAR_FILE_NAME=${PYAPP_PROJECT_NAME}-${PYAPP_PROJECT_VERSION}-${{ steps.set-build-info.outputs.os_name }}-${{ steps.set-build-info.outputs.arch }}.tar.gz
           tar -cvf ${TAR_FILE_NAME} ${PYAPP_PROJECT_NAME}
           echo "tar_file_name=${TAR_FILE_NAME}" >> $GITHUB_OUTPUT
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build-binary.outputs.tar_file_name }}
+          path: pyapp-latest/beta9
+          if-no-files-found: ignore
+          compression-level: "9"
+
       - name: Upload binary
+        if: inputs.app_version == ''
         run: |
           gh release upload ${GITHUB_REF_NAME} "${{ steps.build-binary.outputs.tar_file_name }}"
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -69,12 +69,19 @@ jobs:
           echo "tar_file_name=${TAR_FILE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload binary
-        uses: shallwefootball/s3-upload-action@master
-        id: upload-binary
-        with:
-          aws_key_id: "${{ secrets.TIGRIS_ACCESS_KEY }}"
-          aws_secret_access_key: "${{ secrets.TIGRIS_SECRET_KEY }}"
-          aws_bucket: "release.beam.cloud"
-          source_dir: "${{ steps.build-binary.outputs.tar_file_name }}"
-          destination_dir: "sdk"
-          endpoint: "https://fly.storage.tigris.dev"
+        run: |
+          gh release upload ${GITHUB_REF_NAME} "${{ steps.build-binary.outputs.tar_file_name }}"
+
+      # - name: Upload binary
+      #   uses: shallwefootball/s3-upload-action@master
+      #   id: upload-binary
+      #   with:
+      #     aws_key_id: "${{ secrets.TIGRIS_ACCESS_KEY }}"
+      #     aws_secret_access_key: "${{ secrets.TIGRIS_SECRET_KEY }}"
+      #     aws_bucket: "release.beam.cloud"
+      #     source_dir: "${{ steps.build-binary.outputs.tar_file_name }}"
+      #     destination_dir: "sdk"
+      #     endpoint: "https://fly.storage.tigris.dev"
+
+      # TODO: Generate new formula and push to homebrew-beam
+      #


### PR DESCRIPTION
- Build standalone Python CLI binary with PyApp
- Upload binary to Action Workflow
- Upload binary to GitHub Release when Workflow is triggered by a Release

Resolve BE-1387