### PR TITLE
Fix: error handling in function runner

### DIFF
--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -181,6 +181,7 @@ def runner_context():
         config = get_config_context()
         channel: Channel = get_channel(config)
         yield channel
+        channel.close()
     except RunnerException as exc:
         exit_code = exc.code
     except SystemExit as exc:
@@ -192,8 +193,6 @@ def runner_context():
         if exit_code != 0:
             print(traceback.format_exc())
             sys.exit(exit_code)
-
-        channel.close()
 
 
 def with_runner_context(func: Callable) -> Callable:

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -128,13 +128,12 @@ def main(channel: Channel):
     if not task_id:
         raise RunnerException("Invalid runner environment")
 
-    start_time = time.time()
-
     with StdoutJsonInterceptor(task_id=task_id):
         container_id = config.container_id
         container_hostname = config.container_hostname
 
         # Start the task
+        start_time = time.time()
         start_task_response = start_task(gateway_stub, task_id, container_id)
         if not start_task_response.ok:
             raise RunnerException("Unable to start task")
@@ -202,6 +201,7 @@ def invoke_function(function_stub, context, task_id):
 def complete_task(gateway_stub, result, task_id, container_id, container_hostname, start_time):
     task_status = TaskStatus.Complete
     task_duration = time.time() - start_time
+    keep_warm_seconds = 0
 
     end_task_response = end_task_and_send_callback(
         gateway_stub=gateway_stub,
@@ -212,7 +212,7 @@ def complete_task(gateway_stub, result, task_id, container_id, container_hostnam
             task_status=task_status,
             container_id=container_id,
             container_hostname=container_hostname,
-            keep_warm_seconds=0,
+            keep_warm_seconds=keep_warm_seconds,
         ),
         override_callback_url=None,
     )

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -2,9 +2,7 @@ import json
 import os
 import time
 import traceback
-from concurrent import futures
-from concurrent.futures import CancelledError
-from typing import Optional
+from concurrent.futures import CancelledError, ThreadPoolExecutor
 
 import cloudpickle
 import grpc
