### PR TITLE
Add callback urls to containers and endpoints

### DIFF
--- a/hack/okteto.yaml
+++ b/hack/okteto.yaml
@@ -11,6 +11,7 @@ dev:
         go build -o /workspace/bin/gateway /workspace/cmd/gateway/main.go
         go build -o /workspace/bin/worker /workspace/cmd/worker/main.go
       BUILD_BINARY_PATH: /workspace/bin/gateway
+      CONFIG_PATH: /workspace/config.yaml
     forward:
     - 1993:1993
     - 1994:1994

--- a/hack/okteto.yaml
+++ b/hack/okteto.yaml
@@ -11,7 +11,6 @@ dev:
         go build -o /workspace/bin/gateway /workspace/cmd/gateway/main.go
         go build -o /workspace/bin/worker /workspace/cmd/worker/main.go
       BUILD_BINARY_PATH: /workspace/bin/gateway
-      CONFIG_PATH: /workspace/config.yaml
     forward:
     - 1993:1993
     - 1994:1994

--- a/pkg/abstractions/container/container.go
+++ b/pkg/abstractions/container/container.go
@@ -145,6 +145,7 @@ func (cs *CmdContainerService) ExecuteCommand(in *pb.CommandExecutionRequest, st
 		fmt.Sprintf("HANDLER=%s", stubConfig.Handler),
 		fmt.Sprintf("BETA9_TOKEN=%s", authInfo.Token.Key),
 		fmt.Sprintf("STUB_ID=%s", stub.ExternalId),
+		fmt.Sprintf("CALLBACK_URL=%s", stubConfig.CallbackUrl),
 	}
 
 	env = append(secrets, env...)

--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -45,6 +45,7 @@ func (i *endpointInstance) startContainers(containersToRun int) error {
 		fmt.Sprintf("WORKERS=%d", i.StubConfig.Workers),
 		fmt.Sprintf("KEEP_WARM_SECONDS=%d", i.StubConfig.KeepWarmSeconds),
 		fmt.Sprintf("PYTHON_VERSION=%s", i.StubConfig.PythonVersion),
+		fmt.Sprintf("CALLBACK_URL=%s", i.StubConfig.CallbackUrl),
 		fmt.Sprintf("TIMEOUT=%d", i.StubConfig.TaskPolicy.Timeout),
 	}
 

--- a/pkg/api/v1/task.go
+++ b/pkg/api/v1/task.go
@@ -137,6 +137,10 @@ func (g *TaskGroup) StopTasks(ctx echo.Context) error {
 			continue
 		}
 
+		if task == nil {
+			continue
+		}
+
 		err = g.stopTask(ctx.Request().Context(), task)
 		if err != nil {
 			continue

--- a/sdk/src/beta9/abstractions/container.py
+++ b/sdk/src/beta9/abstractions/container.py
@@ -59,9 +59,10 @@ class Container(RunnerAbstraction):
         image: Image = Image(),
         volumes: Optional[List[Volume]] = None,
         secrets: Optional[List[str]] = None,
+        callback_url: Optional[str] = None,
     ) -> None:
         super().__init__(
-            cpu=cpu, memory=memory, gpu=gpu, image=image, volumes=volumes, secrets=secrets
+            cpu=cpu, memory=memory, gpu=gpu, image=image, volumes=volumes, secrets=secrets, callback_url=callback_url
         )
 
         self.task_id = ""

--- a/sdk/src/beta9/abstractions/container.py
+++ b/sdk/src/beta9/abstractions/container.py
@@ -37,6 +37,8 @@ class Container(RunnerAbstraction):
             A list of secrets that are injected into the container as environment variables. Default is [].
         name (Optional[str]):
             A name for the container. Default is None.
+        callback_url (Optional[str]):
+            An optional URL to send a callback to when a task is completed, timed out, or cancelled.
 
     Example usage:
         ```

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -105,6 +105,7 @@ class Endpoint(RunnerAbstraction):
         name: Optional[str] = None,
         authorized: Optional[bool] = True,
         autoscaler: Optional[Autoscaler] = QueueDepthAutoscaler(),
+        callback_url: Optional[str] = None,
     ):
         super().__init__(
             cpu=cpu,
@@ -122,6 +123,7 @@ class Endpoint(RunnerAbstraction):
             name=name,
             authorized=authorized,
             autoscaler=autoscaler,
+            callback_url=callback_url,
         )
 
         self._endpoint_stub: Optional[EndpointServiceStub] = None

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -71,6 +71,8 @@ class Endpoint(RunnerAbstraction):
         autoscaler (Optional[Autoscaler]):
             Configure a deployment autoscaler - if specified, you can use scale your function horizontally using
             various autoscaling strategies (Defaults to QueueDepthAutoscaler())
+        callback_url (Optional[str]):
+            An optional URL to send a callback to when a task is completed, timed out, or cancelled.
     Example:
         ```python
         from beta9 import endpoint, Image

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -13,7 +13,12 @@ from typing import Any, Callable, Optional, Union
 import requests
 from starlette.responses import Response
 
