### PR TITLE
Add latest version endpoints to deployment endpoints

### DIFF
--- a/pkg/abstractions/endpoint/http.go
+++ b/pkg/abstractions/endpoint/http.go
@@ -1,9 +1,9 @@
 package endpoint
 
 import (
-	"net/http"
 	"strconv"
 
+	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/labstack/echo/v4"
@@ -18,10 +18,14 @@ func registerEndpointRoutes(g *echo.Group, es *HttpEndpointService) *endpointGro
 	group := &endpointGroup{routeGroup: g, es: es}
 
 	g.POST("/id/:stubId", auth.WithAuth(group.endpointRequest))
+	g.POST("/:deploymentName", auth.WithAuth(group.endpointRequest))
+	g.POST("/:deploymentName/latest", auth.WithAuth(group.endpointRequest))
 	g.POST("/:deploymentName/v:version", auth.WithAuth(group.endpointRequest))
 	g.POST("/public/:stubId", auth.WithAssumedStubAuth(group.endpointRequest, group.es.isPublic))
 
 	g.GET("/id/:stubId", auth.WithAuth(group.endpointRequest))
+	g.GET("/:deploymentName", auth.WithAuth(group.endpointRequest))
+	g.GET("/:deploymentName/latest", auth.WithAuth(group.endpointRequest))
 	g.GET("/:deploymentName/v:version", auth.WithAuth(group.endpointRequest))
 	g.GET("/public/:stubId", auth.WithAssumedStubAuth(group.endpointRequest, group.es.isPublic))
 
@@ -35,25 +39,29 @@ func (g *endpointGroup) endpointRequest(ctx echo.Context) error {
 	deploymentName := ctx.Param("deploymentName")
 	version := ctx.Param("version")
 
-	if deploymentName != "" && version != "" {
-		version, err := strconv.Atoi(version)
-		if err != nil {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "invalid deployment version",
-			})
-		}
+	if deploymentName != "" {
+		var deployment *types.DeploymentWithRelated
 
-		deployment, err := g.es.backendRepo.GetDeploymentByNameAndVersion(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, uint(version), types.StubTypeEndpointDeployment)
-		if err != nil {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "invalid deployment",
-			})
+		if version == "" {
+			var err error
+			deployment, err = g.es.backendRepo.GetLatestDeploymentByName(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, types.StubTypeEndpointDeployment)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment")
+			}
+		} else {
+			version, err := strconv.Atoi(version)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment version")
+			}
+
+			deployment, err = g.es.backendRepo.GetDeploymentByNameAndVersion(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, uint(version), types.StubTypeEndpointDeployment)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment")
+			}
 		}
 
 		if !deployment.Active {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "deployment is not active",
-			})
+			return apiv1.HTTPBadRequest("Deployment is not active")
 		}
 
 		stubId = deployment.Stub.ExternalId

--- a/pkg/abstractions/function/http.go
+++ b/pkg/abstractions/function/http.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/task"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -19,6 +20,8 @@ func registerFunctionRoutes(g *echo.Group, fs *RunCFunctionService) *functionGro
 	group := &functionGroup{routerGroup: g, fs: fs}
 
 	g.POST("/id/:stubId", auth.WithAuth(group.FunctionInvoke))
+	g.POST("/:deploymentName", auth.WithAuth(group.FunctionInvoke))
+	g.POST("/:deploymentName/latest", auth.WithAuth(group.FunctionInvoke))
 	g.POST("/:deploymentName/v:version", auth.WithAuth(group.FunctionInvoke))
 
 	return group
@@ -31,25 +34,29 @@ func (g *functionGroup) FunctionInvoke(ctx echo.Context) error {
 	deploymentName := ctx.Param("deploymentName")
 	version := ctx.Param("version")
 
-	if deploymentName != "" && version != "" {
-		version, err := strconv.Atoi(version)
-		if err != nil {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "invalid deployment version",
-			})
-		}
+	if deploymentName != "" {
+		var deployment *types.DeploymentWithRelated
 
-		deployment, err := g.fs.backendRepo.GetDeploymentByNameAndVersion(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, uint(version), types.StubTypeFunctionDeployment)
-		if err != nil {
-			ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "invalid deployment",
-			})
+		if version == "" {
+			var err error
+			deployment, err = g.fs.backendRepo.GetLatestDeploymentByName(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, types.StubTypeFunctionDeployment)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment")
+			}
+		} else {
+			version, err := strconv.Atoi(version)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment version")
+			}
+
+			deployment, err = g.fs.backendRepo.GetDeploymentByNameAndVersion(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, uint(version), types.StubTypeFunctionDeployment)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment")
+			}
 		}
 
 		if !deployment.Active {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "deployment is not active",
-			})
+			return apiv1.HTTPBadRequest("Deployment is not active")
 		}
 
 		stubId = deployment.Stub.ExternalId

