### PR TITLE
Occupy existing machines with workers

### DIFF
--- a/pkg/providers/base.go
+++ b/pkg/providers/base.go
@@ -93,11 +93,11 @@ func (p *ExternalProvider) Reconcile(ctx context.Context, poolName string) {
 						return
 					}
 
-					if !machine.AutoConsolidate {
+					if !machine.State.AutoConsolidate {
 						return
 					}
 
-					lastWorkerSeen, err := strconv.ParseInt(machine.LastKeepalive, 10, 64)
+					lastWorkerSeen, err := strconv.ParseInt(machine.State.LastKeepalive, 10, 64)
 					if err != nil {
 						return
 					}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -124,7 +124,7 @@ type TaskRepository interface {
 }
 
 type ProviderRepository interface {
-	GetMachine(providerName, poolName, machineId string) (*types.ProviderMachineState, error)
+	GetMachine(providerName, poolName, machineId string) (*types.ProviderMachine, error)
 	AddMachine(providerName, poolName, machineId string, machineInfo *types.ProviderMachineState) error
 	RemoveMachine(providerName, poolName, machineId string) error
 	SetMachineKeepAlive(providerName, poolName, machineId string) error

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -24,7 +24,7 @@ func NewProviderRedisRepository(rdb *common.RedisClient) ProviderRepository {
 	return &ProviderRedisRepository{rdb: rdb, lock: lock, lockOptions: lockOptions}
 }
 
-func (r *ProviderRedisRepository) GetMachine(providerName, poolName, machineId string) (*types.ProviderMachineState, error) {
+func (r *ProviderRedisRepository) GetMachine(providerName, poolName, machineId string) (*types.ProviderMachine, error) {
 	ctx := context.TODO()
 
 	stateKey := common.RedisKeys.ProviderMachineState(providerName, poolName, machineId)
@@ -45,7 +45,7 @@ func (r *ProviderRedisRepository) GetMachine(providerName, poolName, machineId s
 		return nil, fmt.Errorf("error parsing machine state for %s: %w", machineId, err)
 	}
 
-	return state, nil
+	return &types.ProviderMachine{State: state}, nil
 }
 
 func (r *ProviderRedisRepository) ListAllMachines(providerName, poolName string) ([]*types.ProviderMachine, error) {

--- a/pkg/repository/testutils.go
+++ b/pkg/repository/testutils.go
@@ -42,6 +42,18 @@ func NewWorkspaceRedisRepositoryForTest(rdb *common.RedisClient) WorkspaceReposi
 	return &WorkspaceRedisRepository{rdb: rdb}
 }
 
+func NewProviderRedisRepositoryForTest(rdb *common.RedisClient) ProviderRepository {
+	lock := common.NewRedisLock(rdb)
+	lockOptions := common.RedisLockOptions{TtlS: 10, Retries: 0}
+	return &ProviderRedisRepository{rdb: rdb, lock: lock, lockOptions: lockOptions}
+}
+
+func NewWorkerPoolRedisRepositoryForTest(rdb *common.RedisClient) WorkerPoolRepository {
+	lock := common.NewRedisLock(rdb)
+	lockOptions := common.RedisLockOptions{TtlS: 10, Retries: 0}
+	return &WorkerPoolRedisRepository{rdb: rdb, lock: lock, lockOptions: lockOptions}
+}
+
 func NewBackendPostgresRepositoryForTest() (BackendRepository, sqlmock.Sqlmock) {
 	mockDB, mock, err := sqlmock.New()
 	if err != nil {

--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -25,6 +25,7 @@ const (
 
 type WorkerPoolController interface {
 	AddWorker(cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error)
+	AddWorkerOnMachine(cpu int64, memory int64, gpuType string, gpuCount uint32, machineId string) (*types.Worker, error)
 	Name() string
 	FreeCapacity() (*WorkerPoolCapacity, error)
 }
@@ -44,13 +45,12 @@ func GenerateWorkerId() string {
 	return uuid.New().String()[:8]
 }
 
-func MonitorPoolSize(wpc WorkerPoolController, workerPool *types.WorkerPoolConfig, workerPoolRepo repository.WorkerPoolRepository) error {
-	config, err := ParsePoolSizingConfig(workerPool.PoolSizing)
-	if err != nil {
-		return err
-	}
-
-	poolSizer, err := NewWorkerPoolSizer(wpc, config, workerPoolRepo)
+func MonitorPoolSize(wpc WorkerPoolController,
+	workerPoolConfig *types.WorkerPoolConfig,
+	workerRepo repository.WorkerRepository,
+	workerPoolRepo repository.WorkerPoolRepository,
+	providerRepo repository.ProviderRepository) error {
+	poolSizer, err := NewWorkerPoolSizer(wpc, workerPoolConfig, workerRepo, workerPoolRepo, providerRepo)
 	if err != nil {
 		return err
 	}

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -84,7 +84,7 @@ func NewExternalWorkerPoolController(
 	}
 
 	// Start monitoring worker pool size
-	err = MonitorPoolSize(wpc, &workerPool, workerPoolRepo)
+	err = MonitorPoolSize(wpc, &workerPool, workerRepo, workerPoolRepo, providerRepo)
 	if err != nil {
 		log.Printf("<pool %s> unable to monitor pool size: %+v\n", wpc.name, err)
 	}
@@ -93,6 +93,50 @@ func NewExternalWorkerPoolController(
 	go provider.Reconcile(context.Background(), wpc.name)
 
 	return wpc, nil
+}
+
+func (wpc *ExternalWorkerPoolController) attemptToAssignWorkerToMachine(workerId string, cpu int64, memory int64, gpuType string, gpuCount uint32, machine *types.ProviderMachine) (*types.Worker, error) {
+	err := wpc.providerRepo.SetMachineLock(wpc.provider.GetName(), wpc.name, machine.State.MachineId)
+	if err != nil {
+		return nil, err
+	}
+
+	defer wpc.providerRepo.RemoveMachineLock(wpc.provider.GetName(), wpc.name, machine.State.MachineId)
+
+	workers, err := wpc.workerRepo.GetAllWorkersOnMachine(machine.State.MachineId)
+	if err != nil || machine.State.Status != types.MachineStatusRegistered {
+		return nil, err
+	}
+
+	remainingMachineCpu := machine.State.Cpu
+	remainingMachineMemory := machine.State.Memory
+	remainingMachineGpuCount := machine.State.GpuCount
+	for _, worker := range workers {
+		remainingMachineCpu -= worker.TotalCpu
+		remainingMachineMemory -= worker.TotalMemory
+		remainingMachineGpuCount -= uint32(worker.TotalGpuCount)
+	}
+
+	if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount {
+		log.Printf("Using existing machine <machineId: %s>, hostname: %s\n", machine.State.MachineId, machine.State.HostName)
+
+		// If there is only one GPU available on the machine, give the worker access to everything
+		// This prevents situations where a user requests a small amount of compute, and the subsequent
+		// request has higher compute requirements
+		if machine.State.GpuCount == 1 {
+			cpu = machine.State.Cpu
+			memory = machine.State.Memory
+		}
+
+		worker, err := wpc.createWorkerOnMachine(workerId, machine.State.MachineId, machine.State, cpu, memory, gpuType, gpuCount)
+		if err != nil {
+			return nil, err
+		}
+
+		return worker, nil
+	}
+
+	return nil, errors.New("machine out of capacity")
 }
 
 func (wpc *ExternalWorkerPoolController) AddWorker(cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {
@@ -105,53 +149,12 @@ func (wpc *ExternalWorkerPoolController) AddWorker(cpu int64, memory int64, gpuT
 
 	// Attempt to schedule the worker on an existing machine first
 	for _, machine := range machines {
-		worker := func() *types.Worker {
-			err := wpc.providerRepo.SetMachineLock(wpc.provider.GetName(), wpc.name, machine.State.MachineId)
-			if err != nil {
-				return nil
-			}
-
-			defer wpc.providerRepo.RemoveMachineLock(wpc.provider.GetName(), wpc.name, machine.State.MachineId)
-
-			workers, err := wpc.workerRepo.GetAllWorkersOnMachine(machine.State.MachineId)
-			if err != nil || machine.State.Status != types.MachineStatusRegistered {
-				return nil
-			}
-
-			remainingMachineCpu := machine.State.Cpu
-			remainingMachineMemory := machine.State.Memory
-			remainingMachineGpuCount := machine.State.GpuCount
-			for _, worker := range workers {
-				remainingMachineCpu -= worker.TotalCpu
-				remainingMachineMemory -= worker.TotalMemory
-				remainingMachineGpuCount -= uint32(worker.TotalGpuCount)
-			}
-
-			if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount {
-				log.Printf("Using existing machine <machineId: %s>, hostname: %s\n", machine.State.MachineId, machine.State.HostName)
-
-				// If there is only one GPU available on the machine, give the worker access to everything
-				// This prevents situations where a user requests a small amount of compute, and the subsequent
-				// request has higher compute requirements
-				if machine.State.GpuCount == 1 {
-					cpu = machine.State.Cpu
-					memory = machine.State.Memory
-				}
-
-				worker, err := wpc.createWorkerOnMachine(workerId, machine.State.MachineId, machine.State, cpu, memory, gpuType, gpuCount)
-				if err != nil {
-					return nil
-				}
-
-				return worker
-			}
-
-			return nil
-		}()
-
-		if worker != nil {
-			return worker, nil
+		worker, err := wpc.attemptToAssignWorkerToMachine(workerId, cpu, memory, gpuType, gpuCount, machine)
+		if err != nil {
+			continue
 		}
+
+		return worker, nil
 	}
 
 	// TODO: replace hard-coded workspace ID with look up of cluster admin
@@ -185,6 +188,22 @@ func (wpc *ExternalWorkerPoolController) AddWorker(cpu int64, memory int64, gpuT
 
 	log.Printf("Machine registered <machineId: %s>, hostname: %s\n", machineId, machineState.HostName)
 	worker, err := wpc.createWorkerOnMachine(workerId, machineId, machineState, cpu, memory, gpuType, gpuCount)
+	if err != nil {
+		return nil, err
+	}
+
+	return worker, nil
+}
+
+func (wpc *ExternalWorkerPoolController) AddWorkerOnMachine(cpu int64, memory int64, gpuType string, gpuCount uint32, machineId string) (*types.Worker, error) {
+	workerId := GenerateWorkerId()
+
+	machine, err := wpc.providerRepo.GetMachine(wpc.provider.GetName(), wpc.name, machineId)
+	if err != nil {
+		return nil, err
+	}
+
+	worker, err := wpc.attemptToAssignWorkerToMachine(workerId, cpu, memory, gpuType, gpuCount, machine)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -31,7 +32,7 @@ type LocalKubernetesWorkerPoolController struct {
 	workerRepo repository.WorkerRepository
 }
 
-func NewLocalKubernetesWorkerPoolController(ctx context.Context, config types.AppConfig, workerPoolName string, workerRepo repository.WorkerRepository, workerPoolRepo repository.WorkerPoolRepository) (WorkerPoolController, error) {
+func NewLocalKubernetesWorkerPoolController(ctx context.Context, config types.AppConfig, workerPoolName string, workerRepo repository.WorkerRepository, workerPoolRepo repository.WorkerPoolRepository, providerRepo repository.ProviderRepository) (WorkerPoolController, error) {
 	kubeConfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -53,7 +54,7 @@ func NewLocalKubernetesWorkerPoolController(ctx context.Context, config types.Ap
 	}
 
 	// Start monitoring worker pool size
-	err = MonitorPoolSize(wpc, &workerPool, workerPoolRepo)
+	err = MonitorPoolSize(wpc, &workerPool, workerRepo, workerPoolRepo, providerRepo)
 	if err != nil {
 		log.Printf("<pool %s> unable to monitor pool size: %+v\n", wpc.name, err)
 	}
@@ -74,6 +75,10 @@ func (wpc *LocalKubernetesWorkerPoolController) FreeCapacity() (*WorkerPoolCapac
 func (wpc *LocalKubernetesWorkerPoolController) AddWorker(cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {
 	workerId := GenerateWorkerId()
 	return wpc.addWorkerWithId(workerId, cpu, memory, gpuType, gpuCount)
+}
+
+func (wpc *LocalKubernetesWorkerPoolController) AddWorkerOnMachine(cpu int64, memory int64, gpuType string, gpuCount uint32, machineId string) (*types.Worker, error) {
+	return nil, errors.New("unimplemented")
 }
 
 func (wpc *LocalKubernetesWorkerPoolController) addWorkerWithId(workerId string, cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {

--- a/pkg/scheduler/pool_sizing_test.go
+++ b/pkg/scheduler/pool_sizing_test.go
@@ -79,13 +79,13 @@ func TestAddWorkerIfNeeded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := &WorkerPoolControllerForTest{
+			controller := &LocalWorkerPoolControllerForTest{
 				name:       "TestPool",
 				workerRepo: workerRepo,
 			}
 			sizer := &WorkerPoolSizer{
-				controller: controller,
-				config:     tt.config,
+				controller:             controller,
+				workerPoolSizingConfig: tt.config,
 			}
 
 			newWorker, err := sizer.addWorkerIfNeeded(tt.freeCapacity)
@@ -192,10 +192,130 @@ func TestParsePoolSizingConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := ParsePoolSizingConfig(*tt.sizingConfigHave)
+			config, err := parsePoolSizingConfig(*tt.sizingConfigHave)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.sizingConfigWant, config)
+		})
+	}
+}
+
+func TestOccupyAvailableMachines(t *testing.T) {
+	s, err := miniredis.Run()
+	assert.NotNil(t, s)
+	assert.Nil(t, err)
+
+	redisClient, err := common.NewRedisClient(types.RedisConfig{Addrs: []string{s.Addr()}, Mode: types.RedisModeSingle})
+	assert.NotNil(t, redisClient)
+	assert.Nil(t, err)
+
+	providerRepo := repo.NewProviderRedisRepositoryForTest(redisClient)
+	workerRepo := repo.NewWorkerRedisRepositoryForTest(redisClient)
+
+	lambdaPoolName := "LambdaLabsPool"
+	controller := &ExternalWorkerPoolControllerForTest{
+		name:         lambdaPoolName,
+		workerRepo:   workerRepo,
+		providerRepo: providerRepo,
+		poolName:     lambdaPoolName,
+		providerName: string(types.ProviderLambdaLabs),
+	}
+
+	sizer := &WorkerPoolSizer{
+		providerRepo: providerRepo,
+		workerRepo:   workerRepo,
+		controller:   controller,
+		workerPoolConfig: &types.WorkerPoolConfig{
+			Provider: &types.ProviderLambdaLabs,
+			GPUType:  "A10G",
+			Mode:     types.PoolModeExternal,
+		},
+		workerPoolSizingConfig: &types.WorkerPoolSizingConfig{
+			DefaultWorkerCpu:      8000,
+			DefaultWorkerMemory:   16000,
+			DefaultWorkerGpuType:  "A10G",
+			DefaultWorkerGpuCount: 1,
+		},
+	}
+
+	// Add some "manually" provisioned machines
+	err = providerRepo.AddMachine(string(types.ProviderLambdaLabs), lambdaPoolName, "machine1", &types.ProviderMachineState{
+		GpuCount:        1,
+		AutoConsolidate: false,
+		Cpu:             30000,
+		Memory:          16000,
+		Status:          types.MachineStatusRegistered,
+	})
+	assert.NoError(t, err)
+
+	err = providerRepo.RegisterMachine(string(types.ProviderLambdaLabs), lambdaPoolName, "machine1", &types.ProviderMachineState{
+		GpuCount:        1,
+		AutoConsolidate: false,
+		Cpu:             30000,
+		Memory:          16000,
+		Status:          types.MachineStatusRegistered,
+	})
+	assert.NoError(t, err)
+
+	err = providerRepo.AddMachine(string(types.ProviderLambdaLabs), lambdaPoolName, "machine2", &types.ProviderMachineState{
+		GpuCount:        1,
+		AutoConsolidate: false,
+		Cpu:             30000,
+		Memory:          10000,
+		Status:          types.MachineStatusRegistered,
+	})
+	assert.NoError(t, err)
+
+	err = providerRepo.RegisterMachine(string(types.ProviderLambdaLabs), lambdaPoolName, "machine2", &types.ProviderMachineState{
+		GpuCount:        1,
+		AutoConsolidate: false,
+		Cpu:             30000,
+		Memory:          16000,
+		Status:          types.MachineStatusRegistered,
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name                           string
+		expectedError                  error
+		expectedWorkersOnMachineBefore int
+		expectedWorkersOnMachineAfter  int
+		machineId                      string
+	}{
+
+		{
+			name:                           "successfully add workers to machine1 and machine2",
+			expectedError:                  nil,
+			expectedWorkersOnMachineBefore: 0,
+			expectedWorkersOnMachineAfter:  1,
+			machineId:                      "machine1",
+		},
+		{
+			name:                           "did not add additional workers to machine2",
+			expectedError:                  nil,
+			expectedWorkersOnMachineBefore: 1,
+			expectedWorkersOnMachineAfter:  1,
+			machineId:                      "machine2",
+		},
+	}
+
+	machines, err := providerRepo.ListAllMachines(string(types.ProviderLambdaLabs), lambdaPoolName)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(machines))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err = sizer.occupyAvailableMachines()
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			workers, err := workerRepo.GetAllWorkersOnMachine(tt.machineId)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedWorkersOnMachineAfter, len(workers))
 		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -51,7 +51,7 @@ func NewScheduler(ctx context.Context, config types.AppConfig, redisClient *comm
 
 		switch pool.Mode {
 		case types.PoolModeLocal:
-			controller, err = NewLocalKubernetesWorkerPoolController(ctx, config, name, workerRepo, workerPoolRepo)
+			controller, err = NewLocalKubernetesWorkerPoolController(ctx, config, name, workerRepo, workerPoolRepo, providerRepo)
 		case types.PoolModeExternal:
 			controller, err = NewExternalWorkerPoolController(ctx, config, name, backendRepo, workerRepo, workerPoolRepo, providerRepo, tailscale, pool.Provider)
 		default:

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2,12 +2,14 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"log"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
 
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -49,7 +51,7 @@ func NewSchedulerForTest() (*Scheduler, error) {
 
 	workerPoolManager := NewWorkerPoolManager(repo.NewWorkerPoolRedisRepository(rdb))
 	for name, pool := range config.Worker.Pools {
-		workerPoolManager.SetPool(name, pool, &WorkerPoolControllerForTest{
+		workerPoolManager.SetPool(name, pool, &LocalWorkerPoolControllerForTest{
 			name:       name,
 			config:     config,
 			workerRepo: workerRepo,
@@ -68,17 +70,17 @@ func NewSchedulerForTest() (*Scheduler, error) {
 	}, nil
 }
 
-type WorkerPoolControllerForTest struct {
+type LocalWorkerPoolControllerForTest struct {
 	name       string
 	config     types.AppConfig
 	workerRepo repo.WorkerRepository
 }
 
-func (wpc *WorkerPoolControllerForTest) generateWorkerId() string {
+func (wpc *LocalWorkerPoolControllerForTest) generateWorkerId() string {
 	return uuid.New().String()[:8]
 }
 
-func (wpc *WorkerPoolControllerForTest) AddWorker(cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {
+func (wpc *LocalWorkerPoolControllerForTest) AddWorker(cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {
 	workerId := wpc.generateWorkerId()
 	worker := &types.Worker{
 		Id:           workerId,
@@ -99,11 +101,123 @@ func (wpc *WorkerPoolControllerForTest) AddWorker(cpu int64, memory int64, gpuTy
 	return worker, nil
 }
 
-func (wpc *WorkerPoolControllerForTest) Name() string {
+func (wpc *LocalWorkerPoolControllerForTest) AddWorkerOnMachine(cpu int64, memory int64, gpuType string, gpuCount uint32, machineId string) (*types.Worker, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (wpc *LocalWorkerPoolControllerForTest) Name() string {
 	return wpc.name
 }
 
-func (wpc *WorkerPoolControllerForTest) FreeCapacity() (*WorkerPoolCapacity, error) {
+func (wpc *LocalWorkerPoolControllerForTest) FreeCapacity() (*WorkerPoolCapacity, error) {
+	return &WorkerPoolCapacity{}, nil
+}
+
+type ExternalWorkerPoolControllerForTest struct {
+	name         string
+	workerRepo   repo.WorkerRepository
+	providerRepo repository.ProviderRepository
+	poolName     string
+	providerName string
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) generateWorkerId() string {
+	return uuid.New().String()[:8]
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) AddWorker(cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {
+	workerId := wpc.generateWorkerId()
+	worker := &types.Worker{
+		Id:           workerId,
+		FreeCpu:      cpu,
+		FreeMemory:   memory,
+		Gpu:          gpuType,
+		FreeGpuCount: gpuCount,
+		Status:       types.WorkerStatusPending,
+		PoolName:     wpc.poolName,
+	}
+
+	// Add the worker state
+	err := wpc.workerRepo.AddWorker(worker)
+	if err != nil {
+		log.Printf("Unable to create worker: %+v\n", err)
+		return nil, err
+	}
+
+	return worker, nil
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) AddWorkerOnMachine(cpu int64, memory int64, gpuType string, gpuCount uint32, machineId string) (*types.Worker, error) {
+	workerId := GenerateWorkerId()
+
+	err := wpc.providerRepo.SetMachineLock(wpc.providerName, wpc.name, machineId)
+	if err != nil {
+		return nil, err
+	}
+	defer wpc.providerRepo.RemoveMachineLock(wpc.providerName, wpc.name, machineId)
+
+	machine, err := wpc.providerRepo.GetMachine(wpc.providerName, wpc.name, machineId)
+	if err != nil {
+		return nil, err
+	}
+
+	workers, err := wpc.workerRepo.GetAllWorkersOnMachine(machineId)
+	if err != nil {
+		return nil, err
+	}
+
+	if machine.State.Status != types.MachineStatusRegistered {
+		return nil, errors.New("machine not registered")
+	}
+
+	remainingMachineCpu := machine.State.Cpu
+	remainingMachineMemory := machine.State.Memory
+	remainingMachineGpuCount := machine.State.GpuCount
+	for _, worker := range workers {
+		remainingMachineCpu -= worker.TotalCpu
+		remainingMachineMemory -= worker.TotalMemory
+		remainingMachineGpuCount -= uint32(worker.TotalGpuCount)
+	}
+
+	if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount {
+		// If there is only one GPU available on the machine, give the worker access to everything
+		// This prevents situations where a user requests a small amount of compute, and the subsequent
+		// request has higher compute requirements
+		if machine.State.GpuCount == 1 {
+			cpu = machine.State.Cpu
+			memory = machine.State.Memory
+		}
+	}
+
+	worker := &types.Worker{
+		Id:            workerId,
+		FreeCpu:       cpu,
+		FreeMemory:    memory,
+		Gpu:           gpuType,
+		FreeGpuCount:  gpuCount,
+		Status:        types.WorkerStatusPending,
+		PoolName:      wpc.poolName,
+		TotalGpuCount: gpuCount,
+		TotalCpu:      cpu,
+		TotalMemory:   memory,
+	}
+
+	worker.MachineId = machineId
+
+	// Add the worker state
+	if err := wpc.workerRepo.AddWorker(worker); err != nil {
+		log.Printf("Unable to create worker: %+v\n", err)
+		return nil, err
+	}
+
+	return worker, nil
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) Name() string {
+	return wpc.name
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) FreeCapacity() (*WorkerPoolCapacity, error) {
 	return &WorkerPoolCapacity{}, nil
 }
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -188,6 +188,7 @@ type WorkerPoolConfig struct {
 	Provider             *MachineProvider                  `key:"provider" json:"provider"`
 	JobSpec              WorkerPoolJobSpecConfig           `key:"jobSpec" json:"job_spec"`
 	PoolSizing           WorkerPoolJobSpecPoolSizingConfig `key:"poolSizing" json:"pool_sizing"`
+	DefaultMachineCost   float64                           `key:"defaultMachineCost" json:"default_machine_cost"`
 	RequiresPoolSelector bool                              `key:"requiresPoolSelector" json:"requires_pool_selector"`
 }
 


### PR DESCRIPTION
- This adds an additional feature to pool sizing that will ensure that machines that are manually added will always have a workers available -- filling out whatever compute capacity is available.
- Refactors pool logic to be a bit more readable
- Adds a AddWorkerOnMachine function to worker pool controller