### PR TITLE
Remove running tasks from endpoint serve autoscaler

### DIFF
--- a/pkg/abstractions/endpoint/autoscaler.go
+++ b/pkg/abstractions/endpoint/autoscaler.go
@@ -72,7 +72,7 @@ func endpointServeScaleFunc(i *endpointInstance, sample *endpointAutoscalerSampl
 		}
 	}
 
-	if sample.TotalRequests == 0 && exists == 0 {
+	if exists == 0 {
 		desiredContainers = 0
 	}
 


### PR DESCRIPTION
This fixes the issue where users with tasks pending have zombie endpoint serves.