### PR TITLE
Feat: Add ability to force stop container via API

### DIFF
--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -125,7 +125,7 @@ func (i *endpointInstance) stopContainers(containersToStop int) error {
 		idx := rnd.Intn(len(containerIds))
 		containerId := containerIds[idx]
 
-		err := i.Scheduler.Stop(containerId)
+		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId})
 		if err != nil {
 			log.Printf("<%s> unable to stop container: %v", i.Name, err)
 			return err

--- a/pkg/abstractions/taskqueue/instance.go
+++ b/pkg/abstractions/taskqueue/instance.go
@@ -112,7 +112,7 @@ func (i *taskQueueInstance) stopContainers(containersToStop int) error {
 		idx := rnd.Intn(len(containerIds))
 		containerId := containerIds[idx]
 
-		err := i.Scheduler.Stop(containerId)
+		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId})
 		if err != nil {
 			log.Printf("<%s> unable to stop container: %v", i.Name, err)
 			return err

--- a/pkg/api/v1/container.go
+++ b/pkg/api/v1/container.go
@@ -76,7 +76,7 @@ func (c *ContainerGroup) StopAllWorkspaceContainers(ctx echo.Context) error {
 	}
 
 	for _, state := range containerStates {
-		err := c.scheduler.Stop(state.ContainerId)
+		err := c.scheduler.Stop(&types.StopContainerArgs{ContainerId: state.ContainerId})
 		if err != nil {
 			log.Println("failed to stop container", state.ContainerId, err)
 		}
@@ -90,6 +90,7 @@ func (c *ContainerGroup) StopAllWorkspaceContainers(ctx echo.Context) error {
 func (c *ContainerGroup) StopContainer(ctx echo.Context) error {
 	workspaceId := ctx.Param("workspaceId")
 	containerId := ctx.Param("containerId")
+	force := ctx.QueryParam("force") == "true"
 
 	state, err := c.containerRepo.GetContainerState(containerId)
 	if err != nil {
@@ -100,7 +101,7 @@ func (c *ContainerGroup) StopContainer(ctx echo.Context) error {
 		return HTTPBadRequest("Invalid workspace id")
 	}
 
-	err = c.scheduler.Stop(containerId)
+	err = c.scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Force: force})
 	if err != nil {
 		if strings.Contains(err.Error(), "event already exists") {
 			return HTTPConflict("Container is already stopping")

--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -216,7 +216,7 @@ func (g *DeploymentGroup) stopDeployments(deployments []types.DeploymentWithRela
 		containers, err := g.containerRepo.GetActiveContainersByStubId(deployment.Stub.ExternalId)
 		if err == nil {
 			for _, container := range containers {
-				g.scheduler.Stop(container.ContainerId)
+				g.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId})
 			}
 		}
 

--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -60,7 +61,7 @@ func (gws GatewayService) StopContainer(ctx context.Context, in *pb.StopContaine
 		}, nil
 	}
 
-	err = gws.scheduler.Stop(in.ContainerId)
+	err = gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: in.ContainerId})
 	if err != nil {
 		return &pb.StopContainerResponse{
 			Ok:       false,

--- a/pkg/gateway/services/deployment.go
+++ b/pkg/gateway/services/deployment.go
@@ -164,7 +164,7 @@ func (gws *GatewayService) stopDeployments(deployments []types.DeploymentWithRel
 		containers, err := gws.containerRepo.GetActiveContainersByStubId(deployment.Stub.ExternalId)
 		if err == nil {
 			for _, container := range containers {
-				gws.scheduler.Stop(container.ContainerId)
+				gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId})
 			}
 		}
 

--- a/pkg/gateway/services/worker.go
+++ b/pkg/gateway/services/worker.go
@@ -185,7 +185,7 @@ func (gws *GatewayService) DrainWorker(ctx context.Context, in *pb.DrainWorkerRe
 	var group errgroup.Group
 	for _, container := range containers {
 		group.Go(func() error {
-			return gws.scheduler.Stop(container.ContainerId)
+			return gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId})
 		})
 	}
 	if err := group.Wait(); err != nil {

--- a/pkg/types/scheduler.go
+++ b/pkg/types/scheduler.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -163,4 +164,37 @@ type QuotaDoesNotExistError struct{}
 
 func (e *QuotaDoesNotExistError) Error() string {
 	return "quota_does_not_exist"
+}
+
+type StopContainerArgs struct {
+	ContainerId string `json:"container_id"`
+	Force       bool   `json:"force"`
+}
+
+func (a StopContainerArgs) ToMap() (map[string]any, error) {
+	data, err := json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func ToStopContainerArgs(m map[string]any) (*StopContainerArgs, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	var result StopContainerArgs
+	if err = json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
 }

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -38,11 +38,15 @@ func (s *Worker) handleStopContainerEvent(event *common.Event) bool {
 	s.containerLock.Lock()
 	defer s.containerLock.Unlock()
 
-	containerId := event.Args["container_id"].(string)
+	stopArgs, err := types.ToStopContainerArgs(event.Args)
+	if err != nil {
+		log.Printf("failed to parse stop container args: %v\n", err)
+		return false
+	}
 
-	if _, exists := s.containerInstances.Get(containerId); exists {
-		log.Printf("<%s> - received stop container event.\n", containerId)
-		s.stopContainerChan <- stopContainerEvent{ContainerId: containerId, Kill: false}
+	if _, exists := s.containerInstances.Get(stopArgs.ContainerId); exists {
+		log.Printf("<%s> - received stop container event.\n", stopArgs.ContainerId)
+		s.stopContainerChan <- stopContainerEvent{ContainerId: stopArgs.ContainerId, Kill: stopArgs.Force}
 	}
 
 	return true

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -362,7 +362,10 @@ func (s *Worker) processStopContainerEvents() {
 			if err != nil {
 				s.stopContainerChan <- event
 				time.Sleep(time.Second)
+				continue
 			}
+
+			s.containerInstances.Delete(event.ContainerId)
 		}
 	}
 }


### PR DESCRIPTION
- Use struct as argument to stop a container
- Use struct on worker side to decide to force stop a container
- Update all references to scheduler.Stop to use struct argument
- Delete container instance after stopContainer called in worker. Otherwise, updateContainerStatus goroutine will send a [another] stop container event an and error will be printed.

Resolve BE-1948