### PR TITLE
Fix: Improve shutdown logic, add more context done checks

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -154,6 +154,8 @@ func (i *AutoscaledInstance) WaitForContainer(ctx context.Context, duration time
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		case <-i.Ctx.Done():
+			return nil, errors.New("instance context done")
 		case <-timeout:
 			return nil, errors.New("timed out waiting for a container")
 		case <-ticker.C:

--- a/pkg/abstractions/common/logs.go
+++ b/pkg/abstractions/common/logs.go
@@ -102,7 +102,7 @@ _stream:
 			}
 
 		case <-ctx.Done():
-			// This ensures when the sdk exists, the message printed is
+			// This ensures when the sdk exits, the message printed is
 			// that the container timed out.
 			if err := l.exitCallback(0); err != nil {
 				break _stream

--- a/pkg/abstractions/common/logs.go
+++ b/pkg/abstractions/common/logs.go
@@ -102,6 +102,11 @@ _stream:
 			}
 
 		case <-ctx.Done():
+			// This ensures when the sdk exists, the message printed is
+			// that the container timed out.
+			if err := l.exitCallback(0); err != nil {
+				break _stream
+			}
 			return nil
 		}
 	}

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -497,6 +497,8 @@ func (rb *RequestBuffer) heartBeat(req *request, containerId string) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-rb.ctx.Done():
+			return
 		case <-ticker.C:
 			rb.rdb.Set(rb.ctx, Keys.endpointRequestHeartbeat(rb.workspace.Name, rb.stubId, req.task.msg.TaskId), containerId, endpointRequestHeartbeatInterval)
 		}

--- a/pkg/abstractions/endpoint/serve.go
+++ b/pkg/abstractions/endpoint/serve.go
@@ -71,6 +71,9 @@ func (es *HttpEndpointService) StartEndpointServe(in *pb.StartEndpointServeReque
 		return nil
 	}
 
+	ctx, cancel := common.MergeContexts(es.ctx, ctx)
+	defer cancel()
+
 	// Keep serve container active for as long as user has their terminal open
 	// We can handle timeouts on the client side
 	// If timeout is set to negative, we want to keep the container alive indefinitely while the user is connected

--- a/pkg/abstractions/function/function.go
+++ b/pkg/abstractions/function/function.go
@@ -188,6 +188,9 @@ func (fs *RunCFunctionService) stream(ctx context.Context, stream pb.FunctionSer
 		return err
 	}
 
+	ctx, cancel := common.MergeContexts(fs.ctx, ctx)
+	defer cancel()
+
 	return logStream.Stream(ctx, authInfo, containerId)
 }
 

--- a/pkg/abstractions/taskqueue/serve.go
+++ b/pkg/abstractions/taskqueue/serve.go
@@ -62,6 +62,9 @@ func (tq *RedisTaskQueue) StartTaskQueueServe(in *pb.StartTaskQueueServeRequest,
 		return nil
 	}
 
+	ctx, cancel := common.MergeContexts(tq.ctx, ctx)
+	defer cancel()
+
 	// Keep serve container active for as long as user has their terminal open
 	// We can handle timeouts on the client side
 	// If timeout is set to negative, we want to keep the container alive indefinitely while the user is connected

--- a/pkg/common/contexts.go
+++ b/pkg/common/contexts.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"context"
+	"sync"
+)
+
+func MergeContexts(ctxs ...context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	for _, c := range ctxs {
+		wg.Add(1)
+		go func(c context.Context) {
+			defer wg.Done()
+			select {
+			case <-c.Done():
+				cancel() // Cancel the derived context if any parent context is done
+			case <-ctx.Done():
+			}
+		}(c)
+	}
+
+	go func() {
+		wg.Wait()
+		cancel() // Ensure derived context is canceled when all goroutines complete
+	}()
+
+	return ctx, cancel
+}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
 	"github.com/beam-cloud/beta9/pkg/abstractions/container"
@@ -454,18 +455,45 @@ func (g *Gateway) Start() error {
 	log.Println("Gateway grpc server running @", g.Config.GatewayService.GRPC.Port)
 
 	terminationSignal := make(chan os.Signal, 1)
-	defer close(terminationSignal)
-
 	signal.Notify(terminationSignal, os.Interrupt, syscall.SIGTERM)
-
 	<-terminationSignal
 	log.Println("Termination signal received. Shutting down...")
-
-	ctx, cancel := context.WithTimeout(g.ctx, g.Config.GatewayService.ShutdownTimeout)
-	defer cancel()
-	g.httpServer.Shutdown(ctx)
-	g.grpcServer.GracefulStop()
-	g.cancelFunc()
+	g.shutdown()
 
 	return nil
+}
+
+// Shutdown gracefully shuts down the gateway.
+// This function is blocking and will only return when the gateway has been shut down.
+func (g *Gateway) shutdown() {
+	ctx, cancel := context.WithTimeout(context.Background(), g.Config.GatewayService.ShutdownTimeout)
+	defer cancel()
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return g.httpServer.Shutdown(ctx)
+	})
+
+	eg.Go(func() error {
+		done := make(chan struct{})
+		go func() {
+			g.grpcServer.GracefulStop()
+			close(done)
+		}()
+
+		select {
+		case <-ctx.Done():
+			g.grpcServer.Stop()
+			return ctx.Err()
+		case <-done:
+			return nil
+		}
+	})
+
+	g.cancelFunc()
+
+	if err := eg.Wait(); err != nil {
+		log.Fatalf("Failed to shutdown gateway: %v", err)
+	}
 }

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -140,6 +140,12 @@ func (s *RunCServer) RunCStreamLogs(req *pb.RunCStreamLogsRequest, stream pb.Run
 	logEntry := &pb.RunCLogEntry{}
 
 	for {
+		select {
+		case <-stream.Context().Done():
+			return errors.New("context cancelled")
+		default:
+		}
+
 		n, err := instance.LogBuffer.Read(buffer)
 		if err == io.EOF {
 			break


### PR DESCRIPTION
- Improve shutdown logic by running server (gRPC/HTTP) shutdowns and global context cancellation in parallel
- Merge global and local contexts to avoid modifying downstream code that doesn't need to know about the global context
- In the runc_server.go RunCStreamLogs func, make sure we can cancel the loop if the gateway is being shutdown 
- Cancel RequestBuffer heartBeat func if gateway is shutting down