### PR TITLE
return entire token on create

### DIFF
--- a/pkg/api/v1/token.go
+++ b/pkg/api/v1/token.go
@@ -42,9 +42,7 @@ func (g *TokenGroup) CreateWorkspaceToken(ctx echo.Context) error {
 		return HTTPInternalServerError("Unable to create token")
 	}
 
-	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"token": token.Key,
-	})
+	return ctx.JSON(http.StatusOK, token)
 }
 
 type ClusterAdminTokensRequestSerializer struct {


### PR DESCRIPTION
Making this change so that when a user creates a token we get all of the token information in the response. This way when a user creates a token in the UI we can just update the list with this new token instead of fetching the entire list again. 