### PR TITLE
Rework and fix subdomain routing

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -101,6 +101,10 @@ func (g *StubGroup) GetURL(ctx echo.Context) error {
 		return HTTPBadRequest("Failed to decode query parameters")
 	}
 
+	if filter.URLType == "" {
+		filter.URLType = g.config.GatewayService.InvokeURLType
+	}
+
 	stub, err := g.backendRepo.GetStubByExternalId(ctx.Request().Context(), filter.StubId)
 	if err != nil {
 		return HTTPInternalServerError("Failed to lookup stub")

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -33,6 +33,7 @@ storage:
 gateway:
   host: beta9-gateway
   externalURL: http://localhost:1994
+  invokeURLType: path
   grpc:
     port: 1993
     maxRecvMsgSize: 1024

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -8,42 +8,37 @@ import (
 )
 
 const (
-	InvokeUrlTypePath       string = "path"
-	InvokeUrlTypeSubdomain  string = "subdomain"
-	invokeUrlIgnoreHostname string = "localhost" // Ignore hostname when building local urls
+	InvokeUrlTypePath string = "path"
+	InvokeUrlTypeHost string = "host"
 )
 
-func BuildDeploymentURL(externalUrl, invokeUrlType string, stub *types.StubWithRelated, deployment *types.Deployment) string {
+func BuildDeploymentURL(externalUrl, urlType string, stub *types.StubWithRelated, deployment *types.Deployment) string {
 	parsedUrl, err := url.Parse(externalUrl)
 	if err != nil {
 		return ""
 	}
 
-	isLocalOrPathBased := parsedUrl.Hostname() == invokeUrlIgnoreHostname || invokeUrlType == InvokeUrlTypePath
+	if urlType == InvokeUrlTypeHost {
+		return fmt.Sprintf("%s://%s-v%d.%s", parsedUrl.Scheme, deployment.Subdomain, deployment.Version, parsedUrl.Host)
+	}
+
 	stubConfig, err := stub.UnmarshalConfig()
 	isPublic := err == nil && !stubConfig.Authorized
 
-	if isLocalOrPathBased {
-		if isPublic {
-			return fmt.Sprintf("%s://%s/%s/public/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
-		}
-		return fmt.Sprintf("%s://%s/%s/%s/v%d", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), deployment.Name, deployment.Version)
+	if isPublic {
+		return fmt.Sprintf("%s://%s/%s/public/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
 	}
-
-	return fmt.Sprintf("%s://%s-v%d.%s", parsedUrl.Scheme, stub.Group, deployment.Version, parsedUrl.Host)
+	return fmt.Sprintf("%s://%s/%s/%s/v%d", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), deployment.Name, deployment.Version)
 }
 
-func BuildServeURL(externalUrl, invokeUrlType string, stub *types.StubWithRelated) string {
+func BuildServeURL(externalUrl, urlType string, stub *types.StubWithRelated) string {
 	parsedUrl, err := url.Parse(externalUrl)
 	if err != nil {
 		return ""
 	}
 
-	isLocalOrPathBased := parsedUrl.Hostname() == invokeUrlIgnoreHostname || invokeUrlType == InvokeUrlTypePath
-
-	if isLocalOrPathBased {
-		return fmt.Sprintf("%s://%s/%s/id/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
+	if urlType == InvokeUrlTypeHost {
+		return fmt.Sprintf("%s://%s.%s", parsedUrl.Scheme, stub.ExternalId, parsedUrl.Host)
 	}
-
-	return fmt.Sprintf("%s://%s.%s", parsedUrl.Scheme, stub.ExternalId, parsedUrl.Host)
+	return fmt.Sprintf("%s://%s/%s/id/%s", parsedUrl.Scheme, parsedUrl.Host, stub.Type.Kind(), stub.ExternalId)
 }

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -7,113 +7,90 @@ import (
 	"github.com/tj/assert"
 )
 
-func TestBuildInvokeURL(t *testing.T) {
+func TestBuildDeploymentURL(t *testing.T) {
+	externalUrl := "http://app.example.com"
+
 	tests := []struct {
 		name        string
-		externalUrl string
 		stub        *types.StubWithRelated
 		deployment  *types.Deployment
 		invokeType  string
-		want        string
+		expectedURL string
 	}{
 		{
-			name:        "should return path url for private deployments",
-			externalUrl: "http://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "c19515e6-13c7-423f-9d91-227082151538",
-					Config:     `{`,
-					Type:       types.StubType(types.StubTypeScheduledJobDeployment),
-				},
-			},
+			name: "returns host-based URL",
+			stub: &types.StubWithRelated{},
 			deployment: &types.Deployment{
-				Name:    "app1",
-				Version: uint(11),
+				Subdomain: "my-app-1234567",
+				Version:   8,
 			},
-			invokeType: InvokeUrlTypePath,
-			want:       "http://app.example.com/schedule/app1/v11",
+			invokeType:  InvokeUrlTypeHost,
+			expectedURL: "http://my-app-1234567-v8.app.example.com",
 		},
 		{
-			name:        "should return path url for public deployments",
-			externalUrl: "https://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "64741d05-2273-422a-8424-2e0760e539d3",
-					Config:     `{"authorized": false}`,
-					Type:       types.StubType(types.StubTypeEndpointDeployment),
-				},
-			},
+			name: "returns path-based URL",
+			stub: &types.StubWithRelated{Stub: types.Stub{
+				Type: types.StubType(types.StubTypeEndpointDeployment),
+			}},
 			deployment: &types.Deployment{
-				Name:    "app2",
-				Version: uint(22),
+				Name:    "my-app",
+				Version: 8,
 			},
-			invokeType: InvokeUrlTypePath,
-			want:       "https://app.example.com/endpoint/public/64741d05-2273-422a-8424-2e0760e539d3",
+			invokeType:  InvokeUrlTypePath,
+			expectedURL: "http://app.example.com/endpoint/my-app/v8",
 		},
 		{
-			name:        "should return path url for serves",
-			externalUrl: "https://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "aff86f02-c968-47a9-9132-0bde826b0aca",
-					Config:     `{}`,
-					Type:       types.StubType(types.StubTypeASGIServe),
-				},
-			},
-			deployment: &types.Deployment{
-				Name:    "app2",
-				Version: uint(28),
-			},
-			invokeType: InvokeUrlTypePath,
-			want:       "https://app.example.com/asgi/id/aff86f02-c968-47a9-9132-0bde826b0aca",
-		},
-		{
-			name:        "should return domain url for deployments",
-			externalUrl: "https://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "20a3f632-a5f8-4013-a2ac-4ab5c80912c7",
-					Config:     `{"authorized": false}`,
-					Type:       types.StubType(types.StubTypeEndpointDeployment),
-					Group:      "app2-fffffff",
-				},
-			},
-			deployment: &types.Deployment{
-				Name:    "app2",
-				Version: uint(23),
-			},
-			invokeType: InvokeUrlTypeSubdomain,
-			want:       "https://app2-fffffff-v23.app.example.com",
-		},
-		{
-			name:        "should return domain url for serves",
-			externalUrl: "https://app.example.com",
-			stub: &types.StubWithRelated{
-				Stub: types.Stub{
-					ExternalId: "aff86f02-c968-47a9-9132-0bde826b0aca",
-					Config:     `{}`,
-					Type:       types.StubType(types.StubTypeASGIServe),
-					Group:      "app2-eeeeeee",
-				},
-			},
-			deployment: &types.Deployment{
-				Name:    "app2",
-				Version: uint(25),
-			},
-			invokeType: InvokeUrlTypeSubdomain,
-			want:       "https://aff86f02-c968-47a9-9132-0bde826b0aca.app.example.com",
+			name: "returns public path-based URL",
+			stub: &types.StubWithRelated{Stub: types.Stub{
+				Type:       types.StubType(types.StubTypeEndpointDeployment),
+				Config:     `{"authorized": false}`,
+				ExternalId: "e9c29586-c465-4a67-9c9b-25293d1ce77b",
+			}},
+			invokeType:  InvokeUrlTypePath,
+			expectedURL: "http://app.example.com/endpoint/public/e9c29586-c465-4a67-9c9b-25293d1ce77b",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var got string
-			if test.stub.Type.IsServe() {
-				got = BuildServeURL(test.externalUrl, test.invokeType, test.stub)
-			} else {
-				got = BuildDeploymentURL(test.externalUrl, test.invokeType, test.stub, test.deployment)
-			}
-			assert.Equal(t, test.want, got)
+			got := BuildDeploymentURL(externalUrl, test.invokeType, test.stub, test.deployment)
+			assert.Equal(t, test.expectedURL, got)
+		})
+	}
+}
+
+func TestBuildServeURL(t *testing.T) {
+	externalUrl := "http://app.example.com"
+
+	tests := []struct {
+		name        string
+		stub        *types.StubWithRelated
+		invokeType  string
+		expectedUrl string
+	}{
+		{
+			name: "returns host-based URL",
+			stub: &types.StubWithRelated{Stub: types.Stub{
+				ExternalId: "e9c29586-c465-4a67-9c9b-25293d1ce77b",
+			}},
+			invokeType:  InvokeUrlTypeHost,
+			expectedUrl: "http://e9c29586-c465-4a67-9c9b-25293d1ce77b.app.example.com",
+		},
+		{
+			name: "returns path-based URL",
+			stub: &types.StubWithRelated{Stub: types.Stub{
+				ExternalId: "e9c29586-c465-4a67-9c9b-25293d1ce77b",
+				Type:       types.StubType(types.StubTypeEndpointDeployment),
+			}},
+			invokeType:  InvokeUrlTypePath,
+			expectedUrl: "http://app.example.com/endpoint/id/e9c29586-c465-4a67-9c9b-25293d1ce77b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := BuildServeURL(externalUrl, test.invokeType, test.stub)
+			assert.Equal(t, test.expectedUrl, got)
 		})
 	}
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -31,6 +31,7 @@ import (
 	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
+	gatewayMiddleware "github.com/beam-cloud/beta9/pkg/gateway/middleware"
 	gatewayservices "github.com/beam-cloud/beta9/pkg/gateway/services"
 	"github.com/beam-cloud/beta9/pkg/network"
 	"github.com/beam-cloud/beta9/pkg/repository"
@@ -155,7 +156,7 @@ func (g *Gateway) initHttp() error {
 		AllowHeaders: g.Config.GatewayService.HTTP.CORS.AllowedHeaders,
 		AllowMethods: g.Config.GatewayService.HTTP.CORS.AllowedMethods,
 	}))
