### PR TITLE
Remove condition and add temporary log

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -38,15 +38,10 @@ jobs:
 
             const release = context.payload.release;
 
-            const lines = release.body.split('\n');
+            // TODO: remove this when after first real release
+            console.log("release", release);
 
-            // Stop the workflow if the release notes do not end with "publish changelog"
-            const lastLine = lines[lines.length - 1].trim().toLowerCase();
-            if (lastLine !== 'publish changelog') {
-              core.setOutput('should_continue', 'false');
-              core.setOutput('error_message', 'Release notes do not end with "publish changelog". Stopping workflow.');
-              return;
-            }
+            const lines = release.body.split('\n');
 
             const feats = [];
             const fixes = [];


### PR DESCRIPTION
Removing condition. This might result in duplicate PRs when multiple releases go out at once, but I think closing duplicates is probably easier than remembering to add the tag line. 

I also added a temporary log of the release. I'm doing this so that I can test against a real release payload when making changes in the future. 