### PR TITLE
log when mountpoint fails and cleanup mountpoint dir 

### DIFF
--- a/pkg/storage/mountpoint.go
+++ b/pkg/storage/mountpoint.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,7 +47,7 @@ func (s *MountPointStorage) Mount(localPath string) error {
 	output, err := s.mountCmd.CombinedOutput()
 	if err != nil {
 		// Cleanup the temporary mountpoint directory if the mount fails
-		errors.Join(err, os.RemoveAll(localPath))
+		os.RemoveAll(localPath)
 		return fmt.Errorf("%+v, %s", err, string(output))
 	}
 
@@ -67,10 +66,7 @@ func (s *MountPointStorage) Unmount(localPath string) error {
 		return fmt.Errorf("error executing mount-s3 umount: %v, output: %s", err, string(output))
 	}
 
-	err = os.RemoveAll(localPath)
-	if err != nil {
-		return fmt.Errorf("error removing mountpoint directory: %v", err)
-	}
+	os.RemoveAll(localPath)
 
 	return nil
 }

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -24,7 +24,6 @@ func (c *ContainerMountManager) SetupContainerMounts(containerId string, mounts 
 		if m.MountType == storage.StorageModeMountPoint && m.MountPointConfig != nil {
 			err := c.setupMountPointS3(containerId, m)
 			if err != nil {
-				log.Printf("<%s> failed to mount s3 bucket with mountpoint-s3: %v", containerId, err)
 				return err
 			}
 		}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -296,11 +296,6 @@ func (s *Worker) RunContainer(request *types.ContainerRequest) error {
 	}
 	log.Printf("<%s> - acquired port: %d\n", containerId, bindPort)
 
-	err = s.containerMountManager.SetupContainerMounts(request.ContainerId, request.Mounts)
-	if err != nil {
-		return err
-	}
-
 	// Read spec from bundle
 	initialBundleSpec, _ := s.readBundleConfig(request.ImageId)
 
@@ -325,6 +320,11 @@ func (s *Worker) RunContainer(request *types.ContainerRequest) error {
 		return err
 	}
 	log.Printf("<%s> - set container address.\n", containerId)
+
+	err = s.containerMountManager.SetupContainerMounts(request.ContainerId, request.Mounts)
+	if err != nil {
+		s.containerLogger.Log(request.ContainerId, request.StubId, fmt.Sprintf("failed to setup container mounts: %v", err))
+	}
 
 	outputChan := make(chan common.OutputMsg)
 	go s.containerWg.Add(1)


### PR DESCRIPTION
This PR adds a container log when a mountpoint setup fails. This way users will know if the credentials they provided were invalid. It also removes the temporary directory from the worker in the case of failure and during clean up. 