### PR TITLE
Fix zero keepwarm taskqueues

### DIFF
--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -303,11 +303,13 @@ func (tq *RedisTaskQueue) TaskQueueComplete(ctx context.Context, in *pb.TaskQueu
 		}, nil
 	}
 
-	err = tq.rdb.SetEx(ctx, Keys.taskQueueKeepWarmLock(authInfo.Workspace.Name, in.StubId, in.ContainerId), 1, time.Duration(in.KeepWarmSeconds)*time.Second).Err()
-	if err != nil {
-		return &pb.TaskQueueCompleteResponse{
-			Ok: false,
-		}, nil
+	if in.KeepWarmSeconds > 0 {
+		err = tq.rdb.SetEx(ctx, Keys.taskQueueKeepWarmLock(authInfo.Workspace.Name, in.StubId, in.ContainerId), 1, time.Duration(in.KeepWarmSeconds)*time.Second).Err()
+		if err != nil {
+			return &pb.TaskQueueCompleteResponse{
+				Ok: false,
+			}, nil
+		}
 	}
 
 	err = tq.rdb.Del(ctx, Keys.taskQueueTaskRunningLock(authInfo.Workspace.Name, in.StubId, in.ContainerId, in.TaskId)).Err()


### PR DESCRIPTION
Fixes an issue where taskqueues with keepwarm set to zero would fail with an "Unable to End Task" error:

```
Running task <cfa3d4cc-b4c7-4c50-ab13-c80e36b2b019>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/taskqueue.py", line 307, in process_tasks
    result = handler(context, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/common.py", line 168, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/beta9/abstractions/taskqueue.py", line 160, in __call__
    return self.local(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/beta9/abstractions/taskqueue.py", line 168, in local
    return self.func(*args, **kwargs)
TypeError: transcribe() missing 1 required positional argument: 'job_id'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/beta9/runner/taskqueue.py", line 330, in process_tasks
    raise RunnerException("Unable to end task")
```