### PR TITLE
Add CPU and memory limits to runc containers

### DIFF
--- a/pkg/common/events.go
+++ b/pkg/common/events.go
@@ -171,7 +171,7 @@ retry:
 			return
 
 		case err := <-errs:
-			log.Printf("error with eventbus subscription: %v\n", err)
+			log.Printf("Error with eventbus subscription: %v\n", err)
 			break retry
 		}
 	}

--- a/pkg/common/redis.go
+++ b/pkg/common/redis.go
@@ -18,6 +18,7 @@ import (
 )
 
 var (
+	ErrNilMessage       = errors.New("redis: nil message")
 	ErrChannelClosed    = errors.New("redis: channel closed")
 	ErrConnectionIssue  = errors.New("redis: connection issue")
 	ErrUnknownRedisMode = errors.New("redis: unknown mode")
@@ -235,6 +236,11 @@ func (r *RedisClient) handleChannelSubs(
 		case message, ok := <-ch:
 			if !ok {
 				errCh <- ErrChannelClosed
+				return
+			}
+
+			if message == nil {
+				errCh <- ErrNilMessage
 				return
 			}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -18,6 +18,7 @@ import (
 	blobcache "github.com/beam-cloud/blobcache-v2/pkg"
 	"github.com/beam-cloud/go-runc"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"tailscale.com/types/ptr"
 
 	common "github.com/beam-cloud/beta9/pkg/common"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
@@ -723,6 +724,21 @@ func (s *Worker) newSpecTemplate() (*specs.Spec, error) {
 	return &newSpec, nil
 }
 
+const (
+	standardCPUShare  uint64 = 1024
+	standardCPUPeriod int64  = 100_000
+)
+
+func calculateCPUShares(millicores int64) uint64 {
+	shares := uint64(millicores) * standardCPUShare / 1000
+	return shares
+}
+
+func calculateCPUQuota(millicores int64) int64 {
+	quota := millicores * standardCPUPeriod / 1000
+	return quota
+}
+
 // Generate a runc spec from a given request
 func (s *Worker) specFromRequest(request *types.ContainerRequest, options *ContainerOptions) (*specs.Spec, error) {
 	os.MkdirAll(filepath.Join(baseConfigPath, request.ContainerId), os.ModePerm)
@@ -735,6 +751,16 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 
 	spec.Process.Cwd = defaultContainerDirectory
 	spec.Process.Args = request.EntryPoint
+
+	spec.Linux.Resources.Memory = &specs.LinuxMemory{
+		Limit: ptr.To(request.Memory * 1024 * 1024),
+	}
+
+	spec.Linux.Resources.CPU = &specs.LinuxCPU{
+		Shares: ptr.To(calculateCPUShares(request.Cpu)),
+		Quota:  ptr.To(calculateCPUQuota(request.Cpu)),
+		Period: ptr.To(uint64(standardCPUPeriod)),
+	}
 
 	env := s.getContainerEnvironment(request, options)
 	if request.Gpu != "" {

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -1,0 +1,57 @@
+package worker
+
+import "testing"
+
+func TestCalculateCPUShares(t *testing.T) {
+	tests := []struct {
+		name       string
+		millicores int64
+		wantShares uint64
+		wantQuota  int64
+	}{
+		{
+			name:       "100m",
+			millicores: 100,
+			wantShares: 102,
+			wantQuota:  10_000,
+		},
+		{
+			name:       "250m",
+			millicores: 250,
+			wantShares: 256,
+			wantQuota:  25_000,
+		},
+		{
+			name:       "1000m",
+			millicores: 1000,
+			wantShares: 1024,
+			wantQuota:  100_000,
+		},
+		{
+			name:       "2000m",
+			millicores: 2000,
+			wantShares: 2048,
+			wantQuota:  200_000,
+		},
+		{
+			name:       "32000m",
+			millicores: 32_000,
+			wantShares: 32_768,
+			wantQuota:  3_200_000,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := calculateCPUShares(test.millicores)
+			if got != test.wantShares {
+				t.Errorf("calculateCPUShares(%d) = %d, want %d", test.millicores, got, test.wantShares)
+			}
+
+			gotQuota := calculateCPUQuota(test.millicores)
+			if gotQuota != test.wantQuota {
+				t.Errorf("calculateCPUQuota(%d) = %d, want %d", test.millicores, gotQuota, test.wantQuota)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will prevent workloads from using up all the memory available on a host which can cause a worker to get OOM'd by the kernel leaving the pod in a bad state.

Resolve BE-1780