### PR TITLE
Feat: Make MaxReplicas configurable in gateway config

### DIFF
--- a/pkg/abstractions/common/autoscaler.go
+++ b/pkg/abstractions/common/autoscaler.go
@@ -22,9 +22,8 @@ type IAutoscaler interface {
 }
 
 const (
-	MaxReplicas uint          = 10                                     // Maximum number of desired replicas that can be returned
-	windowSize  int           = 60                                     // Number of samples in the sampling window
-	sampleRate  time.Duration = time.Duration(1000) * time.Millisecond // Time between samples
+	windowSize int           = 60                                     // Number of samples in the sampling window
+	sampleRate time.Duration = time.Duration(1000) * time.Millisecond // Time between samples
 )
 
 type AutoscalerSample interface{}

--- a/pkg/abstractions/endpoint/autoscaler.go
+++ b/pkg/abstractions/endpoint/autoscaler.go
@@ -50,8 +50,8 @@ func endpointDeploymentScaleFunc(i *endpointInstance, s *endpointAutoscalerSampl
 			desiredContainers += 1
 		}
 
-		// Limit max replicas to either what was set in autoscaler config, or our default of MaxReplicas (whichever is lower)
-		maxReplicas := math.Min(float64(i.StubConfig.Autoscaler.MaxContainers), float64(abstractions.MaxReplicas))
+		// Limit max replicas to either what was set in autoscaler config, or the limit specified on the gateway config (whichever is lower)
+		maxReplicas := math.Min(float64(i.StubConfig.Autoscaler.MaxContainers), float64(i.AppConfig.GatewayService.StubLimits.MaxReplicas))
 		desiredContainers = int(math.Min(maxReplicas, float64(desiredContainers)))
 	}
 

--- a/pkg/abstractions/endpoint/autoscaler_test.go
+++ b/pkg/abstractions/endpoint/autoscaler_test.go
@@ -17,6 +17,12 @@ func TestDeploymentScaleFuncWithDefaults(t *testing.T) {
 				ExternalId: "test",
 			},
 		},
+		AppConfig: types.AppConfig{},
+	}
+	autoscaledInstance.AppConfig.GatewayService = types.GatewayServiceConfig{
+		StubLimits: types.StubLimits{
+			MaxReplicas: 10,
+		},
 	}
 	autoscaledInstance.StubConfig = &types.StubConfigV1{}
 	autoscaledInstance.StubConfig.Autoscaler = &types.Autoscaler{
@@ -63,6 +69,13 @@ func TestDeploymentScaleFuncWithMaxTasksPerContainer(t *testing.T) {
 			Stub: types.Stub{
 				ExternalId: "test",
 			},
+		},
+		AppConfig: types.AppConfig{},
+	}
+
+	autoscaledInstance.AppConfig.GatewayService = types.GatewayServiceConfig{
+		StubLimits: types.StubLimits{
+			MaxReplicas: 10,
 		},
 	}
 	autoscaledInstance.StubConfig = &types.StubConfigV1{}

--- a/pkg/abstractions/taskqueue/autoscaler.go
+++ b/pkg/abstractions/taskqueue/autoscaler.go
@@ -66,8 +66,8 @@ func taskQueueScaleFunc(i *taskQueueInstance, s *taskQueueAutoscalerSample) *abs
 			desiredContainers += 1
 		}
 
-		// Limit max replicas to either what was set in autoscaler config, or our default of MaxReplicas (whichever is lower)
-		maxReplicas := math.Min(float64(i.StubConfig.Autoscaler.MaxContainers), float64(abstractions.MaxReplicas))
+		// Limit max replicas to either what was set in autoscaler config, or the limit specified on the gateway config (whichever is lower)
+		maxReplicas := math.Min(float64(i.StubConfig.Autoscaler.MaxContainers), float64(i.AppConfig.GatewayService.StubLimits.MaxReplicas))
 		desiredContainers = int(math.Min(maxReplicas, float64(desiredContainers)))
 	}
 

--- a/pkg/abstractions/taskqueue/autoscaler_test.go
+++ b/pkg/abstractions/taskqueue/autoscaler_test.go
@@ -16,6 +16,12 @@ func TestDeploymentScaleFuncWithDefaults(t *testing.T) {
 		MaxContainers:     1,
 		TasksPerContainer: 1,
 	}
+	autoscaledInstance.AppConfig = types.AppConfig{}
+	autoscaledInstance.AppConfig.GatewayService = types.GatewayServiceConfig{
+		StubLimits: types.StubLimits{
+			MaxReplicas: 10,
+		},
+	}
 
 	instance := &taskQueueInstance{}
 	instance.AutoscaledInstance = autoscaledInstance
@@ -55,6 +61,12 @@ func TestDeploymentScaleFuncWithMaxTasksPerContainer(t *testing.T) {
 		Type:              "queue_depth",
 		MaxContainers:     3,
 		TasksPerContainer: 1,
+	}
+	autoscaledInstance.AppConfig = types.AppConfig{}
+	autoscaledInstance.AppConfig.GatewayService = types.GatewayServiceConfig{
+		StubLimits: types.StubLimits{
+			MaxReplicas: 10,
+		},
 	}
 
 	// Make sure we scale up to max containers

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -48,6 +48,7 @@ gateway:
   shutdownTimeout: 180s
   stubLimits:
     memory: 32768
+    maxReplicas: 10
 imageService:
   localCacheEnabled: true
   registryStore: local

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -84,7 +84,8 @@ type CORSConfig struct {
 }
 
 type StubLimits struct {
-	Memory uint64 `key:"memory" json:"memory"`
+	Memory      uint64 `key:"memory" json:"memory"`
+	MaxReplicas uint64 `key:"maxReplicas" json:"max_replicas"`
 }
 
 type GatewayServiceConfig struct {


### PR DESCRIPTION
- Expose a maxReplicas config field to set a limit on how far a stub can scale up