### PR TITLE
Check gpu limit before creating stub

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -23,14 +23,7 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 
 	if in.Gpu != "" {
 		concurrencyLimit, err := gws.backendRepo.GetConcurrencyLimitByWorkspaceId(ctx, authInfo.Workspace.ExternalId)
-		if err != nil {
-			return &pb.GetOrCreateStubResponse{
-				Ok:     false,
-				ErrMsg: "Failed to get concurrency limit for workspace",
-			}, nil
-		}
-
-		if concurrencyLimit.GPULimit <= 0 {
+		if err != nil && concurrencyLimit != nil && concurrencyLimit.GPULimit <= 0 {
 			return &pb.GetOrCreateStubResponse{
 				Ok:     false,
 				ErrMsg: "GPU concurrency limit is 0.",

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -21,6 +21,23 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		}, nil
 	}
 
+	if in.Gpu != "" {
+		concurrencyLimit, err := gws.backendRepo.GetConcurrencyLimitByWorkspaceId(ctx, authInfo.Workspace.ExternalId)
+		if err != nil {
+			return &pb.GetOrCreateStubResponse{
+				Ok:     false,
+				ErrMsg: "Failed to get concurrency limit for workspace",
+			}, nil
+		}
+
+		if concurrencyLimit.GPULimit <= 0 {
+			return &pb.GetOrCreateStubResponse{
+				Ok:     false,
+				ErrMsg: "GPU concurrency limit is 0. A payment method is required to deploy with GPUs.",
+			}, nil
+		}
+	}
+
 	autoscaler := &types.Autoscaler{}
 	if in.Autoscaler.Type == "" {
 		autoscaler.Type = types.QueueDepthAutoscaler

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -33,7 +33,7 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		if concurrencyLimit.GPULimit <= 0 {
 			return &pb.GetOrCreateStubResponse{
 				Ok:     false,
-				ErrMsg: "GPU concurrency limit is 0. A payment method is required to deploy with GPUs.",
+				ErrMsg: "GPU concurrency limit is 0.",
 			}, nil
 		}
 	}


### PR DESCRIPTION
This PR adds a check to `GetOrCreateStub` that ensures that the user has a valid GPU limit if they've requested to create a stub that includes a GPU.  