### PR TITLE
Add support for configuring Beta9 via helm values

### DIFF
--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -85,7 +85,7 @@ ingress:
 serviceAccount:
   create: true
 persistence:
-  configHelm:
+  config-helm:
     enabled: true
     type: secret
     name: beta9-config-helm

--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -86,7 +86,7 @@ serviceAccount:
   create: true
 persistence:
   config-helm:
-    enabled: true
+    enabled: {{ if .Values.config }}true{{ else }}false{{ end }}
     type: secret
     name: beta9-config-helm
     globalMounts:

--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -38,6 +38,8 @@ networkpolicies:
 controllers:
   gateway:
     type: deployment
+    annotations:
+      secret-hash: {{ include "sha256sum" (toYaml .Values.config) }}
     containers:
       main:
         command:
@@ -82,6 +84,15 @@ ingress:
     controller: gateway
 serviceAccount:
   create: true
+persistence:
+  configHelm:
+    enabled: true
+    type: secret
+    name: beta9-config-helm
+    globalMounts:
+    - path: /etc/beta9.d/config.yaml
+      subPath: config.yaml
+      readOnly: true
 {{- end -}}
 
 
@@ -90,4 +101,9 @@ serviceAccount:
 metadata:
   labels:
     {{ include "bjw-s.common.lib.metadata.allLabels" . | nindent 4 }}
+{{- end -}}
+
+
+{{- define "sha256sum" -}}
+{{- printf "%s" (. | sha256sum) | quote -}}
 {{- end -}}

--- a/deploy/charts/beta9/templates/secret.yaml
+++ b/deploy/charts/beta9/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.config }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -7,3 +8,4 @@ metadata:
     config-hash: {{ include "sha256sum" (toYaml .Values.config) }}
 data:
   config.yaml: {{ .Values.config | toYaml | b64enc }}
+{{- end }}

--- a/deploy/charts/beta9/templates/secret.yaml
+++ b/deploy/charts/beta9/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: beta9-config-helm
+  annotations:
+    config-hash: {{ include "sha256sum" (toYaml .Values.config) }}
+data:
+  config.yaml: {{ .Values.config | toYaml | b64enc }}

--- a/deploy/charts/beta9/values.local.yaml
+++ b/deploy/charts/beta9/values.local.yaml
@@ -1,3 +1,6 @@
+# This is null so that only the defaults at pkg/common/config.default.yaml are used.
+config: null
+
 images:
   gateway:
     repository: registry.localhost:5000/beta9-gateway

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -5,6 +5,14 @@ global:
   annotations: {}
   nameOverride: beta9
 
+config:
+  worker:
+    imageRegistry: public.ecr.aws/n4e0e1y0
+    imagePVCName: ""
+  imageService:
+    runner:
+      baseImageRegistry: public.ecr.aws/n4e0e1y0
+
 images:
   gateway:
     repository: public.ecr.aws/n4e0e1y0/beta9-gateway

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -5,6 +5,8 @@ global:
   annotations: {}
   nameOverride: beta9
 
+# -- Beta9's configuration.
+# https://github.com/beam-cloud/beta9/blob/main/pkg/common/config.default.yaml
 config:
   worker:
     imageRegistry: public.ecr.aws/n4e0e1y0


### PR DESCRIPTION
- Add new `config` key to helm chart values.yaml file used for configuring Beta9 
- Mount `config` values as a config file in drop-in directory `/etc/beta9.d/`
- Force deployment when values in `config` key change

Resolve BE-1593
