### PR TITLE
Functions in Colab

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.81"
+version = "0.1.82"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import sys
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
@@ -69,9 +70,10 @@ class BaseAbstraction(ABC):
         frames = inspect.stack()
         frame = frames[-1]
 
-        if frame.code_context and any(
-            substr in frame.code_context[0] for substr in ("import beam", "from beam")
-        ):
+        if (
+            frame.code_context
+            and any(substr in frame.code_context[0] for substr in ("import beam", "from beam"))
+        ) or "beam" in sys.modules:
 
             @dataclass
             class SDKSettings(config.SDKSettings):

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import sys
 from abc import ABC
@@ -67,13 +66,8 @@ class BaseAbstraction(ABC):
         by beta9 or beam. This is done by inspecting the first frame loaded
         onto the stack.
         """
-        frames = inspect.stack()
-        frame = frames[-1]
 
-        if (
-            frame.code_context
-            and any(substr in frame.code_context[0] for substr in ("import beam", "from beam"))
-        ) or "beam" in sys.modules:
+        if "beam" in sys.modules:
 
             @dataclass
             class SDKSettings(config.SDKSettings):

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import sys
 import tempfile
 import time
 from queue import Empty, Queue
@@ -213,7 +214,7 @@ class RunnerAbstraction(BaseAbstraction):
         if hasattr(module, "__file__"):
             module_file = os.path.relpath(module.__file__, start=os.getcwd()).replace("/", ".")
             module_name = os.path.splitext(module_file)[0]
-        elif in_jupyter():
+        elif in_ipython_env():
             tmp_file = create_tmp_jupyter_file(module._ih)
             module_name = tmp_file.name.split("/")[-1].removesuffix(".py")
             self.tmp_files.append(tmp_file)
@@ -395,7 +396,10 @@ class RunnerAbstraction(BaseAbstraction):
         return True
 
 
-def in_jupyter() -> bool:
+def in_ipython_env() -> bool:
+    if "google.colab" in sys.modules:
+        return True
+
     try:
         from IPython import get_ipython
 

--- a/sdk/src/beta9/sync.py
+++ b/sdk/src/beta9/sync.py
@@ -70,7 +70,6 @@ class FileSyncer:
 
         terminal.detail(f"Writing {IGNORE_FILE_NAME} file")
         with self.ignore_file_path.open(mode="w") as f:
-            terminal.detail(IGNORE_FILE_CONTENTS)
             f.writelines(IGNORE_FILE_CONTENTS)
 
     def _read_ignore_file(self) -> list:

--- a/sdk/src/beta9/sync.py
+++ b/sdk/src/beta9/sync.py
@@ -40,6 +40,10 @@ __pycache__
 .DS_Store
 .config
 drive/MyDrive
+.coverage
+.pytest_cache
+.ruff_cache
+.dockerignore
 """
 
 

--- a/sdk/src/beta9/sync.py
+++ b/sdk/src/beta9/sync.py
@@ -44,6 +44,7 @@ drive/MyDrive
 .pytest_cache
 .ruff_cache
 .dockerignore
+.ipynb_checkpoints
 """
 
 

--- a/sdk/src/beta9/sync.py
+++ b/sdk/src/beta9/sync.py
@@ -81,8 +81,6 @@ class FileSyncer:
 
         patterns = []
 
-        terminal.header("ignore_file_path", self.ignore_file_path)
-        terminal.header("ignore_file_path.is_file()", self.ignore_file_path.is_file())
         if self.ignore_file_path.is_file():
             with self.ignore_file_path.open() as file:
                 patterns = [line.strip() for line in file.readlines() if line.strip()]
@@ -119,7 +117,6 @@ class FileSyncer:
 
         self._init_ignore_file()
         self.ignore_patterns = self._read_ignore_file()
-        terminal.header("ignore_patterns", self.ignore_patterns)
         temp_zip_name = tempfile.NamedTemporaryFile(delete=False).name
 
         with zipfile.ZipFile(temp_zip_name, "w") as zipf:


### PR DESCRIPTION
This PR fixes functions in Colab. The main issue was that beam was not found in the last frame in the stack did not include a beam import. As a result, the beta9 config was being picked up. 

To fix this, I added a condition to check if beam is in the sys modules (its presence there would imply it was imported). I think we might be able to replace the frame logic entirely with this check. Aside from that, I've added some error handling to the file syncing and added some default ignore paths for google drive. 