### PR TITLE
enable pg_cron in local postgres

### DIFF
--- a/manifests/kustomize/components/postgresql/helm-chart-generator.yaml
+++ b/manifests/kustomize/components/postgresql/helm-chart-generator.yaml
@@ -25,30 +25,30 @@ valuesInline:
     registry: public.ecr.aws
     repository: n4e0e1y0/postgres
     tag: 16.1
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   primary:
     extendedConfiguration: |
       max_connections=400
       shared_buffers='400MB'
       cron.database_name='main'
     initdb:
-          scripts:
-            create_extension.sh: |
-              #!/bin/sh
-              export PGPASSWORD=password
-              cat /opt/bitnami/postgresql/conf/postgresql.conf | grep shared_preload_libraries
+      scripts:
+        create_extension.sh: |
+          #!/bin/sh
+          export PGPASSWORD=password
+          cat /opt/bitnami/postgresql/conf/postgresql.conf | grep shared_preload_libraries
 
-              # Set up pg_cron in main database
-              psql -Upostgres main << EOF
-              SHOW shared_preload_libraries;
-              CREATE EXTENSION IF NOT EXISTS pg_cron;
-              EOF
+          # Set up pg_cron in main database
+          psql -Upostgres main << EOF
+          SHOW shared_preload_libraries;
+          CREATE EXTENSION IF NOT EXISTS pg_cron;
+          EOF
 
-              # Grant usage on the cron schema to both root and postgres users
-              psql -Upostgres -d main <<EOF
-              GRANT USAGE ON SCHEMA cron TO postgres;
-              GRANT USAGE ON SCHEMA cron TO root;
-              EOF
+          # Grant usage on the cron schema to both root and postgres users
+          psql -Upostgres -d main <<EOF
+          GRANT USAGE ON SCHEMA cron TO postgres;
+          GRANT USAGE ON SCHEMA cron TO root;
+          EOF
   volumePermissions:
     enabled: true
   persistence:

--- a/manifests/kustomize/components/postgresql/helm-chart-generator.yaml
+++ b/manifests/kustomize/components/postgresql/helm-chart-generator.yaml
@@ -13,16 +13,42 @@ skipTests: true
 valuesInline:
   nameOverride: *name
   fullnameOverride: *name
+  postgresqlSharedPreloadLibraries: pg_cron
   global:
     postgresql:
       auth:
+        postgresPassword: password
         username: root
         password: password
         database: main
+  image:
+    registry: public.ecr.aws
+    repository: n4e0e1y0/postgres
+    tag: 16.1
+    pullPolicy: Always
   primary:
     extendedConfiguration: |
       max_connections=400
       shared_buffers='400MB'
+      cron.database_name='main'
+    initdb:
+          scripts:
+            create_extension.sh: |
+              #!/bin/sh
+              export PGPASSWORD=password
+              cat /opt/bitnami/postgresql/conf/postgresql.conf | grep shared_preload_libraries
+
+              # Set up pg_cron in main database
+              psql -Upostgres main << EOF
+              SHOW shared_preload_libraries;
+              CREATE EXTENSION IF NOT EXISTS pg_cron;
+              EOF
+
+              # Grant usage on the cron schema to both root and postgres users
+              psql -Upostgres -d main <<EOF
+              GRANT USAGE ON SCHEMA cron TO postgres;
+              GRANT USAGE ON SCHEMA cron TO root;
+              EOF
   volumePermissions:
     enabled: true
   persistence:


### PR DESCRIPTION
The idea is to use this as an event source for cron/scheduled jobs instead of maintaining our own custom logic (i.e. beat).
It should also be supported by [RDS/Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/PostgreSQL_pg_cron.html#PostgreSQL_pg_cron.otherDB), but it might require a little work to set up (@nickpetrovic any thoughts on this?)


NOTE: This required a custom postgres build, based off the bitnami image:

```
FROM bitnami/postgresql:16.1.0-debian-11-r24

USER root

RUN apt-get update \
    && apt-get upgrade -y \
    && apt-get install -y wget gnupg2 lsb-release \
    && echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
    && apt-get update \
    && apt-get install -y \
        postgresql-16-cron \
    && rm -rf /var/lib/apt/lists/ \
    && cp /usr/lib/postgresql/16/lib/pg_cron.so /opt/bitnami/postgresql/lib \
    && cp /usr/share/postgresql/16/extension/pg_cron* /opt/bitnami/postgresql/share/extension \
    && chmod +x /opt/bitnami/postgresql/lib/pg_cron.so

USER 1001
```

example usage:
```
-- pg_cron
select * from cron.job j ;
select * from cron.job_run_details jrd ;

select cron.schedule('nightly-vacuum', '0 10 * * *', 'VACUUM');
select cron.unschedule(1);
```

