### PR TITLE
remove del from queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ oci*
 .coverage
 .htmlcov
 okteto.yaml
+.vscode/launch.json

--- a/sdk/src/beta9/abstractions/queue.py
+++ b/sdk/src/beta9/abstractions/queue.py
@@ -70,9 +70,6 @@ class SimpleQueue(BaseAbstraction):
         r = self.stub.simple_queue_size(SimpleQueueRequest(name=self.name))
         return r.size if r.ok else 0
 
-    def __del__(self):
-        super().__del__()
-
     def put(self, value: Any) -> bool:
         r: SimpleQueuePutResponse = self.stub.simple_queue_put(
             SimpleQueuePutRequest(name=self.name, value=cloudpickle.dumps(value))


### PR DESCRIPTION
When using the queue remotely, you get the error below. 
```
Exception ignored in: <function SimpleQueue.__del__ at 0x104d55f80>
Traceback (most recent call last):
  File "/Users/minzi/Dev/beam/examples/.venv/lib/python3.12/site-packages/beta9/abstractions/queue.py", line 74, in __del__
AttributeError: 'super' object has no attribute '__del__'
```
I dont think the `__del__` method is needed and it causes this problem so I have removed it. There is no `__del__` on the `BaseAbstraction`.