-from ..clients.gateway import GatewayServiceStub, SignPayloadRequest, SignPayloadResponse
+from ..clients.gateway import (
+    EndTaskRequest,
+    GatewayServiceStub,
+    SignPayloadRequest,
+    SignPayloadResponse,
+)
 from ..exceptions import RunnerException
 
 USER_CODE_VOLUME = "/mnt/code"
@@ -186,6 +191,28 @@ def execute_lifecycle_method(name: str) -> Union[Any, None]:
         return result
     except BaseException:
         raise RunnerException()
+
+
+def end_task_and_send_callback(
+    *,
+    gateway_stub,
+    payload,
+    end_task_request: EndTaskRequest,
+):
+    resp = gateway_stub.end_task(end_task_request)
+
+    send_callback(
+        gateway_stub=gateway_stub,
+        context=FunctionContext.new(
+            config=config,
+            task_id=end_task_request.task_id,
+            on_start_value=None,
+        ),
+        payload=payload,
+        task_status=end_task_request.task_status,
+    )
+
+    return resp
 
 
 def send_callback(

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -195,8 +195,8 @@ def execute_lifecycle_method(name: str) -> Union[Any, None]:
 
 def end_task_and_send_callback(
     *,
-    gateway_stub,
-    payload,
+    gateway_stub: GatewayServiceStub,
+    payload: Any,
     end_task_request: EndTaskRequest,
 ):
     resp = gateway_stub.end_task(end_task_request)

--- a/sdk/src/beta9/runner/container.py
+++ b/sdk/src/beta9/runner/container.py
@@ -9,8 +9,9 @@ from ..aio import run_sync
 from ..channel import Channel, with_runner_context
 from ..clients.gateway import EndTaskRequest, GatewayServiceStub, StartTaskRequest
 from ..logging import StdoutJsonInterceptor
-from ..runner.common import config
+from ..runner.common import FunctionContext, config
 from ..type import TaskStatus
+from .common import send_callback
 
 
 class ContainerManager:
@@ -57,6 +58,17 @@ class ContainerManager:
                             task_status=TaskStatus.Complete,
                         )
                     )
+
+                send_callback(
+                    gateway_stub=stub,
+                    context=FunctionContext.new(
+                        config=config,
+                        task_id=self.task_id,
+                        on_start_value=None,
+                    ),
+                    payload=None,
+                    task_status=TaskStatus.Complete,
+                )
 
         run_sync(_run())
 

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -1,10 +1,10 @@
 import asyncio
-import dataclasses
 import logging
 import os
 import signal
 import traceback
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, Dict, Optional, Tuple
 
@@ -98,7 +98,7 @@ class GunicornApplication(BaseApplication):
             os._exit(1)
 
 
-@dataclasses.dataclass
+@dataclass
 class TaskLifecycleData:
     status: TaskStatus
     result: Any

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import logging
 import os
 import signal
@@ -27,6 +28,7 @@ from ..logging import StdoutJsonInterceptor
 from ..runner.common import FunctionContext, FunctionHandler, execute_lifecycle_method
 from ..runner.common import config as cfg
 from ..type import LifeCycleMethod, TaskStatus
+from .common import send_callback
 
 
 class EndpointFilter(logging.Filter):
@@ -96,6 +98,12 @@ class GunicornApplication(BaseApplication):
             os._exit(1)
 
 
+@dataclasses.dataclass
+class TaskLifecycleData:
+    status: TaskStatus
+    result: Any
+
+
 async def task_lifecycle(request: Request):
     task_id = request.headers.get("X-TASK-ID")
     if not task_id:
@@ -110,9 +118,12 @@ async def task_lifecycle(request: Request):
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Failed to start task"
         )
 
+    task_lifecycle_data = TaskLifecycleData(
+        status=TaskStatus.Complete,
+        result=None,
+    )
     try:
-        task_status = TaskStatus.Complete
-        yield task_status
+        yield task_lifecycle_data
         print(f"Task <{task_id}> finished")
     finally:
         request.app.state.gateway_stub.end_task(
@@ -120,8 +131,19 @@ async def task_lifecycle(request: Request):
                 task_id=task_id,
                 container_id=cfg.container_id,
                 keep_warm_seconds=cfg.keep_warm_seconds,
-                task_status=task_status,
+                task_status=task_lifecycle_data.status,
             )
