### PR TITLE
dont prompt in CI

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.64"
+version = "0.1.65"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/cli/main.py
+++ b/sdk/src/beta9/cli/main.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from types import ModuleType
 from typing import Any, Optional
@@ -48,6 +49,8 @@ class CLI:
             self.management_group.add_command(module.management)
 
     def check_config(self) -> None:
+        if os.getenv("CI"):
+            return
         if is_config_empty(self.settings.config_path):
             prompt_first_auth(self.settings)
 


### PR DESCRIPTION
This will stop people from getting the first time prompt if CI is set. Currently even if you provide the token you get hit with it. 