### PR TITLE
Add generic provider

### DIFF
--- a/pkg/providers/generic.go
+++ b/pkg/providers/generic.go
@@ -1,0 +1,43 @@
+package providers
+
+import (
+	"context"
+
+	"github.com/beam-cloud/beta9/pkg/network"
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+type GenericProvider struct {
+	*ExternalProvider
+}
+
+func NewGenericProvider(ctx context.Context, appConfig types.AppConfig, providerRepo repository.ProviderRepository, workerRepo repository.WorkerRepository, tailscale *network.Tailscale) (*GenericProvider, error) {
+	genericProvider := &GenericProvider{}
+
+	baseProvider := NewExternalProvider(ctx, &ExternalProviderConfig{
+		Name:                 string(types.ProviderCrusoe),
+		ClusterName:          appConfig.ClusterName,
+		AppConfig:            appConfig,
+		TailScale:            tailscale,
+		ProviderRepo:         providerRepo,
+		WorkerRepo:           workerRepo,
+		ListMachinesFunc:     genericProvider.listMachines,
+		TerminateMachineFunc: genericProvider.TerminateMachine,
+	})
+	genericProvider.ExternalProvider = baseProvider
+
+	return genericProvider, nil
+}
+
+func (p *GenericProvider) ProvisionMachine(ctx context.Context, poolName, token string, compute types.ProviderComputeRequest) (string, error) {
+	return "", types.NewProviderNotImplemented()
+}
+
+func (p *GenericProvider) listMachines(ctx context.Context, poolName string) (map[string]string, error) {
+	return nil, types.NewProviderNotImplemented()
+}
+
+func (p *GenericProvider) TerminateMachine(ctx context.Context, poolName, instanceId, machineId string) error {
+	return types.NewProviderNotImplemented()
+}

--- a/pkg/providers/generic.go
+++ b/pkg/providers/generic.go
@@ -16,7 +16,7 @@ func NewGenericProvider(ctx context.Context, appConfig types.AppConfig, provider
 	genericProvider := &GenericProvider{}
 
 	baseProvider := NewExternalProvider(ctx, &ExternalProviderConfig{
-		Name:                 string(types.ProviderCrusoe),
+		Name:                 string(types.ProviderGeneric),
 		ClusterName:          appConfig.ClusterName,
 		AppConfig:            appConfig,
 		TailScale:            tailscale,

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -63,6 +63,8 @@ func NewExternalWorkerPoolController(
 		provider, err = providers.NewCrusoeProvider(ctx, config, providerRepo, workerRepo, tailscale)
 	case types.ProviderHydra:
 		provider, err = providers.NewHydraProvider(ctx, config, providerRepo, workerRepo, tailscale)
+	case types.ProviderGeneric:
+		provider, err = providers.NewGenericProvider(ctx, config, providerRepo, workerRepo, tailscale)
 	default:
 		return nil, errors.New("invalid provider name")
 	}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -231,6 +231,7 @@ var (
 	ProviderLambdaLabs MachineProvider = "lambda"
 	ProviderCrusoe     MachineProvider = "crusoe"
 	ProviderHydra      MachineProvider = "hydra"
+	ProviderGeneric    MachineProvider = "generic"
 )
 
 type ProviderConfig struct {
@@ -239,6 +240,7 @@ type ProviderConfig struct {
 	LambdaLabs LambdaLabsProviderConfig `key:"lambda" json:"lambda"`
 	Crusoe     CrusoeProviderConfig     `key:"crusoe" json:"crusoe"`
 	Hydra      HydraProviderConfig      `key:"hydra" json:"hydra"`
+	Generic    GenericProviderConfig    `key:"generic" json:"generic"`
 }
 
 type ProviderAgentConfig struct {
@@ -285,6 +287,10 @@ type CrusoeProviderConfig struct {
 }
 
 type HydraProviderConfig struct {
+	Agent ProviderAgentConfig `key:"agent" json:"agent"`
+}
+
+type GenericProviderConfig struct {
 	Agent ProviderAgentConfig `key:"agent" json:"agent"`
 }
 


### PR DESCRIPTION
- Adds a generic external provider as a catch-all for provider pools that don't have any available apis