### PR TITLE
Stop scheduled jobs from the HTTP frontend

### DIFF
--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -205,6 +205,13 @@ func (g *DeploymentGroup) DownloadDeploymentPackage(ctx echo.Context) error {
 
 func (g *DeploymentGroup) stopDeployments(deployments []types.DeploymentWithRelated, ctx echo.Context) error {
 	for _, deployment := range deployments {
+		// Stop scheduled job
+		if deployment.StubType == types.StubTypeScheduledJobDeployment {
+			if scheduledJob, err := g.backendRepo.GetScheduledJob(ctx.Request().Context(), deployment.Id); err == nil {
+				g.backendRepo.DeleteScheduledJob(ctx.Request().Context(), scheduledJob)
+			}
+		}
+
 		// Stop active containers
 		containers, err := g.containerRepo.GetActiveContainersByStubId(deployment.Stub.ExternalId)
 		if err == nil {

--- a/pkg/gateway/services/deployment.go
+++ b/pkg/gateway/services/deployment.go
@@ -153,7 +153,7 @@ func (gws *GatewayService) DeleteDeployment(ctx context.Context, in *pb.DeleteDe
 
 func (gws *GatewayService) stopDeployments(deployments []types.DeploymentWithRelated, ctx context.Context) error {
 	for _, deployment := range deployments {
-		// Stop scheduled job. To re-enable, a new deployment must be created
+		// Stop scheduled job
 		if deployment.StubType == types.StubTypeScheduledJobDeployment {
 			if scheduledJob, err := gws.backendRepo.GetScheduledJob(ctx, deployment.Id); err == nil {
 				gws.backendRepo.DeleteScheduledJob(ctx, scheduledJob)


### PR DESCRIPTION
Recently discovered we have duplicated logic for stopping containers between the HTTP and gRPC services. This adds stop scheduled job logic to the HTTP service.

Resolve BE-1859