### PR TITLE
Do not prompt user when ending serve

### DIFF
--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -235,21 +235,10 @@ class _CallableWrapper(DeployableMixin):
             self._handle_serve_interrupt()
 
     def _handle_serve_interrupt(self) -> None:
-        response = "y"
-
-        try:
-            response = terminal.prompt(
-                text="Would you like to stop the container? (y/n)", default="y"
-            )
-        except KeyboardInterrupt:
-            pass
-
-        if response == "y":
-            terminal.header("Stopping serve container")
-            self.parent.endpoint_stub.stop_endpoint_serve(
-                StopEndpointServeRequest(stub_id=self.parent.stub_id)
-            )
-
+        terminal.header("Stopping serve container")
+        self.parent.endpoint_stub.stop_endpoint_serve(
+            StopEndpointServeRequest(stub_id=self.parent.stub_id)
+        )
         terminal.print("Goodbye 👋")
         os._exit(0)  # kills all threads immediately
 

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -187,20 +187,10 @@ class _CallableWrapper(DeployableMixin):
             self._handle_serve_interrupt()
 
     def _handle_serve_interrupt(self) -> None:
-        response = "y"
-
-        try:
-            response = terminal.prompt(
-                text="Would you like to stop the container? (y/n)", default="y"
-            )
-        except KeyboardInterrupt:
-            pass
-
-        if response == "y":
-            terminal.header("Stopping serve container")
-            self.parent.taskqueue_stub.stop_task_queue_serve(
-                StopTaskQueueServeRequest(stub_id=self.parent.stub_id)
-            )
+        terminal.header("Stopping serve container")
+        self.parent.taskqueue_stub.stop_task_queue_serve(
+            StopTaskQueueServeRequest(stub_id=self.parent.stub_id)
+        )
 
         terminal.print("Goodbye 👋")
         os._exit(0)  # kills all threads immediately


### PR DESCRIPTION
This change makes it so that serves are terminated immediately on a user interrupt. The current behavior prompts users to ask if they truly want to end the serve. However, regardless of the user's input the session ends. If they chose "n", indicating they wanted the serve to continue, there will still be a container up that they then need to manually stop. 

This change simplifies things and users can easily start a new serve if they closed the old one on accident. 