### PR TITLE
Fix import error in function runner

### DIFF
--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -168,11 +168,11 @@ def main(channel: Channel):
             if not get_args_resp.ok:
                 raise InvalidFunctionArgumentsException
 
-            handler = FunctionHandler()
             payload: dict = _load_args(get_args_resp.args)
             args = payload.get("args") or []
             kwargs = payload.get("kwargs") or {}
 
+            handler = FunctionHandler()
             result = handler(context, *args, **kwargs)
         except BaseException as exc:
             print(traceback.format_exc())


### PR DESCRIPTION
- Fixes an edge case if an import fails during the initial instantiation of FunctionHandler

If import failed, then kwargs/args would not be defined, causing the function container to never exit.