### PR TITLE
remove serve lock when connection is lost for task queue serve

### DIFF
--- a/pkg/abstractions/taskqueue/serve.go
+++ b/pkg/abstractions/taskqueue/serve.go
@@ -40,6 +40,7 @@ func (tq *RedisTaskQueue) StartTaskQueueServe(in *pb.StartTaskQueueServeRequest,
 		1,
 		timeoutDuration,
 	)
+	defer instance.Rdb.Del(context.Background(), Keys.taskQueueServeLock(instance.Workspace.Name, instance.Stub.ExternalId))
 
 	container, err := instance.WaitForContainer(ctx, taskQueueServeContainerTimeout)
 	if err != nil {


### PR DESCRIPTION
same idea as https://github.com/beam-cloud/beta9/pull/539, but for task queue