### PR TITLE
Feat: VLLM abstraction

### DIFF
--- a/sdk/src/beta9/__init__.py
+++ b/sdk/src/beta9/__init__.py
@@ -1,5 +1,5 @@
 from . import env
-from .abstractions import experimental
+from .abstractions import experimental, integrations
 from .abstractions.container import Container
 from .abstractions.endpoint import ASGI as asgi
 from .abstractions.endpoint import Endpoint as endpoint
@@ -35,4 +35,5 @@ __all__ = [
     "experimental",
     "schedule",
     "TaskPolicy",
+    "integrations",
 ]

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -237,6 +237,8 @@ class ASGI(Endpoint):
             @app.post("/warmup")
             async def warmup():
                 return {"status": "warm"}
+
+            return app
         ```
     """
 

--- a/sdk/src/beta9/abstractions/integrations/__init__.py
+++ b/sdk/src/beta9/abstractions/integrations/__init__.py
@@ -1,0 +1,3 @@
+from .vllm import VLLM
+
+__all__ = ["VLLM"]

--- a/sdk/src/beta9/abstractions/integrations/__init__.py
+++ b/sdk/src/beta9/abstractions/integrations/__init__.py
@@ -1,3 +1,3 @@
-from .vllm import VLLMEngineConfig, vllm
+from .vllm import VLLM, VLLMEngineConfig
 
-__all__ = ["vllm", "VLLMEngineConfig"]
+__all__ = ["VLLM", "VLLMEngineConfig"]

--- a/sdk/src/beta9/abstractions/integrations/__init__.py
+++ b/sdk/src/beta9/abstractions/integrations/__init__.py
@@ -1,3 +1,3 @@
-from .vllm import VLLM, EngineConfig
+from .vllm import EngineConfig, vllm
 
-__all__ = ["VLLM", "EngineConfig"]
+__all__ = ["vllm", "EngineConfig"]

--- a/sdk/src/beta9/abstractions/integrations/__init__.py
+++ b/sdk/src/beta9/abstractions/integrations/__init__.py
@@ -1,3 +1,3 @@
-from .vllm import VLLM
+from .vllm import VLLM, EngineConfig
 
-__all__ = ["VLLM"]
+__all__ = ["VLLM", "EngineConfig"]

--- a/sdk/src/beta9/abstractions/integrations/__init__.py
+++ b/sdk/src/beta9/abstractions/integrations/__init__.py
@@ -1,3 +1,3 @@
-from .vllm import EngineConfig, vllm
+from .vllm import VLLMEngineConfig, vllm
 
-__all__ = ["vllm", "EngineConfig"]
+__all__ = ["vllm", "VLLMEngineConfig"]

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -23,7 +23,7 @@ from ...type import GpuType, GpuTypeAlias
 
 # vllm/engine/arg_utils.py:EngineArgs
 @dataclass
-class EngineConfig:
+class VLLMEngineConfig:
     """
     The configuration for the vLLM engine. For more information, see the vllm documentation:
     https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#command-line-arguments-for-the-server
@@ -214,7 +214,7 @@ class vllm(ASGI):
         authorized: bool = True,
         name: Optional[str] = None,
         # vLLM engine config
-        engine_config: EngineConfig = EngineConfig(),
+        engine_config: VLLMEngineConfig = VLLMEngineConfig(),
         # vLLM args
         response_role: Optional[str] = None,
         lora_modules: Optional[List[str]] = None,

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -132,7 +132,7 @@ class VLLMEngineConfig:
     disable_log_requests: bool = False
 
 
-class vllm(ASGI):
+class VLLM(ASGI):
     """
     vllm is a wrapper around the vLLM library that allows you to deploy it as an ASGI app.
 
@@ -203,9 +203,7 @@ class vllm(ASGI):
         cpu: Union[int, float, str] = 1.0,
         memory: Union[int, str] = 128,
         gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
-        image: Image = Image(python_version="python3.11")
-        .add_commands(["export VLLM_TARGET_DEVICE=empty"])
-        .add_python_packages(["fastapi", "vllm"]),
+        image: Image = Image(python_version="python3.11").add_python_packages(["fastapi", "vllm"]),
         workers: int = 1,
         concurrent_requests: int = 1,
         keep_warm_seconds: float = 10.0,

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -132,9 +132,9 @@ class EngineConfig:
     disable_log_requests: bool = False
 
 
-class VLLM(ASGI):
+class vllm(ASGI):
     """
-    VLLM is a wrapper around the vLLM library that allows you to deploy it as an ASGI app.
+    vllm is a wrapper around the vLLM library that allows you to deploy it as an ASGI app.
 
     Parameters:
         cpu (Union[int, float, str]):

--- a/sdk/src/beta9/abstractions/integrations/vllm/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm/vllm.py
@@ -1,0 +1,211 @@
+"""
+beta9 deploy app.py:app
+
+where app.py is just a simple file with the instance of the vllm app
+
+# app.py
+from beta9 import vllm
+
+app = vllm(stub_args, vllm_args)
+
+Then on deploy, we set this up as an ASGI app by having some getter that returns the FASTAPI instance.
+
+app.get_fastapi_app()
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Mapping, Optional, SimpleNamespace, Tuple, Union
+
+from ....abstractions.endpoint import ASGI
+from ....abstractions.image import Image
+from ....abstractions.mixins import DeployableMixin
+from ....abstractions.volume import Volume
+from ....type import GpuType, GpuTypeAlias
+
+
+# vllm/engine/arg_utils.py:EngineArgs
+@dataclass
+class EngineConfig:
+    model: str = "facebook/opt-125m"
+    served_model_name: Optional[Union[str, List[str]]] = None
+    tokenizer: Optional[str] = None
+    task: str = "auto"
+    skip_tokenizer_init: bool = False
+    tokenizer_mode: str = "auto"
+    chat_template_text_format: str = "string"
+    trust_remote_code: bool = False
+    download_dir: Optional[str] = None
+    load_format: str = "auto"
+    config_format: str = "auto"
+    dtype: str = "auto"
+    kv_cache_dtype: str = "auto"
+    quantization_param_path: Optional[str] = None
+    seed: int = 0
+    max_model_len: Optional[int] = None
+    worker_use_ray: bool = False
+    # Note: Specifying a custom executor backend by passing a class
+    # is intended for expert use only. The API may change without
+    # notice.
+    distributed_executor_backend: Optional[Union[str, Any]] = None
+    pipeline_parallel_size: int = 1
+    tensor_parallel_size: int = 1
+    max_parallel_loading_workers: Optional[int] = None
+    block_size: int = 16
+    enable_prefix_caching: bool = False
+    disable_sliding_window: bool = False
+    use_v2_block_manager: bool = True
+    swap_space: float = 4  # GiB
+    cpu_offload_gb: float = 0  # GiB
+    gpu_memory_utilization: float = 0.90
+    max_num_batched_tokens: Optional[int] = None
+    max_num_seqs: int = 256
+    max_logprobs: int = 20  # Default value for OpenAI Chat Completions API
+    disable_log_stats: bool = False
+    revision: Optional[str] = None
+    code_revision: Optional[str] = None
+    rope_scaling: Optional[dict] = None
+    rope_theta: Optional[float] = None
+    tokenizer_revision: Optional[str] = None
+    quantization: Optional[str] = None
+    enforce_eager: Optional[bool] = None
+    max_context_len_to_capture: Optional[int] = None
+    max_seq_len_to_capture: int = 8192
+    disable_custom_all_reduce: bool = False
+    tokenizer_pool_size: int = 0
+    # Note: Specifying a tokenizer pool by passing a class
+    # is intended for expert use only. The API may change without
+    # notice.
+    tokenizer_pool_type: Union[str, Any] = "ray"
+    tokenizer_pool_extra_config: Optional[dict] = None
+    limit_mm_per_prompt: Optional[Mapping[str, int]] = None
+    enable_lora: bool = False
+    max_loras: int = 1
+    max_lora_rank: int = 16
+    enable_prompt_adapter: bool = False
+    max_prompt_adapters: int = 1
+    max_prompt_adapter_token: int = 0
+    fully_sharded_loras: bool = False
+    lora_extra_vocab_size: int = 256
+    long_lora_scaling_factors: Optional[Tuple[float]] = None
+    lora_dtype: Optional[Union[str, Any]] = "auto"
+    max_cpu_loras: Optional[int] = None
+    device: str = "auto"
+    num_scheduler_steps: int = 1
+    multi_step_stream_outputs: bool = True
+    ray_workers_use_nsight: bool = False
+    num_gpu_blocks_override: Optional[int] = None
+    num_lookahead_slots: int = 0
+    model_loader_extra_config: Optional[dict] = None
+    ignore_patterns: Optional[Union[str, List[str]]] = None
+    preemption_mode: Optional[str] = None
+
+    scheduler_delay_factor: float = 0.0
+    enable_chunked_prefill: Optional[bool] = None
+
+    guided_decoding_backend: str = "outlines"
+    # Speculative decoding configuration.
+    speculative_model: Optional[str] = None
+    speculative_model_quantization: Optional[str] = None
+    speculative_draft_tensor_parallel_size: Optional[int] = None
+    num_speculative_tokens: Optional[int] = None
+    speculative_disable_mqa_scorer: Optional[bool] = False
+    speculative_max_model_len: Optional[int] = None
+    speculative_disable_by_batch_size: Optional[int] = None
+    ngram_prompt_lookup_max: Optional[int] = None
+    ngram_prompt_lookup_min: Optional[int] = None
+    spec_decoding_acceptance_method: str = "rejection_sampler"
+    typical_acceptance_sampler_posterior_threshold: Optional[float] = None
+    typical_acceptance_sampler_posterior_alpha: Optional[float] = None
+    qlora_adapter_name_or_path: Optional[str] = None
+    disable_logprobs_during_spec_decoding: Optional[bool] = None
+
+    otlp_traces_endpoint: Optional[str] = None
+    collect_detailed_traces: Optional[str] = None
+    disable_async_output_proc: bool = False
+    override_neuron_config: Optional[Dict[str, Any]] = None
+    mm_processor_kwargs: Optional[Dict[str, Any]] = None
+    scheduling_policy: Literal["fcfs", "priority"] = "fcfs"
+    disable_log_requests: bool = False
+
+
+class VLLM(ASGI, DeployableMixin):
+    def __init__(
+        self,
+        cpu: Union[int, float, str] = 1.0,
+        memory: Union[int, str] = 128,
+        gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
+        image: Image = Image().add_python_packages(["vllm", "fastapi"]),
+        workers: int = 1,
+        concurrent_requests: int = 1,
+        keep_warm_seconds: float = 10.0,
+        max_pending_tasks: int = 100,
+        retries: int = 3,
+        timeout: int = 3600,
+        authorized: bool = True,
+        name: Optional[str] = None,
+        # vLLM engine config
+        engine_config: EngineConfig = EngineConfig(),
+        # vLLM args
+        response_role: Optional[str] = None,
+        lora_modules: Optional[List[str]] = None,
+        prompt_adapters: Optional[List[str]] = None,
+        chat_template: Optional[str] = None,
+        return_tokens_as_token_ids: bool = False,
+        enable_auto_tools: bool = False,
+        tool_call_parser: Optional[str] = None,
+        disable_log_stats: bool = False,
+    ):
+        # ASGI initialization
+        super().__init__(
+            cpu=cpu,
+            memory=memory,
+            gpu=gpu,
+            workers=workers,
+            concurrent_requests=concurrent_requests,
+            keep_warm_seconds=keep_warm_seconds,
+            max_pending_tasks=max_pending_tasks,
+            retries=retries,
+            timeout=timeout,
+            authorized=authorized,
+            name=name,
+            volumes=[Volume(name="vllm-cache", mount_path="/vllm-cache")],
+        )
+
+        self.engine_config = engine_config
+        self.vllm_args = SimpleNamespace(
+            model=engine_config.model,
+            response_role=response_role,
+            lora_modules=lora_modules,
+            prompt_adapters=prompt_adapters,
+            chat_template=chat_template,
+            return_tokens_as_token_ids=return_tokens_as_token_ids,
+            enable_auto_tools=enable_auto_tools,
+            tool_call_parser=tool_call_parser,
+            disable_log_stats=disable_log_stats,
+        )
+
+    def asgi_app(self):
+        # Create the vllm app using the configuration
+        import asyncio
+
+        from fastapi import FastAPI
+
+        from vllm.engine.arg_utils import AsyncEngineArgs
+        from vllm.entrypoints.openai.api_server import (
+            build_async_engine_client_from_engine_args,
+            init_app_state,
+        )
+
+        engine_args = AsyncEngineArgs.from_cli_args(self.engine_config)
+        engine_client = build_async_engine_client_from_engine_args(engine_args)
+        app = FastAPI()
+        model_config = asyncio.run(engine_args.create_model_config())
+
+        init_app_state(
+            engine_client,
+            model_config,
+            app.state,
+            self.vllm_args,
+        )
+
+        return self.app

--- a/sdk/src/beta9/cli/deployment.py
+++ b/sdk/src/beta9/cli/deployment.py
@@ -109,26 +109,31 @@ def create_deployment(service: ServiceClient, name: str, entrypoint: str, url_ty
     if current_dir not in sys.path:
         sys.path.insert(0, current_dir)
 
-    module_path, func_name, *_ = entrypoint.split(":") if ":" in entrypoint else (entrypoint, "")
+    module_path, obj_name, *_ = entrypoint.split(":") if ":" in entrypoint else (entrypoint, "")
     module_name = module_path.replace(".py", "").replace(os.path.sep, ".")
 
     if not Path(module_path).exists():
         terminal.error(f"Unable to find file: '{module_path}'")
 
-    if not func_name:
+    if not obj_name:
         terminal.error(
             "Invalid handler function specified. Expected format: beam deploy [file.py]:[function]"
         )
 
     module = importlib.import_module(module_name)
 
-    user_func: Optional[DeployableMixin] = getattr(module, func_name, None)
-    if user_func is None:
+    user_obj: Optional[DeployableMixin] = getattr(module, obj_name, None)
+    if user_obj is None:
         terminal.error(
-            f"Invalid handler function specified. Make sure '{module_path}' contains the function: '{func_name}'"
+            f"Invalid handler function specified. Make sure '{module_path}' contains the function: '{obj_name}'"
         )
 
-    if not user_func.deploy(name=name, context=service._config, url_type=url_type):  # type: ignore
+    # Class based integrations should have a set_handler method so they don't end up inspecting the sdk when
+    # trying to get the handler
+    if hasattr(user_obj, "set_handler"):
+        user_obj.set_handler(f"{module_name}:{obj_name}")
+
+    if not user_obj.deploy(name=name, context=service._config, url_type=url_type):  # type: ignore
         terminal.error("Deployment failed ☠️")
 
 

--- a/sdk/src/beta9/cli/deployment.py
+++ b/sdk/src/beta9/cli/deployment.py
@@ -128,8 +128,6 @@ def create_deployment(service: ServiceClient, name: str, entrypoint: str, url_ty
             f"Invalid handler function specified. Make sure '{module_path}' contains the function: '{obj_name}'"
         )
 
-    # Class based integrations should have a set_handler method so they don't end up inspecting the sdk when
-    # trying to get the handler
     if hasattr(user_obj, "set_handler"):
         user_obj.set_handler(f"{module_name}:{obj_name}")
 

--- a/sdk/src/beta9/cli/serve.py
+++ b/sdk/src/beta9/cli/serve.py
@@ -62,23 +62,26 @@ def serve(
     if current_dir not in sys.path:
         sys.path.insert(0, current_dir)
 
-    module_path, func_name, *_ = entrypoint.split(":") if ":" in entrypoint else (entrypoint, "")
+    module_path, obj_name, *_ = entrypoint.split(":") if ":" in entrypoint else (entrypoint, "")
     module_name = module_path.replace(".py", "").replace(os.path.sep, ".")
 
     if not Path(module_path).exists():
         terminal.error(f"Unable to find file: '{module_path}'")
 
-    if not func_name:
+    if not obj_name:
         terminal.error(
             "Invalid handler function specified. Expected format: beam serve [file.py]:[function]"
         )
 
     module = importlib.import_module(module_name)
 
-    user_func = getattr(module, func_name, None)
-    if user_func is None:
+    user_obj = getattr(module, obj_name, None)
+    if user_obj is None:
         terminal.error(
-            f"Invalid handler function specified. Make sure '{module_path}' contains the function: '{func_name}'"
+            f"Invalid handler function specified. Make sure '{module_path}' contains the function: '{obj_name}'"
         )
 
-    user_func.serve(timeout=int(timeout), url_type=url_type)  # type:ignore
+    if hasattr(user_obj, "set_handler"):
+        user_obj.set_handler(f"{module_name}:{obj_name}")
+
+    user_obj.serve(timeout=int(timeout), url_type=url_type)  # type:ignore


### PR DESCRIPTION
Resolve BE-1783

This PR adds a VLLM abstraction. Every argument you can provide to `vllm serve ...` is supported and can be passed into the vllm class or as part of the `EngineConfig`. The defaults are the same as the ones in vllm's repo. 

Here is a simple example of how it used: 
```python
from beta9 import integrations

e = integrations.EngineConfig()
e.device = "cpu"

vllm_app = integrations.VLLM(name="vllm-abstraction-1", engine_config=e)
```

And we deploy with:
```bash
beta9 deploy app.py:vllm_app
```

Serve with:
```bash 
beta9 serve app.py:vllm_app
```

Below is an example of serving the above on my local machine. 

In order to get deploying/serving a class to work, I introduced a `set_handler` method. The deploy and serve code now checks if that message is present and uses it to set the user provided `app:obj`. Without this, we end up inspecting the sdk to generate the module:obj and that does not work. 

![Screenshot 2024-10-29 at 17 24 47](https://github.com/user-attachments/assets/6fe41b34-8829-4536-a478-9197035f5b05)