--- a/pkg/abstractions/taskqueue/http.go
+++ b/pkg/abstractions/taskqueue/http.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/task"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -20,6 +21,8 @@ func registerTaskQueueRoutes(g *echo.Group, tq *RedisTaskQueue) *taskQueueGroup 
 	group := &taskQueueGroup{routeGroup: g, tq: tq}
 
 	g.POST("/id/:stubId", auth.WithAuth(group.TaskQueuePut))
+	g.POST("/:deploymentName", auth.WithAuth(group.TaskQueuePut))
+	g.POST("/:deploymentName/latest", auth.WithAuth(group.TaskQueuePut))
 	g.POST("/:deploymentName/v:version", auth.WithAuth(group.TaskQueuePut))
 
 	return group
@@ -32,25 +35,29 @@ func (g *taskQueueGroup) TaskQueuePut(ctx echo.Context) error {
 	deploymentName := ctx.Param("deploymentName")
 	version := ctx.Param("version")
 
-	if deploymentName != "" && version != "" {
-		version, err := strconv.Atoi(version)
-		if err != nil {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "invalid deployment version",
-			})
-		}
+	if deploymentName != "" {
+		var deployment *types.DeploymentWithRelated
 
-		deployment, err := g.tq.backendRepo.GetDeploymentByNameAndVersion(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, uint(version), types.StubTypeTaskQueueDeployment)
-		if err != nil {
-			ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "invalid deployment",
-			})
+		if version == "" {
+			var err error
+			deployment, err = g.tq.backendRepo.GetLatestDeploymentByName(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, types.StubTypeTaskQueueDeployment)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment")
+			}
+		} else {
+			version, err := strconv.Atoi(version)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment version")
+			}
+
+			deployment, err = g.tq.backendRepo.GetDeploymentByNameAndVersion(ctx.Request().Context(), cc.AuthInfo.Workspace.Id, deploymentName, uint(version), types.StubTypeTaskQueueDeployment)
+			if err != nil {
+				return apiv1.HTTPBadRequest("Invalid deployment")
+			}
 		}
 
 		if !deployment.Active {
-			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
-				"error": "deployment is not active",
-			})
+			return apiv1.HTTPBadRequest("Deployment is not active")
 		}
 
 		stubId = deployment.Stub.ExternalId

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -85,7 +85,7 @@ type BackendRepository interface {
 	ListVolumesWithRelated(ctx context.Context, workspaceId uint) ([]types.VolumeWithRelated, error)
 	ListDeploymentsWithRelated(ctx context.Context, filters types.DeploymentFilter) ([]types.DeploymentWithRelated, error)
 	ListDeploymentsPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
-	GetLatestDeploymentByName(ctx context.Context, workspaceId uint, name string, stubType string) (*types.Deployment, error)
+	GetLatestDeploymentByName(ctx context.Context, workspaceId uint, name string, stubType string) (*types.DeploymentWithRelated, error)
 	GetDeploymentByExternalId(ctx context.Context, workspaceId uint, deploymentExternalId string) (*types.DeploymentWithRelated, error)
 	GetDeploymentByNameAndVersion(ctx context.Context, workspaceId uint, name string, version uint, stubType string) (*types.DeploymentWithRelated, error)
 	CreateDeployment(ctx context.Context, workspaceId uint, name string, version uint, stubId uint, stubType string) (*types.Deployment, error)


### PR DESCRIPTION
- Add support for `/` and `/latest` which points to the latest version of a deployment
- Fix a nil pointer error when not returning an error after GetDeploymentByNameAndVersion() returns one

Resolve BE-1532