### PR TITLE
Prevent infinite map loops

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.72"
+version = "0.1.73"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -23,7 +23,7 @@ from ..clients.function import (
     FunctionScheduleRequest,
     FunctionServiceStub,
 )
-from ..env import is_local
+from ..env import called_on_import, is_local
 from ..sync import FileSyncer
 from ..type import GpuType, GpuTypeAlias, TaskPolicy
 from .mixins import DeployableMixin
@@ -135,6 +135,9 @@ class _CallableWrapper(DeployableMixin):
 
     @with_grpc_error_handling
     def __call__(self, *args, **kwargs) -> Any:
+        if called_on_import():
+            return
+
         if not is_local():
             return self.local(*args, **kwargs)
 


### PR DESCRIPTION
If calling a map from inside a another invoked function, there is the possibility to trigger a recursive invocation of the same code (during import). This should hopefully prevent that from happening.