### PR TITLE
Print error logs in function callable

### DIFF
--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -3,7 +3,7 @@ import sys
 import traceback
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Callable, List, NewType, Optional, Tuple, cast
+from typing import Any, Callable, Generator, List, NewType, Optional, Tuple, cast
 
 import grpc
 from grpc import ChannelCredentials
@@ -173,15 +173,21 @@ def prompt_first_auth(settings: SDKSettings) -> None:
     save_config(contexts, settings.config_path)
 
 
-@contextmanager
-def runner_context():
-    exit_code = 0
-
-    try:
+def pass_channel(func: Callable) -> Callable:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         config = get_config_context()
-        channel: Channel = get_channel(config)
-        yield channel
-        channel.close()
+        with get_channel(config) as channel:
+            return func(*args, **kwargs, channel=channel)
+
+    return wrapper
+
+
+@contextmanager
+def handle_error(print_traceback: bool = False):
+    exit_code = 0
+    try:
+        yield
     except RunnerException as exc:
         exit_code = exc.code
     except SystemExit as exc:
@@ -191,8 +197,18 @@ def runner_context():
         exit_code = 1
     finally:
         if exit_code != 0:
-            print(traceback.format_exc())
+            if print_traceback:
+                print(traceback.format_exc())
             sys.exit(exit_code)
+
+
+@contextmanager
+def runner_context() -> Generator[Channel, None, None]:
+    with handle_error(print_traceback=True):
+        config = get_config_context()
+        channel = get_channel(config)
+        yield channel
+        channel.close()
 
 
 def with_runner_context(func: Callable) -> Callable:

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -135,8 +135,8 @@ def _monitor_task(
             os._exit(0)
 
 
-@pass_channel
 @handle_error(print_traceback=False)
+@pass_channel
 def main(channel: Channel):
     function_stub: FunctionServiceStub = FunctionServiceStub(channel)
     gateway_stub: GatewayServiceStub = GatewayServiceStub(channel)


### PR DESCRIPTION
Fixes printing error logs in the function callable. It was removed during a refactor because the error logs were being printed twice, once in function:main() and once in with_runner_context.

To simplify this, we're decoupling the channel decorators and making it optional that the upstream error handler prints a stack trace. Also including a minor change in reordering params for handle_task_failure to be consistent with complete_task.

Resolve BE-1905