-	e.Use(subdomainMiddleware(g.Config.GatewayService.ExternalURL, g.BackendRepo, g.RedisClient))
+	e.Use(gatewayMiddleware.Subdomain(g.Config.GatewayService.ExternalURL, g.BackendRepo, g.RedisClient))
 	e.Use(middleware.Recover())
 
 	// Accept both HTTP/2 and HTTP/1

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -212,6 +212,10 @@ func (gws *GatewayService) GetURL(ctx context.Context, in *pb.GetURLRequest) (*p
 		}, nil
 	}
 
+	if in.UrlType == "" {
+		in.UrlType = gws.appConfig.GatewayService.InvokeURLType
+	}
+
 	// Get URL for Serves
 	if stub.Type.IsServe() {
 		invokeUrl := common.BuildServeURL(gws.appConfig.GatewayService.ExternalURL, in.UrlType, stub)

--- a/pkg/repository/backend_postgres_migrations/016_subdomains.go
+++ b/pkg/repository/backend_postgres_migrations/016_subdomains.go
@@ -1,0 +1,68 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upSubdomain, downSubdomain)
+}
+
+func upSubdomain(ctx context.Context, tx *sql.Tx) error {
+	/*
+		Update the deployment table to include a subdomain column
+	*/
+	createColumn := `
+		ALTER TABLE deployment
+		ADD COLUMN subdomain varchar(64),
+		ADD CONSTRAINT deployment_subdomain_check CHECK (subdomain ~ '^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$');
+	`
+	if _, err := tx.ExecContext(ctx, createColumn); err != nil {
+		return err
+	}
+
+	updateTable := `
+		UPDATE deployment d
+		SET subdomain = NULLIF(
+			CONCAT(
+				REGEXP_REPLACE(d.name, '[^a-zA-Z0-9-]', '-', 'g'),
+				'-',
+				LEFT(md5(d.name || s.type || s.workspace_id), 7)
+			),
+		'-'
+		)
+		FROM stub s
+		WHERE d.stub_id = s.id;
+	`
+	if _, err := tx.ExecContext(ctx, updateTable); err != nil {
+		return err
+	}
+
+	createIndex := `CREATE INDEX IF NOT EXISTS deployment_subdomain_idx ON deployment(subdomain);`
+	if _, err := tx.ExecContext(ctx, createIndex); err != nil {
+		return err
+	}
+
+	/*
+		Remove the group column from the stub table
+	*/
+	dropIndex := `DROP INDEX IF EXISTS stub_group;`
+	if _, err := tx.ExecContext(ctx, dropIndex); err != nil {
+		return err
+	}
+
+	dropColumn := `ALTER TABLE stub DROP COLUMN IF EXISTS "group";`
+	if _, err := tx.ExecContext(ctx, dropColumn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downSubdomain(ctx context.Context, tx *sql.Tx) error {
+	// No need to revert this migration
+	return nil
+}

--- a/pkg/repository/backend_postgres_test.go
+++ b/pkg/repository/backend_postgres_test.go
@@ -1,1 +1,0 @@
-package repository

--- a/pkg/repository/backend_utils.go
+++ b/pkg/repository/backend_utils.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	invalidCharRegexp     = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
+	multipleHyphensRegexp = regexp.MustCompile(`-{2,}`)
+)
+
+// sanitizeDeploymentName cleans up the deployment name according to DNS rules
+func sanitizeDeploymentName(name string) string {
+	s := invalidCharRegexp.ReplaceAllString(name, "-")
+	s = multipleHyphensRegexp.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+
+	return strings.ToLower(s)
+}
+
+func generateHash(hashLength int, inputs ...any) string {
+	inputStrings := make([]string, len(inputs))
+	for i, input := range inputs {
+		inputStrings[i] = fmt.Sprintf("%v", input)
+	}
+
+	data := strings.Join(inputStrings, "")
+	hashBytes := md5.Sum([]byte(data))
+	hashString := hex.EncodeToString(hashBytes[:])
+
+	return hashString[:hashLength]
+}
+
+func generateSubdomain(deploymentName, stubType string, workspaceId uint) string {
+	const maxSubdomainLength = 63
+	const hashLength = 7
+	const hyphenLength = 1
+
+	sanitized := sanitizeDeploymentName(deploymentName)
+	if sanitized == "" {
+		return ""
+	}
+
+	// Adjust the sanitized length to ensure the final subdomain does not exceed 63 characters
+	maxSanitizedLength := maxSubdomainLength - hashLength - hyphenLength
+	if len(sanitized) > maxSanitizedLength {
+		sanitized = sanitized[:maxSanitizedLength]
+	}
+
+	hashPart := generateHash(hashLength, deploymentName, stubType, workspaceId)
+	subdomain := fmt.Sprintf("%s-%s", sanitized, hashPart)
+
+	return subdomain
+}

--- a/pkg/repository/backend_utils_test.go
+++ b/pkg/repository/backend_utils_test.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateSubdomain(t *testing.T) {
+	tests := []struct {
+		name              string
+		deploymentName    string
+		stubType          string
+		workspaceId       uint
+		expectedSubdomain string
+		expectedDuplicate bool
+	}{
+		{
+			"my-app in workspace 1 as endpoint is unique",
+			"my-app",
+			"endpoint/deployment",
+			1,
+			"my-app-a8fc5c8",
+			false,
+		},
+		{
+			"my_app in workspace 1 as endpoint is unique",
+			"my_app",
+			"endpoint/deployment",
+			1,
+			"my-app-0305796",
+			false,
+		},
+		{
+			"my_app in workspace 1 as taskqueue is unique",
+			"my_app",
+			"taskqueue/deployment",
+			1,
+			"my-app-e50a2fc",
+			false,
+		},
+		{
+			"my-app in workspace 2 as endpoint is unique",
+			"my-app",
+			"endpoint/deployment",
+			2,
+			"my-app-0fee434",
+			false,
+		},
+		{
+			"my-app in workspace 2 as endpoint is a duplicate",
+			"my-app",
+			"endpoint/deployment",
+			2,
+			"my-app-0fee434",
+			true,
+		},
+	}
+
+	subdomains := make(map[string]bool)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subdomain := generateSubdomain(test.deploymentName, test.stubType, test.workspaceId)
+			assert.Equal(t, test.expectedSubdomain, subdomain)
+
+			if _, exists := subdomains[subdomain]; exists {
+				assert.True(t, test.expectedDuplicate)
+				return
+			}
+
+			assert.False(t, test.expectedDuplicate)
+			subdomains[subdomain] = true
+		})
+	}
+}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -92,7 +92,7 @@ type BackendRepository interface {
 	GetTaskCountPerDeployment(ctx context.Context, filters types.TaskFilter) ([]types.TaskCountPerDeployment, error)
 	GetOrCreateStub(ctx context.Context, name, stubType string, config types.StubConfigV1, objectId, workspaceId uint, forceCreate bool) (types.Stub, error)
 	GetStubByExternalId(ctx context.Context, externalId string, queryFilters ...types.QueryFilter) (*types.StubWithRelated, error)
-	GetDeploymentByStubGroup(ctx context.Context, version uint, stubGroup string) (*types.DeploymentWithRelated, error)
+	GetDeploymentBySubdomain(ctx context.Context, subdomain string, version uint) (*types.DeploymentWithRelated, error)
 	GetVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error)
 	GetOrCreateVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error)
 	DeleteVolume(ctx context.Context, workspaceId uint, name string) error

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -65,6 +65,7 @@ type Deployment struct {
 	ExternalId  string       `db:"external_id" json:"external_id"`
 	Name        string       `db:"name" json:"name"`
 	Active      bool         `db:"active" json:"active"`
+	Subdomain   string       `db:"subdomain" json:"subdomain"`
 	WorkspaceId uint         `db:"workspace_id" json:"workspace_id"` // Foreign key to Workspace
 	StubId      uint         `db:"stub_id" json:"stub_id"`           // Foreign key to Stub
 	StubType    string       `db:"stub_type" json:"stub_type"`
@@ -231,7 +232,6 @@ type Stub struct {
 	ExternalId    string    `db:"external_id" json:"external_id"`
 	Name          string    `db:"name" json:"name"`
 	Type          StubType  `db:"type" json:"type"`
-	Group         string    `db:"group" json:"group"`
 	Config        string    `db:"config" json:"config"`
 	ConfigVersion uint      `db:"config_version" json:"config_version"`
 	ObjectId      uint      `db:"object_id" json:"object_id"`       // Foreign key to Object

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -91,6 +91,7 @@ type GatewayServiceConfig struct {
 	Host            string        `key:"host" json:"host"`
 	ExternalHost    string        `key:"externalHost" json:"external_host"`
 	ExternalURL     string        `key:"externalURL" json:"external_url"`
+	InvokeURLType   string        `key:"invokeURLType" json:"invoke_url_type"`
 	GRPC            GRPCConfig    `key:"grpc" json:"grpc"`
 	HTTP            HTTPConfig    `key:"http" json:"http"`
 	ShutdownTimeout time.Duration `key:"shutdownTimeout" json:"shutdown_timeout"`

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.82"
+version = "0.1.83"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -116,7 +116,7 @@ class RunnerAbstraction(BaseAbstraction):
         self.config_context: ConfigContext = get_config_context()
         self.tmp_files: List[tempfile.NamedTemporaryFile] = []
 
-    def print_invocation_snippet(self, url_type: str = "subdomain") -> None:
+    def print_invocation_snippet(self, url_type: str = "") -> None:
         """Print curl request to call deployed container URL"""
 
         res = self.gateway_stub.get_url(

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -212,7 +212,7 @@ class _CallableWrapper(DeployableMixin):
         return self.func(*args, **kwargs)
 
     @with_grpc_error_handling
-    def serve(self, timeout: int = 0, url_type: str = "subdomain"):
+    def serve(self, timeout: int = 0, url_type: str = ""):
         stub_type = ENDPOINT_SERVE_STUB_TYPE
 
         if getattr(self.parent, "is_asgi", None):

--- a/sdk/src/beta9/abstractions/mixins.py
+++ b/sdk/src/beta9/abstractions/mixins.py
@@ -1,4 +1,4 @@
-from typing import Callable, ClassVar, Optional
+from typing import Any, Callable, ClassVar, Optional
 
 from .. import terminal
 from ..clients.gateway import DeployStubRequest, DeployStubResponse
@@ -28,7 +28,7 @@ class DeployableMixin:
         name: Optional[str] = None,
         context: Optional[ConfigContext] = None,
         invocation_details_func: Optional[Callable[..., None]] = None,
-        url_type: str = "subdomain",
+        **invocation_details_options: Any,
     ) -> bool:
         self._validate()
 
@@ -55,8 +55,8 @@ class DeployableMixin:
         if deploy_response.ok:
             terminal.header("Deployed 🎉")
             if invocation_details_func:
-                invocation_details_func(url_type=url_type)
+                invocation_details_func(**invocation_details_options)
             else:
-                self.parent.print_invocation_snippet(url_type=url_type)
+                self.parent.print_invocation_snippet(**invocation_details_options)
 
         return deploy_response.ok

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -168,7 +168,7 @@ class _CallableWrapper(DeployableMixin):
         return self.func(*args, **kwargs)
 
     @with_grpc_error_handling
-    def serve(self, timeout: int = 0, url_type: str = "subdomain"):
+    def serve(self, timeout: int = 0, url_type: str = ""):
         if not self.parent.prepare_runtime(
             func=self.func, stub_type=TASKQUEUE_SERVE_STUB_TYPE, force_create_stub=True
         ):

--- a/sdk/src/beta9/cli/deployment.py
+++ b/sdk/src/beta9/cli/deployment.py
@@ -59,9 +59,8 @@ def common(**_):
 )
 @click.option(
     "--url-type",
-    help="The type of URL to get back.",
-    default="path",
-    type=click.Choice(["subdomain", "path"]),
+    help="The type of URL to get back. [default is determined by the server] ",
+    type=click.Choice(["host", "path"]),
 )
 @click.pass_context
 def deploy(ctx: click.Context, name: str, entrypoint: str, url_type: str):
@@ -101,9 +100,8 @@ def management():
 )
 @click.option(
     "--url-type",
-    help="The type of URL to get back.",
-    default="path",
-    type=click.Choice(["subdomain", "path"]),
+    help="The type of URL to get back. [default is determined by the server] ",
+    type=click.Choice(["host", "path"]),
 )
 @extraclick.pass_service_client
 def create_deployment(service: ServiceClient, name: str, entrypoint: str, url_type: str):

--- a/sdk/src/beta9/cli/serve.py
+++ b/sdk/src/beta9/cli/serve.py
@@ -46,9 +46,8 @@ def common(**_):
 )
 @click.option(
     "--url-type",
-    help="The type of URL to get back.",
-    default="subdomain",
-    type=click.Choice(["subdomain", "path"]),
+    help="The type of URL to get back. [default is determined by the server] ",
+    type=click.Choice(["host", "path"]),
 )
 @extraclick.pass_service_client
 @click.pass_context


### PR DESCRIPTION
- Replace stub.group with deployment.subdomain column in the database. This simplifies creating stubs again and moves the subdomain to the model (deployment) that its actually for.
- Fix generating subdomain hash by using deployment.name instead of stub.name. This makes deployment subdomains unique by deployment.name, stubType, and workspaceId.
- Introduce a new setting to control the invoke url type end-users should see in the UI and CLI. This also removes the localhost hardcode and simplifies URL building logic.
- Add a column check constraint on deployment.subdomain
- Move subdomain middleware to a new middleware package
- Update all tests

Resolve BE-1849 BE-1848