### PR TITLE
Improve endpoint request buffering

### DIFF
--- a/pkg/abstractions/common/ring_buffer.go
+++ b/pkg/abstractions/common/ring_buffer.go
@@ -25,10 +25,11 @@ func (rb *RingBuffer[T]) Push(request T, priority bool) {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
+	// If priority is true, move head backward to insert at the front
 	if priority {
-		// Priority insert: move head backward to insert at the front
 		rb.head = (rb.head - 1 + rb.size) % rb.size
 		rb.buffer[rb.head] = request
+
 		if rb.count < rb.size {
 			rb.count++
 		} else {
@@ -36,11 +37,12 @@ func (rb *RingBuffer[T]) Push(request T, priority bool) {
 			rb.tail = (rb.tail - 1 + rb.size) % rb.size
 		}
 	} else {
-		// Normal FIFO insert: insert at the tail
+		// Normal FIFO insert, just insert at the tail
 		rb.buffer[rb.tail] = request
 		rb.tail = (rb.tail + 1) % rb.size
+
+		// Buffer is full, move head forward to overwrite oldest element
 		if rb.count == rb.size {
-			// Buffer is full, move head forward to overwrite oldest element
 			rb.head = (rb.head + 1) % rb.size
 		} else {
 			rb.count++

--- a/pkg/abstractions/common/ring_buffer.go
+++ b/pkg/abstractions/common/ring_buffer.go
@@ -25,19 +25,19 @@ func (rb *RingBuffer[T]) Push(request T, priority bool) {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
-	// If priority is true, move head backward to insert at the front
 	if priority {
-		rb.head = (rb.head - 1 + rb.size) % rb.size
-		rb.buffer[rb.head] = request
-
-		if rb.count < rb.size {
-			rb.count++
+		if rb.count == rb.size {
+			// Buffer is full, overwrite the oldest element at head without moving pointers
+			// No adjustment to head or tail, since the count remains the same
+			rb.buffer[rb.head] = request
 		} else {
-			// Buffer is full, adjust tail as the oldest element is dropped
-			rb.tail = (rb.tail - 1 + rb.size) % rb.size
+			// Move head backward to insert at front
+			rb.head = (rb.head - 1 + rb.size) % rb.size
+			rb.buffer[rb.head] = request
+			rb.count++
 		}
 	} else {
-		// Normal FIFO insert, just insert at the tail
+		// Normal FIFO insert at tail
 		rb.buffer[rb.tail] = request
 		rb.tail = (rb.tail + 1) % rb.size
 

--- a/pkg/abstractions/common/ring_buffer_test.go
+++ b/pkg/abstractions/common/ring_buffer_test.go
@@ -107,7 +107,7 @@ func TestRingBuffer_PriorityPushOnFullBuffer(t *testing.T) {
 	rb.Push(3, false)
 	rb.Push(0, true) // priority push to head
 
-	// First we insert 1,2, and 3:
+	// First we insert 1, 2, and 3:
 	// -> [1,2,3]
 
 	// Then we insert 0 with priority, which should end up like:

--- a/pkg/abstractions/common/ring_buffer_test.go
+++ b/pkg/abstractions/common/ring_buffer_test.go
@@ -1,0 +1,135 @@
+package abstractions
+
+import (
+	"testing"
+)
+
+func TestRingBuffer_PushAndPop(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Test normal push and pop
+	rb.Push(1, false)
+	rb.Push(2, false)
+	rb.Push(3, false)
+
+	if rb.Len() != 3 {
+		t.Errorf("expected length 3, got %d", rb.Len())
+	}
+
+	val, ok := rb.Pop()
+	if !ok || val != 1 {
+		t.Errorf("expected 1, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 2 {
+		t.Errorf("expected 2, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 3 {
+		t.Errorf("expected 3, got %v", val)
+	}
+
+	// Test pop on empty buffer
+	_, ok = rb.Pop()
+	if ok {
+		t.Errorf("expected false, got %v", ok)
+	}
+}
+
+func TestRingBuffer_PriorityPush(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Test priority push
+	rb.Push(1, false)
+	rb.Push(2, false)
+	rb.Push(3, false)
+	rb.Push(0, true) // priority push at head
+
+	val, ok := rb.Pop()
+	if !ok || val != 0 {
+		t.Errorf("expected 0 (priority), got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 1 {
+		t.Errorf("expected 1, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 2 {
+		t.Errorf("expected 2, got %v", val)
+	}
+}
+
+func TestRingBuffer_FullBuffer(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Fill buffer and check overflow behavior
+	rb.Push(1, false)
+	rb.Push(2, false)
+	rb.Push(3, false)
+	rb.Push(4, false) // should overwrite 1
+
+	if rb.Len() != 3 {
+		t.Errorf("expected length 3, got %d", rb.Len())
+	}
+
+	val, ok := rb.Pop()
+	if !ok || val != 2 {
+		t.Errorf("expected 2, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 3 {
+		t.Errorf("expected 3, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 4 {
+		t.Errorf("expected 4, got %v", val)
+	}
+
+	// Since the last item was overwritten, buffer should now be empty
+	_, ok = rb.Pop()
+	if ok {
+		t.Errorf("expected false, got %v", ok)
+	}
+}
+
+func TestRingBuffer_PriorityPushOnFullBuffer(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Fill buffer with some stuff, then add a higher priority item
+	rb.Push(1, false)
+	rb.Push(2, false)
+	rb.Push(3, false)
+	rb.Push(0, true) // priority push to head
+
+	// First we insert 1,2, and 3:
+	// -> [1,2,3]
+
+	// Then we insert 0 with priority, which should end up like:
+	// -> [0,2,3]
+
+	if rb.Len() != 3 {
+		t.Errorf("expected length 3, got %d", rb.Len())
+	}
+
+	val, ok := rb.Pop()
+	if !ok || val != 0 {
+		t.Errorf("expected 0 (priority), got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 2 {
+		t.Errorf("expected 2, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 3 {
+		t.Errorf("expected 3, got %v", val)
+	}
+
+}

--- a/pkg/abstractions/common/ring_buffer_test.go
+++ b/pkg/abstractions/common/ring_buffer_test.go
@@ -39,7 +39,7 @@ func TestRingBuffer_PushAndPop(t *testing.T) {
 }
 
 func TestRingBuffer_PriorityPush(t *testing.T) {
-	rb := NewRingBuffer[int](3)
+	rb := NewRingBuffer[int](4)
 
 	// Test priority push
 	rb.Push(1, false)
@@ -60,6 +60,11 @@ func TestRingBuffer_PriorityPush(t *testing.T) {
 	val, ok = rb.Pop()
 	if !ok || val != 2 {
 		t.Errorf("expected 2, got %v", val)
+	}
+
+	val, ok = rb.Pop()
+	if !ok || val != 3 {
+		t.Errorf("expected 3, got %v", val)
 	}
 }
 

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -268,8 +268,8 @@ func (rb *RequestBuffer) acquireRequestToken(containerId string) error {
 		return err
 	}
 
-	// If the token count is negative, we exceeded our threshold of available request tokens
-	// -- just reverse the operation
+	// If the token count is negative, we exceeded our threshold of
+	// available request tokens, just reverse the operation
 	if tokenCount < 0 {
 		rb.rdb.Incr(rb.ctx, tokenKey)
 		return errors.New("too many in-flight requests")

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -290,6 +290,11 @@ func (rb *RequestBuffer) acquireRequestToken(containerId string) error {
 }
 
 func (rb *RequestBuffer) releaseRequestToken(containerId string) error {
+	// TODO: if a gateway crashes before releasing the token, it could lead to a drift
+	// in the count of available request tokens for a particular container. To handle this
+	// we could move the release logic to the task implementation (e.g. task.Complete), so that
+	// it handles the release of the token and is not tied to a specific gateway
+
 	tokenKey := Keys.endpointRequestTokens(rb.workspace.Name, rb.stubId, containerId)
 
 	err := rb.rdb.Incr(rb.ctx, tokenKey).Err()

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -209,6 +209,7 @@ func (rb *RequestBuffer) discoverContainers() {
 							address:          containerAddress,
 							inFlightRequests: inFlightRequests,
 						}
+
 						return
 					}
 				}(containerState)

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -99,7 +99,7 @@ func (rb *RequestBuffer) ForwardRequest(ctx echo.Context, payload *types.TaskPay
 		done:        done,
 		payload:     payload,
 		taskMessage: taskMessage,
-	})
+	}, false)
 
 	for {
 		select {
@@ -325,7 +325,7 @@ func (rb *RequestBuffer) handleRequest(req request) {
 	rb.availableContainersLock.RLock()
 
 	if len(rb.availableContainers) == 0 {
-		rb.buffer.Push(req)
+		rb.buffer.Push(req, true)
 		rb.availableContainersLock.RUnlock()
 		return
 	}
@@ -338,7 +338,7 @@ func (rb *RequestBuffer) handleRequest(req request) {
 
 	err := rb.acquireRequestToken(c.id)
 	if err != nil {
-		rb.buffer.Push(req)
+		rb.buffer.Push(req, true)
 		return
 	}
 

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -250,7 +250,6 @@ func (rb *RequestBuffer) requestTokens(containerId string) (int, error) {
 	} else if err == redis.Nil {
 		maxTokens := int(rb.stubConfig.Workers)
 
-		// Try to set the key if it doesn't exist
 		created, err := rb.rdb.SetNX(rb.ctx, tokenKey, maxTokens, 0).Result()
 		if err != nil {
 			return 0, err
@@ -260,12 +259,12 @@ func (rb *RequestBuffer) requestTokens(containerId string) (int, error) {
 			return maxTokens, nil
 		}
 
-		maxTokens, err = rb.rdb.Get(rb.ctx, tokenKey).Int()
+		tokens, err := rb.rdb.Get(rb.ctx, tokenKey).Int()
 		if err != nil {
 			return 0, err
 		}
 
-		return maxTokens, nil
+		return tokens, nil
 	}
 
 	return val, nil

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	requestProcessingInterval time.Duration = time.Millisecond * 500
+	requestProcessingInterval time.Duration = time.Millisecond * 100
 )
 
 type request struct {

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	requestProcessingInterval time.Duration = time.Millisecond * 100
+	requestProcessingInterval time.Duration = time.Millisecond * 50
 )
 
 type request struct {
@@ -196,10 +196,6 @@ func (rb *RequestBuffer) discoverContainers() {
 
 					availableTokens, err := rb.requestTokens(cs.ContainerId)
 					if err != nil {
-						return
-					}
-
-					if availableTokens <= 0 {
 						return
 					}
 

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -237,7 +237,7 @@ func (es *HttpEndpointService) getOrCreateEndpointInstance(stubId string, option
 		return nil, err
 	}
 
-	requestBufferSize := int(stubConfig.MaxPendingTasks)
+	requestBufferSize := int(stubConfig.MaxPendingTasks) + 1
 	if requestBufferSize < endpointMinRequestBufferSize {
 		requestBufferSize = endpointMinRequestBufferSize
 	}

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -311,7 +311,7 @@ type keys struct{}
 var (
 	endpointKeepWarmLock     string = "endpoint:%s:%s:keep_warm_lock:%s"
 	endpointInstanceLock     string = "endpoint:%s:%s:instance_lock"
-	endpointRequestsInFlight string = "endpoint:%s:%s:requests_in_flight:%s"
+	endpointRequestTokens    string = "endpoint:%s:%s:request_tokens:%s"
 	endpointRequestHeartbeat string = "endpoint:%s:%s:request_heartbeat:%s"
 	endpointServeLock        string = "endpoint:%s:%s:serve_lock"
 )
@@ -324,8 +324,8 @@ func (k *keys) endpointInstanceLock(workspaceName, stubId string) string {
 	return fmt.Sprintf(endpointInstanceLock, workspaceName, stubId)
 }
 
-func (k *keys) endpointRequestsInFlight(workspaceName, stubId, containerId string) string {
-	return fmt.Sprintf(endpointRequestsInFlight, workspaceName, stubId, containerId)
+func (k *keys) endpointRequestTokens(workspaceName, stubId, containerId string) string {
+	return fmt.Sprintf(endpointRequestTokens, workspaceName, stubId, containerId)
 }
 
 func (k *keys) endpointRequestHeartbeat(workspaceName, stubId, taskId string) string {

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -45,8 +45,8 @@ type HttpEndpointService struct {
 }
 
 var (
-	DefaultEndpointRequestTimeoutS int    = 600  // 10 minutes
-	DefaultEndpointRequestTTL      uint32 = 1200 // 20 minutes
+	DefaultEndpointRequestTimeoutS int    = 600 // 10 minutes
+	DefaultEndpointRequestTTL      uint32 = 600 // 10 minutes
 	ASGIRoutePrefix                string = "/asgi"
 
 	endpointContainerPrefix                 string        = "endpoint"

--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -70,7 +70,7 @@ func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellation
 		return err
 	}
 
-	return nil
+	return t.es.taskDispatcher.Complete(ctx, t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId)
 }
 
 func (t *EndpointTask) HeartBeat(ctx context.Context) (bool, error) {

--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -30,10 +30,7 @@ func (t *EndpointTask) Execute(ctx context.Context, options ...interface{}) erro
 		return err
 	}
 
-	return instance.buffer.ForwardRequest(echoCtx, &types.TaskPayload{
-		Args:   t.msg.Args,
-		Kwargs: t.msg.Kwargs,
-	}, t.msg)
+	return instance.buffer.ForwardRequest(echoCtx, t)
 }
 
 func (t *EndpointTask) Retry(ctx context.Context) error {
@@ -62,6 +59,8 @@ func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellation
 		task.Status = types.TaskStatusExpired
 	case types.TaskExceededRetryLimit:
 		task.Status = types.TaskStatusError
+	case types.TaskRequestCancelled:
+		task.Status = types.TaskStatusCancelled
 	default:
 		task.Status = types.TaskStatusError
 	}

--- a/pkg/gateway/services/task.go
+++ b/pkg/gateway/services/task.go
@@ -70,6 +70,12 @@ func (gws *GatewayService) EndTask(ctx context.Context, in *pb.EndTaskRequest) (
 		return &pb.EndTaskResponse{Ok: false}, nil
 	}
 
+	if task.Status.IsCompleted() {
+		return &pb.EndTaskResponse{
+			Ok: true,
+		}, nil
+	}
+
 	task.EndedAt = sql.NullTime{Time: time.Now(), Valid: true}
 	task.Status = types.TaskStatus(in.TaskStatus)
 

--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -184,7 +184,11 @@ func (d *Dispatcher) retryTask(ctx context.Context, task types.TaskInterface, ta
 
 	// Hit retry limit, cancel task and resolve
 	if taskMessage.Retries >= taskMessage.Policy.MaxRetries {
-		log.Printf("<dispatcher> hit retry limit, not reinserting task <%s> into queue: %s\n", taskMessage.TaskId, taskMessage.StubId)
+
+		// Don't bother logging it if the retry limit is set to 0, it's just noise
+		if taskMessage.Policy.MaxRetries != 0 {
+			log.Printf("<dispatcher> hit retry limit, not reinserting task <%s> into queue: %s\n", taskMessage.TaskId, taskMessage.StubId)
+		}
 
 		err = task.Cancel(ctx, types.TaskExceededRetryLimit)
 		if err != nil {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -27,6 +27,7 @@ type TaskCancellationReason string
 const (
 	TaskExpired            TaskCancellationReason = "expired"
 	TaskExceededRetryLimit TaskCancellationReason = "exceeded_retry_limit"
+	TaskRequestCancelled   TaskCancellationReason = "request_cancelled"
 )
 
 type TaskInterface interface {


### PR DESCRIPTION
Some quick fixes for endpoint request buffering, implements a lock-less flow control setup using tokens

- Instead of relying on locking, invert request counter to use token based flow control where max requests per container is equal to the number of available workers in the endpoint. This is very similar to the way it was before, but with more checks around capacity / combining set/get operations into a single atomic operation

- Check available containers without lock, _before_ trying to pop the request from the buffer to prevent unnecessary pops from fifo

- If requests are cancelled client side, cancel the tasks in the database / task dispatcher immediately

- Add priority flag to ring buffer to prioritize failed request retries before newer requests (also add some test cases for it)

- Some clean up and stuff


**NOTE**: Currently this uses the number of workers available to the endpoint as the request limit per container, but this could be something else that we allow users to set on the stub config. 