### PR TITLE
Fix: Allow any method for ASGI applications

### DIFF
--- a/pkg/abstractions/endpoint/http.go
+++ b/pkg/abstractions/endpoint/http.go
@@ -35,27 +35,16 @@ func registerEndpointRoutes(g *echo.Group, es *HttpEndpointService) *endpointGro
 func registerASGIRoutes(g *echo.Group, es *HttpEndpointService) *endpointGroup {
 	group := &endpointGroup{routeGroup: g, es: es}
 
-	g.POST("/id/:stubId", auth.WithAuth(group.ASGIRequest))
-	g.POST("/id/:stubId/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.POST("/:deploymentName", auth.WithAuth(group.ASGIRequest))
-	g.POST("/:deploymentName/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.POST("/:deploymentName/latest", auth.WithAuth(group.ASGIRequest))
-	g.POST("/:deploymentName/latest/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.POST("/:deploymentName/v:version", auth.WithAuth(group.ASGIRequest))
-	g.POST("/:deploymentName/v:version/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.POST("/public/:stubId", auth.WithAssumedStubAuth(group.ASGIRequest, group.es.isPublic))
-	g.POST("/public/:stubId/:subPath", auth.WithAssumedStubAuth(group.ASGIRequest, group.es.isPublic))
-
-	g.GET("/id/:stubId", auth.WithAuth(group.ASGIRequest))
-	g.GET("/id/:stubId/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.GET("/:deploymentName", auth.WithAuth(group.ASGIRequest))
-	g.GET("/:deploymentName/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.GET("/:deploymentName/latest", auth.WithAuth(group.ASGIRequest))
-	g.GET("/:deploymentName/latest/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.GET("/:deploymentName/v:version", auth.WithAuth(group.ASGIRequest))
-	g.GET("/:deploymentName/v:version/:subPath", auth.WithAuth(group.ASGIRequest))
-	g.GET("/public/:stubId", auth.WithAssumedStubAuth(group.ASGIRequest, group.es.isPublic))
-	g.GET("/public/:stubId/:subPath", auth.WithAssumedStubAuth(group.ASGIRequest, group.es.isPublic))
+	g.Any("/id/:stubId", auth.WithAuth(group.ASGIRequest))
+	g.Any("/id/:stubId/:subPath", auth.WithAuth(group.ASGIRequest))
+	g.Any("/:deploymentName", auth.WithAuth(group.ASGIRequest))
+	g.Any("/:deploymentName/:subPath", auth.WithAuth(group.ASGIRequest))
+	g.Any("/:deploymentName/latest", auth.WithAuth(group.ASGIRequest))
+	g.Any("/:deploymentName/latest/:subPath", auth.WithAuth(group.ASGIRequest))
+	g.Any("/:deploymentName/v:version", auth.WithAuth(group.ASGIRequest))
+	g.Any("/:deploymentName/v:version/:subPath", auth.WithAuth(group.ASGIRequest))
+	g.Any("/public/:stubId", auth.WithAssumedStubAuth(group.ASGIRequest, group.es.isPublic))
+	g.Any("/public/:stubId/:subPath", auth.WithAssumedStubAuth(group.ASGIRequest, group.es.isPublic))
 
 	return group
 }


### PR DESCRIPTION
Currently, only GET and POST work for ASGI applications.

None of these endpoints will work.
```python
    @myapp.head("/head", summary="Test head method", description="This is a test")
    async def head():
        resp = Response(status_code=200)
        resp.headers["X-Test"] = "test"
        return resp

    @myapp.put("/put")
    async def put():
        return {"message": "put"}

    @myapp.delete("/delete")
    async def delete():
        return {"message": "delete"}

    @myapp.options("/options")
    async def options():
        return {"message": "options"}

    @myapp.patch("/patch")
    async def patch():
        return {"message": "patch"}
```
Before the change:
```bash
curl -X PATCH 'http://localhost:1994/asgi/asgi-test-app/latest/patch' \                                                           
-H 'Connection: keep-alive' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer y6ranIRfAb01QsyhpZl4jZru3e-Q0lpIMf0UTC5S2lXsVf46UuRtJ6XJLyRejfn6ToyIc8vOQvwvYOfgUMGnuQ==' \
-d '{}'
{"message":"Not Found"}
```
After the change:
```bash
curl -X PATCH 'http://localhost:1994/asgi/asgi-test-app/latest/patch' \                                                        
-H 'Connection: keep-alive' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer y6ranIRfAb01QsyhpZl4jZru3e-Q0lpIMf0UTC5S2lXsVf46UuRtJ6XJLyRejfn6ToyIc8vOQvwvYOfgUMGnuQ==' \
-d '{}'
{"message":"patch"}
```
