### PR TITLE
Add init lock for gateway

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -151,7 +151,7 @@ func (g *Gateway) initLock() (func(), error) {
 
 	return func() {
 		if err := lock.Release(lockKey); err != nil {
-			log.Printf("Failed to release migration lock: %v", err)
+			log.Println("Failed to release init lock:", err)
 		}
 	}, nil
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -141,8 +141,8 @@ func NewGateway() (*Gateway, error) {
 	return gateway, nil
 }
 
-func (g *Gateway) initLock() (func(), error) {
-	lockKey := "gateway:init:lock"
+func (g *Gateway) initLock(name string) (func(), error) {
+	lockKey := fmt.Sprintf("gateway:init:%v:lock", name)
 	lock := common.NewRedisLock(g.RedisClient)
 
 	if err := lock.Acquire(g.ctx, lockKey, common.RedisLockOptions{TtlS: 10, Retries: 1}); err != nil {

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -52,7 +52,7 @@ func GenerateDSN(config types.PostgresConfig) string {
 	)
 }
 
-type LockMigrationFunc func(string) (func(), error)
+type MigrationLockFunc func(string) (func(), error)
 
 type PostgresBackendRepository struct {
 	client    *sqlx.DB
@@ -60,7 +60,7 @@ type PostgresBackendRepository struct {
 	eventRepo EventRepository
 }
 
-func NewBackendPostgresRepository(config types.PostgresConfig, eventRepo EventRepository, obtainMigrationLock LockMigrationFunc) (*PostgresBackendRepository, error) {
+func NewBackendPostgresRepository(config types.PostgresConfig, eventRepo EventRepository, obtainMigrationLock MigrationLockFunc) (*PostgresBackendRepository, error) {
 	dsn := GenerateDSN(config)
 
 	db, err := sqlx.Connect("postgres", dsn)

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -52,7 +52,7 @@ func GenerateDSN(config types.PostgresConfig) string {
 	)
 }
 
-type LockMigrationFunc func() (func(), error)
+type LockMigrationFunc func(string) (func(), error)
 
 type PostgresBackendRepository struct {
 	client    *sqlx.DB
@@ -74,7 +74,7 @@ func NewBackendPostgresRepository(config types.PostgresConfig, eventRepo EventRe
 		eventRepo: eventRepo,
 	}
 
-	if release, err := obtainMigrationLock(); err == nil {
+	if release, err := obtainMigrationLock("postgres"); err == nil {
 		defer release()
 		if err := repo.migrate(); err != nil {
 			log.Fatalf("Failed to run backend migrations: %v", err)


### PR DESCRIPTION
Initially this would be used for database migrations. It is generic enough that it can be used in the future for other initialization locks.

In the database repo, this attempts to acquire a lock and when it does, a function is returned. This function is used to release the lock. If a lock is unable to be obtained, then the error is ignored and the system resumes normal operation. 

Resolve BE-1861