### PR TITLE
Clean up iptables rules even if device isn't found

### DIFF
--- a/pkg/providers/base.go
+++ b/pkg/providers/base.go
@@ -66,7 +66,7 @@ func (p *ExternalProvider) Reconcile(ctx context.Context, poolName string) {
 				if _, ok := err.(*types.ProviderNotImplemented); ok {
 					return
 				} else {
-					log.Printf("<provider %s>: unable to list machines - %v\n", "providerName", err)
+					log.Printf("<provider %s>: unable to list machines - %v\n", p.Name, err)
 					continue
 				}
 			}

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -509,18 +509,16 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 	namespace := containerId
 
 	hostVeth, err := netlink.LinkByName(vethHost)
-	if err != nil {
-		return err
-	}
+	if err == nil {
+		// Remove the veth from the bridge
+		if err := netlink.LinkSetNoMaster(hostVeth); err != nil {
+			return err
+		}
 
-	// Remove the veth from the bridge
-	if err := netlink.LinkSetNoMaster(hostVeth); err != nil {
-		return err
-	}
-
-	// Immediately delete the veth without setting it down first
-	if err := netlink.LinkDel(hostVeth); err != nil {
-		return err
+		// Immediately delete the veth without setting it down first
+		if err := netlink.LinkDel(hostVeth); err != nil {
+			return err
+		}
 	}
 
 	containerIp, err := m.workerRepo.GetContainerIp(m.networkPrefix, containerId)


### PR DESCRIPTION
- FIX: If for some reason a device is not found, make sure to delete the rest of the network resources regardless
- FIX: print correct provider name on error