### PR TITLE
Fix: Client websocket connection hangs when server disconnects

### DIFF
--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -552,7 +552,6 @@ func (rb *RequestBuffer) proxyWebsocketConnection(r *request, c container, diale
 	}
 
 	go rb.heartBeat(r, c.id) // Send heartbeat via redis for duration of request
-
 	go forwardWSConn(wsSrc.NetConn(), wsDst.NetConn())
 	forwardWSConn(wsDst.NetConn(), wsSrc.NetConn())
 	return nil

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"sort"
@@ -119,7 +118,6 @@ func (rb *RequestBuffer) ForwardRequest(ctx echo.Context, task *EndpointTask) er
 		case <-rb.ctx.Done():
 			return nil
 		case <-ctx.Request().Context().Done():
-			log.Println("REQUEST CANCELLED")
 			if !req.processed {
 				rb.cancelInFlightTask(req.task)
 			}
@@ -387,8 +385,6 @@ func (rb *RequestBuffer) handleWSRequest(req *request, c container) {
 	if err != nil {
 		return
 	}
-
-	log.Println("WS Connection closed")
 }
 
 func (rb *RequestBuffer) handleHttpRequest(req *request, c container) {
@@ -568,7 +564,7 @@ func forwardWSConn(src net.Conn, dst net.Conn) {
 		dst.Close()
 	}()
 
-	_, err := io.Copy(dst, src)
+	_, err := io.Copy(src, dst)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
```
_, err := io.Copy(src, dst)
```
io.Copy doesn't automatically fail when `src` connection closes. 

This change guarantees that when at least connection fails (either src, dst) the other one also disconnects