### PR TITLE
Fix: Capture full repo path when parsing custom base images

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -465,14 +465,17 @@ func (b *Builder) generatePipInstallCommand(pythonPackages []string, pythonVersi
 var imageNamePattern = regexp.MustCompile(
 	`^` + // Assert position at the start of the string
 		`(?:(?P<Registry>(?:(?:localhost|[\w.-]+(?:\.[\w.-]+)+)(?::\d+)?)|[\w]+:\d+)\/)?` + // Optional registry, which can be localhost, a domain with optional port, or a simple registry with port
-		`(?P<Namespace>(?:[a-z0-9]+(?:(?:[._]|__|[-]*)[a-z0-9]+)*)\/)*` + // Optional namespace, which can contain multiple segments separated by slashes
-		`(?P<Repo>[a-z0-9][-a-z0-9._]+)` + // Required repository name, must start with alphanumeric and can contain alphanumerics, hyphens, dots, and underscores
+		`(?P<Repo>(?:[\w][\w.-]*(?:/[\w][\w.-]*)*))?` + // Full repository path including namespace
 		`(?::(?P<Tag>[\w][\w.-]{0,127}))?` + // Optional tag, which starts with a word character and can contain word characters, dots, and hyphens
 		`(?:@(?P<Digest>[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9A-Fa-f]{32,}))?` + // Optional digest, which is a hash algorithm followed by a colon and a hexadecimal hash
 		`$`, // Assert position at the end of the string
 )
 
 func ExtractImageNameAndTag(imageRef string) (BaseImage, error) {
+	if imageRef == "" {
+		return BaseImage{}, errors.New("invalid image URI format")
+	}
+
 	matches := imageNamePattern.FindStringSubmatch(imageRef)
 	if matches == nil {
 		return BaseImage{}, errors.New("invalid image URI format")
@@ -490,7 +493,11 @@ func ExtractImageNameAndTag(imageRef string) (BaseImage, error) {
 		registry = "docker.io"
 	}
 
-	repo := result["Namespace"] + result["Repo"]
+	repo := result["Repo"]
+	if repo == "" {
+		return BaseImage{}, errors.New("invalid image URI format")
+	}
+
 	tag, digest := result["Tag"], result["Digest"]
 	if tag == "" && digest == "" {
 		tag = "latest"

--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -80,8 +80,14 @@ func TestExtractImageNameAndTag(t *testing.T) {
 		{
 			ref:          "nvcr.io/nim/meta/llama-3.1-8b-instruct:1.1.0",
 			wantTag:      "1.1.0",
-			wantRepo:     "meta/llama-3.1-8b-instruct",
+			wantRepo:     "nim/meta/llama-3.1-8b-instruct",
 			wantRegistry: "nvcr.io",
+		},
+		{
+			ref:          "ghcr.io/gis-ops/docker-valhalla/valhalla:latest",
+			wantTag:      "latest",
+			wantRepo:     "gis-ops/docker-valhalla/valhalla",
+			wantRegistry: "ghcr.io",
 		},
 	}
 


### PR DESCRIPTION
This fixes custom base image parsing. In the example below, we currently drop the "nim" in the path. Any path greater than length two will have this same issue. To simplify things I have removed the "namespace" part of the regex and just capture the full repo path. I've added a test and fixed the test below. All previous tests still pass. 

```
		{
			ref:          "nvcr.io/nim/meta/llama-3.1-8b-instruct:1.1.0",
			wantTag:      "1.1.0",
			wantRepo:     "nim/meta/llama-3.1-8b-instruct",
			wantRegistry: "nvcr.io",
		},
```