### PR TITLE
Fix: exit more loops when context is cancelled

### DIFF
--- a/pkg/abstractions/function/function.go
+++ b/pkg/abstractions/function/function.go
@@ -303,6 +303,9 @@ func (fs *RunCFunctionService) FunctionMonitor(req *pb.FunctionMonitorRequest, s
 						return
 					}
 
+				case <-fs.ctx.Done():
+					return
+
 				case <-ctx.Done():
 					return
 
@@ -318,6 +321,9 @@ func (fs *RunCFunctionService) FunctionMonitor(req *pb.FunctionMonitorRequest, s
 
 	for {
 		select {
+		case <-fs.ctx.Done():
+			return nil
+
 		case <-stream.Context().Done():
 			return nil
 

--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -35,6 +36,7 @@ type WorkerPoolController interface {
 	AddWorkerToMachine(cpu int64, memory int64, gpuType string, gpuCount uint32, machineId string) (*types.Worker, error)
 	Name() string
 	FreeCapacity() (*WorkerPoolCapacity, error)
+	Context() context.Context
 }
 
 type WorkerPoolConfig struct {

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -93,9 +93,13 @@ func NewExternalWorkerPoolController(
 	}
 
 	// Reconcile nodes with state
-	go provider.Reconcile(context.Background(), wpc.name)
+	go provider.Reconcile(ctx, wpc.name)
 
 	return wpc, nil
+}
+
+func (wpc *ExternalWorkerPoolController) Context() context.Context {
+	return wpc.ctx
 }
 
 func (wpc *ExternalWorkerPoolController) AddWorker(cpu int64, memory int64, gpuCount uint32) (*types.Worker, error) {

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -37,10 +37,17 @@ func NewWorkerPoolSizer(controller WorkerPoolController,
 }
 
 func (s *WorkerPoolSizer) Start() {
+	ctx := s.controller.Context()
 	ticker := time.NewTicker(poolMonitoringInterval)
 	defer ticker.Stop()
 
 	for range ticker.C {
+		select {
+		case <-ctx.Done():
+			return // Context has been cancelled
+		default: // Continue processing requests
+		}
+
 		func() {
 			freeCapacity, err := s.controller.FreeCapacity()
 			if err != nil {

--- a/pkg/scheduler/pool_sizing_test.go
+++ b/pkg/scheduler/pool_sizing_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -216,6 +217,7 @@ func TestOccupyAvailableMachines(t *testing.T) {
 
 	lambdaPoolName := "LambdaLabsPool"
 	controller := &ExternalWorkerPoolControllerForTest{
+		ctx:          context.Background(),
 		name:         lambdaPoolName,
 		workerRepo:   workerRepo,
 		providerRepo: providerRepo,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -52,6 +52,7 @@ func NewSchedulerForTest() (*Scheduler, error) {
 	workerPoolManager := NewWorkerPoolManager()
 	for name, pool := range config.Worker.Pools {
 		workerPoolManager.SetPool(name, pool, &LocalWorkerPoolControllerForTest{
+			ctx:        context.Background(),
 			name:       name,
 			config:     config,
 			workerRepo: workerRepo,
@@ -72,9 +73,14 @@ func NewSchedulerForTest() (*Scheduler, error) {
 }
 
 type LocalWorkerPoolControllerForTest struct {
+	ctx        context.Context
 	name       string
 	config     types.AppConfig
 	workerRepo repo.WorkerRepository
+}
+
+func (wpc *LocalWorkerPoolControllerForTest) Context() context.Context {
+	return wpc.ctx
 }
 
 func (wpc *LocalWorkerPoolControllerForTest) generateWorkerId() string {
@@ -114,11 +120,16 @@ func (wpc *LocalWorkerPoolControllerForTest) FreeCapacity() (*WorkerPoolCapacity
 }
 
 type ExternalWorkerPoolControllerForTest struct {
+	ctx          context.Context
 	name         string
 	workerRepo   repo.WorkerRepository
 	providerRepo repository.ProviderRepository
 	poolName     string
 	providerName string
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) Context() context.Context {
+	return wpc.ctx
 }
 
 func (wpc *ExternalWorkerPoolControllerForTest) generateWorkerId() string {


### PR DESCRIPTION
Check if context is done in
- Provider's Reconcile func
- LocalKubernetesWorkerPoolController's deleteStalePendingWorkerJobs func
- RunCFunctionService's FunctionMonitor func
- WorkerPoolSizer's Start func
- Add exportable context on worker pool controllers