### PR TITLE
Feat: Add new filter fields to task list command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ verify-protocol:
 test-pkg:
 	go test -v ./pkg/... -bench=./pkg/..
 
-# build-test can be run with "local" to run extra tests when pointing to your local 
+# build-test can be run with "local" to run extra tests when pointing to your local
 # dev setup. It will also exclude custom image tests due to arm64 issues on mac.
 build-test:
 	poetry config virtualenvs.in-project true

--- a/bin/delete_workers.sh
+++ b/bin/delete_workers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Deleting worker jobs..."
-kubectl delete job -l run.beam.cloud/role=worker
+kubectl delete job --now --cascade=foreground -l run.beam.cloud/role=worker
 
 echo "Deleting scheduler keys..."
 if kubectl get sts redis-master &> /dev/null; then

--- a/pkg/gateway/services/task.go
+++ b/pkg/gateway/services/task.go
@@ -114,6 +114,14 @@ func (gws *GatewayService) ListTasks(ctx context.Context, in *pb.ListTasksReques
 		switch clientField {
 		case "status":
 			taskFilter.Status = strings.Join(value.Values, ",")
+		case "stub-id", "stub-ids", "stub_id", "stub_ids":
+			taskFilter.StubIds = value.Values
+		case "stub-name", "stub-names", "stub_name", "stub_names":
+			taskFilter.StubNames = value.Values
+		case "id", "ids", "task-id", "task-ids", "task_id", "task_ids":
+			taskFilter.TaskIds = value.Values
+		case "container-id", "container-ids", "container_id", "container_ids":
+			taskFilter.ContainerIds = value.Values
 		}
 	}
 

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -551,20 +551,30 @@ func (c *PostgresBackendRepository) listTaskWithRelatedQueryBuilder(filters type
 		qb = qb.Where(squirrel.Eq{"s.external_id": filters.StubIds})
 	}
 
-	if filters.StubType != "" {
-		stubTypes := strings.Split(filters.StubType, ",")
-		if len(stubTypes) > 0 {
-			qb = qb.Where(squirrel.Eq{"s.type": stubTypes})
-		}
+	if len(filters.StubNames) > 0 {
+		qb = qb.Where(squirrel.Eq{"s.name": filters.StubNames})
 	}
 
-	if filters.TaskId != "" {
-		if err := uuid.Validate(filters.TaskId); err != nil {
-			// Postgres will throw an error if the uuid is invalid, which results in a 500 to the client
-			// So instead, we will make the query valid and make it return no results
-			qb = qb.Where(squirrel.Eq{"t.external_id": nil})
-		} else {
-			qb = qb.Where(squirrel.Eq{"t.external_id": filters.TaskId})
+	if len(filters.StubTypes) > 0 {
+		qb = qb.Where(squirrel.Eq{"s.type": filters.StubTypes})
+	}
+
+	if len(filters.ContainerIds) > 0 {
+		qb = qb.Where(squirrel.Eq{"t.container_id": filters.ContainerIds})
+	}
+
+	if len(filters.TaskIds) > 0 {
+		validTaskIds := []string{}
+
+		for _, taskId := range filters.TaskIds {
+			// Filter out invalid UUIDs
+			if _, err := uuid.Parse(taskId); err == nil {
+				validTaskIds = append(validTaskIds, taskId)
+			}
+		}
+
+		if len(validTaskIds) > 0 {
+			qb = qb.Where(squirrel.Eq{"t.external_id": validTaskIds})
 		}
 	}
 

--- a/pkg/types/filters.go
+++ b/pkg/types/filters.go
@@ -43,10 +43,12 @@ type DeploymentFilter struct {
 type TaskFilter struct {
 	BaseFilter
 	WorkspaceID    uint        `query:"workspace_id"`
-	TaskId         string      `query:"task_id"`
-	StubType       string      `query:"stub_type"`
+	TaskIds        StringSlice `query:"task_ids"`
 	StubIds        StringSlice `query:"stub_ids"`
+	StubNames      StringSlice `query:"stub_names"`
+	StubTypes      StringSlice `query:"stub_types"`
 	Status         string      `query:"status"`
+	ContainerIds   StringSlice `query:"container_ids"`
 	CreatedAtStart string      `query:"created_at_start"`
 	CreatedAtEnd   string      `query:"created_at_end"`
 	MinDuration    uint        `query:"min_duration"`

--- a/sdk/src/beta9/cli/task.py
+++ b/sdk/src/beta9/cli/task.py
@@ -35,8 +35,11 @@ def management():
       # List the first 10 tasks
       {cli_name} task list --limit 10
 
-      # List tasks with status 'running' or 'pending' and stub-id 'function/test:handler'
-      {cli_name} task list --filter status=running,pending --filter stub-id=function/test:handler
+      # List tasks with two different statuses and a specific stub name
+      {cli_name} task list --filter status=running,pending --filter stub-name=function/test:handler
+
+      # List tasks that belong to two different stubs
+      {cli_name} task list --filter stub-id=function/test:handler,endpoint/test:handler
 
       # List tasks and output in JSON format
       {cli_name} task list --format json

--- a/sdk/src/beta9/cli/task.py
+++ b/sdk/src/beta9/cli/task.py
@@ -39,7 +39,10 @@ def management():
       {cli_name} task list --filter status=running,pending --filter stub-name=function/test:handler
 
       # List tasks that belong to two different stubs
-      {cli_name} task list --filter stub-id=function/test:handler,endpoint/test:handler
+      {cli_name} task list --filter stub-id=function/test:handler1,endpoint/test:handler2
+
+      # List tasks that are on a specific container
+      {cli_name} task list --filter container-id=endpoint-05cc6c0d-fef2-491c-b9b7-313cc21c3496-3cef29e8
 
       # List tasks and output in JSON format
       {cli_name} task list --format json


### PR DESCRIPTION
We had some of these filters before. I think the functionality was lost when we moved to using Squirrel.

This re-adds `stub-id`, `stub-name`, and `stub-type`, but in this iteration, all of these can now accept multiple values (comma delimited). And this adds new filter fields `container-id` and `task-id`. Lastly, all filter fields have a combination of names that are single, plural, hyphened, and underscored. 

Resolve BE-2026