### PR TITLE
Don't allow double hyphens in subdomain name

### DIFF
--- a/pkg/repository/backend_postgres_migrations/016_subdomains.go
+++ b/pkg/repository/backend_postgres_migrations/016_subdomains.go
@@ -27,14 +27,17 @@ func upSubdomain(ctx context.Context, tx *sql.Tx) error {
 	updateTable := `
 		UPDATE deployment d
 		SET subdomain = NULLIF(
-			LOWER(
-				CONCAT(
-					REGEXP_REPLACE(d.name, '[^a-zA-Z0-9-]', '-', 'g'),
-					'-',
-					LEFT(md5(d.name || s.type || s.workspace_id), 7)
-				)
+			REGEXP_REPLACE(
+				TRIM(BOTH '-' FROM LOWER(
+					CONCAT(
+						REGEXP_REPLACE(d.name, '[^a-zA-Z0-9]+', '-', 'g'),
+						'-',
+						LEFT(md5(d.name || s.type || s.workspace_id), 7)
+					)
+				)),
+				'-+', '-', 'g'
 			),
-		'-'
+			''
 		)
 		FROM stub s
 		WHERE d.stub_id = s.id;


### PR DESCRIPTION
There is a constraint on the subdomain column that does not allow double hyphens for DNS purposes. This migration generates the subdomain column and needs to remove double hyphens with a single hyphen before inserting into subdomain column.

Resolve BE-1849