### PR TITLE
Don't allow workers to be created with zero gpu count in gpu pools

### DIFF
--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -157,12 +157,18 @@ func parsePoolSizingConfig(config types.WorkerPoolJobSpecPoolSizingConfig) (*typ
 		c.DefaultWorkerMemory = defaultWorkerMemory
 	}
 
-	if defaultWorkerGpuType, err := ParseGPUType(config.DefaultWorkerGpuType); err == nil {
+	defaultWorkerGpuType, err := ParseGPUType(config.DefaultWorkerGpuType)
+	if err == nil {
 		c.DefaultWorkerGpuType = defaultWorkerGpuType.String()
 	}
 
 	if defaultWorkerGpuCount, err := ParseGpuCount(config.DefaultWorkerGpuCount); err == nil {
 		c.DefaultWorkerGpuCount = uint32(defaultWorkerGpuCount)
+	}
+
+	// Don't allow creation of workers with no gpu count if there is a GPU type set
+	if c.DefaultWorkerGpuCount <= 0 && defaultWorkerGpuType != "" {
+		c.DefaultWorkerGpuCount = 1
 	}
 
 	return c, nil


### PR DESCRIPTION
This fixes an edge case with pool sizing where if the default gpu count is set to zero, but free gpu count is set > 0. 

This change ensures if you're resizing a pool with a GPU type set, that you never request workers without any GPUs.