### PR TITLE
Pipeline worker gets

### DIFF
--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -218,6 +218,9 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 	for i, cmd := range cmds {
 		res, err := cmd.Result()
 		if err != nil {
+			// If the state key does not exist, remove it from the worker index
+			indexKey := common.RedisKeys.SchedulerWorkerIndex()
+			r.rdb.SRem(context.TODO(), indexKey, keys[i]).Err()
 			continue
 		}
 

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -216,7 +216,7 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 		return nil, fmt.Errorf("failed to execute pipeline: %v", err)
 	}
 
-	workers := make([]*types.Worker, len(keys))
+	var workers []*types.Worker
 	for i, cmd := range cmds {
 		res, err := cmd.Result()
 		if err != nil {
@@ -229,7 +229,8 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 		if err = common.ToStruct(res, worker); err != nil {
 			return nil, fmt.Errorf("failed to deserialize worker state <%v>: %v", keys[i], err)
 		}
-		workers[i] = worker
+
+		workers = append(workers, worker)
 	}
 
 	log.Printf("workers; %+v\n", workers)

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -209,6 +209,8 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 		cmds[i] = pipe.HGetAll(context.TODO(), key)
 	}
 
+	log.Println("keys: ", keys)
+
 	_, err := pipe.Exec(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute pipeline: %v", err)
@@ -218,7 +220,7 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 	for i, cmd := range cmds {
 		res, err := cmd.Result()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get worker <%s>: %v", keys[i], err)
+			continue
 		}
 
 		workerId := strings.Split(keys[i], ":")[len(strings.Split(keys[i], ":"))-1]
@@ -228,6 +230,11 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 			return nil, fmt.Errorf("failed to deserialize worker state <%v>: %v", keys[i], err)
 		}
 		workers[i] = worker
+	}
+
+	log.Printf("workers; %+v\n", workers)
+	for _, w := range workers {
+		log.Printf("worker: %+v\n", w)
 	}
 
 	return workers, nil

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -209,8 +209,6 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 		cmds[i] = pipe.HGetAll(context.TODO(), key)
 	}
 
-	log.Println("keys: ", keys)
-
 	_, err := pipe.Exec(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute pipeline: %v", err)
@@ -231,11 +229,6 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 		}
 
 		workers = append(workers, worker)
-	}
-
-	log.Printf("workers; %+v\n", workers)
-	for _, w := range workers {
-		log.Printf("worker: %+v\n", w)
 	}
 
 	return workers, nil


### PR DESCRIPTION
- When not locking, use a redis pipeline to retrieve workers to avoid many synchronous HGetAll calls in series