### PR TITLE
Feat: Allow Worker to shutdown when signaled with SIGTERM

### DIFF
--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -45,7 +45,7 @@ type ContainerRepository interface {
 	SetContainerAddress(containerId string, addr string) error
 	GetContainerAddress(containerId string) (string, error)
 	UpdateContainerStatus(string, types.ContainerStatus, time.Duration) error
-	DeleteContainerState(*types.ContainerRequest) error
+	DeleteContainerState(containerId string) error
 	SetWorkerAddress(containerId string, addr string) error
 	SetContainerStateWithConcurrencyLimit(quota *types.ConcurrencyLimit, request *types.ContainerRequest) error
 	GetWorkerAddress(ctx context.Context, containerId string) (string, error)

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -161,9 +161,7 @@ func (cr *ContainerRedisRepository) UpdateContainerStatus(containerId string, st
 	return nil
 }
 
-func (cr *ContainerRedisRepository) DeleteContainerState(request *types.ContainerRequest) error {
-	containerId := request.ContainerId
-
+func (cr *ContainerRedisRepository) DeleteContainerState(containerId string) error {
 	err := cr.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerContainerLock(containerId), common.RedisLockOptions{TtlS: 10, Retries: 0})
 	if err != nil {
 		return err

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -330,7 +330,7 @@ func (s *Scheduler) addRequestToBacklog(request *types.ContainerRequest) error {
 		}
 
 		log.Printf("Giving up on request <%s> after %d attempts or due to max retry duration exceeded\n", request.ContainerId, request.RetryCount)
-		s.containerRepo.DeleteContainerState(&types.ContainerRequest{ContainerId: request.ContainerId})
+		s.containerRepo.DeleteContainerState(request.ContainerId)
 	}()
 
 	return nil

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -1,0 +1,508 @@
+package worker
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	common "github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/storage"
+	types "github.com/beam-cloud/beta9/pkg/types"
+	runc "github.com/beam-cloud/go-runc"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	baseConfigPath            string = "/tmp"
+	defaultContainerDirectory string = "/mnt/code"
+)
+
+var (
+	//go:embed base_runc_config.json
+	baseRuncConfigRaw string
+)
+
+// handleStopContainerEvent used by the event bus to stop a container.
+// Containers are stopped by sending a stop container event to stopContainerChan.
+func (s *Worker) handleStopContainerEvent(event *common.Event) bool {
+	s.containerLock.Lock()
+	defer s.containerLock.Unlock()
+
+	containerId := event.Args["container_id"].(string)
+
+	if _, exists := s.containerInstances.Get(containerId); exists {
+		log.Printf("<%s> - received stop container event.\n", containerId)
+		s.stopContainerChan <- stopContainerEvent{ContainerId: containerId, Kill: false}
+	}
+
+	return true
+}
+
+// stopContainer stops a runc container.
+// It will remove the container state if the contaienr is forcefully killed.
+// Otherwise, the container state will be removed after the termination grace period in clearContainer().
+func (s *Worker) stopContainer(containerId string, kill bool) error {
+	log.Printf("<%s> - stopping container.\n", containerId)
+
+	if _, exists := s.containerInstances.Get(containerId); !exists {
+		log.Printf("<%s> - container not found.\n", containerId)
+		return nil
+	}
+
+	signal := int(syscall.SIGTERM)
+	if kill {
+		signal = int(syscall.SIGKILL)
+		s.containerRepo.DeleteContainerState(containerId)
+	}
+
+	err := s.runcHandle.Kill(context.Background(), containerId, signal, &runc.KillOpts{All: true})
+	if err != nil {
+		log.Printf("<%s> - unable to stop container: %v\n", containerId, err)
+
+		if strings.Contains(err.Error(), "container does not exist") {
+			s.containerNetworkManager.TearDown(containerId)
+			return nil
+		}
+
+		return err
+	}
+
+	log.Printf("<%s> - container stopped.\n", containerId)
+	return nil
+}
+
+const ExitCodeSigterm = 143
+
+func (s *Worker) finalizeContainer(containerId string, request *types.ContainerRequest, exitCode *int) {
+	defer s.containerWg.Done()
+
+	if *exitCode < 0 {
+		*exitCode = 1
+	} else if *exitCode == ExitCodeSigterm {
+		*exitCode = 0
+	}
+
+	err := s.containerRepo.SetContainerExitCode(containerId, *exitCode)
+	if err != nil {
+		log.Printf("<%s> - failed to set exit code: %v\n", containerId, err)
+	}
+
+	s.clearContainer(containerId, request, time.Duration(s.config.Worker.TerminationGracePeriod)*time.Second, *exitCode)
+}
+
+func (s *Worker) clearContainer(containerId string, request *types.ContainerRequest, delay time.Duration, exitCode int) {
+	s.containerLock.Lock()
+
+	// De-allocate GPU devices so they are available for new containers
+	if request.Gpu != "" {
+		s.containerCudaManager.UnassignGPUDevices(containerId)
+	}
+
+	// Tear down container network components
+	err := s.containerNetworkManager.TearDown(request.ContainerId)
+	if err != nil {
+		log.Printf("<%s> - failed to clean up container network: %v\n", request.ContainerId, err)
+	}
+
+	s.completedRequests <- request
+	s.containerLock.Unlock()
+
+	// Set container exit code on instance
+	instance, exists := s.containerInstances.Get(containerId)
+	if exists {
+		instance.ExitCode = exitCode
+		s.containerInstances.Set(containerId, instance)
+	}
+
+	go func() {
+		// Allow for some time to pass before clearing the container. This way we can handle some last
+		// minute logs or events or if the user wants to inspect the container before it's cleared.
+		time.Sleep(delay)
+
+		s.containerInstances.Delete(containerId)
+		err := s.containerRepo.DeleteContainerState(containerId)
+		if err != nil {
+			log.Printf("<%s> - failed to remove container state: %v\n", containerId, err)
+		}
+	}()
+}
+
+// Spawn a single container and stream output to stdout/stderr
+func (s *Worker) RunContainer(request *types.ContainerRequest) error {
+	containerId := request.ContainerId
+	bundlePath := filepath.Join(s.imageMountPath, request.ImageId)
+
+	// Pull image
+	log.Printf("<%s> - lazy-pulling image: %s\n", containerId, request.ImageId)
+	err := s.imageClient.PullLazy(request)
+	if err != nil && request.SourceImage != nil {
+		log.Printf("<%s> - lazy-pull failed, pulling source image: %s\n", containerId, *request.SourceImage)
+		err = s.imageClient.PullAndArchiveImage(context.TODO(), *request.SourceImage, request.ImageId, request.SourceImageCreds)
+		if err == nil {
+			err = s.imageClient.PullLazy(request)
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	bindPort, err := getRandomFreePort()
+	if err != nil {
+		return err
+	}
+	log.Printf("<%s> - acquired port: %d\n", containerId, bindPort)
+
+	// Read spec from bundle
+	initialBundleSpec, _ := s.readBundleConfig(request.ImageId)
+
+	opts := &ContainerOptions{
+		BundlePath:  bundlePath,
+		BindPort:    bindPort,
+		InitialSpec: initialBundleSpec,
+	}
+
+	err = s.containerMountManager.SetupContainerMounts(request)
+	if err != nil {
+		s.containerLogger.Log(request.ContainerId, request.StubId, fmt.Sprintf("failed to setup container mounts: %v", err))
+	}
+
+	// Generate dynamic runc spec for this container
+	spec, err := s.specFromRequest(request, opts)
+	if err != nil {
+		return err
+	}
+	log.Printf("<%s> - successfully created spec from request.\n", containerId)
+
+	// Set an address (ip:port) for the pod/container in Redis. Depending on the stub type,
+	// gateway may need to directly interact with this pod/container.
+	containerAddr := fmt.Sprintf("%s:%d", s.podAddr, bindPort)
+	err = s.containerRepo.SetContainerAddress(request.ContainerId, containerAddr)
+	if err != nil {
+		return err
+	}
+	log.Printf("<%s> - set container address.\n", containerId)
+
+	outputChan := make(chan common.OutputMsg)
+	go s.containerWg.Add(1)
+
+	// Start the container
+	go s.spawn(request, spec, outputChan, opts)
+
+	log.Printf("<%s> - spawned successfully.\n", containerId)
+	return nil
+}
+
+func (s *Worker) readBundleConfig(imageId string) (*specs.Spec, error) {
+	imageConfigPath := filepath.Join(s.imageMountPath, imageId, "initial_config.json")
+
+	data, err := os.ReadFile(imageConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	specTemplate := strings.TrimSpace(string(data))
+	var spec specs.Spec
+
+	err = json.Unmarshal([]byte(specTemplate), &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &spec, nil
+}
+
+// Generate a runc spec from a given request
+func (s *Worker) specFromRequest(request *types.ContainerRequest, options *ContainerOptions) (*specs.Spec, error) {
+	os.MkdirAll(filepath.Join(baseConfigPath, request.ContainerId), os.ModePerm)
+	configPath := filepath.Join(baseConfigPath, request.ContainerId, "config.json")
+
+	spec, err := s.newSpecTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	spec.Process.Cwd = defaultContainerDirectory
+	spec.Process.Args = request.EntryPoint
+
+	if s.config.Worker.RunCResourcesEnforced {
+		spec.Linux.Resources.CPU = getLinuxCPU(request)
+		spec.Linux.Resources.Memory = getLinuxMemory(request)
+	}
+
+	env := s.getContainerEnvironment(request, options)
+	if request.Gpu != "" {
+		spec.Hooks.Prestart[0].Args = append(spec.Hooks.Prestart[0].Args, configPath, "prestart")
+
+		existingCudaFound := false
+		env, existingCudaFound = s.containerCudaManager.InjectEnvVars(env, options)
+		if !existingCudaFound {
+			// If the container image does not have cuda libraries installed, mount cuda libs from the host
+			spec.Mounts = s.containerCudaManager.InjectMounts(spec.Mounts)
+		}
+
+		// Assign n-number of GPUs to a container
+		assignedGpus, err := s.containerCudaManager.AssignGPUDevices(request.ContainerId, request.GpuCount)
+		if err != nil {
+			return nil, err
+		}
+		env = append(env, fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", assignedGpus.String()))
+
+		spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, assignedGpus.devices...)
+
+	} else {
+		spec.Hooks.Prestart = nil
+	}
+
+	spec.Process.Env = append(spec.Process.Env, env...)
+	spec.Root.Readonly = false
+
+	var volumeCacheMap map[string]string = make(map[string]string)
+
+	// Add bind mounts to runc spec
+	for _, m := range request.Mounts {
+		// Skip mountpoint storage if the local path does not exist (mounting failed)
+		if m.MountType == storage.StorageModeMountPoint {
+			if _, err := os.Stat(m.LocalPath); os.IsNotExist(err) {
+				continue
+			}
+		} else {
+			volumeCacheMap[filepath.Base(m.MountPath)] = m.LocalPath
+
+			if _, err := os.Stat(m.LocalPath); os.IsNotExist(err) {
+				err := os.MkdirAll(m.LocalPath, 0755)
+				if err != nil {
+					log.Printf("<%s> - failed to create mount directory: %v\n", request.ContainerId, err)
+				}
+			}
+		}
+
+		mode := "rw"
+		if m.ReadOnly {
+			mode = "ro"
+		}
+
+		if m.LinkPath != "" {
+			err = forceSymlink(m.MountPath, m.LinkPath)
+			if err != nil {
+				log.Printf("<%s> - unable to symlink volume: %v", request.ContainerId, err)
+			}
+		}
+
+		spec.Mounts = append(spec.Mounts, specs.Mount{
+			Type:        "none",
+			Source:      m.LocalPath,
+			Destination: m.MountPath,
+			Options:     []string{"rbind", mode},
+		})
+	}
+
+	// If volume caching is enabled, set it up and add proper mounts to spec
+	if s.fileCacheManager.CacheAvailable() && request.Workspace.VolumeCacheEnabled {
+		err = s.fileCacheManager.EnableVolumeCaching(request.Workspace.Name, volumeCacheMap, spec)
+		if err != nil {
+			log.Printf("<%s> - failed to setup volume caching: %v", request.ContainerId, err)
+		}
+	}
+
+	// Configure resolv.conf
+	resolvMount := specs.Mount{
+		Type:        "none",
+		Source:      "/workspace/resolv.conf",
+		Destination: "/etc/resolv.conf",
+		Options: []string{"ro",
+			"rbind",
+			"rprivate",
+			"nosuid",
+			"noexec",
+			"nodev"},
+	}
+
+	if s.config.Worker.UseHostResolvConf {
+		resolvMount.Source = "/etc/resolv.conf"
+	}
+
+	spec.Mounts = append(spec.Mounts, resolvMount)
+
+	return spec, nil
+}
+
+func (s *Worker) newSpecTemplate() (*specs.Spec, error) {
+	var newSpec specs.Spec
+	specTemplate := strings.TrimSpace(string(baseRuncConfigRaw))
+	err := json.Unmarshal([]byte(specTemplate), &newSpec)
+	if err != nil {
+		return nil, err
+	}
+	return &newSpec, nil
+}
+
+func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, options *ContainerOptions) []string {
+	env := []string{
+		fmt.Sprintf("BIND_PORT=%d", options.BindPort),
+		fmt.Sprintf("CONTAINER_HOSTNAME=%s", fmt.Sprintf("%s:%d", s.podAddr, options.BindPort)),
+		fmt.Sprintf("CONTAINER_ID=%s", request.ContainerId),
+		fmt.Sprintf("BETA9_GATEWAY_HOST=%s", os.Getenv("BETA9_GATEWAY_HOST")),
+		fmt.Sprintf("BETA9_GATEWAY_PORT=%s", os.Getenv("BETA9_GATEWAY_PORT")),
+		"PYTHONUNBUFFERED=1",
+	}
+
+	env = append(env, request.Env...)
+	return env
+}
+
+// spawn a container using runc binary
+func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, outputChan chan common.OutputMsg, opts *ContainerOptions) {
+	ctx, cancel := context.WithCancel(s.ctx)
+
+	s.workerRepo.AddContainerToWorker(s.workerId, request.ContainerId)
+	defer s.workerRepo.RemoveContainerFromWorker(s.workerId, request.ContainerId)
+	defer cancel()
+
+	exitCode := -1
+	containerId := request.ContainerId
+
+	// Unmount external s3 buckets
+	defer s.containerMountManager.RemoveContainerMounts(containerId)
+
+	// Cleanup container state and resources
+	defer s.finalizeContainer(containerId, request, &exitCode)
+
+	// Create overlayfs for container
+	overlay := s.createOverlay(request, opts.BundlePath)
+
+	containerInstance := &ContainerInstance{
+		Id:         containerId,
+		StubId:     request.StubId,
+		BundlePath: opts.BundlePath,
+		Overlay:    overlay,
+		Spec:       spec,
+		ExitCode:   -1,
+		OutputWriter: common.NewOutputWriter(func(s string) {
+			outputChan <- common.OutputMsg{
+				Msg:     string(s),
+				Done:    false,
+				Success: false,
+			}
+		}),
+		LogBuffer: common.NewLogBuffer(),
+	}
+	s.containerInstances.Set(containerId, containerInstance)
+
+	// Every 30 seconds, update container status
+	go s.updateContainerStatus(request)
+
+	// Set worker hostname
+	hostname := fmt.Sprintf("%s:%d", s.podAddr, s.runcServer.port)
+	s.containerRepo.SetWorkerAddress(containerId, hostname)
+
+	// Handle stdout/stderr from spawned container
+	go s.containerLogger.CaptureLogs(containerId, outputChan)
+
+	go func() {
+		time.Sleep(time.Second)
+
+		s.containerLock.Lock()
+		defer s.containerLock.Unlock()
+
+		_, exists := s.containerInstances.Get(containerId)
+		if !exists {
+			return
+		}
+
+		if _, err := s.containerRepo.GetContainerState(containerId); err != nil {
+			if _, ok := err.(*types.ErrContainerStateNotFound); ok {
+				log.Printf("<%s> - container state not found, returning\n", containerId)
+				return
+			}
+		}
+
+		// Update container status to running
+		s.containerRepo.UpdateContainerStatus(containerId, types.ContainerStatusRunning, time.Duration(types.ContainerStateTtlS)*time.Second)
+	}()
+
+	// Setup container overlay filesystem
+	err := containerInstance.Overlay.Setup()
+	if err != nil {
+		log.Printf("<%s> failed to setup overlay: %v", containerId, err)
+		return
+	}
+	defer containerInstance.Overlay.Cleanup()
+	spec.Root.Path = containerInstance.Overlay.TopLayerPath()
+
+	// Setup container network namespace / devices
+	err = s.containerNetworkManager.Setup(containerId, spec)
+	if err != nil {
+		log.Printf("<%s> failed to setup container network: %v", containerId, err)
+		return
+	}
+
+	// Expose the bind port
+	err = s.containerNetworkManager.ExposePort(containerId, opts.BindPort, opts.BindPort)
+	if err != nil {
+		log.Printf("<%s> failed to expose container bind port: %v", containerId, err)
+		return
+	}
+
+	// Write runc config spec to disk
+	configContents, err := json.MarshalIndent(spec, "", " ")
+	if err != nil {
+		return
+	}
+
+	configPath := filepath.Join(baseConfigPath, containerId, "config.json")
+	err = os.WriteFile(configPath, configContents, 0644)
+	if err != nil {
+		return
+	}
+
+	// Log metrics
+	go s.workerMetrics.EmitContainerUsage(ctx, request)
+	go s.eventRepo.PushContainerStartedEvent(containerId, s.workerId, request)
+	defer func() { go s.eventRepo.PushContainerStoppedEvent(containerId, s.workerId, request) }()
+
+	// Capture resource usage (cpu/mem/gpu)
+	pidChan := make(chan int, 1)
+	go s.collectAndSendContainerMetrics(ctx, request, spec, pidChan)
+
+	// Invoke runc process (launch the container)
+	exitCode, err = s.runcHandle.Run(s.ctx, containerId, opts.BundlePath, &runc.CreateOpts{
+		OutputWriter: containerInstance.OutputWriter,
+		ConfigPath:   configPath,
+		Started:      pidChan,
+	})
+
+	// Send last log message since the container has exited
+	outputChan <- common.OutputMsg{
+		Msg:     "",
+		Done:    true,
+		Success: err == nil,
+	}
+}
+
+func (s *Worker) createOverlay(request *types.ContainerRequest, bundlePath string) *common.ContainerOverlay {
+	// For images that have a rootfs, set that as the root path
+	// otherwise, assume runc config files are in the rootfs themselves
+	rootPath := filepath.Join(bundlePath, "rootfs")
+	if _, err := os.Stat(rootPath); os.IsNotExist(err) {
+		rootPath = bundlePath
+	}
+
+	overlayPath := baseConfigPath
+	if s.isBuildRequest(request) {
+		overlayPath = "/dev/shm"
+	}
+
+	return common.NewContainerOverlay(request.ContainerId, rootPath, overlayPath)
+}
+
+// isBuildRequest checks if the sourceImage field is not-nil, which means the container request is for a build container
+func (s *Worker) isBuildRequest(request *types.ContainerRequest) bool {
+	return request.SourceImage != nil
+}

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -22,6 +22,9 @@ import (
 const (
 	baseConfigPath            string = "/tmp"
 	defaultContainerDirectory string = "/mnt/code"
+
+	exitCodeSigterm int = 143 // Means the container received a SIGTERM by the underlying operating system
+	exitCodeSigkill int = 137 // Means the container received a SIGKILL by the underlying operating system
 )
 
 var (
@@ -78,14 +81,12 @@ func (s *Worker) stopContainer(containerId string, kill bool) error {
 	return nil
 }
 
-const ExitCodeSigterm = 143
-
 func (s *Worker) finalizeContainer(containerId string, request *types.ContainerRequest, exitCode *int) {
 	defer s.containerWg.Done()
 
 	if *exitCode < 0 {
 		*exitCode = 1
-	} else if *exitCode == ExitCodeSigterm {
+	} else if *exitCode == exitCodeSigterm {
 		*exitCode = 0
 	}
 

--- a/pkg/worker/runc_resources.go
+++ b/pkg/worker/runc_resources.go
@@ -1,0 +1,36 @@
+package worker
+
+import (
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	standardCPUShare  uint64 = 1024
+	standardCPUPeriod int64  = 100_000
+)
+
+func calculateCPUShares(millicores int64) uint64 {
+	shares := uint64(millicores) * standardCPUShare / 1000
+	return shares
+}
+
+func calculateCPUQuota(millicores int64) int64 {
+	quota := millicores * standardCPUPeriod / 1000
+	return quota
+}
+
+func getLinuxCPU(request *types.ContainerRequest) *specs.LinuxCPU {
+	return &specs.LinuxCPU{
+		Shares: ptr.To(calculateCPUShares(request.Cpu)),
+		Quota:  ptr.To(calculateCPUQuota(request.Cpu)),
+		Period: ptr.To(uint64(standardCPUPeriod)),
+	}
+}
+
+func getLinuxMemory(request *types.ContainerRequest) *specs.LinuxMemory {
+	return &specs.LinuxMemory{
+		Limit: ptr.To(request.Memory * 1024 * 1024),
+	}
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -2,15 +2,13 @@ package worker
 
 import (
 	"context"
-	_ "embed"
-	"encoding/json"
+
 	"errors"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
+	"os/signal"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -18,7 +16,6 @@ import (
 	blobcache "github.com/beam-cloud/blobcache-v2/pkg"
 	"github.com/beam-cloud/go-runc"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"k8s.io/utils/ptr"
 
 	common "github.com/beam-cloud/beta9/pkg/common"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
@@ -29,6 +26,9 @@ import (
 const (
 	requestProcessingInterval     time.Duration = 100 * time.Millisecond
 	containerStatusUpdateInterval time.Duration = 30 * time.Second
+
+	containerLogsPath          string  = "/var/log/worker"
+	defaultWorkerSpindownTimeS float64 = 300 // 5 minutes
 )
 
 type Worker struct {
@@ -88,15 +88,6 @@ type stopContainerEvent struct {
 	ContainerId string
 	Kill        bool
 }
-
-var (
-	//go:embed base_runc_config.json
-	baseRuncConfigRaw          string
-	baseConfigPath             string  = "/tmp"
-	containerLogsPath          string  = "/var/log/worker"
-	defaultContainerDirectory  string  = "/mnt/code"
-	defaultWorkerSpindownTimeS float64 = 300 // 5 minutes
-)
 
 func NewWorker() (*Worker, error) {
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
@@ -225,12 +216,9 @@ func (s *Worker) Run() error {
 		return err
 	}
 
+	go s.listenForShutdown()
 	go s.manageWorkerCapacity()
 	go s.processStopContainerEvents()
-	defer func() {
-		close(s.completedRequests)
-		close(s.stopContainerChan)
-	}()
 
 	lastContainerRequest := time.Now()
 	for {
@@ -281,595 +269,113 @@ func (s *Worker) Run() error {
 	return s.shutdown()
 }
 
-// Only exit if there are no containers running, and no containers have recently been spun up on this worker
-func (s *Worker) shouldShutDown(lastContainerRequest time.Time) bool {
-	if (time.Since(lastContainerRequest).Seconds() > defaultWorkerSpindownTimeS) && s.containerInstances.Len() == 0 {
-		return true
-	}
-	return false
+// listenForShutdown listens for SIGINT and SIGTERM signals and cancels the worker context
+func (s *Worker) listenForShutdown() {
+	terminate := make(chan os.Signal, 1)
+	signal.Notify(terminate, syscall.SIGINT, syscall.SIGTERM)
+
+	<-terminate
+	log.Println("Shutdown signal received.")
+
+	s.cancel()
 }
 
-// Spawn a single container and stream output to stdout/stderr
-func (s *Worker) RunContainer(request *types.ContainerRequest) error {
-	containerId := request.ContainerId
-	bundlePath := filepath.Join(s.imageMountPath, request.ImageId)
-
-	// Pull image
-	log.Printf("<%s> - lazy-pulling image: %s\n", containerId, request.ImageId)
-	err := s.imageClient.PullLazy(request)
-	if err != nil && request.SourceImage != nil {
-		log.Printf("<%s> - lazy-pull failed, pulling source image: %s\n", containerId, *request.SourceImage)
-		err = s.imageClient.PullAndArchiveImage(context.TODO(), *request.SourceImage, request.ImageId, request.SourceImageCreds)
-		if err == nil {
-			err = s.imageClient.PullLazy(request)
+// Exit if there are no containers running and no containers have recently been spun up on this
+// worker, or if a shutdown signal has been received.
+func (s *Worker) shouldShutDown(lastContainerRequest time.Time) bool {
+	select {
+	case <-s.ctx.Done():
+		return true
+	default:
+		if (time.Since(lastContainerRequest).Seconds() > defaultWorkerSpindownTimeS) && s.containerInstances.Len() == 0 {
+			return true
 		}
+		return false
 	}
-	if err != nil {
-		return err
-	}
-
-	bindPort, err := getRandomFreePort()
-	if err != nil {
-		return err
-	}
-	log.Printf("<%s> - acquired port: %d\n", containerId, bindPort)
-
-	// Read spec from bundle
-	initialBundleSpec, _ := s.readBundleConfig(request.ImageId)
-
-	opts := &ContainerOptions{
-		BundlePath:  bundlePath,
-		BindPort:    bindPort,
-		InitialSpec: initialBundleSpec,
-	}
-
-	err = s.containerMountManager.SetupContainerMounts(request)
-	if err != nil {
-		s.containerLogger.Log(request.ContainerId, request.StubId, fmt.Sprintf("failed to setup container mounts: %v", err))
-	}
-
-	// Generate dynamic runc spec for this container
-	spec, err := s.specFromRequest(request, opts)
-	if err != nil {
-		return err
-	}
-	log.Printf("<%s> - successfully created spec from request.\n", containerId)
-
-	// Set an address (ip:port) for the pod/container in Redis. Depending on the stub type,
-	// gateway may need to directly interact with this pod/container.
-	containerAddr := fmt.Sprintf("%s:%d", s.podAddr, bindPort)
-	err = s.containerRepo.SetContainerAddress(request.ContainerId, containerAddr)
-	if err != nil {
-		return err
-	}
-	log.Printf("<%s> - set container address.\n", containerId)
-
-	outputChan := make(chan common.OutputMsg)
-	go s.containerWg.Add(1)
-
-	// Start the container
-	go s.spawn(request, spec, outputChan, opts)
-
-	log.Printf("<%s> - spawned successfully.\n", containerId)
-	return nil
 }
 
 func (s *Worker) updateContainerStatus(request *types.ContainerRequest) error {
+	ticker := time.NewTicker(containerStatusUpdateInterval)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(containerStatusUpdateInterval)
-
-		s.containerLock.Lock()
-		_, exists := s.containerInstances.Get(request.ContainerId)
-		s.containerLock.Unlock()
-
-		if !exists {
+		select {
+		case <-s.ctx.Done():
 			return nil
-		}
+		case <-ticker.C:
+			s.containerLock.Lock()
+			_, exists := s.containerInstances.Get(request.ContainerId)
+			s.containerLock.Unlock()
 
-		log.Printf("<%s> - container still running: %s\n", request.ContainerId, request.ImageId)
-
-		// Stop container if it is "orphaned" - meaning it's running but has no associated state
-		state, err := s.containerRepo.GetContainerState(request.ContainerId)
-		if err != nil {
-			if _, ok := err.(*types.ErrContainerStateNotFound); ok {
-				log.Printf("<%s> - container state not found, stopping container\n", request.ContainerId)
-				s.stopContainerChan <- stopContainerEvent{ContainerId: request.ContainerId, Kill: true}
+			if !exists {
 				return nil
 			}
 
-			continue
-		}
+			log.Printf("<%s> - container still running: %s\n", request.ContainerId, request.ImageId)
 
-		err = s.containerRepo.UpdateContainerStatus(request.ContainerId, state.Status, time.Duration(types.ContainerStateTtlS)*time.Second)
-		if err != nil {
-			log.Printf("<%s> - unable to update container state: %v\n", request.ContainerId, err)
-		}
-
-		// If container is supposed to be stopped, but isn't gone after TerminationGracePeriod seconds
-		// ensure it is killed after that
-		if state.Status == types.ContainerStatusStopping {
-			go func() {
-				time.Sleep(time.Duration(s.config.Worker.TerminationGracePeriod) * time.Second)
-
-				_, exists := s.containerInstances.Get(request.ContainerId)
-				if !exists {
-					return
+			// Stop container if it is "orphaned" - meaning it's running but has no associated state
+			state, err := s.containerRepo.GetContainerState(request.ContainerId)
+			if err != nil {
+				if _, ok := err.(*types.ErrContainerStateNotFound); ok {
+					log.Printf("<%s> - container state not found, stopping container\n", request.ContainerId)
+					s.stopContainerChan <- stopContainerEvent{ContainerId: request.ContainerId, Kill: true}
+					return nil
 				}
 
-				log.Printf("<%s> - container still running after stop event %ds ago - force killing\n", request.ContainerId, s.config.Worker.TerminationGracePeriod)
-				s.stopContainerChan <- stopContainerEvent{
-					ContainerId: request.ContainerId,
-					Kill:        true,
-				}
-			}()
+				continue
+			}
+
+			err = s.containerRepo.UpdateContainerStatus(request.ContainerId, state.Status, time.Duration(types.ContainerStateTtlS)*time.Second)
+			if err != nil {
+				log.Printf("<%s> - unable to update container state: %v\n", request.ContainerId, err)
+			}
+
+			// If container is supposed to be stopped, but isn't gone after TerminationGracePeriod seconds
+			// ensure it is killed after that
+			if state.Status == types.ContainerStatusStopping {
+				go func() {
+					time.Sleep(time.Duration(s.config.Worker.TerminationGracePeriod) * time.Second)
+
+					_, exists := s.containerInstances.Get(request.ContainerId)
+					if !exists {
+						return
+					}
+
+					log.Printf("<%s> - container still running after stop event %ds ago - force killing\n", request.ContainerId, s.config.Worker.TerminationGracePeriod)
+					s.stopContainerChan <- stopContainerEvent{
+						ContainerId: request.ContainerId,
+						Kill:        true,
+					}
+				}()
+			}
 		}
 	}
-}
-
-// stopContainer stops a running container by containerId, if it exists on this worker
-func (s *Worker) stopContainer(event *common.Event) bool {
-	s.containerLock.Lock()
-	defer s.containerLock.Unlock()
-
-	containerId := event.Args["container_id"].(string)
-
-	var err error = nil
-	if _, exists := s.containerInstances.Get(containerId); exists {
-		log.Printf("<%s> - received stop container event.\n", containerId)
-		s.stopContainerChan <- stopContainerEvent{ContainerId: containerId, Kill: false}
-	}
-
-	return err == nil
 }
 
 func (s *Worker) processStopContainerEvents() {
 	for event := range s.stopContainerChan {
-		log.Printf("<%s> - stopping container.\n", event.ContainerId)
-
-		instance, exists := s.containerInstances.Get(event.ContainerId)
-		if !exists {
-			continue
-		}
-
-		// Container has already exited, just skip this event
-		if instance.ExitCode >= 0 {
-			continue
-		}
-
-		signal := int(syscall.SIGTERM)
-		if event.Kill {
-			signal = int(syscall.SIGKILL)
-		}
-
-		err := s.runcHandle.Kill(s.ctx, event.ContainerId, signal, &runc.KillOpts{
-			All: true,
-		})
-		if err != nil {
-			log.Printf("<%s> - unable to stop container: %v\n", event.ContainerId, err)
-
-			if strings.Contains(err.Error(), "container does not exist") {
-				// In case container network is still around for some reason, get rid of it
-				s.containerNetworkManager.TearDown(event.ContainerId)
-				continue
-			}
-
-			s.stopContainerChan <- event
-			time.Sleep(time.Second)
-			continue
-		}
-
-		log.Printf("<%s> - container stopped.\n", event.ContainerId)
-	}
-}
-
-const ExitCodeSigterm = 143
-
-func (s *Worker) terminateContainer(containerId string, request *types.ContainerRequest, exitCode *int, containerErr *error) {
-	defer s.containerWg.Done()
-
-	if *exitCode < 0 {
-		*exitCode = 1
-	} else if *exitCode == ExitCodeSigterm {
-		*exitCode = 0
-	}
-
-	err := s.containerRepo.SetContainerExitCode(containerId, *exitCode)
-	if err != nil {
-		log.Printf("<%s> - failed to set exit code: %v\n", containerId, err)
-	}
-
-	s.clearContainer(containerId, request, time.Duration(s.config.Worker.TerminationGracePeriod)*time.Second, *exitCode)
-}
-
-func (s *Worker) clearContainer(containerId string, request *types.ContainerRequest, delay time.Duration, exitCode int) {
-	s.containerLock.Lock()
-
-	// De-allocate GPU devices so they are available for new containers
-	if request.Gpu != "" {
-		s.containerCudaManager.UnassignGPUDevices(containerId)
-	}
-
-	// Tear down container network components
-	err := s.containerNetworkManager.TearDown(request.ContainerId)
-	if err != nil {
-		log.Printf("<%s> - failed to clean up container network: %v\n", request.ContainerId, err)
-	}
-
-	s.completedRequests <- request
-	s.containerLock.Unlock()
-
-	// Set container exit code on instance
-	instance, exists := s.containerInstances.Get(containerId)
-	if exists {
-		instance.ExitCode = exitCode
-		s.containerInstances.Set(containerId, instance)
-	}
-
-	go func() {
-		// Allow for some time to pass before clearing the container. This way we can handle some last
-		// minute logs or events or if the user wants to inspect the container before it's cleared.
-		time.Sleep(delay)
-
-		s.containerInstances.Delete(containerId)
-		err := s.containerRepo.DeleteContainerState(request)
-		if err != nil {
-			log.Printf("<%s> - failed to remove container state: %v\n", containerId, err)
-		}
-
-	}()
-}
-
-// isBuildRequest checks if the sourceImage field is not-nil, which means the container request is for a build container
-func (s *Worker) isBuildRequest(request *types.ContainerRequest) bool {
-	return request.SourceImage != nil
-}
-
-func (s *Worker) createOverlay(request *types.ContainerRequest, bundlePath string) *common.ContainerOverlay {
-	// For images that have a rootfs, set that as the root path
-	// otherwise, assume runc config files are in the rootfs themselves
-	rootPath := filepath.Join(bundlePath, "rootfs")
-	if _, err := os.Stat(rootPath); os.IsNotExist(err) {
-		rootPath = bundlePath
-	}
-
-	overlayPath := baseConfigPath
-	if s.isBuildRequest(request) {
-		overlayPath = "/dev/shm"
-	}
-
-	return common.NewContainerOverlay(request.ContainerId, rootPath, overlayPath)
-}
-
-// spawn a container using runc binary
-func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, outputChan chan common.OutputMsg, opts *ContainerOptions) {
-	ctx, cancel := context.WithCancel(s.ctx)
-
-	s.workerRepo.AddContainerToWorker(s.workerId, request.ContainerId)
-	defer s.workerRepo.RemoveContainerFromWorker(s.workerId, request.ContainerId)
-	defer cancel()
-
-	var containerErr error = nil
-
-	exitCode := -1
-	containerId := request.ContainerId
-
-	// Unmount external s3 buckets
-	defer s.containerMountManager.RemoveContainerMounts(containerId)
-
-	// Clear out all files in the container's directory
-	defer func() {
-		s.terminateContainer(containerId, request, &exitCode, &containerErr)
-	}()
-
-	// Create overlayfs for container
-	overlay := s.createOverlay(request, opts.BundlePath)
-
-	containerInstance := &ContainerInstance{
-		Id:         containerId,
-		StubId:     request.StubId,
-		BundlePath: opts.BundlePath,
-		Overlay:    overlay,
-		Spec:       spec,
-		ExitCode:   -1,
-		OutputWriter: common.NewOutputWriter(func(s string) {
-			outputChan <- common.OutputMsg{
-				Msg:     string(s),
-				Done:    false,
-				Success: false,
-			}
-		}),
-		LogBuffer: common.NewLogBuffer(),
-	}
-	s.containerInstances.Set(containerId, containerInstance)
-
-	// Every 30 seconds, update container status
-	go s.updateContainerStatus(request)
-
-	// Set worker hostname
-	hostname := fmt.Sprintf("%s:%d", s.podAddr, s.runcServer.port)
-	s.containerRepo.SetWorkerAddress(request.ContainerId, hostname)
-
-	// Handle stdout/stderr from spawned container
-	go s.containerLogger.CaptureLogs(request.ContainerId, outputChan)
-
-	go func() {
-		time.Sleep(time.Second)
-
-		s.containerLock.Lock()
-		defer s.containerLock.Unlock()
-
-		_, exists := s.containerInstances.Get(containerId)
-		if !exists {
+		select {
+		case <-s.ctx.Done():
 			return
-		}
-
-		if _, err := s.containerRepo.GetContainerState(containerId); err != nil {
-			if _, ok := err.(*types.ErrContainerStateNotFound); ok {
-				log.Printf("<%s> - container state not found, returning\n", containerId)
-				return
-			}
-		}
-
-		// Update container status to running
-		s.containerRepo.UpdateContainerStatus(containerId, types.ContainerStatusRunning, time.Duration(types.ContainerStateTtlS)*time.Second)
-	}()
-
-	// Setup container overlay filesystem
-	err := containerInstance.Overlay.Setup()
-	if err != nil {
-		log.Printf("<%s> failed to setup overlay: %v", containerId, err)
-		containerErr = err
-		return
-	}
-	defer containerInstance.Overlay.Cleanup()
-	spec.Root.Path = containerInstance.Overlay.TopLayerPath()
-
-	// Setup container network namespace / devices
-	err = s.containerNetworkManager.Setup(containerId, spec)
-	if err != nil {
-		log.Printf("<%s> failed to setup container network: %v", containerId, err)
-		containerErr = err
-		return
-	}
-
-	// Expose the bind port
-	err = s.containerNetworkManager.ExposePort(containerId, opts.BindPort, opts.BindPort)
-	if err != nil {
-		log.Printf("<%s> failed to expose container bind port: %v", containerId, err)
-		containerErr = err
-		return
-	}
-
-	// Write runc config spec to disk
-	configContents, err := json.MarshalIndent(spec, "", " ")
-	if err != nil {
-		containerErr = err
-		return
-	}
-
-	configPath := filepath.Join(baseConfigPath, containerId, "config.json")
-	err = os.WriteFile(configPath, configContents, 0644)
-	if err != nil {
-		containerErr = err
-		return
-	}
-
-	// Log metrics
-	go s.workerMetrics.EmitContainerUsage(ctx, request)
-	go s.eventRepo.PushContainerStartedEvent(request.ContainerId, s.workerId, request)
-	defer func() { go s.eventRepo.PushContainerStoppedEvent(request.ContainerId, s.workerId, request) }()
-
-	// Capture resource usage (cpu/mem/gpu)
-	pidChan := make(chan int, 1)
-	go s.collectAndSendContainerMetrics(ctx, request, spec, pidChan)
-
-	// Invoke runc process (launch the container)
-	exitCode, err = s.runcHandle.Run(s.ctx, containerId, opts.BundlePath, &runc.CreateOpts{
-		OutputWriter: containerInstance.OutputWriter,
-		ConfigPath:   configPath,
-		Started:      pidChan,
-	})
-
-	// Send last log message since the container has exited
-	outputChan <- common.OutputMsg{
-		Msg:     "",
-		Done:    true,
-		Success: err == nil,
-	}
-
-	if err != nil {
-		containerErr = err
-		return
-	}
-
-	if exitCode != 0 {
-		containerErr = fmt.Errorf("unable to run container: %d", exitCode)
-	}
-}
-
-func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, options *ContainerOptions) []string {
-	env := []string{
-		fmt.Sprintf("BIND_PORT=%d", options.BindPort),
-		fmt.Sprintf("CONTAINER_HOSTNAME=%s", fmt.Sprintf("%s:%d", s.podAddr, options.BindPort)),
-		fmt.Sprintf("CONTAINER_ID=%s", request.ContainerId),
-		fmt.Sprintf("BETA9_GATEWAY_HOST=%s", os.Getenv("BETA9_GATEWAY_HOST")),
-		fmt.Sprintf("BETA9_GATEWAY_PORT=%s", os.Getenv("BETA9_GATEWAY_PORT")),
-		"PYTHONUNBUFFERED=1",
-	}
-
-	env = append(env, request.Env...)
-	return env
-}
-
-func (s *Worker) readBundleConfig(imageId string) (*specs.Spec, error) {
-	imageConfigPath := filepath.Join(s.imageMountPath, imageId, "initial_config.json")
-
-	data, err := os.ReadFile(imageConfigPath)
-	if err != nil {
-		return nil, err
-	}
-
-	specTemplate := strings.TrimSpace(string(data))
-	var spec specs.Spec
-
-	err = json.Unmarshal([]byte(specTemplate), &spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &spec, nil
-}
-
-func (s *Worker) newSpecTemplate() (*specs.Spec, error) {
-	var newSpec specs.Spec
-	specTemplate := strings.TrimSpace(string(baseRuncConfigRaw))
-	err := json.Unmarshal([]byte(specTemplate), &newSpec)
-	if err != nil {
-		return nil, err
-	}
-	return &newSpec, nil
-}
-
-const (
-	standardCPUShare  uint64 = 1024
-	standardCPUPeriod int64  = 100_000
-)
-
-func calculateCPUShares(millicores int64) uint64 {
-	shares := uint64(millicores) * standardCPUShare / 1000
-	return shares
-}
-
-func calculateCPUQuota(millicores int64) int64 {
-	quota := millicores * standardCPUPeriod / 1000
-	return quota
-}
-
-// Generate a runc spec from a given request
-func (s *Worker) specFromRequest(request *types.ContainerRequest, options *ContainerOptions) (*specs.Spec, error) {
-	os.MkdirAll(filepath.Join(baseConfigPath, request.ContainerId), os.ModePerm)
-	configPath := filepath.Join(baseConfigPath, request.ContainerId, "config.json")
-
-	spec, err := s.newSpecTemplate()
-	if err != nil {
-		return nil, err
-	}
-
-	spec.Process.Cwd = defaultContainerDirectory
-	spec.Process.Args = request.EntryPoint
-
-	if s.config.Worker.RunCResourcesEnforced {
-		spec.Linux.Resources.CPU = &specs.LinuxCPU{
-			Shares: ptr.To(calculateCPUShares(request.Cpu)),
-			Quota:  ptr.To(calculateCPUQuota(request.Cpu)),
-			Period: ptr.To(uint64(standardCPUPeriod)),
-		}
-		spec.Linux.Resources.Memory = &specs.LinuxMemory{
-			Limit: ptr.To(request.Memory * 1024 * 1024),
-		}
-	}
-
-	env := s.getContainerEnvironment(request, options)
-	if request.Gpu != "" {
-		spec.Hooks.Prestart[0].Args = append(spec.Hooks.Prestart[0].Args, configPath, "prestart")
-
-		existingCudaFound := false
-		env, existingCudaFound = s.containerCudaManager.InjectEnvVars(env, options)
-		if !existingCudaFound {
-			// If the container image does not have cuda libraries installed, mount cuda libs from the host
-			spec.Mounts = s.containerCudaManager.InjectMounts(spec.Mounts)
-		}
-
-		// Assign n-number of GPUs to a container
-		assignedGpus, err := s.containerCudaManager.AssignGPUDevices(request.ContainerId, request.GpuCount)
-		if err != nil {
-			return nil, err
-		}
-		env = append(env, fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", assignedGpus.String()))
-
-		spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, assignedGpus.devices...)
-
-	} else {
-		spec.Hooks.Prestart = nil
-	}
-
-	spec.Process.Env = append(spec.Process.Env, env...)
-	spec.Root.Readonly = false
-
-	var volumeCacheMap map[string]string = make(map[string]string)
-
-	// Add bind mounts to runc spec
-	for _, m := range request.Mounts {
-		// Skip mountpoint storage if the local path does not exist (mounting failed)
-		if m.MountType == storage.StorageModeMountPoint {
-			if _, err := os.Stat(m.LocalPath); os.IsNotExist(err) {
-				continue
-			}
-		} else {
-			volumeCacheMap[filepath.Base(m.MountPath)] = m.LocalPath
-
-			if _, err := os.Stat(m.LocalPath); os.IsNotExist(err) {
-				err := os.MkdirAll(m.LocalPath, 0755)
-				if err != nil {
-					log.Printf("<%s> - failed to create mount directory: %v\n", request.ContainerId, err)
-				}
-			}
-		}
-
-		mode := "rw"
-		if m.ReadOnly {
-			mode = "ro"
-		}
-
-		if m.LinkPath != "" {
-			err = forceSymlink(m.MountPath, m.LinkPath)
+		default:
+			err := s.stopContainer(event.ContainerId, event.Kill)
 			if err != nil {
-				log.Printf("<%s> - unable to symlink volume: %v", request.ContainerId, err)
+				s.stopContainerChan <- event
+				time.Sleep(time.Second)
 			}
 		}
-
-		spec.Mounts = append(spec.Mounts, specs.Mount{
-			Type:        "none",
-			Source:      m.LocalPath,
-			Destination: m.MountPath,
-			Options:     []string{"rbind", mode},
-		})
 	}
-
-	// If volume caching is enabled, set it up and add proper mounts to spec
-	if s.fileCacheManager.CacheAvailable() && request.Workspace.VolumeCacheEnabled {
-		err = s.fileCacheManager.EnableVolumeCaching(request.Workspace.Name, volumeCacheMap, spec)
-		if err != nil {
-			log.Printf("<%s> - failed to setup volume caching: %v", request.ContainerId, err)
-		}
-	}
-
-	// Configure resolv.conf
-	resolvMount := specs.Mount{
-		Type:        "none",
-		Source:      "/workspace/resolv.conf",
-		Destination: "/etc/resolv.conf",
-		Options: []string{"ro",
-			"rbind",
-			"rprivate",
-			"nosuid",
-			"noexec",
-			"nodev"},
-	}
-
-	if s.config.Worker.UseHostResolvConf {
-		resolvMount.Source = "/etc/resolv.conf"
-	}
-
-	spec.Mounts = append(spec.Mounts, resolvMount)
-
-	return spec, nil
 }
 
 func (s *Worker) manageWorkerCapacity() {
 	for request := range s.completedRequests {
 		err := s.processCompletedRequest(request)
 		if err != nil {
+			if _, ok := err.(*types.ErrWorkerNotFound); ok {
+				s.cancel()
+				return
+			}
+
 			log.Printf("Unable to process completed request: %v\n", err)
 			s.completedRequests <- request
 			continue
@@ -901,7 +407,7 @@ func (s *Worker) keepalive() {
 }
 
 func (s *Worker) startup() error {
-	log.Printf("Worker starting up.")
+	log.Println("Worker starting up.")
 
 	err := s.workerRepo.ToggleWorkerAvailable(s.workerId)
 	if err != nil {
@@ -910,7 +416,7 @@ func (s *Worker) startup() error {
 
 	eventBus := common.NewEventBus(
 		s.redisClient,
-		common.EventBusSubscriber{Type: common.EventTypeStopContainer, Callback: s.stopContainer},
+		common.EventBusSubscriber{Type: common.EventTypeStopContainer, Callback: s.handleStopContainerEvent},
 	)
 
 	s.eventBus = eventBus
@@ -931,6 +437,17 @@ func (s *Worker) shutdown() error {
 	log.Println("Shutting down...")
 	defer s.eventRepo.PushWorkerStoppedEvent(s.workerId)
 
+	// Stops goroutines
+	s.cancel()
+
+	// Stop all running containers forcefully
+	s.containerInstances.Range(func(containerId string, _ *ContainerInstance) bool {
+		if err := s.stopContainer(containerId, true); err != nil {
+			log.Printf("Failed to stop container: %v\n", err)
+		}
+		return true // continue iterating
+	})
+
 	var errs error
 	if worker, err := s.workerRepo.GetWorkerById(s.workerId); err != nil {
 		errs = errors.Join(errs, err)
@@ -941,7 +458,6 @@ func (s *Worker) shutdown() error {
 		}
 	}
 
-	s.cancel()
 	err := s.storage.Unmount(s.config.Storage.FilesystemPath)
 	if err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to unmount storage: %v", err))


### PR DESCRIPTION
## Summary

This PR mostly does 2 things.

- Move code around so worker.go isn't over 1k lines long
- Allow for the worker to terminate when a SIGTERM is received. This is done by having goroutines use select with ctx.Done to complete their loops and stopping (SIGKILL) all containers in the shutdown function.

## Changes

- Move logic in processStopContainerEvents func to stopContainer func so stopContainer can be called elsewhere
- When calling stopContainer, do not check for container exit code. Container could still be running, terminate it anyway.
- Added listenForShutdown
- Forcefully stop all containers in the shutdown function. If we've gotten this far, containers should not be running otherwise unmounting clip images will hang.
- Moved calling of cancel() above stopping containers in shutdown. This stops all goroutines from running before stopping containers.
- Shutdown worker if worker is not found while in manage capacity goroutine. Usually thousands of "unable to process completed request" messages would be printed. This stops that.
- Change DeleteContainerState so it receives a containerId vs a ContainerRequest - we only used the containerId.
- Move container-specific and helper functions to lifecycle.go
- Rename terminateContainer to finalizeContainer to confusion with stopContainer func
- Remove containerErr var since it wasn't being used
- Move CPU and Memory Linux resource calculations to runc_resources.go

Resolve BE-1954