### PR TITLE
Don't cache latest version in subdomain middleware

### DIFF
--- a/pkg/gateway/middleware/subdomain.go
+++ b/pkg/gateway/middleware/subdomain.go
@@ -75,7 +75,9 @@ func Subdomain(externalURL string, backendRepo SubdomainBackendRepo, redisClient
 				}
 
 				handlerPath = buildHandlerPath(stub, fields)
-				redisClient.Set(ctx.Request().Context(), handlerKey, handlerPath, handlerKeyTtl)
+				if fields.Version > 0 || fields.StubId != "" {
+					redisClient.Set(ctx.Request().Context(), handlerKey, handlerPath, handlerKeyTtl)
+				}
 			}
 
 			handlerPathFull := path.Join("/", handlerPath, ctx.Request().URL.Path)


### PR DESCRIPTION
Only cache routes when a versioned or stub ID (e.g. serve) host is used. This ensures that non-versioned or "latest" hosts will always get the latest version of the callable.

Resolve BE-1860