### PR TITLE
Make deployment URLs the same regardless if public/private

### DIFF
--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -25,14 +25,11 @@ func BuildDeploymentURL(externalUrl, invokeUrlType string, stub *types.StubWithR
 
 	if isLocalOrPathBased {
 		if isPublic {
-			return fmt.Sprintf("%s://%s/public/%s", parsedUrl.Scheme, parsedUrl.Host, stub.ExternalId)
+			return fmt.Sprintf("%s://%s/%s/public/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
 		}
 		return fmt.Sprintf("%s://%s/%s/%s/v%d", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), deployment.Name, deployment.Version)
 	}
 
-	if isPublic {
-		return fmt.Sprintf("%s://%s.%s", parsedUrl.Scheme, stub.ExternalId, parsedUrl.Host)
-	}
 	return fmt.Sprintf("%s://%s-v%d.%s", parsedUrl.Scheme, stub.Group, deployment.Version, parsedUrl.Host)
 }
 
@@ -47,5 +44,6 @@ func BuildServeURL(externalUrl, invokeUrlType string, stub *types.StubWithRelate
 	if isLocalOrPathBased {
 		return fmt.Sprintf("%s://%s/%s/id/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
 	}
+
 	return fmt.Sprintf("%s://%s.%s", parsedUrl.Scheme, stub.ExternalId, parsedUrl.Host)
 }

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -17,7 +17,7 @@ func TestBuildInvokeURL(t *testing.T) {
 		want        string
 	}{
 		{
-			name:        "should return non-public url when stubConfig is invalid",
+			name:        "should return path url for private deployments",
 			externalUrl: "http://app.example.com",
 			stub: &types.StubWithRelated{
 				Stub: types.Stub{
@@ -30,11 +30,11 @@ func TestBuildInvokeURL(t *testing.T) {
 				Name:    "app1",
 				Version: uint(11),
 			},
-			invokeType: "path",
+			invokeType: InvokeUrlTypePath,
 			want:       "http://app.example.com/schedule/app1/v11",
 		},
 		{
-			name:        "should return path based public url",
+			name:        "should return path url for public deployments",
 			externalUrl: "https://app.example.com",
 			stub: &types.StubWithRelated{
 				Stub: types.Stub{
@@ -47,28 +47,28 @@ func TestBuildInvokeURL(t *testing.T) {
 				Name:    "app2",
 				Version: uint(22),
 			},
-			invokeType: "path",
-			want:       "https://app.example.com/public/64741d05-2273-422a-8424-2e0760e539d3",
+			invokeType: InvokeUrlTypePath,
+			want:       "https://app.example.com/endpoint/public/64741d05-2273-422a-8424-2e0760e539d3",
 		},
 		{
-			name:        "should return path based private url",
+			name:        "should return path url for serves",
 			externalUrl: "https://app.example.com",
 			stub: &types.StubWithRelated{
 				Stub: types.Stub{
-					ExternalId: "20a3f632-a5f8-4013-a2ac-4ab5c80912c7",
-					Config:     `{"authorized": true}`,
-					Type:       types.StubType(types.StubTypeEndpointDeployment),
+					ExternalId: "aff86f02-c968-47a9-9132-0bde826b0aca",
+					Config:     `{}`,
+					Type:       types.StubType(types.StubTypeASGIServe),
 				},
 			},
 			deployment: &types.Deployment{
 				Name:    "app2",
-				Version: uint(23),
+				Version: uint(28),
 			},
-			invokeType: "path",
-			want:       "https://app.example.com/endpoint/app2/v23",
+			invokeType: InvokeUrlTypePath,
+			want:       "https://app.example.com/asgi/id/aff86f02-c968-47a9-9132-0bde826b0aca",
 		},
 		{
-			name:        "should return domain based public url",
+			name:        "should return domain url for deployments",
 			externalUrl: "https://app.example.com",
 			stub: &types.StubWithRelated{
 				Stub: types.Stub{
@@ -82,46 +82,11 @@ func TestBuildInvokeURL(t *testing.T) {
 				Name:    "app2",
 				Version: uint(23),
 			},
-			invokeType: "domain",
-			want:       "https://20a3f632-a5f8-4013-a2ac-4ab5c80912c7.app.example.com",
+			invokeType: InvokeUrlTypeSubdomain,
+			want:       "https://app2-fffffff-v23.app.example.com",
 		},
 		{
-			name:        "should return domain based private url",
-			externalUrl: "https://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "44ad2b42-69be-49f8-806d-e0ee644f9341",
-					Config:     `{"authorized": true}`,
-					Type:       types.StubType(types.StubTypeASGIDeployment),
-					Group:      "app2-fffffff",
-				},
-			},
-			deployment: &types.Deployment{
-				Name:    "app2",
-				Version: uint(24),
-			},
-			invokeType: "domain",
-			want:       "https://app2-fffffff-v24.app.example.com",
-		},
-		{
-			name:        "should return path based serve url",
-			externalUrl: "https://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "aff86f02-c968-47a9-9132-0bde826b0aca",
-					Config:     `{}`,
-					Type:       types.StubType(types.StubTypeASGIServe),
-				},
-			},
-			deployment: &types.Deployment{
-				Name:    "app2",
-				Version: uint(28),
-			},
-			invokeType: "path",
-			want:       "https://app.example.com/asgi/id/aff86f02-c968-47a9-9132-0bde826b0aca",
-		},
-		{
-			name:        "should return domain based serve url",
+			name:        "should return domain url for serves",
 			externalUrl: "https://app.example.com",
 			stub: &types.StubWithRelated{
 				Stub: types.Stub{
@@ -135,7 +100,7 @@ func TestBuildInvokeURL(t *testing.T) {
 				Name:    "app2",
 				Version: uint(25),
 			},
-			invokeType: "domain",
+			invokeType: InvokeUrlTypeSubdomain,
 			want:       "https://aff86f02-c968-47a9-9132-0bde826b0aca.app.example.com",
 		},
 	}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -155,7 +155,7 @@ func (g *Gateway) initHttp() error {
 		AllowHeaders: g.Config.GatewayService.HTTP.CORS.AllowedHeaders,
 		AllowMethods: g.Config.GatewayService.HTTP.CORS.AllowedMethods,
 	}))
-	e.Use(subdomainMiddleware(g.Config.GatewayService.ExternalURL, g.BackendRepo))
+	e.Use(subdomainMiddleware(g.Config.GatewayService.ExternalURL, g.BackendRepo, g.RedisClient))
 	e.Use(middleware.Recover())
 
 	// Accept both HTTP/2 and HTTP/1


### PR DESCRIPTION
- Make deployment URLs the same regardless if public/private
- Cache the subdomain and handler path after database lookup
- Fix public path-based urls

Resolve BE-1841