### PR TITLE
Add drop-in config directory

### DIFF
--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -71,12 +71,6 @@ func NewHTTPEndpointService(
 	ctx context.Context,
 	opts EndpointServiceOpts,
 ) (EndpointService, error) {
-	configManager, err := common.NewConfigManager[types.AppConfig]()
-	if err != nil {
-		return nil, err
-	}
-	config := configManager.GetConfig()
-
 	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
 	if err != nil {
 		return nil, err
@@ -84,7 +78,7 @@ func NewHTTPEndpointService(
 
 	es := &HttpEndpointService{
 		ctx:               ctx,
-		config:            config,
+		config:            opts.Config,
 		rdb:               opts.RedisClient,
 		keyEventManager:   keyEventManager,
 		scheduler:         opts.Scheduler,

--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -80,15 +80,9 @@ func NewRedisTaskQueueService(
 		return nil, err
 	}
 
-	configManager, err := common.NewConfigManager[types.AppConfig]()
-	if err != nil {
-		return nil, err
-	}
-	config := configManager.GetConfig()
-
 	tq := &RedisTaskQueue{
 		ctx:             ctx,
-		config:          config,
+		config:          opts.Config,
 		rdb:             opts.RedisClient,
 		scheduler:       opts.Scheduler,
 		stubConfigCache: common.NewSafeMap[*types.StubConfigV1](),

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -265,6 +265,7 @@ func (g *Gateway) registerServices() error {
 
 	// Register endpoint service
 	ws, err := endpoint.NewHTTPEndpointService(g.ctx, endpoint.EndpointServiceOpts{
+		Config:         g.Config,
 		ContainerRepo:  g.ContainerRepo,
 		BackendRepo:    g.BackendRepo,
 		TaskRepo:       g.TaskRepo,


### PR DESCRIPTION
Since our config library (koanf) allows us to load and overwrite configs in the order they are loaded, the plan for this is to be able to generate a config (Secret) via helm and mount it under the drop-in config directory.

- Load configs from drop-in directory (/etc/beta9.d/)
- Reuse top-level config in taskqueue and endpoint abstractions
- Don't use global config format when load configs

Resolve BE-1593