### PR TITLE
support env var references in commands

### DIFF
--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"log"
 
+	"github.com/pkg/errors"
+
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/network"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/scheduler"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
-	"github.com/pkg/errors"
 )
 
 type ImageService interface {
@@ -30,6 +31,7 @@ type ImageServiceOpts struct {
 	ContainerRepo repository.ContainerRepository
 	Scheduler     *scheduler.Scheduler
 	Tailscale     *network.Tailscale
+	BackendRepo   repository.BackendRepository
 }
 
 func NewRuncImageService(
@@ -41,7 +43,7 @@ func NewRuncImageService(
 		return nil, err
 	}
 
-	builder, err := NewBuilder(opts.Config, registry, opts.Scheduler, opts.Tailscale, opts.ContainerRepo)
+	builder, err := NewBuilder(opts.Config, registry, opts.Scheduler, opts.Tailscale, opts.ContainerRepo, opts.BackendRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -13,31 +13,31 @@ import (
 	"github.com/labstack/echo-contrib/pprof"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"google.golang.org/grpc"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc"
 
-	"github.com/beam-cloud/beta9/pkg/abstractions/endpoint"
-	"github.com/beam-cloud/beta9/pkg/abstractions/secret"
-	"github.com/beam-cloud/beta9/pkg/task"
 	"github.com/beam-cloud/beta9/pkg/abstractions/container"
+	"github.com/beam-cloud/beta9/pkg/abstractions/endpoint"
 	_signal "github.com/beam-cloud/beta9/pkg/abstractions/experimental/signal"
 	"github.com/beam-cloud/beta9/pkg/abstractions/function"
 	"github.com/beam-cloud/beta9/pkg/abstractions/image"
 	dmap "github.com/beam-cloud/beta9/pkg/abstractions/map"
-	simplequeue "github.com/beam-cloud/beta9/pkg/abstractions/queue"
-	"github.com/beam-cloud/beta9/pkg/abstractions/taskqueue"
-	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
-	"github.com/beam-cloud/beta9/pkg/network"
-	metrics "github.com/beam-cloud/beta9/pkg/repository/metrics"
 	output "github.com/beam-cloud/beta9/pkg/abstractions/output"
+	simplequeue "github.com/beam-cloud/beta9/pkg/abstractions/queue"
+	"github.com/beam-cloud/beta9/pkg/abstractions/secret"
+	"github.com/beam-cloud/beta9/pkg/abstractions/taskqueue"
 	volume "github.com/beam-cloud/beta9/pkg/abstractions/volume"
+	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
 	gatewayservices "github.com/beam-cloud/beta9/pkg/gateway/services"
+	"github.com/beam-cloud/beta9/pkg/network"
 	"github.com/beam-cloud/beta9/pkg/repository"
+	metrics "github.com/beam-cloud/beta9/pkg/repository/metrics"
 	"github.com/beam-cloud/beta9/pkg/scheduler"
 	"github.com/beam-cloud/beta9/pkg/storage"
+	"github.com/beam-cloud/beta9/pkg/task"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 )
@@ -218,6 +218,7 @@ func (g *Gateway) registerServices() error {
 		ContainerRepo: g.ContainerRepo,
 		Scheduler:     g.Scheduler,
 		Tailscale:     g.Tailscale,
+		BackendRepo:   g.BackendRepo,
 	})
 	if err != nil {
 		return err

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -114,6 +114,7 @@ type BackendRepository interface {
 	GetSecretByName(ctx context.Context, workspace *types.Workspace, name string) (*types.Secret, error)
 	GetSecretByNameDecrypted(ctx context.Context, workspace *types.Workspace, name string) (*types.Secret, error)
 	ListSecrets(ctx context.Context, workspace *types.Workspace) ([]types.Secret, error)
+	ListSecretsDecrypted(ctx context.Context, workspace *types.Workspace) ([]types.Secret, error)
 	UpdateSecret(ctx context.Context, workspace *types.Workspace, tokenId uint, secretId string, value string) (*types.Secret, error)
 	DeleteSecret(ctx context.Context, workspace *types.Workspace, secretName string) error
 }


### PR DESCRIPTION
This change allows users to reference secrets as environment variables in their image build. 

For instance, lets say I create a secret called `TEST_TOKEN` like this: 
```beta9 secret create TEST_TOKEN hello```
and another to specify the numpy version I want:
```
beta9 secret create NUMPY_VERSION 1.22.3
```

We can now access those values as environment variables. 

```
from beta9 import endpoint, Image

@endpoint(
    cpu=1.0,
    memory=128,
    image=Image(
        commands=['echo $TEST_TOKEN'],
        python_packages=['numpy==$NUMPY_VERSION']
    )
)
def multiply(x, y, z):
    result = x * 2
    return {"result": result}
```