### PR TITLE
Various image / cache fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/moby/sys/mountinfo v0.7.1
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/umoci v0.4.7
 	github.com/openmeterio/openmeter v1.0.0-beta.47
@@ -167,6 +166,7 @@ require (
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/sys/mountinfo v0.7.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
-	github.com/beam-cloud/blobcache-v2 v0.0.0-20240813141158-9c5b6ba2e16e
-	github.com/beam-cloud/clip v0.0.0-20240731234427-47b5b1ade542
+	github.com/beam-cloud/blobcache-v2 v0.0.0-20240826215017-49e9cf89f2ec
+	github.com/beam-cloud/clip v0.0.0-20240826213603-297f53aa0e53
 	github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170
 	github.com/bsm/redislock v0.9.4
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZ
 github.com/aws/smithy-go v1.20.0 h1:6+kZsCXZwKxZS9RfISnPc4EXlHoyAkm2hPuM8X2BrrQ=
 github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe7dklGc=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20240813141158-9c5b6ba2e16e h1:qeTze2lUIoEJqtivVSkSBpW8m/dm6UopZlD3o6V7ZOU=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20240813141158-9c5b6ba2e16e/go.mod h1:83LTfvBamsIBjB0UerapS407tHG0ehAiTKlUfWxT7tU=
-github.com/beam-cloud/clip v0.0.0-20240731234427-47b5b1ade542 h1:WdueJFxuvyeKFrkEou5yFAYyRDiCp+XR60vum2RlqwY=
-github.com/beam-cloud/clip v0.0.0-20240731234427-47b5b1ade542/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20240826215017-49e9cf89f2ec h1:gIwMAGDaAJjoLwDvoCABV5QY9w2U2c87/8gV40C3MPI=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20240826215017-49e9cf89f2ec/go.mod h1:83LTfvBamsIBjB0UerapS407tHG0ehAiTKlUfWxT7tU=
+github.com/beam-cloud/clip v0.0.0-20240826213603-297f53aa0e53 h1:bjO7GY46LLhwp/o3QbLcnxRkQ5ayYTp3w09t/9DiYpE=
+github.com/beam-cloud/clip v0.0.0-20240826213603-297f53aa0e53/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/common/registry.go
+++ b/pkg/common/registry.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	s3ImageRegistryStoreName = "s3"
+	S3ImageRegistryStore     = "s3"
+	LocalImageRegistryStore  = "local"
 	remoteImageFileExtension = "rclip"
 	localImageFileExtension  = "clip"
 )
@@ -31,9 +32,9 @@ func NewImageRegistry(config types.ImageServiceConfig) (*ImageRegistry, error) {
 	var err error
 	var store ObjectStore
 
-	var imageFileExtension string = "clip"
+	var imageFileExtension string = localImageFileExtension
 	switch config.RegistryStore {
-	case s3ImageRegistryStoreName:
+	case S3ImageRegistryStore:
 		imageFileExtension = remoteImageFileExtension
 		store, err = NewS3Store(config.Registries.S3)
 		if err != nil {
@@ -97,7 +98,6 @@ type S3Store struct {
 func (s *S3Store) Put(ctx context.Context, localPath string, key string) error {
 	f, err := os.Open(localPath)
 	if err != nil {
-		log.Printf("error opening file<%s>: %v", localPath, err)
 		return err
 	}
 	defer f.Close()
@@ -195,7 +195,6 @@ type LocalObjectStore struct {
 func (s *LocalObjectStore) Put(ctx context.Context, localPath string, key string) error {
 	srcFile, err := os.Open(localPath)
 	if err != nil {
-		log.Printf("error opening file<%s>: %v", localPath, err)
 		return err
 	}
 	defer srcFile.Close()
@@ -203,14 +202,12 @@ func (s *LocalObjectStore) Put(ctx context.Context, localPath string, key string
 	destPath := filepath.Join(s.Path, key)
 	destFile, err := os.Create(destPath)
 	if err != nil {
-		log.Printf("error creating file<%s>: %v", destPath, err)
 		return err
 	}
 	defer destFile.Close()
 
 	_, err = io.Copy(destFile, srcFile)
 	if err != nil {
-		log.Printf("error copying file<%s>: %v", destPath, err)
 		return err
 	}
 
@@ -221,21 +218,18 @@ func (s *LocalObjectStore) Get(ctx context.Context, key string, localPath string
 	srcPath := filepath.Join(s.Path, key)
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
-		log.Printf("error opening file<%s>: %v\n", localPath, err)
 		return err
 	}
 	defer srcFile.Close()
 
 	destFile, err := os.Create(localPath)
 	if err != nil {
-		log.Printf("error creating file<%s>: %v\n", localPath, err)
 		return err
 	}
 	defer destFile.Close()
 
 	_, err = io.Copy(destFile, srcFile)
 	if err != nil {
-		log.Printf("error copying file<%s>: %v\n", localPath, err)
 		return err
 	}
 


### PR DESCRIPTION
- [CLIP] Fall back to remote source if cache file fails
- [Blobcache] Retry reads 3 times
- [Blobcache] Don't try to retrieve content from cache until we have discovered nearby hosts
- [Blobcache] Lock when storing content from source, to prevent duplicate requests going to cache server
- [Worker] Don't check mountpoint, rely on in-memory fuse server to determine if there is a valid mount running
- [Misc.] Clean up image registry types and logs
