### PR TITLE
Add validations to Runner

### DIFF
--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -23,7 +23,7 @@ from ...clients.gateway import (
 from ...config import ConfigContext, SDKSettings, get_config_context, get_settings
 from ...env import called_on_import
 from ...sync import FileSyncer, SyncEventHandler
-from ...type import _AUTOSCALERS, Autoscaler, GpuType, QueueDepthAutoscaler
+from ...type import _AUTOSCALERS, Autoscaler, GpuType, GpuTypeAlias, QueueDepthAutoscaler
 
 CONTAINER_STUB_TYPE = "container"
 FUNCTION_STUB_TYPE = "function"
@@ -42,7 +42,7 @@ class RunnerAbstraction(BaseAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: Union[GpuType, str] = GpuType.NoGPU,
+        gpu: GpuTypeAlias = GpuType.NoGPU,
         image: Image = Image(),
         workers: int = 1,
         keep_warm_seconds: float = 10.0,

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -267,6 +267,7 @@ class RunnerAbstraction(BaseAbstraction):
                 self.image_available = True
                 self.image_id = image_build_result.image_id
             else:
+                terminal.error("Image build failed", exit=False)
                 return False
 
         if not self.files_synced:
@@ -276,10 +277,12 @@ class RunnerAbstraction(BaseAbstraction):
                 self.files_synced = True
                 self.object_id = sync_result.object_id
             else:
+                terminal.error("File sync failed", exit=False)
                 return False
 
         for v in self.volumes:
             if not v.ready and not v.get_or_create():
+                terminal.error(f"Volume is not ready: {v.name}", exit=False)
                 return False
 
         try:
@@ -290,6 +293,10 @@ class RunnerAbstraction(BaseAbstraction):
 
         autoscaler_type = _AUTOSCALERS.get(type(self.autoscaler), None)
         if autoscaler_type is None:
+            terminal.error(
+                f"Invalid Autoscaler class: {type(self.autoscaler).__name__}",
+                exit=False,
+            )
             return False
 
         if not self.stub_created:

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -20,7 +20,7 @@ from ..clients.endpoint import (
 )
 from ..clients.gateway import DeployStubRequest, DeployStubResponse
 from ..env import is_local
-from ..type import Autoscaler, QueueDepthAutoscaler
+from ..type import Autoscaler, GpuType, QueueDepthAutoscaler
 
 
 class Endpoint(RunnerAbstraction):
@@ -93,7 +93,7 @@ class Endpoint(RunnerAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: str = "",
+        gpu: Union[GpuType, str] = "",
         image: Image = Image(),
         timeout: int = 180,
         workers: int = 1,

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -20,7 +20,7 @@ from ..clients.endpoint import (
 )
 from ..clients.gateway import DeployStubRequest, DeployStubResponse
 from ..env import is_local
-from ..type import Autoscaler, GpuType, QueueDepthAutoscaler
+from ..type import Autoscaler, GpuType, GpuTypeAlias, QueueDepthAutoscaler
 
 
 class Endpoint(RunnerAbstraction):
@@ -93,7 +93,7 @@ class Endpoint(RunnerAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: Union[GpuType, str] = "",
+        gpu: GpuTypeAlias = GpuType.NoGPU,
         image: Image = Image(),
         timeout: int = 180,
         workers: int = 1,

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -20,6 +20,7 @@ from ..clients.function import (
 from ..clients.gateway import DeployStubRequest, DeployStubResponse
 from ..env import is_local
 from ..sync import FileSyncer
+from ..type import GpuType
 
 
 class Function(RunnerAbstraction):
@@ -74,7 +75,7 @@ class Function(RunnerAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: str = "",
+        gpu: Union[GpuType, str] = "",
         image: Image = Image(),
         timeout: int = 3600,
         retries: int = 3,

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -170,7 +170,7 @@ class _CallableWrapper:
     def remote(self, *args, **kwargs) -> Any:
         return self(*args, **kwargs)
 
-    def serve(self):
+    def serve(self, **kwargs):
         terminal.error("Serve has not yet been implemented for functions.")
 
     def deploy(self, name: str) -> bool:

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -20,7 +20,7 @@ from ..clients.function import (
 from ..clients.gateway import DeployStubRequest, DeployStubResponse
 from ..env import is_local
 from ..sync import FileSyncer
-from ..type import GpuType
+from ..type import GpuType, GpuTypeAlias
 
 
 class Function(RunnerAbstraction):
@@ -75,7 +75,7 @@ class Function(RunnerAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: Union[GpuType, str] = "",
+        gpu: GpuTypeAlias = GpuType.NoGPU,
         image: Image = Image(),
         timeout: int = 3600,
         retries: int = 3,

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -24,7 +24,7 @@ from ..clients.taskqueue import (
     TaskQueueServiceStub,
 )
 from ..env import is_local
-from ..type import Autoscaler, QueueDepthAutoscaler
+from ..type import Autoscaler, GpuType, QueueDepthAutoscaler
 
 
 class TaskQueue(RunnerAbstraction):
@@ -96,7 +96,7 @@ class TaskQueue(RunnerAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: str = "",
+        gpu: Union[GpuType, str] = "",
         image: Image = Image(),
         timeout: int = 3600,
         retries: int = 3,

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -24,7 +24,7 @@ from ..clients.taskqueue import (
     TaskQueueServiceStub,
 )
 from ..env import is_local
-from ..type import Autoscaler, GpuType, QueueDepthAutoscaler
+from ..type import Autoscaler, GpuType, GpuTypeAlias, QueueDepthAutoscaler
 
 
 class TaskQueue(RunnerAbstraction):
@@ -96,7 +96,7 @@ class TaskQueue(RunnerAbstraction):
         self,
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
-        gpu: Union[GpuType, str] = "",
+        gpu: GpuTypeAlias = GpuType.NoGPU,
         image: Image = Image(),
         timeout: int = 3600,
         retries: int = 3,

--- a/sdk/src/beta9/type.py
+++ b/sdk/src/beta9/type.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Protocol
+from typing import Literal, Protocol, Union
 
 
 class LifeCycleMethod(str, Enum):
@@ -82,6 +82,23 @@ class GpuType(str, Enum):
     A100_80 = "A100-80"
     H100 = "H100"
     A6000 = "A6000"
+
+
+# Add GpuType str literals. Must copy/paste for now.
+# https://github.com/python/typing/issues/781
+GpuTypeLiteral = Literal[
+    "",
+    "any",
+    "T4",
+    "L4",
+    "A10G",
+    "A100_40",
+    "A100_80",
+    "H100",
+    "A6000",
+]
+
+GpuTypeAlias = Union[GpuType, GpuTypeLiteral]
 
 
 QUEUE_DEPTH_AUTOSCALER_TYPE = "queue_depth"


### PR DESCRIPTION
- Add GPU validation before runner/stub preparation
- Add better type annotations for GpuType and GpuTypeLiteral (strings)
- Add printing of errors when `prepare_runtime` fails on certain validations
- Fix serving a function (ensure not implemented error is printed)

Resolve BE-1500