### PR TITLE
Ability to stop scheduled jobs

### DIFF
--- a/manifests/kustomize/components/monitoring/fluent-bit.yaml
+++ b/manifests/kustomize/components/monitoring/fluent-bit.yaml
@@ -46,7 +46,7 @@ valuesInline:
           Path             /var/log/worker/*.log
           Parser           json-parser
           Mem_Buf_Limit    100MB
-          Skip_Long_Lines  Off
+          Skip_Long_Lines  On
           Refresh_Interval 5
       [INPUT]
           Name   http
@@ -79,7 +79,7 @@ valuesInline:
           Host                ${ELASTICSEARCH_HOST}
           Port                ${ELASTICSEARCH_PORT}
           Logstash_Format     On
-          Logstash_Prefix     events
+          Logstash_Prefix     worker-logs
           Retry_Limit         False
           Time_Key_Nanos      On
           Suppress_Type_Name  On

--- a/pkg/gateway/services/deployment.go
+++ b/pkg/gateway/services/deployment.go
@@ -153,6 +153,13 @@ func (gws *GatewayService) DeleteDeployment(ctx context.Context, in *pb.DeleteDe
 
 func (gws *GatewayService) stopDeployments(deployments []types.DeploymentWithRelated, ctx context.Context) error {
 	for _, deployment := range deployments {
+		// Stop scheduled job. To re-enable, a new deployment must be created
+		if deployment.StubType == types.StubTypeScheduledJobDeployment {
+			if scheduledJob, err := gws.backendRepo.GetScheduledJob(ctx, deployment.Id); err == nil {
+				gws.backendRepo.DeleteScheduledJob(ctx, scheduledJob)
+			}
+		}
+
 		// Stop active containers
 		containers, err := gws.containerRepo.GetActiveContainersByStubId(deployment.Stub.ExternalId)
 		if err == nil {


### PR DESCRIPTION
When stopping a deployment, also stop a scheduled job by deleting it.

Match fluent-bit logging settings with production.

Resolve BE-1713