### PR TITLE
Fix default gateway values and improve error handling in SDK

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.74"
+version = "0.1.75"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/cli/config.py
+++ b/sdk/src/beta9/cli/config.py
@@ -134,7 +134,7 @@ def create_context(config_path: Path, **kwargs):
     contexts = load_config(config_path)
 
     if name := kwargs.get("name"):
-        if name in contexts:
+        if name in contexts and contexts[name].is_valid():
             text = f"Context '{name}' already exists. Overwrite?"
             if terminal.prompt(text=text, default="n").lower() in ["n", "no"]:
                 return

--- a/sdk/src/beta9/cli/extraclick.py
+++ b/sdk/src/beta9/cli/extraclick.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 import click
 
 from ..abstractions import base as base_abstraction
-from ..channel import ServiceClient
+from ..channel import ServiceClient, with_grpc_error_handling
 from ..clients.gateway import (
     StringList,
 )
@@ -173,6 +173,7 @@ def pass_service_client(func: Callable):
 
     @config_context_option
     @functools.wraps(func)
+    @with_grpc_error_handling
     def decorator(context: Optional[str] = None, *args, **kwargs):
         ctx = click.get_current_context()
 

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -178,8 +178,8 @@ def prompt_for_config_context(
             terminal.warn("Name is invalid.")
 
         if settings.use_defaults_in_prompt:
-            gateway_host = DEFAULT_GATEWAY_HOST
-            gateway_port = DEFAULT_GATEWAY_PORT
+            gateway_host = settings.gateway_host
+            gateway_port = settings.gateway_port
         else:
             while not (gateway_host := prompt_gateway_host()) or not validate_ip_or_dns(
                 gateway_host

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -68,6 +68,9 @@ class ConfigContext:
             return True
         return False
 
+    def is_valid(self) -> bool:
+        return all([self.token, self.gateway_host, self.gateway_port])
+
 
 def set_settings(s: Optional[SDKSettings] = None) -> None:
     if s is None:
@@ -175,7 +178,7 @@ def prompt_for_config_context(
     )
 
     try:
-        while not name and (name := prompt_name()):
+        while not name and not (name := prompt_name()):
             terminal.warn("Name is invalid.")
 
         if settings.use_defaults_in_prompt:

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -184,7 +184,7 @@ def prompt_for_config_context(
             while not (gateway_host := prompt_gateway_host()) or not validate_ip_or_dns(
                 gateway_host
             ):
-                terminal.warn("Gateway host is invalid.")
+                terminal.warn("Gateway host is invalid or unreachable.")
 
             while not (gateway_port := prompt_gateway_port()) or not validate_port(gateway_port):
                 terminal.warn("Gateway port is invalid.")

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -134,9 +134,9 @@ def is_config_empty(path: Optional[Union[Path, str]] = None) -> bool:
 
 
 def get_config_context(name: str = DEFAULT_CONTEXT_NAME) -> ConfigContext:
-    config = load_config()
-    if name in config:
-        return config[name]
+    contexts = load_config()
+    if name in contexts:
+        return contexts[name]
 
     gateway_host = os.getenv("BETA9_GATEWAY_HOST", None)
     gateway_port = os.getenv("BETA9_GATEWAY_PORT", None)
@@ -150,8 +150,9 @@ def get_config_context(name: str = DEFAULT_CONTEXT_NAME) -> ConfigContext:
         )
 
     terminal.header(f"Context '{name}' does not exist. Let's try setting it up.")
-    _, config = prompt_for_config_context(name=name)
-    return config
+    contexts[name] = prompt_for_config_context(name=name, require_token=True)[1]
+    save_config(contexts)
+    return contexts[name]
 
 
 def prompt_for_config_context(
@@ -174,7 +175,7 @@ def prompt_for_config_context(
     )
 
     try:
-        while not (name := prompt_name()) or not isinstance(name, str):
+        while not name and (name := prompt_name()):
             terminal.warn("Name is invalid.")
 
         if settings.use_defaults_in_prompt:


### PR DESCRIPTION
- Fix default gateway host/port value (Get from SDK settings which can be set externally)
- Use better gRPC error messaging happen when building Click service client
- When we get a context and it doesn't exist, prompt for it, but also save it
- When validating the gateway host, mention it might also be unreachable
- Don't prompt for overwriting a config if it is invalid (no host, port, or token is set), just overwrite it

Resolve BE-1752