### PR TITLE
Fix timing issues in worker

### DIFF
--- a/pkg/storage/juicefs.go
+++ b/pkg/storage/juicefs.go
@@ -122,7 +122,7 @@ func (s *JuiceFsStorage) Format(fsName string) error {
 }
 
 func (s *JuiceFsStorage) Unmount(localPath string) error {
-	cmd := exec.Command("juicefs", "umount", localPath)
+	cmd := exec.Command("juicefs", "umount", "--force", localPath)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -281,9 +281,6 @@ func (s *Worker) RunContainer(request *types.ContainerRequest) error {
 		return err
 	}
 
-	// Every 30 seconds, update container status
-	go s.updateContainerStatus(request)
-
 	bindPort, err := GetRandomFreePort()
 	if err != nil {
 		return err
@@ -542,6 +539,9 @@ func (s *Worker) spawn(request *types.ContainerRequest, bundlePath string, spec 
 		LogBuffer: common.NewLogBuffer(),
 	}
 	s.containerInstances.Set(containerId, containerInstance)
+
+	// Every 30 seconds, update container status
+	go s.updateContainerStatus(request)
 
 	// Set worker hostname
 	hostname := fmt.Sprintf("%s:%d", s.podAddr, defaultWorkerServerPort)


### PR DESCRIPTION
- If the container instance is not set, the worker would never maintain the worker status and the TTL would expire. This moves the goroutine to directly after the container instance is set in memory.
 
- Force unmount juicefs (fixes the below error):

```
2024/07/10 19:18:53 Worker exited with error: failed to unmount storage: error executing juicefs umount: exit status 1, output: 2024/07/10 19:18:53.699538 juicefs[117] <FATAL>: fusermount: failed to unmount /data: Device or resource busy [main.go:31]
```