### PR TITLE
Sanitize secret's values

### DIFF
--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -74,6 +74,7 @@ func (g *DeploymentGroup) ListDeployments(ctx echo.Context) error {
 		if deployments, err := g.backendRepo.ListDeploymentsWithRelated(ctx.Request().Context(), filters); err != nil {
 			return HTTPInternalServerError("Failed to list deployments")
 		} else {
+			sanitizeDeployments(deployments)
 			return ctx.JSON(http.StatusOK, deployments)
 		}
 
@@ -93,6 +94,7 @@ func (g *DeploymentGroup) RetrieveDeployment(ctx echo.Context) error {
 	} else if deployment == nil {
 		return HTTPNotFound()
 	} else {
+		deployment.Stub.SanitizeConfig()
 		return ctx.JSON(http.StatusOK, deployment)
 	}
 }
@@ -178,6 +180,7 @@ func (g *DeploymentGroup) ListLatestDeployments(ctx echo.Context) error {
 	if deployments, err := g.backendRepo.ListLatestDeploymentsWithRelatedPaginated(ctx.Request().Context(), filters); err != nil {
 		return HTTPInternalServerError("Failed to list deployments")
 	} else {
+		sanitizeDeployments(deployments.Data)
 		return ctx.JSON(http.StatusOK, deployments)
 	}
 }
@@ -230,4 +233,10 @@ func (g *DeploymentGroup) stopDeployments(deployments []types.DeploymentWithRela
 
 func getPackagePath(workspaceName, objectId string) string {
 	return path.Join("/data/objects/", workspaceName, objectId)
+}
+
+func sanitizeDeployments(deployments []types.DeploymentWithRelated) {
+	for i := range deployments {
+		deployments[i].Stub.SanitizeConfig()
+	}
 }

--- a/pkg/api/v1/task.go
+++ b/pkg/api/v1/task.go
@@ -88,7 +88,7 @@ func (g *TaskGroup) ListTasksPaginated(ctx echo.Context) error {
 		return HTTPInternalServerError("Failed to list tasks")
 	} else {
 		for i := range tasks.Data {
-			tasks.Data[i].SanitizeStubConfig()
+			tasks.Data[i].Stub.SanitizeConfig()
 			g.addOutputsToTask(ctx.Request().Context(), workspace.Name, &tasks.Data[i])
 			g.addStatsToTask(ctx.Request().Context(), workspace.Name, &tasks.Data[i])
 		}
@@ -112,8 +112,7 @@ func (g *TaskGroup) RetrieveTask(ctx echo.Context) error {
 		if task == nil {
 			return HTTPNotFound()
 		}
-
-		task.SanitizeStubConfig()
+		task.Stub.SanitizeConfig()
 		g.addOutputsToTask(ctx.Request().Context(), cc.AuthInfo.Workspace.Name, task)
 		g.addStatsToTask(ctx.Request().Context(), cc.AuthInfo.Workspace.Name, task)
 

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -102,8 +102,10 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		}
 
 		stubConfig.Secrets = append(stubConfig.Secrets, types.Secret{
-			Name:  secret.Name,
-			Value: secret.Value,
+			Name:      secret.Name,
+			Value:     secret.Value,
+			CreatedAt: secret.CreatedAt,
+			UpdatedAt: secret.UpdatedAt,
 		})
 	}
 


### PR DESCRIPTION
- Remove (encrypted) secret values from deployment responses
- Move sanitize stub function from task to stub struct
- Update task response function calls to sanitize values; this means secrets come back in the task response, but the values are not returned.
- Add created and updated at dates to stub config of secret so they have valid dates in the frontend
- Remove "empty" attributes of secret type for workspace id and last updated by (both are private ids)

Resolve BE-1799