### PR TITLE
Add deployment info to task with related query

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -536,10 +536,12 @@ func (r *PostgresBackendRepository) ListTasks(ctx context.Context) ([]types.Task
 
 func (c *PostgresBackendRepository) listTaskWithRelatedQueryBuilder(filters types.TaskFilter) squirrel.SelectBuilder {
 	qb := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).Select(
-		"t.*, w.external_id AS \"workspace.external_id\", w.name AS \"workspace.name\", s.external_id AS \"stub.external_id\", s.name AS \"stub.name\", s.config AS \"stub.config\", s.type AS \"stub.type\"",
+		"t.*, w.external_id AS \"workspace.external_id\", w.name AS \"workspace.name\", s.external_id AS \"stub.external_id\", s.name AS \"stub.name\", s.config AS \"stub.config\", s.type AS \"stub.type\", d.external_id AS \"deployment.external_id\", d.name AS \"deployment.name\", d.version AS \"deployment.version\"",
 	).From("task t").
 		Join("workspace w ON t.workspace_id = w.id").
-		Join("stub s ON t.stub_id = s.id").OrderBy("t.id DESC")
+		Join("stub s ON t.stub_id = s.id").
+		Join("deployment d ON s.id = d.stub_id").
+		OrderBy("t.id DESC")
 
 	// Apply filters
 	if filters.WorkspaceID > 0 {

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -132,10 +132,11 @@ type Task struct {
 
 type TaskWithRelated struct {
 	Task
-	Outputs   []TaskOutput `json:"outputs"`
-	Stats     TaskStats    `json:"stats"`
-	Workspace Workspace    `db:"workspace" json:"workspace"`
-	Stub      Stub         `db:"stub" json:"stub"`
+	Deployment Deployment   `db:"deployment" json:"deployment"`
+	Outputs    []TaskOutput `json:"outputs"`
+	Stats      TaskStats    `json:"stats"`
+	Workspace  Workspace    `db:"workspace" json:"workspace"`
+	Stub       Stub         `db:"stub" json:"stub"`
 }
 
 func (t *TaskWithRelated) SanitizeStubConfig() error {


### PR DESCRIPTION
This PR adds deployment information to the task with related query. The query will now return the deployment name, version, and external ID. This can be used to link tasks to their deployment in the UI.