### PR TITLE
Fix: Added middleware and passed request headers down from buffer for websockets

### DIFF
--- a/sdk/src/beta9/middleware.py
+++ b/sdk/src/beta9/middleware.py
@@ -1,0 +1,88 @@
+import os
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Any, Optional
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import HTTPConnection
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from .clients.gateway import (
+    EndTaskRequest,
+    StartTaskRequest,
+)
+from .logging import StdoutJsonInterceptor
+from .runner.common import config as cfg
+from .runner.common import end_task_and_send_callback
+from .type import TaskStatus
+
+
+@dataclass
+class TaskLifecycleData:
+    status: TaskStatus
+    result: Any
+    override_callback_url: Optional[str] = None
+
+
+async def run_task(request, func, func_args):
+    task_id = request.headers.get("X-TASK-ID")
+    if not task_id:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Task ID missing")
+
+    os.environ["TASK_ID"] = task_id
+    with StdoutJsonInterceptor(task_id=task_id):
+        print(f"Received task <{task_id}>")
+        start_response = request.app.state.gateway_stub.start_task(
+            StartTaskRequest(task_id=task_id, container_id=cfg.container_id)
+        )
+        if not start_response.ok:
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Failed to start task"
+            )
+
+        task_lifecycle_data = TaskLifecycleData(
+            status=TaskStatus.Complete, result=None, override_callback_url=None
+        )
+
+        try:
+            request.state.task_lifecycle_data = task_lifecycle_data
+            response = await func(*func_args)
+            print(f"Task <{task_id}> finished")
+            return response
+        finally:
+            if "TASK_ID" in os.environ:
+                del os.environ["TASK_ID"]
+
+            end_task_and_send_callback(
+                gateway_stub=request.app.state.gateway_stub,
+                payload=task_lifecycle_data.result,
+                end_task_request=EndTaskRequest(
+                    task_id=task_id,
+                    container_id=cfg.container_id,
+                    keep_warm_seconds=cfg.keep_warm_seconds,
+                    task_status=task_lifecycle_data.status,
+                ),
+                override_callback_url=task_lifecycle_data.override_callback_url,
+            )
+
+
+class WebsocketTaskLifecycleMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "websocket":
+            await self.app(scope, receive, send)
+            return
+
+        request = HTTPConnection(scope, receive)
+        return await run_task(request, self.app, (scope, receive, send))
+
+
+class TaskLifecycleMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/health":
+            return await call_next(request)
+
+        return await run_task(request, call_next, (request,))

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -4,17 +4,14 @@ import os
 import signal
 import traceback
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, Dict, Optional, Tuple
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
 from gunicorn.app.base import Arbiter, BaseApplication
 from starlette.applications import Starlette
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import HTTPConnection
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp
 from uvicorn.workers import UvicornWorker
 
 from ..abstractions.base.runner import (
@@ -24,15 +21,17 @@ from ..abstractions.base.runner import (
 )
 from ..channel import runner_context
 from ..clients.gateway import (
-    EndTaskRequest,
     GatewayServiceStub,
-    StartTaskRequest,
 )
-from ..logging import StdoutJsonInterceptor
+from ..middleware import (
+    TaskLifecycleData,
+    TaskLifecycleMiddleware,
+    WebsocketTaskLifecycleMiddleware,
+)
 from ..runner.common import FunctionContext, FunctionHandler, execute_lifecycle_method
 from ..runner.common import config as cfg
 from ..type import LifeCycleMethod, TaskStatus
-from .common import end_task_and_send_callback, is_asgi3
+from .common import is_asgi3
 
 
 class EndpointFilter(logging.Filter):
@@ -119,76 +118,6 @@ class OnStartMethodHandler:
         while self._is_running:
             self._worker.notify()
             await asyncio.sleep(1)
-
-
-@dataclass
-class TaskLifecycleData:
-    status: TaskStatus
-    result: Any
-    override_callback_url: Optional[str] = None
-
-
-async def runTask(request, func, func_args):
-    task_id = request.headers.get("X-TASK-ID")
-    if not task_id:
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Task ID missing")
-
-    os.environ["TASK_ID"] = task_id
-    with StdoutJsonInterceptor(task_id=task_id):
-        print(f"Received task <{task_id}>")
-        start_response = request.app.state.gateway_stub.start_task(
-            StartTaskRequest(task_id=task_id, container_id=cfg.container_id)
-        )
-        if not start_response.ok:
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Failed to start task"
-            )
-
-        task_lifecycle_data = TaskLifecycleData(
-            status=TaskStatus.Complete, result=None, override_callback_url=None
-        )
-
-        try:
-            request.state.task_lifecycle_data = task_lifecycle_data
-            response = await func(*func_args)
-            print(f"Task <{task_id}> finished")
-            return response
-        finally:
-            if "TASK_ID" in os.environ:
-                del os.environ["TASK_ID"]
-
-            end_task_and_send_callback(
-                gateway_stub=request.app.state.gateway_stub,
-                payload=task_lifecycle_data.result,
-                end_task_request=EndTaskRequest(
-                    task_id=task_id,
-                    container_id=cfg.container_id,
-                    keep_warm_seconds=cfg.keep_warm_seconds,
-                    task_status=task_lifecycle_data.status,
-                ),
-                override_callback_url=task_lifecycle_data.override_callback_url,
-            )
-
-
-class WebsocketTaskLifecycleMiddleware:
-    def __init__(self, app: ASGIApp) -> None:
-        self.app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "websocket":
-            await self.app(scope, receive, send)
-            return
-
-        request = HTTPConnection(scope, receive)
-        return await runTask(request, self.app, (scope, receive, send))
-
-
-class TaskLifecycleMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path == "/health":
-            return await call_next(request)
-
-        return await runTask(request, call_next, (request,))
 
 
 def get_task_lifecycle_data(request: Request):

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -13,7 +13,8 @@ from fastapi.responses import JSONResponse, Response
 from gunicorn.app.base import Arbiter, BaseApplication
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.types import ASGIApp
+from starlette.requests import HTTPConnection
+from starlette.types import ASGIApp, Receive, Scope, Send
 from uvicorn.workers import UvicornWorker
 
 from ..abstractions.base.runner import (
@@ -127,51 +128,67 @@ class TaskLifecycleData:
     override_callback_url: Optional[str] = None
 
 
+async def runTask(request, func, func_args):
+    task_id = request.headers.get("X-TASK-ID")
+    if not task_id:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Task ID missing")
+
+    os.environ["TASK_ID"] = task_id
+    with StdoutJsonInterceptor(task_id=task_id):
+        print(f"Received task <{task_id}>")
+        start_response = request.app.state.gateway_stub.start_task(
+            StartTaskRequest(task_id=task_id, container_id=cfg.container_id)
+        )
+        if not start_response.ok:
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Failed to start task"
+            )
+
+        task_lifecycle_data = TaskLifecycleData(
+            status=TaskStatus.Complete, result=None, override_callback_url=None
+        )
+
+        try:
+            request.state.task_lifecycle_data = task_lifecycle_data
+            response = await func(*func_args)
+            print(f"Task <{task_id}> finished")
+            return response
+        finally:
+            if "TASK_ID" in os.environ:
+                del os.environ["TASK_ID"]
+
+            end_task_and_send_callback(
+                gateway_stub=request.app.state.gateway_stub,
+                payload=task_lifecycle_data.result,
+                end_task_request=EndTaskRequest(
+                    task_id=task_id,
+                    container_id=cfg.container_id,
+                    keep_warm_seconds=cfg.keep_warm_seconds,
+                    task_status=task_lifecycle_data.status,
+                ),
+                override_callback_url=task_lifecycle_data.override_callback_url,
+            )
+
+
+class WebsocketTaskLifecycleMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "websocket":
+            await self.app(scope, receive, send)
+            return
+
+        request = HTTPConnection(scope, receive)
+        return await runTask(request, self.app, (scope, receive, send))
+
+
 class TaskLifecycleMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         if request.url.path == "/health":
             return await call_next(request)
 
