### PR TITLE
Add events for task.created and task.updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ proxy:
 
 runner:
 	for target in py312 py311 py310 py39 py38; do \
-		docker build . --no-cache --target $$target -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:$$target-$(runnerTag); \
+		docker build . --no-cache --target $$target --platform=linux/amd64 -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:$$target-$(runnerTag); \
 		docker push localhost:5001/beta9-runner:$$target-$(runnerTag); \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ proxy:
 
 runner:
 	for target in py312 py311 py310 py39 py38; do \
-		docker build . --no-cache --target $$target --platform=linux/amd64 -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:$$target-$(runnerTag); \
+		docker build . --no-cache --target $$target -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:$$target-$(runnerTag); \
 		docker push localhost:5001/beta9-runner:$$target-$(runnerTag); \
 	done
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -85,7 +85,8 @@ func NewGateway() (*Gateway, error) {
 		return nil, err
 	}
 
-	backendRepo, err := repository.NewBackendPostgresRepository(config.Database.Postgres)
+	eventRepo := repository.NewTCPEventClientRepo(config.Monitoring.FluentBit.Events)
+	backendRepo, err := repository.NewBackendPostgresRepository(config.Database.Postgres, eventRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,6 @@ func NewGateway() (*Gateway, error) {
 		return nil, err
 	}
 
-	eventRepo := repository.NewTCPEventClientRepo(config.Monitoring.FluentBit.Events)
 	containerRepo := repository.NewContainerRedisRepository(redisClient)
 	providerRepo := repository.NewProviderRedisRepository(redisClient)
 	taskRepo := repository.NewTaskRedisRepository(redisClient)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -149,6 +149,8 @@ type EventRepository interface {
 	PushDeployStubEvent(workspaceId string, stub *types.Stub)
 	PushServeStubEvent(workspaceId string, stub *types.Stub)
 	PushRunStubEvent(workspaceId string, stub *types.Stub)
+	PushTaskUpdatedEvent(task *types.TaskWithRelated)
+	PushTaskCreatedEvent(task *types.TaskWithRelated)
 }
 
 type MetricsRepository interface {

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -229,3 +229,53 @@ func (t *TCPEventClientRepo) PushRunStubEvent(workspaceId string, stub *types.St
 		},
 	)
 }
+
+func (t *TCPEventClientRepo) PushTaskUpdatedEvent(task *types.TaskWithRelated) {
+	event := types.EventTaskSchema{
+		ID:          task.ExternalId,
+		Status:      task.Status,
+		ContainerID: task.ContainerId,
+		CreatedAt:   task.CreatedAt,
+		StubID:      task.Stub.ExternalId,
+		WorkspaceID: task.Workspace.ExternalId,
+	}
+
+	if task.StartedAt.Valid {
+		event.StartedAt = &task.StartedAt.Time
+	}
+
+	if task.EndedAt.Valid {
+		event.EndedAt = &task.EndedAt.Time
+	}
+
+	t.pushEvent(
+		types.EventTaskUpdated,
+		types.EventTaskSchemaVersion,
+		event,
+	)
+}
+
+func (t *TCPEventClientRepo) PushTaskCreatedEvent(task *types.TaskWithRelated) {
+	event := types.EventTaskSchema{
+		ID:          task.ExternalId,
+		Status:      task.Status,
+		ContainerID: task.ContainerId,
+		CreatedAt:   task.CreatedAt,
+		StubID:      task.Stub.ExternalId,
+		WorkspaceID: task.Workspace.ExternalId,
+	}
+
+	if task.StartedAt.Valid {
+		event.StartedAt = &task.StartedAt.Time
+	}
+
+	if task.EndedAt.Valid {
+		event.EndedAt = &task.EndedAt.Time
+	}
+
+	t.pushEvent(
+		types.EventTaskCreated,
+		types.EventTaskSchemaVersion,
+		event,
+	)
+}

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -1,6 +1,10 @@
 package types
 
