### PR TITLE
Send errors to callback url in function invocations

### DIFF
--- a/sdk/src/beta9/exceptions.py
+++ b/sdk/src/beta9/exceptions.py
@@ -5,5 +5,26 @@ class RunnerException(SystemExit):
         super().__init__(*args)
 
 
-class InvalidFunctionArgumentsException(RuntimeError):
-    pass
+class InvalidFunctionArgumentsError(RuntimeError):
+    def __init__(self):
+        super().__init__("Invalid function arguments")
+
+
+class FunctionSetResultError(RunnerException):
+    def __init__(self):
+        super().__init__("Unable to set function result")
+
+
+class TaskStartError(RunnerException):
+    def __init__(self):
+        super().__init__("Unable to start task")
+
+
+class TaskEndError(RunnerException):
+    def __init__(self):
+        super().__init__("Unable to end task")
+
+
+class InvalidRunnerEnvironmentError(RunnerException):
+    def __init__(self):
+        super().__init__("Invalid runner environment")

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -17,6 +17,7 @@ from starlette.responses import Response
 
 from ..clients.gateway import (
     EndTaskRequest,
+    EndTaskResponse,
     GatewayServiceStub,
     SignPayloadRequest,
     SignPayloadResponse,
@@ -30,18 +31,18 @@ USER_CACHE_DIR = "/cache"
 
 @dataclass
 class Config:
-    container_id: Optional[str]
-    container_hostname: Optional[str]
-    stub_id: Optional[str]
-    stub_type: Optional[str]
-    workers: Optional[int]
-    keep_warm_seconds: Optional[int]
-    timeout: Optional[int]
+    container_id: str
+    container_hostname: str
+    stub_id: str
+    stub_type: str
+    workers: int
+    keep_warm_seconds: int
+    timeout: int
     python_version: str
     handler: str
-    on_start: Optional[str]
-    callback_url: Optional[str]
-    task_id: Optional[str]
+    on_start: str
+    callback_url: str
+    task_id: str
     bind_port: int
     volume_cache_map: Dict
 
@@ -232,7 +233,7 @@ def end_task_and_send_callback(
     payload: Any,
     end_task_request: EndTaskRequest,
     override_callback_url: Optional[str] = None,
-):
+) -> EndTaskResponse:
     resp = gateway_stub.end_task(end_task_request)
 
     send_callback(

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -330,4 +330,5 @@ def is_asgi3(app: Any) -> bool:
 
 class ThreadPoolExecutorOverride(ThreadPoolExecutor):
     def __exit__(self, *_, **__):
+        # cancel_futures added in 3.9
         self.shutdown(cancel_futures=True)

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -44,7 +44,7 @@ from ..type import TaskExitCode, TaskStatus
 @dataclass
 class InvokeResult:
     result: Optional[str] = None
-    callback_url_override: Optional[str] = None
+    callback_url: Optional[str] = None
     exception: Optional[BaseException] = None
 
 
@@ -225,13 +225,13 @@ def invoke_function(
 
         return InvokeResult(
             result=result,
-            callback_url_override=callback_url,
+            callback_url=callback_url,
         )
     except BaseException as e:
         return InvokeResult(
             result=result,
             exception=e,
-            callback_url_override=callback_url,
+            callback_url=callback_url,
         )
 
 
@@ -258,7 +258,7 @@ def complete_task(
             container_hostname=container_hostname,
             keep_warm_seconds=keep_warm_seconds,
         ),
-        override_callback_url=result.callback_url_override,
+        override_callback_url=result.callback_url,
     )
 
     if not end_task_response.ok:
@@ -288,7 +288,7 @@ def handle_task_failure(
             container_hostname=container_hostname,
             keep_warm_seconds=keep_warm_seconds,
         ),
-        override_callback_url=result.callback_url_override,
+        override_callback_url=result.callback_url,
     )
 
 


### PR DESCRIPTION
- Send exceptions/errors to callback if they happen
- Make Config fields required (not optional)
- Cleanup errors with custom exception classes
- Improve type annotations

Resolve BE-1904