### PR TITLE
Fix: Support threaded execution of remote function

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.89"
+version = "0.1.90"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/terminal.py
+++ b/sdk/src/beta9/terminal.py
@@ -28,6 +28,7 @@ if env.is_local():
     rich.traceback.install()
 
 _console = Console()
+_current_status = None
 
 
 def header(text: str, subtext: str = "") -> None:
@@ -77,8 +78,16 @@ def url(text: str) -> None:
 
 @contextmanager
 def progress(task_name: str) -> Generator[rich.status.Status, None, None]:
-    with _console.status(task_name, spinner="dots", spinner_style="white") as s:
-        yield s
+    global _current_status
+    if _current_status is not None:
+        yield _current_status
+    else:
+        with _console.status(task_name, spinner="dots", spinner_style="white") as s:
+            _current_status = s
+            try:
+                yield s
+            finally:
+                _current_status = None
 
 
 def progress_open(file, mode, **kwargs):


### PR DESCRIPTION
Resolve BE-1936

The first thing that this fixes is the `rich` status bar being contended for across threads. As things currently are, all the threads try to start their own status context manager. This is not allowed and we crash. With the change, I add a global status and a counter for the number of threads using it. If the status is already set, the thread just increments the counter and uses it. Then when its done it decrements the counter, which when zero triggers the status to be unset. This way, the global status is instantiated only once and lives until the last remote returns. 

Some changes were also made to file syncing. Previously each thread would attempt to do the syncing fully on its own. this caused race conditions in the backend when unarchiving the object. Now, only the thread that grabs the global lock will be able to sync the workspace object. Subsequent threads can check the the global workspace object ID. If it is set they skip syncing and use that object in the stub creation. You can see below that a single upload is performed. When run again, no uploads occur (though we still zip the workspace once to make the head request). 

```bash
~/Dev/beam/baps/nested-remote main ❯ python app.py                                                                                                                                                                                                                                                               8s   beta9-py3.12
=> Building image 
=> Building image 
=> Building image 
=> Using cached image 
=> Using cached image 
=> Syncing files 
=> Using cached image 
Reading .beta9ignore file
Collecting files from /Users/minzi/Dev/beam/baps/nested-remote
Added /Users/minzi/Dev/beam/baps/nested-remote/app.py
Collected object is 785.00 B
=> Uploading 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 785/785 bytes 0:00:00
=> Files synced 
=> Files already synced 
=> Files already synced 
=> Running function: <app:f2> 
=> Running function: <app:f1> 
=> Running function: <app:f3> 
f2
f1
f3
=> Function complete <c92e3125-33fe-434f-a4e0-374973089ea3> 
=> Function complete <b4ec0c33-c81e-4ad8-af9a-2f0666d15115> 
=> Function complete <47ae3861-63ab-41b0-a672-58c6062585e9> 
['f2', 'f1', 'f3']
~/Dev/beam/baps/nested-remote main ❯ python app.py                                                                                                                                                                                                                                                               8s   beta9-py3.12
=> Building image 
=> Building image 
=> Building image 
=> Using cached image 
=> Syncing files 
=> Using cached image 
=> Using cached image 
Reading .beta9ignore file
Collecting files from /Users/minzi/Dev/beam/baps/nested-remote
Added /Users/minzi/Dev/beam/baps/nested-remote/app.py
Collected object is 785.00 B
=> Files already synced 
=> Files already synced 
=> Files already synced 
=> Running function: <app:f1> 
=> Running function: <app:f2> 
=> Running function: <app:f3> 
f2
f1
f3
=> Function complete <30e9641f-01b6-4537-baa5-d7718306442b> 
=> Function complete <a1c6432e-6850-4daa-aa68-570e9425108e> 
=> Function complete <5fcfb10b-e53c-4bd8-a923-eba7c014daaa> 
['f1', 'f2', 'f3']
```