### PR TITLE
Allow using defaults when prompting for config values

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.73"
+version = "0.1.74"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/cli/config.py
+++ b/sdk/src/beta9/cli/config.py
@@ -140,7 +140,7 @@ def create_context(config_path: Path, **kwargs):
                 return
 
     # Prompt user for context settings
-    name, context = prompt_for_config_context(**kwargs)
+    name, context = prompt_for_config_context(require_token=True, **kwargs)
 
     # Save context to config
     contexts[name] = context


### PR DESCRIPTION
- Allow using gateway host and port defaults when prompting for config
- Require token when calling config create command (during prompt, not for cli command)
- Print message when user input prompts are invalid

Resolve BE-1752