### PR TITLE
Allow passing kwargs to click's entrypoint

### DIFF
--- a/sdk/src/beta9/cli/main.py
+++ b/sdk/src/beta9/cli/main.py
@@ -39,8 +39,8 @@ class CLI:
             context_settings=context_settings,
         )
 
-    def __call__(self) -> None:
-        self.common_group.main(prog_name=self.settings.name.lower())
+    def __call__(self, **kwargs) -> None:
+        self.common_group.main(prog_name=self.settings.name.lower(), **kwargs)
 
     def register(self, module: ModuleType) -> None:
         if hasattr(module, "common"):


### PR DESCRIPTION
- Allow ability to override how Click handles its exit behavior from beam-client

Resolve BE-1786