-import cloudevents "github.com/cloudevents/sdk-go/v2/event"
+import (
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2/event"
+)
 
 type EventSink = func(event []cloudevents.Event)
 
@@ -15,6 +19,25 @@ var (
 	EventStubDeploy         = "stub.deploy"
 	EventStubServe          = "stub.serve"
 	EventStubRun            = "stub.run"
+
+	/*
+		Stripe events utilize a format of <resource>.<action>
+		1.	<resource>: This indicates the type of object or resource that the event pertains to, such as payment_intent, invoice, customer, subscription, etc.
+		2.	<action>: This indicates the specific action or change that occurred with that resource, such as created, updated, deleted, succeeded, etc.
+
+		Usually this is past tense because it indicates something that has already happened.
+		stub.ran
+		stub.deployed
+		stub.served
+
+		container.lifecycle.updated
+		worker.lifecycle.updated
+
+		the container.metrics event is slightly different because they are snapshots of a resource not a change in state
+		we might need to altered this or rethink concept of an event
+	*/
+	EventTaskUpdated = "task.update"
+	EventTaskCreated = "task.created"
 )
 
 var (
@@ -92,4 +115,17 @@ type EventStubSchema struct {
 	StubType    StubType `json:"stub_type"`
 	WorkspaceID string   `json:"workspace_id"`
 	StubConfig  string   `json:"stub_config"`
+}
+
+var EventTaskSchemaVersion = "1.0"
+
+type EventTaskSchema struct {
+	ID          string     `json:"id"`
+	Status      TaskStatus `json:"status"`
+	ContainerID string     `json:"container_id"`
+	StartedAt   *time.Time `json:"started_at"`
+	EndedAt     *time.Time `json:"ended_at"`
+	WorkspaceID string     `json:"workspace_id"`
+	StubID      string     `json:"stub_id"`
+	CreatedAt   time.Time  `json:"created_at"`
 }

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -13,19 +13,16 @@ type EventClient interface {
 }
 
 var (
-	EventContainerLifecycle = "container.lifecycle"
-	EventContainerMetrics   = "container.metrics"
-	EventWorkerLifecycle    = "worker.lifecycle"
-	EventStubDeploy         = "stub.deploy"
-	EventStubServe          = "stub.serve"
-	EventStubRun            = "stub.run"
-
 	/*
 		Stripe events utilize a format of <resource>.<action>
 		1.	<resource>: This indicates the type of object or resource that the event pertains to, such as payment_intent, invoice, customer, subscription, etc.
 		2.	<action>: This indicates the specific action or change that occurred with that resource, such as created, updated, deleted, succeeded, etc.
+	*/
+	EventTaskUpdated = "task.updated"
+	EventTaskCreated = "task.created"
 
-		Usually this is past tense because it indicates something that has already happened.
+	/*
+		TODO: Requires updates
 		stub.ran
 		stub.deployed
 		stub.served
@@ -33,11 +30,15 @@ var (
 		container.lifecycle.updated
 		worker.lifecycle.updated
 
-		the container.metrics event is slightly different because they are snapshots of a resource not a change in state
-		we might need to altered this or rethink concept of an event
+		Need to update logic the locations that use these events
 	*/
-	EventTaskUpdated = "task.update"
-	EventTaskCreated = "task.created"
+
+	EventContainerLifecycle = "container.lifecycle"
+	EventContainerMetrics   = "container.metrics"
+	EventWorkerLifecycle    = "worker.lifecycle"
+	EventStubDeploy         = "stub.deploy"
+	EventStubServe          = "stub.serve"
+	EventStubRun            = "stub.run"
 )
 
 var (


### PR DESCRIPTION
I'm looking for opinions on where to push events for these backend transactions. 
Rather than updating in 15 places where `backendRepo.UpdateTask` is called, I currently have the event happen after the database transaction is fulfilled.

Alternative to this, I can write a layer on top of `backendRepo` such as `backendRepoWithEvents` or something similar that wraps functions such as 
- `UpdateTask`
- `CreateTask`
- and other places where we might want events following a database transaction such as `CreateDeployment`