-        task_id = request.headers.get("X-TASK-ID")
-        if not task_id:
-            raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Task ID missing")
-
-        os.environ["TASK_ID"] = task_id
-
-        with StdoutJsonInterceptor(task_id=task_id):
-            print(f"Received task <{task_id}>")
-            start_response = request.app.state.gateway_stub.start_task(
-                StartTaskRequest(task_id=task_id, container_id=cfg.container_id)
-            )
-            if not start_response.ok:
-                raise HTTPException(
-                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Failed to start task"
-                )
-
-            task_lifecycle_data = TaskLifecycleData(
-                status=TaskStatus.Complete, result=None, override_callback_url=None
-            )
-
-            try:
-                request.state.task_lifecycle_data = task_lifecycle_data
-                response = await call_next(request)
-                print(f"Task <{task_id}> finished")
-                return response
-            finally:
-                if "TASK_ID" in os.environ:
-                    del os.environ["TASK_ID"]
-
-                end_task_and_send_callback(
-                    gateway_stub=request.app.state.gateway_stub,
-                    payload=task_lifecycle_data.result,
-                    end_task_request=EndTaskRequest(
-                        task_id=task_id,
-                        container_id=cfg.container_id,
-                        keep_warm_seconds=cfg.keep_warm_seconds,
-                        task_status=task_lifecycle_data.status,
-                    ),
-                    override_callback_url=task_lifecycle_data.override_callback_url,
-                )
+        return await runTask(request, call_next, (request,))
 
 
 def get_task_lifecycle_data(request: Request):
@@ -209,6 +226,7 @@ class EndpointManager:
             self.app = FastAPI(lifespan=self.lifespan)
 
         self.app.add_middleware(TaskLifecycleMiddleware)
+        self.app.add_middleware(WebsocketTaskLifecycleMiddleware)
 
         # Register signal handlers
         signal.signal(signal.SIGTERM, self.shutdown)


### PR DESCRIPTION
The TaskMiddleware used the BasicMiddleware class which happened to skip the dispatch function if the type of http connection is a websocket conenction. This adds a new middleware to handle the task lifecycle functionality for just websockets