### PR TITLE
Fix help and version output in CLI

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.35"
+version = "0.1.37"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/cli/main.py
+++ b/sdk/src/beta9/cli/main.py
@@ -38,8 +38,8 @@ class CLI:
             context_settings=context_settings,
         )
 
-    def __call__(self, *args: Any, **kwargs: Any) -> None:
-        self.common_group.main(*args, **kwargs)
+    def __call__(self) -> None:
+        self.common_group.main(prog_name=self.settings.name.lower())
 
     def register(self, module: ModuleType) -> None:
         if hasattr(module, "common"):


### PR DESCRIPTION
When using pyapp to build a binary, the --help and --version options output `Usage: python -m beam [OPTIONS] COMMAND [ARGS]... ` and `python -m beam, version 0.2.23` respectively. This fixes that so the `python -m beam` portion is just `beam`.

Resolve BE-1387