### PR TITLE
delete tokens and return full token on create

### DIFF
--- a/pkg/api/v1/token.go
+++ b/pkg/api/v1/token.go
@@ -26,6 +26,7 @@ func NewTokenGroup(g *echo.Group, backendRepo repository.BackendRepository, conf
 	g.POST("/:workspaceId", auth.WithWorkspaceAuth(group.CreateWorkspaceToken))
 	g.GET("/:workspaceId", auth.WithWorkspaceAuth(group.ListWorkspaceTokens))
 	g.POST("/:workspaceId/:tokenId/toggle", auth.WithWorkspaceAuth(group.ToggleWorkspaceToken))
+	g.DELETE("/:workspaceId/:tokenId", auth.WithWorkspaceAuth(group.ToggleWorkspaceToken))
 
 	return group
 }
@@ -109,4 +110,22 @@ func (g *TokenGroup) ToggleWorkspaceToken(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, token)
+}
+
+func (g *TokenGroup) DeleteWorkspaceToken(ctx echo.Context) error {
+	workspaceId := ctx.Param("workspaceId")
+	workspace, err := g.backendRepo.GetWorkspaceByExternalId(ctx.Request().Context(), workspaceId)
+	if err != nil {
+		return HTTPBadRequest("Invalid workspace ID")
+	}
+
+	extTokenId := ctx.Param("tokenId")
+	err = g.backendRepo.DeleteToken(ctx.Request().Context(), workspace.Id, extTokenId)
+	if err != nil {
+		return HTTPInternalServerError("Failed to delete token")
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]interface{}{
+		"ok": true,
+	})
 }

--- a/pkg/api/v1/token.go
+++ b/pkg/api/v1/token.go
@@ -26,7 +26,7 @@ func NewTokenGroup(g *echo.Group, backendRepo repository.BackendRepository, conf
 	g.POST("/:workspaceId", auth.WithWorkspaceAuth(group.CreateWorkspaceToken))
 	g.GET("/:workspaceId", auth.WithWorkspaceAuth(group.ListWorkspaceTokens))
 	g.POST("/:workspaceId/:tokenId/toggle", auth.WithWorkspaceAuth(group.ToggleWorkspaceToken))
-	g.DELETE("/:workspaceId/:tokenId", auth.WithWorkspaceAuth(group.ToggleWorkspaceToken))
+	g.DELETE("/:workspaceId/:tokenId", auth.WithWorkspaceAuth(group.DeleteWorkspaceToken))
 
 	return group
 }

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -268,6 +268,12 @@ func (r *PostgresBackendRepository) ToggleToken(ctx context.Context, workspaceId
 	return token, nil
 }
 
+func (r *PostgresBackendRepository) DeleteToken(ctx context.Context, workspaceId uint, extTokenId string) error {
+	query := `DELETE FROM token WHERE external_id = $1 AND workspace_id = $2;`
+	_, err := r.client.ExecContext(ctx, query, extTokenId, workspaceId)
+	return err
+}
+
 func (r *PostgresBackendRepository) RevokeTokenByExternalId(ctx context.Context, externalId string) error {
 	updateQuery := `
     UPDATE token

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -69,6 +69,7 @@ type BackendRepository interface {
 	ListTokens(ctx context.Context, workspaceId uint) ([]types.Token, error)
 	UpdateTokenAsClusterAdmin(ctx context.Context, tokenId string, disabled bool) error
 	ToggleToken(ctx context.Context, workspaceId uint, extTokenId string) (types.Token, error)
+	DeleteToken(ctx context.Context, workspaceId uint, extTokenId string) error
 	GetTask(ctx context.Context, externalId string) (*types.Task, error)
 	GetTaskWithRelated(ctx context.Context, externalId string) (*types.TaskWithRelated, error)
 	GetTaskByWorkspace(ctx context.Context, externalId string, workspace *types.Workspace) (*types.TaskWithRelated, error)


### PR DESCRIPTION
This PR adds support for additional support for tokens to the gateway. It allows us to delete tokens and we will now return the full token object upon creation. This is useful because it allows users to make subsequent requests using the external token ID without needing to fetch or re-fetch the full list of tokens.  