### PR TITLE
Add deployment download route

### DIFF
--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -1,7 +1,6 @@
 package apiv1
 
 import (
-	"fmt"
 	"net/http"
 	"path"
 
@@ -197,7 +196,6 @@ func (g *DeploymentGroup) DownloadDeploymentPackage(ctx echo.Context) error {
 		return HTTPInternalServerError("Failed to get object")
 	}
 	path := getPackagePath(workspace.Name, object.ExternalId)
-	fmt.Println(path)
 
 	return ctx.File(path)
 }

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -345,6 +345,23 @@ func (r *PostgresBackendRepository) GetObjectByExternalId(ctx context.Context, e
 	return object, nil
 }
 
+func (r *PostgresBackendRepository) GetObjectByExternalStubId(ctx context.Context, stubId string, workspaceId uint) (types.Object, error) {
+	query := `
+	SELECT o.id, o.external_id, o.hash, o.size, o.created_at
+	FROM object o
+	INNER JOIN stub s ON o.id = s.object_id
+	WHERE s.external_id = $1 AND o.workspace_id = $2;
+	`
+
+	var object types.Object
+	err := r.client.GetContext(ctx, &object, query, stubId, workspaceId)
+	if err != nil {
+		return types.Object{}, err
+	}
+
+	return object, nil
+}
+
 func (r *PostgresBackendRepository) UpdateObjectSizeByExternalId(ctx context.Context, externalId string, size int) error {
 	query := `
 	UPDATE object

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -61,6 +61,7 @@ type BackendRepository interface {
 	CreateObject(ctx context.Context, hash string, size int64, workspaceId uint) (types.Object, error)
 	GetObjectByHash(ctx context.Context, hash string, workspaceId uint) (types.Object, error)
 	GetObjectByExternalId(ctx context.Context, externalId string, workspaceId uint) (types.Object, error)
+	GetObjectByExternalStubId(ctx context.Context, stubId string, workspaceId uint) (types.Object, error)
 	UpdateObjectSizeByExternalId(ctx context.Context, externalId string, size int) error
 	DeleteObjectByExternalId(ctx context.Context, externalId string) error
 	CreateToken(ctx context.Context, workspaceId uint, tokenType string, reusable bool) (types.Token, error)


### PR DESCRIPTION
This PR adds a route to the gateway for downloading deployment objects. It uses the stub ID to generate the download path and returns the file at that path. This will allow us to build a download option into the UI so that users can quickly access/verify their deployed code. 