### PR TITLE
Feat: Allow task queues to have public endpoints

### DIFF
--- a/pkg/abstractions/taskqueue/http.go
+++ b/pkg/abstractions/taskqueue/http.go
@@ -24,6 +24,7 @@ func registerTaskQueueRoutes(g *echo.Group, tq *RedisTaskQueue) *taskQueueGroup 
 	g.POST("/:deploymentName", auth.WithAuth(group.TaskQueuePut))
 	g.POST("/:deploymentName/latest", auth.WithAuth(group.TaskQueuePut))
 	g.POST("/:deploymentName/v:version", auth.WithAuth(group.TaskQueuePut))
+	g.POST("/public/:stubId", auth.WithAssumedStubAuth(group.TaskQueuePut, group.tq.isPublic))
 
 	return group
 }

--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -142,6 +142,19 @@ func NewRedisTaskQueueService(
 	return tq, nil
 }
 
+func (tq *RedisTaskQueue) isPublic(stubId string) (*types.Workspace, error) {
+	instance, err := tq.getOrCreateQueueInstance(stubId)
+	if err != nil {
+		return nil, err
+	}
+
+	if instance.StubConfig.Authorized {
+		return nil, errors.New("unauthorized")
+	}
+
+	return instance.Workspace, nil
+}
+
 func (tq *RedisTaskQueue) taskQueueTaskFactory(ctx context.Context, msg types.TaskMessage) (types.TaskInterface, error) {
 	return &TaskQueueTask{
 		tq:  tq,

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -75,6 +75,9 @@ class TaskQueue(RunnerAbstraction):
         name (Optional[str]):
             An optional name for this task_queue, used during deployment. If not specified, you must specify the name
             at deploy time with the --name argument
+        authorized (Optional[str]):
+            If false, allows the endpoint to be invoked without an auth token.
+            Default is True.
         autoscaler (Autoscaler):
             Configure a deployment autoscaler - if specified, you can use scale your function horizontally using
             various autoscaling strategies. Default is QueueDepthAutoscaler().
@@ -111,6 +114,7 @@ class TaskQueue(RunnerAbstraction):
         volumes: Optional[List[Volume]] = None,
         secrets: Optional[List[str]] = None,
         name: Optional[str] = None,
+        authorized: bool = True,
         autoscaler: Autoscaler = QueueDepthAutoscaler(),
         task_policy: TaskPolicy = TaskPolicy(),
     ) -> None:
@@ -129,6 +133,7 @@ class TaskQueue(RunnerAbstraction):
             volumes=volumes,
             secrets=secrets,
             name=name,
+            authorized=authorized,
             autoscaler=autoscaler,
             task_policy=task_policy,
         )


### PR DESCRIPTION
Allows task queue to be configured as a public (no auth required) endpoint.