### PR TITLE
add check to ensure observer exists before joining

### DIFF
--- a/sdk/src/beta9/runner/serve.py
+++ b/sdk/src/beta9/runner/serve.py
@@ -53,8 +53,9 @@ class ServeGateway:
 
     def shutdown(self, signum=None, frame=None) -> None:
         self.kill_subprocess()
-        self.observer.stop()
-        self.observer.join(timeout=0.1)
+        if self.observer.is_alive():
+            self.observer.stop()
+            self.observer.join(timeout=0.1)
         self.exit_event.set()
         self.restart_event.set()
 


### PR DESCRIPTION
This change should prevent the following error (which occurs when quickly starting/stopping a serve)

```
2024-10-02T13:18:02.950571248Z:
entry = (p, self.stat(p))
^^^^^^^^^^^^
File "/usr/local/lib/python3.11/dist-packages/beta9/runner/serve.py", line 57, in shutdown
self.observer.join(timeout=0.1)
File "/usr/lib/python3.11/threading.py", line 1114, in join
2024-10-02T13:18:02.950571269Z:
raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "<frozen runpy>", line 198, in _run_module_as_main
File "<frozen runpy>", line 88, in _run_code
File "/usr/local/lib/python3.11/dist-packages/beta9/runner/serve.py", line 116, in <module>
sg = ServeGateway()
^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/dist-packages/beta9/runner/serve.py", line 52, in __init__
self.observer.start()
File "/usr/local/lib/python3.11/dist-packages/watchdog/observers/api.py", line 282, in start
2024-10-02T13:18:02.950734957Z:
self._remove_emitter(emitter)
```