### PR TITLE
Endpoints should at least transition from pending to expires

### DIFF
--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -253,7 +253,7 @@ func (rb *RequestBuffer) incrementRequestsInFlight(containerId string) error {
 		return err
 	}
 
-	err = rb.rdb.Expire(rb.ctx, Keys.endpointRequestsInFlight(rb.workspace.Name, rb.stubId, containerId), time.Duration(EndpointRequestTimeoutS)*time.Second).Err()
+	err = rb.rdb.Expire(rb.ctx, Keys.endpointRequestsInFlight(rb.workspace.Name, rb.stubId, containerId), time.Duration(rb.stubConfig.TaskPolicy.Timeout)*time.Second).Err()
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func (rb *RequestBuffer) decrementRequestsInFlight(containerId string) error {
 		return err
 	}
 
-	err = rb.rdb.Expire(rb.ctx, Keys.endpointRequestsInFlight(rb.workspace.Name, rb.stubId, containerId), time.Duration(EndpointRequestTimeoutS)*time.Second).Err()
+	err = rb.rdb.Expire(rb.ctx, Keys.endpointRequestsInFlight(rb.workspace.Name, rb.stubId, containerId), time.Duration(rb.stubConfig.TaskPolicy.Timeout)*time.Second).Err()
 	if err != nil {
 		return err
 	}

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -44,8 +44,9 @@ type HttpEndpointService struct {
 }
 
 var (
-	EndpointRequestTimeoutS int    = 600 // 10 minutes
-	ASGIRoutePrefix         string = "/asgi"
+	DefaultEndpointRequestTimeoutS int    = 600  // 10 minutes
+	DefaultEndpointRequestTTL      int    = 7200 // 2 hours
+	ASGIRoutePrefix                string = "/asgi"
 
 	endpointContainerPrefix                 string        = "endpoint"
 	endpointRoutePrefix                     string        = "/endpoint"

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -45,7 +45,7 @@ type HttpEndpointService struct {
 
 var (
 	DefaultEndpointRequestTimeoutS int    = 600  // 10 minutes
-	DefaultEndpointRequestTTL      int    = 7200 // 2 hours
+	DefaultEndpointRequestTTL      int    = 1200 // 20 minutes
 	ASGIRoutePrefix                string = "/asgi"
 
 	endpointContainerPrefix                 string        = "endpoint"

--- a/pkg/abstractions/function/function.go
+++ b/pkg/abstractions/function/function.go
@@ -29,7 +29,7 @@ type FunctionService interface {
 }
 
 const (
-	FunctionDefaultTaskTTL int = 3600 * 12 // 12 hours
+	DefaultFunctionDefaultTaskTTL int = 3600 * 12 // 12 hours
 
 	functionRoutePrefix             string        = "/function"
 	scheduleRoutePrefix             string        = "/schedule"

--- a/pkg/abstractions/function/function.go
+++ b/pkg/abstractions/function/function.go
@@ -29,7 +29,7 @@ type FunctionService interface {
 }
 
 const (
-	DefaultFunctionDefaultTaskTTL int = 3600 * 12 // 12 hours
+	DefaultFunctionTaskTTL int = 3600 * 12 // 12 hours
 
 	functionRoutePrefix             string        = "/function"
 	scheduleRoutePrefix             string        = "/schedule"

--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -46,7 +46,7 @@ type TaskQueueServiceOpts struct {
 }
 
 const (
-	DefaultTaskQueueDefaultTaskTTL int = 3600 * 2 // 2 hours
+	DefaultTaskQueueTaskTTL int = 3600 * 2 // 2 hours
 
 	taskQueueContainerPrefix                 string        = "taskqueue"
 	taskQueueRoutePrefix                     string        = "/taskqueue"

--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -46,7 +46,7 @@ type TaskQueueServiceOpts struct {
 }
 
 const (
-	TaskQueueDefaultTaskTTL int = 3600 * 2 // 2 hours
+	DefaultTaskQueueDefaultTaskTTL int = 3600 * 2 // 2 hours
 
 	taskQueueContainerPrefix                 string        = "taskqueue"
 	taskQueueRoutePrefix                     string        = "/taskqueue"

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -159,22 +159,22 @@ func (gws *GatewayService) configureTaskPolicy(policy *pb.TaskPolicy, stubType t
 	case types.StubTypeASGI:
 		fallthrough
 	case types.StubTypeEndpoint:
-		p.Timeout = int(math.Min(float64(policy.Timeout), float64(endpoint.EndpointRequestTimeoutS)))
+		p.Timeout = int(math.Min(float64(policy.Timeout), float64(endpoint.DefaultEndpointRequestTimeoutS)))
 		if p.Timeout <= 0 {
-			p.Timeout = endpoint.EndpointRequestTimeoutS
+			p.Timeout = endpoint.DefaultEndpointRequestTimeoutS
 		}
 		p.MaxRetries = 0
-		p.TTL = math.MaxUint32 // No TTL for endpoint tasks
+		p.TTL = uint32(endpoint.DefaultEndpointRequestTTL) // Endpoints should still transition to expire from pending if it never runs
 
 	case types.StubTypeScheduledJob:
 		fallthrough
 	case types.StubTypeFunction:
 		if p.TTL == 0 {
-			p.TTL = uint32(function.FunctionDefaultTaskTTL)
+			p.TTL = uint32(function.DefaultFunctionDefaultTaskTTL)
 		}
 	case types.StubTypeTaskQueue:
 		if p.TTL == 0 {
-			p.TTL = uint32(taskqueue.TaskQueueDefaultTaskTTL)
+			p.TTL = uint32(taskqueue.DefaultTaskQueueDefaultTaskTTL)
 		}
 	}
 

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -170,11 +170,11 @@ func (gws *GatewayService) configureTaskPolicy(policy *pb.TaskPolicy, stubType t
 		fallthrough
 	case types.StubTypeFunction:
 		if p.TTL == 0 {
-			p.TTL = uint32(function.DefaultFunctionDefaultTaskTTL)
+			p.TTL = uint32(function.DefaultFunctionTaskTTL)
 		}
 	case types.StubTypeTaskQueue:
 		if p.TTL == 0 {
-			p.TTL = uint32(taskqueue.DefaultTaskQueueDefaultTaskTTL)
+			p.TTL = uint32(taskqueue.DefaultTaskQueueTaskTTL)
 		}
 	}
 


### PR DESCRIPTION
One special condition we need to consider.

Current behavior:
If a request to endpoint is made, and it starts running on a container -> even if you disconnect the client request the task will still run.
However, if a request to endpoint is made but then client disconnects before the task goes inflight, the task will never run because the request's context is canceled before it ever reached he gunicorn server. Therefore a task like this is stuck in PENDING forever (which this PR helps transitions such tasks to expired)

This behavior of the request state is not anything new and is the current behavior in prod.