### PR TITLE
Fix race condition under load test with endpoint task creation

### DIFF
--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -21,7 +21,7 @@ func (t *EndpointTask) Execute(ctx context.Context, options ...interface{}) erro
 		return err
 	}
 
-	_, err = t.es.backendRepo.CreateTask(echoCtx.Request().Context(), &types.TaskParams{
+	_, err = t.es.backendRepo.CreateTask(context.Background(), &types.TaskParams{
 		TaskId:      t.msg.TaskId,
 		StubId:      instance.Stub.Id,
 		WorkspaceId: instance.Stub.WorkspaceId,


### PR DESCRIPTION
We noticed that under heavy load tests, the top few tasks were stuck in pending. It turns out this was due to the echo context being used for task creation in backend_postgres. This makes sure we don't interrupt that sql operation.