### PR TITLE
Make public URL's subdomain just the StubID

### DIFF
--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -25,13 +25,13 @@ func BuildDeploymentURL(externalUrl, invokeUrlType string, stub *types.StubWithR
 
 	if isLocalOrPathBased {
 		if isPublic {
-			return fmt.Sprintf("%s://%s/public/%s", parsedUrl.Scheme, parsedUrl.Hostname(), stub.ExternalId)
+			return fmt.Sprintf("%s://%s/public/%s", parsedUrl.Scheme, parsedUrl.Host, stub.ExternalId)
 		}
-		return fmt.Sprintf("%s://%s/%s/%s/v%d", parsedUrl.Scheme, parsedUrl.Hostname(), stub.Type.Kind(), deployment.Name, deployment.Version)
+		return fmt.Sprintf("%s://%s/%s/%s/v%d", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), deployment.Name, deployment.Version)
 	}
 
 	if isPublic {
-		return fmt.Sprintf("%s://%s-%s.%s", parsedUrl.Scheme, stub.Group, stub.ExternalId, parsedUrl.Host)
+		return fmt.Sprintf("%s://%s.%s", parsedUrl.Scheme, stub.ExternalId, parsedUrl.Host)
 	}
 	return fmt.Sprintf("%s://%s-v%d.%s", parsedUrl.Scheme, stub.Group, deployment.Version, parsedUrl.Host)
 }
@@ -45,7 +45,7 @@ func BuildServeURL(externalUrl, invokeUrlType string, stub *types.StubWithRelate
 	isLocalOrPathBased := parsedUrl.Hostname() == invokeUrlIgnoreHostname || invokeUrlType == InvokeUrlTypePath
 
 	if isLocalOrPathBased {
-		return fmt.Sprintf("%s://%s/%s/id/%s", parsedUrl.Scheme, parsedUrl.Hostname(), stub.Type.Kind(), stub.ExternalId)
+		return fmt.Sprintf("%s://%s/%s/id/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
 	}
-	return fmt.Sprintf("%s://%s-%s.%s", parsedUrl.Scheme, stub.Group, stub.ExternalId, parsedUrl.Host)
+	return fmt.Sprintf("%s://%s.%s", parsedUrl.Scheme, stub.ExternalId, parsedUrl.Host)
 }

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -83,7 +83,7 @@ func TestBuildInvokeURL(t *testing.T) {
 				Version: uint(23),
 			},
 			invokeType: "domain",
-			want:       "https://app2-fffffff-20a3f632-a5f8-4013-a2ac-4ab5c80912c7.app.example.com",
+			want:       "https://20a3f632-a5f8-4013-a2ac-4ab5c80912c7.app.example.com",
 		},
 		{
 			name:        "should return domain based private url",
@@ -136,7 +136,7 @@ func TestBuildInvokeURL(t *testing.T) {
 				Version: uint(25),
 			},
 			invokeType: "domain",
-			want:       "https://app2-eeeeeee-aff86f02-c968-47a9-9132-0bde826b0aca.app.example.com",
+			want:       "https://aff86f02-c968-47a9-9132-0bde826b0aca.app.example.com",
 		},
 	}
 


### PR DESCRIPTION
- Since subdomains can only be 64 characters long, public URL subdomains will only be the StubID.
- Improve regex logic by replacing name/hash with stub group
- Use Host and not Hostname when generating URLs to preserve the port
- Update tests

Resolve BE-1841