### PR TITLE
Don't scale up stopped serves

### DIFF
--- a/pkg/abstractions/endpoint/autoscaler.go
+++ b/pkg/abstractions/endpoint/autoscaler.go
@@ -65,16 +65,14 @@ func endpointServeScaleFunc(i *endpointInstance, sample *endpointAutoscalerSampl
 	desiredContainers := 1
 
 	timeoutKey := Keys.endpointServeLock(i.Workspace.Name, i.Stub.ExternalId)
-
-	ttl, err := i.Rdb.TTL(i.Ctx, timeoutKey).Result()
+	exists, err := i.Rdb.Exists(i.Ctx, timeoutKey).Result()
 	if err != nil {
 		return &abstractions.AutoscalerResult{
 			ResultValid: false,
 		}
 	}
 
-	// When ttl is -2 the key does not exist. If the ttl has not been reset recently, don't scale it back up.
-	if (ttl == -2 && sample.TotalRequests == 0) || (endpointServeContainerTimeout.Seconds()-ttl.Seconds() > 20 && sample.CurrentContainers == 0) {
+	if sample.TotalRequests == 0 && exists == 0 {
 		desiredContainers = 0
 	}
 

--- a/pkg/abstractions/endpoint/serve.go
+++ b/pkg/abstractions/endpoint/serve.go
@@ -43,6 +43,7 @@ func (es *HttpEndpointService) StartEndpointServe(in *pb.StartEndpointServeReque
 		1,
 		timeoutDuration,
 	)
+	defer instance.Rdb.Del(context.Background(), Keys.endpointServeLock(instance.Workspace.Name, instance.Stub.ExternalId))
 
 	container, err := instance.WaitForContainer(ctx, endpointServeContainerTimeout)
 	if err != nil {


### PR DESCRIPTION
Currently, if you stop a container that is part of a serve with 
```
beta9 container stop CONTAINER_ID
```
the container will just be scaled back up. It will eventually go away after the TTL expires. It should go away when it is told to. 

With this change, we check to see if the TTL has been recently reset before scaling the container back up. During serves, TTL is reset every time the user syncs new changes. So, if the TTL is stale when the container has gone down, we will assume the container is really meant to be stopped. 