### PR TITLE
Fix: Secrets, autoscaler, and chat templates for vLLM abstraction

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.103"
+version = "0.1.104"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/integrations/__init__.py
+++ b/sdk/src/beta9/abstractions/integrations/__init__.py
@@ -1,3 +1,3 @@
-from .vllm import VLLM, VLLMEngineConfig
+from .vllm import VLLM, VLLMArgs, VLLMEngineConfig
 
-__all__ = ["VLLM", "VLLMEngineConfig"]
+__all__ = ["VLLM", "VLLMArgs", "VLLMEngineConfig"]

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -234,6 +234,7 @@ class VLLM(ASGI):
         lora_modules: Optional[List[str]] = None,
         prompt_adapters: Optional[List[str]] = None,
         chat_template: Optional[str] = None,
+        chat_template_url: Optional[str] = None,
         return_tokens_as_token_ids: bool = False,
         enable_auto_tools: bool = False,
         enable_auto_tool_choice: bool = False,
@@ -260,6 +261,7 @@ class VLLM(ASGI):
             autoscaler=autoscaler,
         )
 
+        self.chat_template_url = chat_template_url
         self.engine_config = engine_config
         self.vllm_args = SimpleNamespace(
             model=engine_config.model,
@@ -295,10 +297,10 @@ class VLLM(ASGI):
         from vllm.engine.async_llm_engine import AsyncLLMEngine
         from vllm.usage.usage_lib import UsageContext
 
-        if self.vllm_args.chat_template:
+        if self.chat_template_url:
             import requests
 
-            response = requests.get(self.vllm_args.chat_template)
+            response = requests.get(self.chat_template_url)
             with open("./vllm-cache/chat_template.jinja", "wb") as file:
                 file.write(response.content)
             self.vllm_args.chat_template = "./vllm-cache/chat_template.jinja"

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -180,6 +180,9 @@ class VLLM(ASGI):
         prompt_adapters (List[str]):
             The prompt adapters to use.
         chat_template (str):
+            This is the path to the chat template you wish to use if one is in your working directory.
+            It can be left empty for the default template of `NONE` or you can use `chat_template_url` instead.
+        chat_template_url (str):
             The chat template to use. Unlike vLLM, this template is expected to be a downloadable link to a jinja template file.
             That template will be downloaded and used. Here is a good repo of chat templates that you can link to:
             https://github.com/chujiezheng/chat_templates/tree/main.

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -367,6 +367,14 @@ class VLLM(ASGI):
                 "You must specify an app name (either in the decorator or via the --name argument)."
             )
 
+        if (
+            self.engine_config.download_dir != DEFAULT_VLLM_CACHE_DIR
+            and self.engine_config.download_dir not in [v.mount_path for v in self.volumes]
+        ):
+            terminal.error(
+                "The engine's download directory must match a mount path in the volumes list."
+            )
+
         if context is not None:
             self.config_context = context
 


### PR DESCRIPTION
This PR makes two important corrections to the VLLM abstraction. 

First, it adds the secrets parameters. This is critical as it allows us to pass `HF_TOKEN` as a secret, which is required to download many of the models. 

Second, it adds a chat_template_url parameter. If set, we download this template and override the chat_template arg.