### PR TITLE
Fix subdomain routing with different deployment name

### DIFF
--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -26,7 +26,7 @@ var (
 
 type SubdomainBackendRepo interface {
 	GetStubByExternalId(ctx context.Context, externalId string, queryFilters ...types.QueryFilter) (*types.StubWithRelated, error)
-	GetDeploymentByStubGroup(ctx context.Context, name string, version uint, stubGroup string) (*types.DeploymentWithRelated, error)
+	GetDeploymentByStubGroup(ctx context.Context, version uint, stubGroup string) (*types.DeploymentWithRelated, error)
 }
 
 // subdomainMiddleware is a middleware that parses the subdomain from the request and routes it to the correct handler.
@@ -126,10 +126,12 @@ func getStubForSubdomain(ctx context.Context, repo SubdomainBackendRepo, fields 
 	}
 
 	version := parseVersion(fields.Version)
-	deployment, err := repo.GetDeploymentByStubGroup(ctx, fields.Name, version, fields.StubGroup)
+	deployment, err := repo.GetDeploymentByStubGroup(ctx, version, fields.StubGroup)
 	if err != nil {
 		return nil, err
 	}
+
+	fields.Name = deployment.Name
 
 	return &deployment.Stub, nil
 }

--- a/pkg/gateway/middleware_test.go
+++ b/pkg/gateway/middleware_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 type middlewareRepoForTest struct {
-	stub *types.Stub
+	deployName string
+	stub       *types.Stub
 }
 
 func (r *middlewareRepoForTest) GetStubByExternalId(ctx context.Context, externalId string, queryFilters ...types.QueryFilter) (*types.StubWithRelated, error) {
@@ -21,81 +22,103 @@ func (r *middlewareRepoForTest) GetStubByExternalId(ctx context.Context, externa
 		Stub: *r.stub,
 	}, nil
 }
-func (r *middlewareRepoForTest) GetDeploymentByStubGroup(ctx context.Context, name string, version uint, stubGroup string) (*types.DeploymentWithRelated, error) {
+
+func (r *middlewareRepoForTest) GetDeploymentByStubGroup(ctx context.Context, version uint, stubGroup string) (*types.DeploymentWithRelated, error) {
 	return &types.DeploymentWithRelated{
+		Deployment: types.Deployment{
+			Name: r.deployName,
+		},
 		Stub: *r.stub,
 	}, nil
 }
 
 func TestSubdomainMiddleware(t *testing.T) {
 	tests := []struct {
-		name     string
-		host     string
-		stubType types.StubType
-		expected map[string]string
+		name       string
+		host       string
+		deployName string
+		stubType   types.StubType
+		expected   map[string]string
 	}{
 		{
-			name:     "subdomain-with-name-hash",
-			host:     "task2-7a7db8c.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-name-hash",
+			host:       "task2-7a7db8c.app.example.com",
+			deployName: "task2",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/task2",
 			},
 		},
 		{
-			name:     "subdomain-with-name-hash-and-latest",
-			host:     "task2-7a7db8c-latest.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-name-hash-and-latest",
+			host:       "task2-7a7db8c-latest.app.example.com",
+			deployName: "task2",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/task2/latest",
 			},
 		},
 		{
-			name:     "subdomain-with-name-hash-and-version",
-			host:     "task2-7a7db8c-v1.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-name-hash-and-version",
+			host:       "task2-7a7db8c-v1.app.example.com",
+			deployName: "task2",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/task2/v1",
 			},
 		},
 		{
-			name:     "subdomain-with-name-hash-and-stubid",
-			host:     "task2-7a7db8c-8f32e485-2b2e-4238-9878-490eb9b0a9d3.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-name-hash-and-stubid",
+			host:       "task2-7a7db8c-8f32e485-2b2e-4238-9878-490eb9b0a9d3.app.example.com",
+			deployName: "task2",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/id/8f32e485-2b2e-4238-9878-490eb9b0a9d3",
 			},
 		},
 		{
-			name:     "subdomain-with-hyphen-name-and-hash",
-			host:     "hello-world-7a7db8c.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-hyphen-name-and-hash",
+			host:       "hello-world-7a7db8c.app.example.com",
+			deployName: "hello-world",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/hello-world",
 			},
 		},
 		{
-			name:     "subdomain-with-hyphen-name-and-hash-and-version",
-			host:     "hello-world-123-7a7db8c-v3.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-hyphen-name-and-hash-and-version",
+			host:       "hello-world-123-7a7db8c-v3.app.example.com",
+			deployName: "hello-world-123",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/hello-world-123/v3",
 			},
 		},
 		{
-			name:     "subdomain-with-hyphen-name-and-hash-and-latest",
-			host:     "hello-world-123-7a7db8c-latest.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-hyphen-name-and-hash-and-latest",
+			host:       "hello-world-123-7a7db8c-latest.app.example.com",
+			deployName: "hello-world-123",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/hello-world-123/latest",
 			},
 		},
 		{
-			name:     "subdomain-with-hyphen-name-and-hash-and-stubid",
-			host:     "hello-world-again-and-again-7a7db8c-8f32e485-2b2e-4238-9878-490eb9b0a9d3.app.example.com",
-			stubType: "taskqueue/deployment",
+			name:       "subdomain-with-hyphen-name-and-hash-and-stubid",
+			host:       "hello-world-again-and-again-7a7db8c-8f32e485-2b2e-4238-9878-490eb9b0a9d3.app.example.com",
+			deployName: "hello-world-again-and-again",
+			stubType:   "taskqueue/deployment",
 			expected: map[string]string{
 				"path": "/taskqueue/id/8f32e485-2b2e-4238-9878-490eb9b0a9d3",
+			},
+		},
+		{
+			name:       "subdomain-with-hyphen-name-and-hash-and-version-and-deploy-name",
+			host:       "hello-world-again-and-again-7a7db8c-v10.app.example.com",
+			deployName: "my-name",
+			stubType:   "taskqueue/deployment",
+			expected: map[string]string{
+				"path": "/taskqueue/my-name/v10",
 			},
 		},
 	}
@@ -104,6 +127,7 @@ func TestSubdomainMiddleware(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			e := echo.New()
 			repo := &middlewareRepoForTest{
+				deployName: test.deployName,
 				stub: &types.Stub{
 					Type: test.stubType,
 				},

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -92,7 +92,7 @@ type BackendRepository interface {
 	GetTaskCountPerDeployment(ctx context.Context, filters types.TaskFilter) ([]types.TaskCountPerDeployment, error)
 	GetOrCreateStub(ctx context.Context, name, stubType string, config types.StubConfigV1, objectId, workspaceId uint, forceCreate bool) (types.Stub, error)
 	GetStubByExternalId(ctx context.Context, externalId string, queryFilters ...types.QueryFilter) (*types.StubWithRelated, error)
-	GetDeploymentByStubGroup(ctx context.Context, name string, version uint, stubGroup string) (*types.DeploymentWithRelated, error)
+	GetDeploymentByStubGroup(ctx context.Context, version uint, stubGroup string) (*types.DeploymentWithRelated, error)
 	GetVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error)
 	GetOrCreateVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error)
 	DeleteVolume(ctx context.Context, workspaceId uint, name string) error


### PR DESCRIPTION
- Stub function name is not always the same as deployment name
- Return deployment name in query
- Override parsed fields with deployment name

Resolve BE-1820