### PR TITLE
support relative path for module file

### DIFF
--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -181,7 +181,7 @@ class RunnerAbstraction(BaseAbstraction):
 
         module = inspect.getmodule(func)  # Determine module / function name
         if module:
-            module_file = os.path.basename(module.__file__)
+            module_file = os.path.relpath(module.__file__, start=os.getcwd()).replace("/", ".")
             module_name = os.path.splitext(module_file)[0]
         else:
             module_name = "__main__"


### PR DESCRIPTION
Small change to use relative path when parsing the module. With this change, it is possible to run functions from parent directories or do deploys from parent directories. 

Before:
```bash
python 01_getting_started/quickstart.py                                                                                                                                                                           
{'sum': 285}
=> Building image 
=> Using cached image 
=> Syncing files 
Added...
=> Files synced 
=> Running function: <quickstart:square> 
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/common.py", line 150, in _load
    target_module = importlib.import_module(module)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'quickstart'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/function.py", line 171, in main
    handler = FunctionHandler()
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/common.py", line 134, in __init__
    self._load()
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/common.py", line 157, in _load
    raise RunnerException()
beta9.exceptions.RunnerException
⠼ Working...
```

Now:
```bash
python 01_getting_started/quickstart.py                                                                                                                                                                           
{'sum': 285}
=> Building image 
=> Using cached image 
=> Syncing files 
Added...
=> Files synced 
=> Running function: <01_getting_started.quickstart:square> 
=> Function complete <6d9e20f0-03cc-4345-b42d-ddb21edf10ea> 
```