@@ -12,25 +10,21 @@ import grpc
 from ..channel import Channel, with_runner_context
 from ..clients.function import (
     FunctionGetArgsRequest,
-    FunctionGetArgsResponse,
     FunctionMonitorRequest,
     FunctionMonitorResponse,
     FunctionServiceStub,
     FunctionSetResultRequest,
-    FunctionSetResultResponse,
 )
 from ..clients.gateway import (
     EndTaskRequest,
     GatewayServiceStub,
     StartTaskRequest,
-    StartTaskResponse,
 )
 from ..exceptions import InvalidFunctionArgumentsException, RunnerException
 from ..logging import StdoutJsonInterceptor
 from ..runner.common import (
     FunctionContext,
     FunctionHandler,
-    ThreadPoolExecutorOverride,
     config,
     end_task_and_send_callback,
     send_callback,
@@ -131,87 +125,120 @@ def main(channel: Channel):
     gateway_stub: GatewayServiceStub = GatewayServiceStub(channel)
     task_id = config.task_id
 
-    with StdoutJsonInterceptor(task_id=task_id), ThreadPoolExecutorOverride() as thread_pool:
+    if not task_id:
+        raise RunnerException("Invalid runner environment")
+
+    start_time = time.time()
+
+    with StdoutJsonInterceptor(task_id=task_id):
         container_id = config.container_id
         container_hostname = config.container_hostname
-        if not task_id:
-            raise RunnerException("Invalid runner environment")
 
         # Start the task
-        start_time = time.time()
-        start_task_response: StartTaskResponse = gateway_stub.start_task(
-            StartTaskRequest(task_id=task_id, container_id=container_id)
-        )
-
+        start_task_response = start_task(gateway_stub, task_id, container_id)
         if not start_task_response.ok:
             raise RunnerException("Unable to start task")
 
-        # Kick off monitoring task
         context = FunctionContext.new(config=config, task_id=task_id)
-        monitor_task = thread_pool.submit(
-            _monitor_task,
-            context=context,
-            stub_id=config.stub_id,
-            task_id=task_id,
-            container_id=config.container_id,
-            function_stub=function_stub,
-            gateway_stub=gateway_stub,
-        )
-        futures.thread._threads_queues.clear()
 
-        task_status = TaskStatus.Complete
-        error: Optional[BaseException] = None
-
-        # Invoke function
-        try:
-            get_args_resp: FunctionGetArgsResponse = function_stub.function_get_args(
-                FunctionGetArgsRequest(task_id=task_id)
-            )
-
-            if not get_args_resp.ok:
-                raise InvalidFunctionArgumentsException
-
-            payload: dict = _load_args(get_args_resp.args)
-            args = payload.get("args") or []
-            kwargs = payload.get("kwargs") or {}
-
-            handler = FunctionHandler()
-            result = handler(context, *args, **kwargs)
-        except BaseException as exc:
-            print(traceback.format_exc())
-            result = error = exc
-            task_status = TaskStatus.Error
-        finally:
-            pickled_result = cloudpickle.dumps(result)
-            set_result_resp: FunctionSetResultResponse = function_stub.function_set_result(
-                FunctionSetResultRequest(task_id=task_id, result=pickled_result)
-            )
-            if not set_result_resp.ok:
-                raise RunnerException("Unable to set function result")
-
-        task_duration = time.time() - start_time
-
-        end_task_response = end_task_and_send_callback(
-            gateway_stub=gateway_stub,
-            payload=result,
-            end_task_request=EndTaskRequest(
+        # Start monitoring the task
+        with ThreadPoolExecutor() as thread_pool:
+            monitor_future = thread_pool.submit(
+                _monitor_task,
+                context=context,
+                stub_id=config.stub_id,
                 task_id=task_id,
-                task_duration=task_duration,
-                task_status=task_status,
                 container_id=container_id,
-                container_hostname=container_hostname,
-                keep_warm_seconds=0,
-            ),
-            override_callback_url=kwargs.get("callback_url"),
-        )
+                function_stub=function_stub,
+                gateway_stub=gateway_stub,
+            )
 
-        if not end_task_response.ok:
-            raise RunnerException("Unable to end task")
+            # Invoke the function and handle its result
+            try:
+                result = invoke_function(function_stub, context, task_id)
+            except BaseException as e:
+                handle_task_failure(e, gateway_stub, task_id, container_id, container_hostname)
+                raise
+            finally:
+                monitor_future.cancel()
 
-        monitor_task.cancel()
+            # End the task and send callback
+            complete_task(
+                gateway_stub,
+                result,
+                task_id,
+                container_id,
+                container_hostname,
+                start_time,
+            )
 
-        if error is not None and task_status == TaskStatus.Error:
-            raise error.with_traceback(error.__traceback__)
+
+def start_task(gateway_stub, task_id, container_id):
+    return gateway_stub.start_task(StartTaskRequest(task_id=task_id, container_id=container_id))
+
+
+def invoke_function(function_stub, context, task_id):
+    get_args_resp = function_stub.function_get_args(FunctionGetArgsRequest(task_id=task_id))
+    if not get_args_resp.ok:
+        raise InvalidFunctionArgumentsException("Invalid function arguments")
+
+    payload = _load_args(get_args_resp.args)
+    args = payload.get("args", [])
+    kwargs = payload.get("kwargs", {})
+
+    handler = FunctionHandler()
+    result = handler(context, *args, **kwargs)
+
+    pickled_result = cloudpickle.dumps(result)
+    set_result_resp = function_stub.function_set_result(
+        FunctionSetResultRequest(task_id=task_id, result=pickled_result)
+    )
+    if not set_result_resp.ok:
+        raise RunnerException("Unable to set function result")
+
+    return result
+
+
+def complete_task(gateway_stub, result, task_id, container_id, container_hostname, start_time):
+    task_status = TaskStatus.Complete
+    task_duration = time.time() - start_time
+
+    end_task_response = end_task_and_send_callback(
+        gateway_stub=gateway_stub,
+        payload=result,
+        end_task_request=EndTaskRequest(
+            task_id=task_id,
+            task_duration=task_duration,
+            task_status=task_status,
+            container_id=container_id,
+            container_hostname=container_hostname,
+            keep_warm_seconds=0,
+        ),
+        override_callback_url=None,
+    )
+
+    if not end_task_response.ok:
+        raise RunnerException("Unable to end task")
+
+
+def handle_task_failure(exception, gateway_stub, task_id, container_id, container_hostname):
+    result = str(exception)
+    task_status = TaskStatus.Error
+    task_duration = 0
+    keep_warm_seconds = 0
+
+    end_task_and_send_callback(
+        gateway_stub=gateway_stub,
+        payload=result,
+        end_task_request=EndTaskRequest(
+            task_id=task_id,
+            task_duration=task_duration,
+            task_status=task_status,
+            container_id=container_id,
+            container_hostname=container_hostname,
+            keep_warm_seconds=keep_warm_seconds,
+        ),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Marks the task status as error when it fails
- Fixes or prevents container from running until task expires e.g. "container still running"
- Fixes issue where CLI never exits - still mentions "Waiting..." even though the error has been printed
- Fixes scoping with some vars

Resolve BE-1904