### PR TITLE
Add stats to task API

### DIFF
--- a/pkg/api/v1/task.go
+++ b/pkg/api/v1/task.go
@@ -131,7 +131,7 @@ func (g *TaskGroup) addStatsToTask(ctx context.Context, workspaceName string, ta
 		return err
 	}
 
-	task.Stats.InFlight = uint32(tasksInFlight)
+	task.Stats.QueueDepth = uint32(tasksInFlight)
 	return nil
 }
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -174,7 +174,7 @@ func (g *Gateway) initHttp() error {
 	apiv1.NewMachineGroup(g.baseRouteGroup.Group("/machine", authMiddleware), g.ProviderRepo, g.Tailscale, g.Config)
 	apiv1.NewWorkspaceGroup(g.baseRouteGroup.Group("/workspace", authMiddleware), g.BackendRepo, g.Config)
 	apiv1.NewTokenGroup(g.baseRouteGroup.Group("/token", authMiddleware), g.BackendRepo, g.Config)
-	apiv1.NewTaskGroup(g.baseRouteGroup.Group("/task", authMiddleware), g.RedisClient, g.BackendRepo, g.TaskDispatcher, g.Config)
+	apiv1.NewTaskGroup(g.baseRouteGroup.Group("/task", authMiddleware), g.RedisClient, g.TaskRepo, g.BackendRepo, g.TaskDispatcher, g.Config)
 	apiv1.NewContainerGroup(g.baseRouteGroup.Group("/container", authMiddleware), g.BackendRepo, g.ContainerRepo, *g.Scheduler, g.Config)
 	apiv1.NewStubGroup(g.baseRouteGroup.Group("/stub", authMiddleware), g.BackendRepo, g.Config)
 	apiv1.NewConcurrencyLimitGroup(g.baseRouteGroup.Group("/concurrency-limit", authMiddleware), g.BackendRepo, g.WorkspaceRepo)

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -130,6 +130,7 @@ type Task struct {
 type TaskWithRelated struct {
 	Task
 	Outputs   []TaskOutput `json:"outputs"`
+	Stats     TaskStats    `json:"stats"`
 	Workspace Workspace    `db:"workspace" json:"workspace"`
 	Stub      Stub         `db:"stub" json:"stub"`
 }
@@ -166,6 +167,10 @@ type TaskOutput struct {
 	Name      string `json:"name"`
 	URL       string `json:"url"`
 	ExpiresIn uint32 `json:"expires_in"`
+}
+
+type TaskStats struct {
+	InFlight uint32 `json:"tasks_in_flight"`
 }
 
 type StubConfigV1 struct {

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -170,7 +170,7 @@ type TaskOutput struct {
 }
 
 type TaskStats struct {
-	InFlight uint32 `json:"tasks_in_flight"`
+	QueueDepth uint32 `json:"queue_depth"`
 }
 
 type StubConfigV1 struct {


### PR DESCRIPTION
- Add `stats.queue_depth` to task get and list endpoints

Resolve BE-1487