### PR TITLE
fix: bubble up exceptions invoking functions

### DIFF
--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -186,7 +186,7 @@ def pass_channel(func: Callable) -> Callable:
 
 
 @contextmanager
-def handle_error(print_traceback: bool = False):
+def handle_error():
     exit_code = 0
     try:
         yield
@@ -201,8 +201,7 @@ def handle_error(print_traceback: bool = False):
         exit_code = 1
     finally:
         if exit_code != 0:
-            if print_traceback:
-                print(traceback.format_exc())
+            print(traceback.format_exc())
             sys.exit(exit_code)
 
 

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -162,7 +162,7 @@ class FunctionHandler:
             self.pass_context = "context" in sig.parameters
             self.is_async = asyncio.iscoroutinefunction(self.handler.func)
         except BaseException:
-            raise RunnerException()
+            raise RunnerException(f"Error loading handler: {traceback.format_exc()}")
 
     def __call__(self, context: FunctionContext, *args: Any, **kwargs: Any) -> Any:
         if self.handler is None:

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -136,7 +136,7 @@ def _monitor_task(
 
 
 @json_output_interceptor(task_id=config.task_id)
-@handle_error(print_traceback=False)
+@handle_error(print_traceback=True)
 @pass_channel
 def main(channel: Channel):
     function_stub: FunctionServiceStub = FunctionServiceStub(channel)
@@ -174,7 +174,6 @@ def main(channel: Channel):
     if result.exception:
         thread_pool.shutdown(wait=False)
         handle_task_failure(gateway_stub, result, task_id, container_id, container_hostname)
-        print(result.exception)
         raise result.exception
 
     # End the task and send callback
@@ -227,7 +226,6 @@ def invoke_function(
             callback_url=callback_url,
         )
     except BaseException as e:
-        print(f"{traceback.format_exc()}")
         return InvokeResult(
             result=result,
             exception=e,

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -227,6 +227,7 @@ def invoke_function(
             callback_url=callback_url,
         )
     except BaseException as e:
+        print(f"{traceback.format_exc()}")
         return InvokeResult(
             result=result,
             exception=e,

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -136,7 +136,7 @@ def _monitor_task(
 
 
 @json_output_interceptor(task_id=config.task_id)
-@handle_error(print_traceback=True)
+@handle_error()
 @pass_channel
 def main(channel: Channel):
     function_stub: FunctionServiceStub = FunctionServiceStub(channel)


### PR DESCRIPTION
- fix a bug where exceptions raised while loading a handler are not visible to users in logs