### PR TITLE
Fix unexpected task monitor exception

### DIFF
--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -116,11 +116,11 @@ def _monitor_task(
             backoff *= 2
             retry += 1
 
-        except CancelledError:
+        except (CancelledError, ValueError):
             return
 
         except BaseException:
-            print("Unexpected error occurred in task monitor")
+            print(f"Unexpected error occurred in task monitor: {traceback.format_exc()}")
             os._exit(0)
 
 

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -253,11 +253,11 @@ class TaskQueueWorker:
                 backoff *= 2
                 retry += 1
 
-            except CancelledError:
+            except (CancelledError, ValueError):
                 return
 
             except BaseException:
-                print("Unexpected error occurred in task monitor")
+                print(f"Unexpected error occurred in task monitor: {traceback.format_exc()}")
                 os._exit(0)
 
     @with_runner_context


### PR DESCRIPTION
If a function completes very quickly, it can sometimes raise a `ValueError`, as monitor_task tries to call a stub with a closed channel. This handles the error and also adds an extra log in case other exceptions pop up that we haven't handled properly.