### PR TITLE
Fix: Add lock in sdk when creating stub to prevent races when using multiple threads

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.92"
+version = "0.1.93"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import sys
 import tempfile
+import threading
 import time
 from queue import Empty, Queue
 from typing import Callable, List, Optional, Union
@@ -51,6 +52,20 @@ TASKQUEUE_SERVE_STUB_TYPE = "taskqueue/serve"
 ENDPOINT_SERVE_STUB_TYPE = "endpoint/serve"
 ASGI_SERVE_STUB_TYPE = "asgi/serve"
 FUNCTION_SERVE_STUB_TYPE = "function/serve"
+
+_stub_creation_lock = threading.Lock()
+_stub_created_for_workspace = False
+
+
+def _get_stub_created_for_workspace() -> bool:
+    global _stub_created_for_workspace
+    _stub_created_for_workspace = False
+    return _stub_created_for_workspace
+
+
+def _set_stub_created_for_workspace(value: bool) -> None:
+    global _stub_created_for_workspace
+    _stub_created_for_workspace = value
 
 
 class RunnerAbstraction(BaseAbstraction):
@@ -349,39 +364,47 @@ class RunnerAbstraction(BaseAbstraction):
             return False
 
         if not self.stub_created:
-            stub_response: GetOrCreateStubResponse = self.gateway_stub.get_or_create_stub(
-                GetOrCreateStubRequest(
-                    object_id=self.object_id,
-                    image_id=self.image_id,
-                    stub_type=stub_type,
-                    name=stub_name,
-                    python_version=self.image.python_version,
-                    cpu=self.cpu,
-                    memory=self.memory,
-                    gpu=self.gpu,
-                    handler=self.handler,
-                    on_start=self.on_start,
-                    callback_url=self.callback_url,
-                    keep_warm_seconds=self.keep_warm_seconds,
-                    workers=self.workers,
-                    max_pending_tasks=self.max_pending_tasks,
-                    volumes=[v.export() for v in self.volumes],
-                    secrets=self.secrets,
-                    force_create=force_create_stub,
-                    authorized=self.authorized,
-                    autoscaler=AutoscalerProto(
-                        type=autoscaler_type,
-                        max_containers=self.autoscaler.max_containers,
-                        tasks_per_container=self.autoscaler.tasks_per_container,
-                    ),
-                    task_policy=TaskPolicyProto(
-                        max_retries=self.task_policy.max_retries,
-                        timeout=self.task_policy.timeout,
-                        ttl=self.task_policy.ttl,
-                    ),
-                    concurrent_requests=self.concurrent_requests,
-                )
+            stub_request = GetOrCreateStubRequest(
+                object_id=self.object_id,
+                image_id=self.image_id,
+                stub_type=stub_type,
+                name=stub_name,
+                python_version=self.image.python_version,
+                cpu=self.cpu,
+                memory=self.memory,
+                gpu=self.gpu,
+                handler=self.handler,
+                on_start=self.on_start,
+                callback_url=self.callback_url,
+                keep_warm_seconds=self.keep_warm_seconds,
+                workers=self.workers,
+                max_pending_tasks=self.max_pending_tasks,
+                volumes=[v.export() for v in self.volumes],
+                secrets=self.secrets,
+                force_create=force_create_stub,
+                authorized=self.authorized,
+                autoscaler=AutoscalerProto(
+                    type=autoscaler_type,
+                    max_containers=self.autoscaler.max_containers,
+                    tasks_per_container=self.autoscaler.tasks_per_container,
+                ),
+                task_policy=TaskPolicyProto(
+                    max_retries=self.task_policy.max_retries,
+                    timeout=self.task_policy.timeout,
+                    ttl=self.task_policy.ttl,
+                ),
+                concurrent_requests=self.concurrent_requests,
             )
+            if _get_stub_created_for_workspace():
+                stub_response: GetOrCreateStubResponse = self.gateway_stub.get_or_create_stub(
+                    stub_request
+                )
+            else:
+                with _stub_creation_lock:
+                    stub_response: GetOrCreateStubResponse = self.gateway_stub.get_or_create_stub(
+                        stub_request
+                    )
+                    _set_stub_created_for_workspace(True)
 
             if stub_response.ok:
                 self.stub_created = True

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -57,7 +57,7 @@ _stub_creation_lock = threading.Lock()
 _stub_created_for_workspace = False
 
 
-def _get_stub_created_for_workspace() -> bool:
+def _is_stub_created_for_workspace() -> bool:
     global _stub_created_for_workspace
     _stub_created_for_workspace = False
     return _stub_created_for_workspace
@@ -395,7 +395,7 @@ class RunnerAbstraction(BaseAbstraction):
                 ),
                 concurrent_requests=self.concurrent_requests,
             )
-            if _get_stub_created_for_workspace():
+            if _is_stub_created_for_workspace():
                 stub_response: GetOrCreateStubResponse = self.gateway_stub.get_or_create_stub(
                     stub_request
                 )


### PR DESCRIPTION
Below you can see the get or create stub request to the gateway fail. This occurs because multiple requests are made with the same object id. Whichever call extracts the object first will succeed and any others will fail (assuming they go down the path of creating the stub). To fix this problem, I added a thread lock to the `get_or_create_stub` call in `prepare_runtime`. This guarantees that only one of the threads will try to create stub and the remaining threads will just retrieve the previously created stub instead of potentially trying to create one themselves. 
```bash
=> Building image 
=> Building image 
=> Building image 
=> Using cached image 
=> Syncing files 
=> Using cached image 
Reading .beta9ignore file
=> Using cached image 
Collecting files from /Users/minzi/Dev/beam/baps/thread-fn
Added /Users/minzi/Dev/beam/baps/thread-fn/lalal
Added /Users/minzi/Dev/beam/baps/thread-fn/app.py
Added /Users/minzi/Dev/beam/baps/thread-fn/bloooper
Collected object is 969.00 B
=> Uploading 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 969/969 bytes 0:00:00
=> Files synced 
=> Files already synced 
=> Files already synced 
Failed to get or create stub
=> Running function: <app:f1> 
=> Running function: <app:f3> 
f1
f3
=> Function complete <798bb012-4f93-4b13-9137-05256d1c3f48> 
=> Function complete <bd558c36-f538-420a-b631-dc6821c49309> 
[None, 'f1', 'f3']
```