### PR TITLE
Fix: Stop container response when already stopping

### DIFF
--- a/pkg/api/v1/base.go
+++ b/pkg/api/v1/base.go
@@ -25,6 +25,10 @@ func HTTPInternalServerError(message string) error {
 	return NewHTTPError(http.StatusInternalServerError, message)
 }
 
+func HTTPConflict(message string) error {
+	return NewHTTPError(http.StatusConflict, message)
+}
+
 func HTTPUnauthorized(message string) error {
 	return NewHTTPError(http.StatusUnauthorized, message)
 }

--- a/pkg/api/v1/container.go
+++ b/pkg/api/v1/container.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/repository"
@@ -101,6 +102,9 @@ func (c *ContainerGroup) StopContainer(ctx echo.Context) error {
 
 	err = c.scheduler.Stop(containerId)
 	if err != nil {
+		if strings.Contains(err.Error(), "event already exists") {
+			return HTTPConflict("Container is already stopping")
+		}
 		return HTTPInternalServerError("Failed to stop container")
 	}
 


### PR DESCRIPTION
When a container is already in the process of being stopped, this will return a 409 Conflict response instead of a 500 Internal Server Error. This is a better response for clients that need to understand whether or not a stop container request is already in progress.

Example of 409 according to Mozilla:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409#concurrent_tasks_disallowed
