### PR TITLE
Add outputs to a task in the task api

### DIFF
--- a/pkg/api/v1/task.go
+++ b/pkg/api/v1/task.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/beam-cloud/beta9/pkg/abstractions/output"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/repository"
@@ -14,6 +15,8 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/labstack/echo/v4"
 )
+
+var DefaultTaskOutputExpirationS uint32 = 3600
 
 type TaskGroup struct {
 	routerGroup    *echo.Group
@@ -67,6 +70,8 @@ func (g *TaskGroup) AggregateTasksByTimeWindow(ctx echo.Context) error {
 }
 
 func (g *TaskGroup) ListTasksPaginated(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+
 	filters, err := g.preprocessFilters(ctx)
 	if err != nil {
 		return err
@@ -77,12 +82,15 @@ func (g *TaskGroup) ListTasksPaginated(ctx echo.Context) error {
 	} else {
 		for i := range tasks.Data {
 			tasks.Data[i].SanitizeStubConfig()
+			g.addOutputsToTask(ctx.Request().Context(), cc.AuthInfo.Workspace.Name, &tasks.Data[i])
 		}
 		return ctx.JSON(http.StatusOK, tasks)
 	}
 }
 
 func (g *TaskGroup) RetrieveTask(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+
 	taskId := ctx.Param("taskId")
 	if task, err := g.backendRepo.GetTaskWithRelated(ctx.Request().Context(), taskId); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to retrieve task")
@@ -92,8 +100,25 @@ func (g *TaskGroup) RetrieveTask(ctx echo.Context) error {
 		}
 
 		task.SanitizeStubConfig()
+		g.addOutputsToTask(ctx.Request().Context(), cc.AuthInfo.Workspace.Name, task)
+
 		return ctx.JSON(http.StatusOK, task)
 	}
+}
+
+func (g *TaskGroup) addOutputsToTask(ctx context.Context, workspaceName string, task *types.TaskWithRelated) error {
+	task.Outputs = []types.TaskOutput{}
+	outputFiles := output.GetTaskOutputFiles(workspaceName, task)
+
+	for outputId, fileName := range outputFiles {
+		url, err := output.SetPublicURL(ctx, g.config, g.backendRepo, g.redisClient, workspaceName, task.ExternalId, outputId, fileName, DefaultTaskOutputExpirationS)
+		if err != nil {
+			return err
+		}
+		task.Outputs = append(task.Outputs, types.TaskOutput{Name: fileName, URL: url, ExpiresIn: DefaultTaskOutputExpirationS})
+	}
+
+	return nil
 }
 
 type StopTasksRequest struct {

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -128,8 +128,9 @@ type Task struct {
 
 type TaskWithRelated struct {
 	Task
-	Workspace Workspace `db:"workspace" json:"workspace"`
-	Stub      Stub      `db:"stub" json:"stub"`
+	Outputs   []TaskOutput `json:"outputs"`
+	Workspace Workspace    `db:"workspace" json:"workspace"`
+	Stub      Stub         `db:"stub" json:"stub"`
 }
 
 func (t *TaskWithRelated) SanitizeStubConfig() error {
@@ -158,6 +159,12 @@ type TaskCountByTime struct {
 	Time         time.Time       `db:"time" json:"time"`
 	Count        uint            `count:"count" json:"count"`
 	StatusCounts json.RawMessage `db:"status_counts" json:"status_counts"`
+}
+
+type TaskOutput struct {
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	ExpiresIn uint32 `json:"expires_in"`
 }
 
 type StubConfigV1 struct {


### PR DESCRIPTION
- Add a new `output` list to a `task` object that consists of outputs associated with the task
- Generates new public URLs for outputs that expire in 1h
- Reworks some previously private Output service methods to be public
