### PR TITLE
Reconfigure worker and agent config for multi-worker agents

### DIFF
--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -292,12 +292,6 @@ func (wpc *ExternalWorkerPoolController) createWorkerJob(workerId, machineId str
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: ptr.To(true),
 			},
-			Ports: []corev1.ContainerPort{
-				{
-					Name:          "metrics",
-					ContainerPort: int32(wpc.config.Monitoring.Prometheus.Port),
-				},
-			},
 			Env:          env,
 			VolumeMounts: wpc.getWorkerVolumeMounts(),
 			Resources:    resources,

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -55,7 +55,7 @@ func NewRunCServer(containerInstances *common.SafeMap[*ContainerInstance], image
 }
 
 func (s *RunCServer) Start() error {
-	listener, err := net.Listen("tcp", ":0") // Random port
+	listener, err := net.Listen("tcp", ":0") // // Random free port
 	if err != nil {
 		log.Fatalf("failed to listen: %v\n", err)
 	}

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -35,6 +35,7 @@ type RunCServer struct {
 	pb.UnimplementedRunCServiceServer
 	containerInstances *common.SafeMap[*ContainerInstance]
 	imageClient        *ImageClient
+	port               int
 }
 
 func NewRunCServer(containerInstances *common.SafeMap[*ContainerInstance], imageClient *ImageClient) (*RunCServer, error) {
@@ -54,10 +55,13 @@ func NewRunCServer(containerInstances *common.SafeMap[*ContainerInstance], image
 }
 
 func (s *RunCServer) Start() error {
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", defaultWorkerServerPort))
+	listener, err := net.Listen("tcp", ":0") // Random port
 	if err != nil {
 		log.Fatalf("failed to listen: %v\n", err)
 	}
+
+	s.port = listener.Addr().(*net.TCPAddr).Port
+	log.Printf("RunCServer started on port %d\n", s.port)
 
 	grpcServer := grpc.NewServer()
 	pb.RegisterRunCServiceServer(grpcServer, s)

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	defaultWorkingDirectory string = "/mnt/code"
-	defaultWorkerServerPort int    = 1989
 )
 
 type RunCServer struct {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -544,7 +544,7 @@ func (s *Worker) spawn(request *types.ContainerRequest, bundlePath string, spec 
 	go s.updateContainerStatus(request)
 
 	// Set worker hostname
-	hostname := fmt.Sprintf("%s:%d", s.podAddr, defaultWorkerServerPort)
+	hostname := fmt.Sprintf("%s:%d", s.podAddr, s.runcServer.port)
 	s.containerRepo.SetWorkerAddress(request.ContainerId, hostname)
 
 	// Handle stdout/stderr from spawned container


### PR DESCRIPTION
There are issues with multi-worker workloads stemming from shared access to host ports.
1. Remove container assignment of host port 9090 from all pods in external manifest. We don't need a prometheus metrics endpoint since we push metrics
2. Dynamically acquire any free host port for RunCServer. Currently all workers attempt to acquire port 1989