### PR TITLE
Fix external tailscale cfg

### DIFF
--- a/pkg/providers/remote_config.go
+++ b/pkg/providers/remote_config.go
@@ -49,11 +49,7 @@ func GetRemoteConfig(baseConfig types.AppConfig, tailscale *network.Tailscale) (
 		remoteConfig.Storage.JuiceFS.RedisURI = fmt.Sprintf("rediss://:%s@%s/0", juicefsRedisPassword, juiceFsRedisHostname)
 	}
 
-	gatewayGrpcHostname, err := network.ResolveTailscaleService("gateway-proxy", connectTimeout)
-	if err != nil {
-		return nil, err
-	}
-	remoteConfig.GatewayService.Host = strings.Split(gatewayGrpcHostname, ":")[0]
+	remoteConfig.GatewayService.Host = strings.TrimPrefix(remoteConfig.GatewayService.ExternalURL, "https://")
 
 	if baseConfig.ImageService.BlobCacheEnabled {
 		blobcacheRedisHostname, err := network.ResolveTailscaleService("blobcache-redis", connectTimeout)

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/beam-cloud/beta9/pkg/network"
 	"github.com/beam-cloud/beta9/pkg/providers"
@@ -364,11 +365,11 @@ func (wpc *ExternalWorkerPoolController) getWorkerEnvironment(workerId, machineI
 		},
 		{
 			Name:  "BETA9_GATEWAY_HOST",
-			Value: wpc.config.GatewayService.Host,
+			Value: strings.TrimPrefix(wpc.config.GatewayService.ExternalURL, "https://"),
 		},
 		{
 			Name:  "BETA9_GATEWAY_PORT",
-			Value: fmt.Sprint(wpc.config.GatewayService.GRPC.Port),
+			Value: "443",
 		},
 		{
 			Name:  "POD_HOSTNAME",

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -609,8 +609,8 @@ func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, option
 		fmt.Sprintf("BIND_PORT=%d", options.BindPort),
 		fmt.Sprintf("CONTAINER_HOSTNAME=%s", fmt.Sprintf("%s:%d", s.podAddr, options.BindPort)),
 		fmt.Sprintf("CONTAINER_ID=%s", request.ContainerId),
-		fmt.Sprintf("BETA9_GATEWAY_HOST=%s", s.config.GatewayService.Host),
-		fmt.Sprintf("BETA9_GATEWAY_PORT=%d", s.config.GatewayService.GRPC.Port),
+		fmt.Sprintf("BETA9_GATEWAY_HOST=%s", os.Getenv("BETA9_GATEWAY_HOST")),
+		fmt.Sprintf("BETA9_GATEWAY_PORT=%s", os.Getenv("BETA9_GATEWAY_PORT")),
 		"PYTHONUNBUFFERED=1",
 	}
 


### PR DESCRIPTION
- use external hostname instead of service
- remove tailscale lookup of gateway since it's exposed to internet already