### PR TITLE
Fix: Parse requirements.txt when using chained image builder

### DIFF
--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -242,13 +242,19 @@ class Image(BaseAbstraction):
         order they are added.
 
         Parameters:
-            packages: The Python packages to add. Valid package names are: numpy, pandas==2.2.2, etc.
+            packages: The Python packages to add or the path to a requirements.txt file. Valid package names are: numpy, pandas==2.2.2, etc.
 
         Returns:
             Image: The Image object.
         """
+
         if isinstance(packages, str):
-            packages = self._sanitize_python_packages(self._load_requirements_file(packages))
+            try:
+                packages = self._sanitize_python_packages(self._load_requirements_file(packages))
+            except FileNotFoundError:
+                raise ValueError(
+                    f"Could not find valid requirements.txt file at {packages}. Libraries must be specified as a list of valid package names or a path to a requirements.txt file."
+                )
 
         for package in packages:
             self.build_steps.append(BuildStep(command=package, type="pip"))

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -234,7 +234,7 @@ class Image(BaseAbstraction):
             self.build_steps.append(BuildStep(command=command, type="shell"))
         return self
 
-    def add_python_packages(self, packages: Sequence[str]) -> "Image":
+    def add_python_packages(self, packages: Union[Sequence[str], str]) -> "Image":
         """
         Add python packages that will be installed when building the image.
 
@@ -247,6 +247,9 @@ class Image(BaseAbstraction):
         Returns:
             Image: The Image object.
         """
+        if isinstance(packages, str):
+            packages = self._sanitize_python_packages(self._load_requirements_file(packages))
+
         for package in packages:
             self.build_steps.append(BuildStep(command=package, type="pip"))
         return self


### PR DESCRIPTION
This is a small change to allow users to pass a requirements.txt path instead of a list of python packages. 