### PR TITLE
[Bug] Worker timeout applies to on start function

### DIFF
--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -163,7 +163,7 @@ class FunctionHandler:
         return self.handler(*args, **kwargs)
 
 
-def execute_lifecycle_method(*, name: str) -> Union[Any, None]:
+def execute_lifecycle_method(name: str) -> Union[Any, None]:
     """Executes a container lifecycle method defined by the user and return it's value"""
 
     if sys.path[0] != USER_CODE_VOLUME:

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import signal
@@ -77,7 +78,7 @@ class GunicornApplication(BaseApplication):
         logger.propagate = False
 
         try:
-            mg = EndpointManager(logger=logger)
+            mg = EndpointManager(logger=logger, worker=worker)
             asgi_app: ASGIApp = mg.app
 
             # Override the default starlette app
@@ -124,6 +125,25 @@ async def task_lifecycle(request: Request):
         )
 
 
+class OnStartMethodHandler:
+    def __init__(self, worker):
+        self._is_running = True
+        self._worker = worker
+
+    async def start(self):
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(self._continously_notify_worker())
+        result = await loop.run_in_executor(None, execute_lifecycle_method, LifeCycleMethod.OnStart)
+        self._is_running = False
+        await task
+        return result
+
+    async def _continously_notify_worker(self):
+        while self._is_running:
+            self._worker.notify()
+            await asyncio.sleep(1)
+
+
 class EndpointManager:
     @asynccontextmanager
     async def lifespan(self, _: FastAPI):
@@ -131,18 +151,20 @@ class EndpointManager:
             self.app.state.gateway_stub = GatewayServiceStub(channel)
             yield
 
-    def __init__(self, logger: logging.Logger) -> None:
+    def __init__(self, logger: logging.Logger, worker: UvicornWorker) -> None:
         self.logger = logger
         self.pid: int = os.getpid()
         self.exit_code: int = 0
         self.app = FastAPI(lifespan=self.lifespan)
+        self.worker = worker
 
         # Register signal handlers
         signal.signal(signal.SIGTERM, self.shutdown)
 
         # Load handler and execute on_start method
         self.handler: FunctionHandler = FunctionHandler()
-        self.on_start_value = execute_lifecycle_method(name=LifeCycleMethod.OnStart)
+        # self.on_start_value = execute_lifecycle_method(name=LifeCycleMethod.OnStart)
+        self.on_start_value = asyncio.run(OnStartMethodHandler(worker).start())
 
         @self.app.get("/health")
         async def health():
@@ -221,13 +243,16 @@ class EndpointManager:
 
 
 if __name__ == "__main__":
+    os.mkdir("/tmp/worker")
+
     options = {
         "bind": [f"[::]:{cfg.bind_port}"],
         "workers": cfg.concurrency,
         "worker_class": "uvicorn.workers.UvicornWorker",
+        "worker_tmp_dir": "/tmp/worker",
         "loglevel": "info",
         "post_fork": GunicornApplication.post_fork_initialize,
-        "timeout": cfg.timeout,
+        "timeout": 30,
     }
 
     GunicornApplication(Starlette(), options).run()

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -156,7 +156,6 @@ class EndpointManager:
         self.pid: int = os.getpid()
         self.exit_code: int = 0
         self.app = FastAPI(lifespan=self.lifespan)
-        self.worker = worker
 
         # Register signal handlers
         signal.signal(signal.SIGTERM, self.shutdown)

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -243,16 +243,13 @@ class EndpointManager:
 
 
 if __name__ == "__main__":
-    os.mkdir("/tmp/worker")
-
     options = {
         "bind": [f"[::]:{cfg.bind_port}"],
         "workers": cfg.concurrency,
         "worker_class": "uvicorn.workers.UvicornWorker",
-        "worker_tmp_dir": "/tmp/worker",
         "loglevel": "info",
         "post_fork": GunicornApplication.post_fork_initialize,
-        "timeout": 30,
+        "timeout": cfg.timeout,
     }
 
     GunicornApplication(Starlette(), options).run()

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -132,13 +132,13 @@ class OnStartMethodHandler:
 
     async def start(self):
         loop = asyncio.get_running_loop()
-        task = loop.create_task(self._continously_notify_worker())
+        task = loop.create_task(self._keep_worker_alive())
         result = await loop.run_in_executor(None, execute_lifecycle_method, LifeCycleMethod.OnStart)
         self._is_running = False
         await task
         return result
 
-    async def _continously_notify_worker(self):
+    async def _keep_worker_alive(self):
         while self._is_running:
             self._worker.notify()
             await asyncio.sleep(1)
@@ -163,7 +163,6 @@ class EndpointManager:
 
         # Load handler and execute on_start method
         self.handler: FunctionHandler = FunctionHandler()
-        # self.on_start_value = execute_lifecycle_method(name=LifeCycleMethod.OnStart)
         self.on_start_value = asyncio.run(OnStartMethodHandler(worker).start())
 
         @self.app.get("/health")


### PR DESCRIPTION
Gunicorn worker timeout is based off the difference between `current_time` and the `last_modified` time of `tmp` file that belongs to the Worker.

This method here forcefully keeps the worker's post_fork method alive by updating that `tmp` every second