### PR TITLE
Feat: Realtime abstraction built on top of asgi

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.93"
+version = "0.1.94"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/__init__.py
+++ b/sdk/src/beta9/__init__.py
@@ -3,6 +3,7 @@ from .abstractions import experimental
 from .abstractions.container import Container
 from .abstractions.endpoint import ASGI as asgi
 from .abstractions.endpoint import Endpoint as endpoint
+from .abstractions.endpoint import RealtimeASGI as realtime
 from .abstractions.function import Function as function
 from .abstractions.function import Schedule as schedule
 from .abstractions.image import Image
@@ -24,6 +25,7 @@ __all__ = [
     "function",
     "endpoint",
     "asgi",
+    "realtime",
     "Container",
     "env",
     "GpuType",

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -3,6 +3,8 @@ import threading
 import traceback
 from typing import Any, Callable, List, Optional, Union
 
+from uvicorn.protocols.utils import ClientDisconnected
+
 from .. import terminal
 from ..abstractions.base.runner import (
     ASGI_DEPLOYMENT_STUB_TYPE,
@@ -375,7 +377,12 @@ class RealtimeASGI(ASGI):
                                 await websocket.send_bytes(output)
 
                         await asyncio.sleep(REALTIME_ASGI_SLEEP_INTERVAL_SECONDS)
-                    except (WebSocketDisconnect, WebSocketException, RuntimeError):
+                    except (
+                        WebSocketDisconnect,
+                        WebSocketException,
+                        RuntimeError,
+                        ClientDisconnected,
+                    ):
                         return
                     except BaseException:
                         print(f"Unhandled exception in websocket stream: {traceback.format_exc()}")

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -304,8 +304,6 @@ class RealtimeASGI(ASGI):
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
             Default is 3600. Set it to -1 to disable the timeout.
-        retries (Optional[int]):
-            The maximum number of times a task will be retried if the container crashes. Default is 3.
         workers (Optional[int]):
             The number of processes handling tasks per container.
             Modifying this parameter can improve throughput for certain workloads.
@@ -340,9 +338,6 @@ class RealtimeASGI(ASGI):
             various autoscaling strategies (Defaults to QueueDepthAutoscaler())
         callback_url (Optional[str]):
             An optional URL to send a callback to when a task is completed, timed out, or cancelled.
-        task_policy (TaskPolicy):
-            The task policy for the function. This helps manage the lifecycle of an individual task.
-            Setting values here will override timeout and retries.
     Example:
         ```python
         from beta9 import realtime

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -336,7 +336,7 @@ class RealtimeASGI(ASGI):
                     data = await websocket.receive_text()
                     internal_asgi_app.input_queue.put(data)
 
-                    if not internal_asgi_app.input_queue.empty():
+                    while not internal_asgi_app.input_queue.empty():
                         output = internal_asgi_app.handler(
                             context=internal_asgi_app.context,
                             input=internal_asgi_app.input_queue.get(),

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -345,7 +345,7 @@ class RealtimeASGI(ASGI):
             Setting values here will override timeout and retries.
     Example:
         ```python
-        from beta9 import realtime, Image
+        from beta9 import realtime
 
         def generate_text():
             return ["this", "could", "be", "anything"]

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -5,7 +5,7 @@ import signal
 import traceback
 from contextlib import asynccontextmanager
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
@@ -146,7 +146,17 @@ class EndpointManager:
                 task_id=None,
                 on_start_value=self.on_start_value,
             )
-            self.app = self.handler(context)
+
+            app: Union[FastAPI, None] = None
+            internal_asgi_app = self.handler.handler.func.internal_asgi_app
+            if internal_asgi_app is not None:
+                app = internal_asgi_app
+                app.context = context
+                app.handler = self.handler
+            else:
+                app = self.handler(context)
+
+            self.app = app
             if not is_asgi3(self.app):
                 raise ValueError("Invalid ASGI app returned from handler")
 

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -148,7 +148,7 @@ class EndpointManager:
             )
 
             app: Union[FastAPI, None] = None
-            internal_asgi_app = self.handler.handler.func.internal_asgi_app
+            internal_asgi_app = getattr(self.handler.handler.func, "internal_asgi_app", None)
             if internal_asgi_app is not None:
                 app = internal_asgi_app
                 app.context = context


### PR DESCRIPTION
This is an experimental decorator that configures a basic websocket streaming example under the hood. The idea is to have a drop-in-place feature that lets users create streaming handlers that can do image generation, chat, etc. without writing the ASGI boilerplate.

**TODO**:
- [x] Add automatic type inference
- [ ] Create client examples

```
from beta9 import realtime


def load_model():
    return "my_model"


@realtime(
    cpu=1,
    memory=128,
    timeout=180,
    concurrent_requests=10,
    on_start=load_model,
    authorized=False,
)
def handler(*, context, input: str):
    print(context.on_start_value)
    return input

```

The output from this echo server looks like this:
```
luke@Lukes-MBP beta9 % websocat ws://localhost:1994/asgi/public/bbfb4433-9685-4f79-9d92-68fb57b240c3
do something
do something
echo
echo
here
here
```