### PR TITLE
Handle errors in runner properly

### DIFF
--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -183,7 +183,6 @@ def runner_context():
         yield channel
     except RunnerException as exc:
         exit_code = exc.code
-        raise
     except SystemExit as exc:
         exit_code = exc.code
         raise

--- a/sdk/src/beta9/exceptions.py
+++ b/sdk/src/beta9/exceptions.py
@@ -1,6 +1,7 @@
 class RunnerException(SystemExit):
     def __init__(self, message="", *args):
         self.message = message
+        self.code = 1
         super().__init__(*args)
 
 

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import traceback
+from concurrent import futures
 from concurrent.futures import CancelledError, ThreadPoolExecutor
 from multiprocessing import Event, Process, set_start_method
 from multiprocessing.synchronize import Event as TEvent
@@ -268,6 +269,7 @@ class TaskQueueWorker:
         # Load handler and execute on_start method
         handler = FunctionHandler()
         on_start_value = execute_lifecycle_method(name=LifeCycleMethod.OnStart)
+        thread_pool = ThreadPoolExecutor()
 
         print(f"Worker[{self.worker_index}] ready")
         while True:
@@ -276,7 +278,7 @@ class TaskQueueWorker:
                 time.sleep(TASK_POLLING_INTERVAL)
                 continue
 
-            with StdoutJsonInterceptor(task_id=task.id), ThreadPoolExecutor() as thread_pool:
+            with StdoutJsonInterceptor(task_id=task.id):
                 print(f"Running task <{task.id}>")
 
                 context = FunctionContext.new(
@@ -294,6 +296,7 @@ class TaskQueueWorker:
                     taskqueue_stub=taskqueue_stub,
                     gateway_stub=gateway_stub,
                 )
+                futures.thread._threads_queues.clear()
 
                 start_time = time.time()
                 task_status = TaskStatus.Complete


### PR DESCRIPTION
Fixes a couple of bugs:
- ThreadPoolExecutors will block indefinitely if cancel is not called on a task - this removes the wait / join at the end. Without this the process could hang indefinitely
- Moves the ThreadPoolExecutor outside of the context, this was preventing exceptions from bubbling up correctly
- Adds retry logic to end task (affects task queue and function runners)