+        )
+
+        send_callback(
+            gateway_stub=request.app.state.gateway_stub,
+            context=FunctionContext.new(
+                config=cfg,
+                task_id=task_id,
+                on_start_value=None,
+            ),
+            payload=task_lifecycle_data.result,
+            task_status=task_lifecycle_data.status,
         )
 
 
@@ -170,20 +192,26 @@ class EndpointManager:
 
         @self.app.get("/")
         @self.app.post("/")
-        async def function(request: Request, task_status: str = Depends(task_lifecycle)):
+        async def function(
+            request: Request,
+            task_lifecycle_data: TaskLifecycleData = Depends(task_lifecycle),
+        ):
             task_id = request.headers.get("X-TASK-ID")
             payload = await request.json()
+            gateway_stub = request.app.state.gateway_stub
 
             status_code = HTTPStatus.OK
             with StdoutJsonInterceptor(task_id=task_id):
-                result, err = await self._call_function(task_id=task_id, payload=payload)
+                task_lifecycle_data.result, err = await self._call_function(
+                    gateway_stub=gateway_stub, task_id=task_id, payload=payload
+                )
                 if err:
-                    task_status = TaskStatus.Error
+                    task_lifecycle_data.status = TaskStatus.Error
 
-            if task_status == TaskStatus.Error:
+            if task_lifecycle_data.status == TaskStatus.Error:
                 status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
-            return self._create_response(body=result, status_code=status_code)
+            return self._create_response(body=task_lifecycle_data.result, status_code=status_code)
 
     def _create_response(self, *, body: Any, status_code: int = HTTPStatus.OK) -> Response:
         if isinstance(body, Response):
@@ -198,7 +226,9 @@ class EndpointManager:
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 
-    async def _call_function(self, task_id: str, payload: dict) -> Tuple[Response, Any]:
+    async def _call_function(
+        self, gateway_stub: GatewayServiceStub, task_id: str, payload: dict
+    ) -> Tuple[Response, Any]:
         error = None
         response_body = {}
 

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -198,12 +198,11 @@ class EndpointManager:
         ):
             task_id = request.headers.get("X-TASK-ID")
             payload = await request.json()
-            gateway_stub = request.app.state.gateway_stub
 
             status_code = HTTPStatus.OK
             with StdoutJsonInterceptor(task_id=task_id):
                 task_lifecycle_data.result, err = await self._call_function(
-                    gateway_stub=gateway_stub, task_id=task_id, payload=payload
+                    task_id=task_id, payload=payload
                 )
                 if err:
                     task_lifecycle_data.status = TaskStatus.Error
@@ -226,9 +225,7 @@ class EndpointManager:
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 
-    async def _call_function(
-        self, gateway_stub: GatewayServiceStub, task_id: str, payload: dict
-    ) -> Tuple[Response, Any]:
+    async def _call_function(self, task_id: str, payload: dict) -> Tuple[Response, Any]:
         error = None
         response_body = {}
 

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -26,7 +26,13 @@ from ..clients.gateway import (
 )
 from ..exceptions import InvalidFunctionArgumentsException, RunnerException
 from ..logging import StdoutJsonInterceptor
-from ..runner.common import FunctionContext, FunctionHandler, config, send_callback
+from ..runner.common import (
+    FunctionContext,
+    FunctionHandler,
+    config,
+    end_task_and_send_callback,
+    send_callback,
+)
 from ..type import TaskExitCode, TaskStatus
 
 
@@ -183,29 +189,23 @@ def main(channel: Channel):
 
         task_duration = time.time() - start_time
 
-        # End the task
-        end_task_response = gateway_stub.end_task(
-            EndTaskRequest(
+        end_task_response = end_task_and_send_callback(
+            gateway_stub=gateway_stub,
+            payload=result,
+            end_task_request=EndTaskRequest(
                 task_id=task_id,
                 task_duration=task_duration,
                 task_status=task_status,
                 container_id=container_id,
                 container_hostname=container_hostname,
                 keep_warm_seconds=0,
-            )
+            ),
         )
 
         if not end_task_response.ok:
             raise RunnerException("Unable to end task")
 
         monitor_task.cancel()
-
-        send_callback(
-            gateway_stub=gateway_stub,
-            context=context,
-            payload=result,
-            task_status=task_status,
-        )  # Send callback to callback_url, if defined
 
         if error is not None and task_status == TaskStatus.Error:
             raise error.with_traceback(error.__traceback__)


### PR DESCRIPTION
The way we add callbacks is not ideal but currently there are some nuances between abstractions that require task callbacks to be built case by case. 
One of these nuances is how we `end_task` in endpoint. It's location of handling is different than that of task queue, containers, and functions. 
We place `send_callback` after the `end_task` functions.