### PR TITLE
Ping database in health check

### DIFF
--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -53,10 +53,11 @@ controllers:
             enabled: true
             custom: true
             spec:
+              successThreshold: 1
               failureThreshold: 3
               initialDelaySeconds: 5
               periodSeconds: 5
-              timeoutSeconds: 2
+              timeoutSeconds: 1
               httpGet:
                 path: /api/v1/health
                 port: 1994

--- a/pkg/api/v1/health.go
+++ b/pkg/api/v1/health.go
@@ -1,39 +1,47 @@
 package apiv1
 
 import (
-	"context"
-	"log"
 	"net/http"
 
 	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/labstack/echo/v4"
+	"golang.org/x/sync/errgroup"
 )
 
 type HealthGroup struct {
 	redisClient *common.RedisClient
+	backendRepo repository.BackendRepository
 	routerGroup *echo.Group
 }
 
-func NewHealthGroup(g *echo.Group, rdb *common.RedisClient) *HealthGroup {
-	group := &HealthGroup{routerGroup: g, redisClient: rdb}
+func NewHealthGroup(g *echo.Group, rdb *common.RedisClient, backendRepo repository.BackendRepository) *HealthGroup {
+	group := &HealthGroup{routerGroup: g, redisClient: rdb, backendRepo: backendRepo}
 
 	g.GET("", group.HealthCheck)
 
 	return group
 }
 
-func (h *HealthGroup) HealthCheck(ctx echo.Context) error {
-	err := h.redisClient.Ping(context.Background()).Err()
+func (h *HealthGroup) HealthCheck(c echo.Context) error {
+	g, ctx := errgroup.WithContext(c.Request().Context())
 
-	if err != nil {
-		log.Printf("health check failed: %v\n", err)
-		return ctx.JSON(http.StatusInternalServerError, map[string]interface{}{
+	g.Go(func() error {
+		return h.redisClient.Ping(ctx).Err()
+	})
+
+	g.Go(func() error {
+		return h.backendRepo.Ping()
+	})
+
+	if err := g.Wait(); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"status": "not ok",
 			"error":  err.Error(),
 		})
 	}
 
-	return ctx.JSON(http.StatusOK, map[string]interface{}{
+	return c.JSON(http.StatusOK, map[string]string{
 		"status": "ok",
 	})
 }

--- a/pkg/api/v1/health.go
+++ b/pkg/api/v1/health.go
@@ -1,6 +1,7 @@
 package apiv1
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/beam-cloud/beta9/pkg/common"
@@ -35,6 +36,7 @@ func (h *HealthGroup) HealthCheck(c echo.Context) error {
 	})
 
 	if err := g.Wait(); err != nil {
+		log.Println("Health check failed: ", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"status": "not ok",
 			"error":  err.Error(),

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -192,7 +192,7 @@ func (g *Gateway) initHttp() error {
 	g.baseRouteGroup = e.Group(apiv1.HttpServerBaseRoute)
 	g.rootRouteGroup = e.Group(apiv1.HttpServerRootRoute)
 
-	apiv1.NewHealthGroup(g.baseRouteGroup.Group("/health"), g.RedisClient)
+	apiv1.NewHealthGroup(g.baseRouteGroup.Group("/health"), g.RedisClient, g.BackendRepo)
 	apiv1.NewMachineGroup(g.baseRouteGroup.Group("/machine", authMiddleware), g.ProviderRepo, g.Tailscale, g.Config)
 	apiv1.NewWorkspaceGroup(g.baseRouteGroup.Group("/workspace", authMiddleware), g.BackendRepo, g.Config)
 	apiv1.NewTokenGroup(g.baseRouteGroup.Group("/token", authMiddleware), g.BackendRepo, g.Config)

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -85,6 +85,10 @@ func (r *PostgresBackendRepository) Migrate() error {
 	return nil
 }
 
+func (r *PostgresBackendRepository) Ping() error {
+	return r.client.Ping()
+}
+
 func (r *PostgresBackendRepository) generateExternalId() (string, error) {
 	id, err := uuid.NewRandom()
 	if err != nil {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -124,6 +124,7 @@ type BackendRepository interface {
 	DeletePreviousScheduledJob(ctx context.Context, deployment *types.Deployment) error
 	GetScheduledJob(ctx context.Context, deploymentId uint) (*types.ScheduledJob, error)
 	ListenToChannel(ctx context.Context, channel string) (<-chan string, error)
+	Ping() error
 }
 
 type TaskRepository interface {


### PR DESCRIPTION
- Fails the HTTP health check if it cannot ping the database
- Pass readiness probe on just 1 successful check
- Lower readiness probe timeout to 1 second

Resolve BE-1866