### PR TITLE
Allow dots and underscores in repo name

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -11,16 +11,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/pkg/errors"
+
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/network"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/scheduler"
 	"github.com/beam-cloud/beta9/pkg/types"
-
-	"github.com/google/uuid"
-	"github.com/mitchellh/hashstructure/v2"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -380,7 +380,7 @@ var imageNamePattern = regexp.MustCompile(
 	`^` + // Assert position at the start of the string
 		`(?:(?P<Registry>(?:(?:localhost|[\w.-]+(?:\.[\w.-]+)+)(?::\d+)?)|[\w]+:\d+)\/)?` + // Optional registry, which can be localhost, a domain with optional port, or a simple registry with port
 		`(?P<Namespace>(?:[a-z0-9]+(?:(?:[._]|__|[-]*)[a-z0-9]+)*)\/)*` + // Optional namespace, which can contain multiple segments separated by slashes
-		`(?P<Repo>[a-z0-9-]+)` + // Required repository name, which must match the pattern [a-z0-9-]
+		`(?P<Repo>[a-z0-9][-a-z0-9._]+)` + // Required repository name, must start with alphanumeric and can contain alphanumerics, hyphens, dots, and underscores
 		`(?::(?P<Tag>[\w][\w.-]{0,127}))?` + // Optional tag, which starts with a word character and can contain word characters, dots, and hyphens
 		`(?:@(?P<Digest>[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9A-Fa-f]{32,}))?` + // Optional digest, which is a hash algorithm followed by a colon and a hexadecimal hash
 		`$`, // Assert position at the end of the string

--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -77,6 +77,18 @@ func TestExtractImageNameAndTag(t *testing.T) {
 			wantRepo:     "myapp/service",
 			wantRegistry: "111111111111.dkr.ecr.us-east-1.amazonaws.com",
 		},
+		{
+			ref:          "nvcr.io/nim/meta/llama-3.1-8b-instruct:1.1.0",
+			wantTag:      "1.1.0",
+			wantRepo:     "meta/llama-3.1-8b-instruct",
+			wantRegistry: "nvcr.io",
+		},
+		{
+			ref:          "nvcr.io/nvidia/tao/tao-toolkit:5.3.0-pyt",
+			wantTag:      "5.3.0-pyt",
+			wantRepo:     "tao/tao-toolkit",
+			wantRegistry: "nvcr.io",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -83,12 +83,6 @@ func TestExtractImageNameAndTag(t *testing.T) {
 			wantRepo:     "meta/llama-3.1-8b-instruct",
 			wantRegistry: "nvcr.io",
 		},
-		{
-			ref:          "nvcr.io/nvidia/tao/tao-toolkit:5.3.0-pyt",
-			wantTag:      "5.3.0-pyt",
-			wantRepo:     "tao/tao-toolkit",
-			wantRegistry: "nvcr.io",
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This image still fails for me because the repo name contains dots: `nvcr.io/nim/meta/llama-3.1-8b-instruct:1.1.0`. It can be fixed by updating the regex to: `(?P<Repo>[a-z0-9][-a-z0-9._]+)`