### PR TITLE
Flush output and volume data to disk on completion

### DIFF
--- a/pkg/abstractions/output/output.go
+++ b/pkg/abstractions/output/output.go
@@ -123,7 +123,7 @@ func (o *OutputRedisService) writeToFile(ctx context.Context, contentCh <-chan O
 		}
 	}
 
-	return outputId, nil
+	return outputId, file.Sync()
 }
 
 func (o *OutputRedisService) OutputStat(ctx context.Context, in *pb.OutputStatRequest) (*pb.OutputStatResponse, error) {

--- a/pkg/abstractions/volume/volume.go
+++ b/pkg/abstractions/volume/volume.go
@@ -325,7 +325,7 @@ func (vs *GlobalVolumeService) copyPathStream(ctx context.Context, stream <-chan
 		}
 	}
 
-	return nil
+	return file.Sync()
 }
 
 func (vs *GlobalVolumeService) deletePath(ctx context.Context, inputPath string, workspace *types.Workspace) ([]string, error) {


### PR DESCRIPTION
Fixes an issue where an output may not be written to disk. This applies the same change to volume uploads.

Resolve BE-1692