### PR TITLE
Fix hanging build container

### DIFF
--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -213,6 +213,8 @@ func (s *RunCServer) RunCArchive(req *pb.RunCArchiveRequest, stream pb.RunCServi
 
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case progress, ok := <-progressChan:
 				if !ok {
 					return


### PR DESCRIPTION
I noticed there were was a hanging build container, which seemed to have tried to shut down but was still blocked in an "archiving image" state:

```
2024/09/18 03:02:39 Creating a new archive from directory: /dev/shm/build-af70c46c/layer-0/merged
2024/09/18 03:03:06 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:03:36 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:04:06 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:04:36 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:05:06 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:05:36 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:06:06 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:06:34 Unmounting layer: /dev/shm/build-af70c46c/layer-0/merged
2024/09/18 03:06:34 Unable to unmount layer: exit status 32
2024/09/18 03:06:34 Removed container build-af70c46c from worker 064a9468
2024/09/18 03:06:36 <build-af70c46c> - container still running: 53fd754ed84aed3c
2024/09/18 03:07:04 Shutting down...
2024/09/18 03:07:04 JuiceFS filesystem unmounted from: '/data'
2024/09/18 03:07:04 Un-mounting image: 53fd754ed84aed3c
2024/09/18 03:07:07 Creating an RCLIP and storing original archive on S3
2024/09/18 03:07:07 Archive created, uploading...
2024/09/18 03:07:07 Image upload progress: 0/100
{"level":"info","ts":"2024-09-18T08:13:00.888Z","caller":"pkg/logger.go:70","msg":"Removed host @ blobcache-host-bc5f92.tailc480d.ts.net:2049 (PrivateAddr=10.110.55.174:2049, RTT=0s)"}
{"level":"info","ts":"2024-09-18T08:13:05.648Z","caller":"pkg/logger.go:70","msg":"Added new host @ blobcache-host-b69db4.tailc480d.ts.net:2049 (PrivateAddr=10.110.55.174:2049, RTT=0s)"}
{"level":"info","ts":"2024-09-18T12:31:44.696Z","caller":"pkg/logger.go:70","msg":"Removed host @ blobcache-host-b47960.tailc480d.ts.net:2049 (PrivateAddr=10.110.64.77:2049, RTT=0s)"}
{"level":"info","ts":"2024-09-18T12:31:50.646Z","caller":"pkg/logger.go:70","msg":"Added new host @ blobcache-host-65f1db.tailc480d.ts.net:2049 (PrivateAddr=10.110.64.77:2049, RTT=0s)"}
{"level":"info","ts":"2024-09-18T13:53:02.285Z","caller":"pkg/logger.go:70","msg":"Removed host @ blobcache-host-73925d.tailc480d.ts.net:2049 (PrivateAddr=10.110.2.157:2049, RTT=0s)"}
{"level":"info","ts":"2024-09-18T13:53:10.647Z","caller":"pkg/logger.go:70","msg":"Added new host @ blobcache-host-2cfc52.tailc480d.ts.net:2049 (PrivateAddr=10.110.2.157:2049, RTT=0s)"}
```

I think the solution is to make sure the archive runc grpc service properly utilizes it's context.