### PR TITLE
Add pre-emptible flag to worker pool config

### DIFF
--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -37,6 +37,7 @@ type WorkerPoolController interface {
 	Name() string
 	FreeCapacity() (*WorkerPoolCapacity, error)
 	Context() context.Context
+	IsPreemptable() bool
 }
 
 type WorkerPoolConfig struct {

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -410,6 +410,10 @@ func (wpc *ExternalWorkerPoolController) getWorkerEnvironment(workerId, machineI
 			Name:  "NETWORK_PREFIX",
 			Value: machineId,
 		},
+		{
+			Name:  "PREEMPTABLE",
+			Value: strconv.FormatBool(wpc.workerPool.Preemptable),
+		},
 	}
 
 	remoteConfig, err := providers.GetRemoteConfig(wpc.config, wpc.tailscale)

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -102,6 +102,10 @@ func (wpc *ExternalWorkerPoolController) Context() context.Context {
 	return wpc.ctx
 }
 
+func (wpc *ExternalWorkerPoolController) IsPreemptable() bool {
+	return wpc.workerPool.Preemptable
+}
+
 func (wpc *ExternalWorkerPoolController) AddWorker(cpu int64, memory int64, gpuCount uint32) (*types.Worker, error) {
 	workerId := GenerateWorkerId()
 
@@ -355,6 +359,7 @@ func (wpc *ExternalWorkerPoolController) createWorkerJob(workerId, machineId str
 		Status:        types.WorkerStatusPending,
 		Priority:      wpc.workerPool.Priority,
 		BuildVersion:  wpc.config.Worker.ImageTag,
+		Preemptable:   wpc.workerPool.Preemptable,
 	}, nil
 }
 

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -379,6 +379,10 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerEnvironment(workerId st
 				},
 			},
 		},
+		{
+			Name:  "PREEMPTABLE",
+			Value: strconv.FormatBool(wpc.workerPool.Preemptable),
+		},
 	}
 
 	if wpc.config.Worker.UseGatewayServiceHostname {

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -68,6 +68,10 @@ func (wpc *LocalKubernetesWorkerPoolController) Context() context.Context {
 	return wpc.ctx
 }
 
+func (wpc *LocalKubernetesWorkerPoolController) IsPreemptable() bool {
+	return wpc.workerPool.Preemptable
+}
+
 func (wpc *LocalKubernetesWorkerPoolController) Name() string {
 	return wpc.name
 }
@@ -235,6 +239,7 @@ func (wpc *LocalKubernetesWorkerPoolController) createWorkerJob(workerId string,
 		Status:        types.WorkerStatusPending,
 		Priority:      wpc.workerPool.Priority,
 		BuildVersion:  wpc.config.Worker.ImageTag,
+		Preemptable:   wpc.workerPool.Preemptable,
 	}
 }
 

--- a/pkg/scheduler/pool_manager.go
+++ b/pkg/scheduler/pool_manager.go
@@ -46,6 +46,21 @@ func (m *WorkerPoolManager) GetPoolByGPU(gpuType string) (*WorkerPool, bool) {
 	return wp, ok
 }
 
+// GetPoolsByGPU retrieves all WorkerPools by their GPU type.
+// It returns a slice of matching WorkerPools.
+func (m *WorkerPoolManager) GetPoolsByGPU(gpuType string) []*WorkerPool {
+	var pools []*WorkerPool
+
+	m.poolMap.Range(func(key string, value *WorkerPool) bool {
+		if value.Config.GPUType == gpuType {
+			pools = append(pools, value)
+		}
+		return true
+	})
+
+	return pools
+}
+
 func (m *WorkerPoolManager) SetPool(name string, config types.WorkerPoolConfig, controller WorkerPoolController) {
 	m.poolMap.Set(name, &WorkerPool{Name: name, Config: config, Controller: controller})
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -246,6 +246,7 @@ func (s *Scheduler) StartProcessingRequests() {
 							log.Printf("Unable to schedule request for container<%s>: %v\n", request.ContainerId, err)
 							s.addRequestToBacklog(request)
 						}
+
 						return
 					}
 				}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -173,21 +173,25 @@ func (s *Scheduler) getControllers(request *types.ContainerRequest) ([]WorkerPoo
 			return nil, errors.New("no controller found for request")
 		}
 		controllers = append(controllers, wp.Controller)
-	} else if len(request.GpuRequest) == 0 {
-		wp, ok := s.workerPoolManager.GetPool("default")
+
+	} else if !request.RequiresGPU() {
+		wp, ok := s.workerPoolManager.GetPool(types.DefaultCPUWorkerPoolName)
 		if !ok {
 			return nil, errors.New("no controller found for request")
 		}
 		controllers = append(controllers, wp.Controller)
+
 	} else {
 		for _, gpu := range request.GpuRequest {
-			wp, ok := s.workerPoolManager.GetPoolByGPU(gpu)
-			if ok {
-				controllers = append(controllers, wp.Controller)
+			pools := s.workerPoolManager.GetPoolsByGPU(gpu)
+
+			for _, pool := range pools {
+				controllers = append(controllers, pool.Controller)
 			}
 		}
 	}
 
+	controllers = filterControllersByFlags(controllers, request)
 	if len(controllers) == 0 {
 		return nil, errors.New("no controller found for request")
 	}
@@ -279,6 +283,19 @@ func (s *Scheduler) scheduleRequest(worker *types.Worker, request *types.Contain
 	return s.workerRepo.ScheduleContainerRequest(worker, request)
 }
 
+func filterControllersByFlags(controllers []WorkerPoolController, request *types.ContainerRequest) []WorkerPoolController {
+	filteredControllers := []WorkerPoolController{}
+	for _, controller := range controllers {
+		if !request.Preemptable && controller.IsPreemptable() {
+			continue
+		}
+
+		filteredControllers = append(filteredControllers, controller)
+	}
+
+	return filteredControllers
+}
+
 func filterWorkersByPoolSelector(workers []*types.Worker, request *types.ContainerRequest) []*types.Worker {
 	filteredWorkers := []*types.Worker{}
 	for _, worker := range workers {
@@ -335,6 +352,19 @@ func filterWorkersByResources(workers []*types.Worker, request *types.ContainerR
 	return filteredWorkers
 }
 
+func filterWorkersByFlags(workers []*types.Worker, request *types.ContainerRequest) []*types.Worker {
+	filteredWorkers := []*types.Worker{}
+	for _, worker := range workers {
+		if !request.Preemptable && worker.Preemptable {
+			continue
+		}
+
+		filteredWorkers = append(filteredWorkers, worker)
+	}
+
+	return filteredWorkers
+}
+
 type scoredWorker struct {
 	worker *types.Worker
 	score  int32
@@ -353,6 +383,7 @@ func (s *Scheduler) selectWorker(request *types.ContainerRequest) (*types.Worker
 
 	filteredWorkers := filterWorkersByPoolSelector(workers, request)     // Filter workers by pool selector
 	filteredWorkers = filterWorkersByResources(filteredWorkers, request) // Filter workers resource requirements
+	filteredWorkers = filterWorkersByFlags(filteredWorkers, request)     // Filter workers by flags
 
 	if len(filteredWorkers) == 0 {
 		return nil, &types.ErrNoSuitableWorkerFound{}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -814,7 +814,6 @@ func TestPreemptableWorker(t *testing.T) {
 	// Select a worker for the request, this one should succeed since there is an available preemptable worker
 	worker, err := wb.selectWorker(nonPreemptableRequest)
 	assert.Nil(t, err)
-
 	assert.Equal(t, worker.Id, newNonPreemptableWorker.Id)
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -83,6 +83,10 @@ func (wpc *LocalWorkerPoolControllerForTest) Context() context.Context {
 	return wpc.ctx
 }
 
+func (wpc *LocalWorkerPoolControllerForTest) IsPreemptable() bool {
+	return false
+}
+
 func (wpc *LocalWorkerPoolControllerForTest) generateWorkerId() string {
 	return uuid.New().String()[:8]
 }
@@ -130,6 +134,10 @@ type ExternalWorkerPoolControllerForTest struct {
 
 func (wpc *ExternalWorkerPoolControllerForTest) Context() context.Context {
 	return wpc.ctx
+}
+
+func (wpc *ExternalWorkerPoolControllerForTest) IsPreemptable() bool {
+	return false
 }
 
 func (wpc *ExternalWorkerPoolControllerForTest) generateWorkerId() string {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -758,6 +758,66 @@ func TestRequiresPoolSelectorWorker(t *testing.T) {
 	assert.Equal(t, types.WorkerStatusAvailable, updatedWorker.Status)
 }
 
+func TestPreemptableWorker(t *testing.T) {
+	wb, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	assert.NotNil(t, wb)
+
+	newPreemptableWorker := &types.Worker{
+		Id:          "worker1",
+		Status:      types.WorkerStatusAvailable,
+		FreeCpu:     2000,
+		FreeMemory:  2000,
+		Gpu:         "",
+		PoolName:    "cpu",
+		Preemptable: true,
+	}
+
+	// Create a new worker that is preemptable
+	err = wb.workerRepo.AddWorker(newPreemptableWorker)
+	assert.Nil(t, err)
+
+	nonPreemptableRequest := &types.ContainerRequest{
+		Cpu:    1000,
+		Memory: 1000,
+		Gpu:    "",
+	}
+
+	// Select a worker for the request, this one should not succeed since the only available worker is preemptable
+	_, err = wb.selectWorker(nonPreemptableRequest)
+	assert.Equal(t, &types.ErrNoSuitableWorkerFound{}, err)
+
+	preemptableRequest := &types.ContainerRequest{
+		Cpu:         1000,
+		Memory:      1000,
+		Gpu:         "",
+		Preemptable: true,
+	}
+
+	// Select a worker for the request, this one should succeed since there is an available preemptable worker
+	_, err = wb.selectWorker(preemptableRequest)
+	assert.Nil(t, err)
+
+	newNonPreemptableWorker := &types.Worker{
+		Id:         "worker2",
+		Status:     types.WorkerStatusAvailable,
+		FreeCpu:    2000,
+		FreeMemory: 2000,
+		Gpu:        "",
+		PoolName:   "cpu2",
+	}
+
+	// Create a new worker that is non preemptable
+	err = wb.workerRepo.AddWorker(newNonPreemptableWorker)
+	assert.Nil(t, err)
+
+	// Select a worker for the request, this one should succeed since there is an available preemptable worker
+	worker, err := wb.selectWorker(nonPreemptableRequest)
+	assert.Nil(t, err)
+
+	assert.Equal(t, worker.Id, newNonPreemptableWorker.Id)
+}
+
 func TestPoolPriority(t *testing.T) {
 	wb, err := NewSchedulerForTest()
 	assert.Nil(t, err)

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -213,6 +213,7 @@ type WorkerPoolConfig struct {
 	DefaultMachineCost   float64                           `key:"defaultMachineCost" json:"default_machine_cost"`
 	RequiresPoolSelector bool                              `key:"requiresPoolSelector" json:"requires_pool_selector"`
 	Priority             int32                             `key:"priority" json:"priority"`
+	Preemptable          bool                              `key:"preemptable" json:"preemptable"`
 }
 
 type WorkerPoolJobSpecConfig struct {

--- a/pkg/types/scheduler.go
+++ b/pkg/types/scheduler.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+const (
+	DefaultCPUWorkerPoolName = "default"
+)
+
 type WorkerStatus string
 
 const (
@@ -30,6 +34,7 @@ type Worker struct {
 	ResourceVersion      int64        `json:"resource_version" redis:"resource_version"`
 	RequiresPoolSelector bool         `json:"requires_pool_selector" redis:"requires_pool_selector"`
 	Priority             int32        `json:"priority" redis:"priority"`
+	Preemptable          bool         `json:"preemptable" redis:"preemptable"`
 	BuildVersion         string       `json:"build_version" redis:"build_version"`
 }
 
@@ -88,6 +93,7 @@ type ContainerRequest struct {
 	Mounts           []Mount         `json:"mounts"`
 	RetryCount       int             `json:"retry_count"`
 	PoolSelector     string          `json:"pool_selector"`
+	Preemptable      bool            `json:"preemptable"`
 }
 
 func (c *ContainerRequest) RequiresGPU() bool {


### PR DESCRIPTION
- Adds an optional (default=false) preemptible flag
- Allows filtering of workers by request flags
- Allows filtering of worker pool controllers by request flags

**NOTE**: behavior of the schedule should not change unless we modify container requests going into the schedule with the `Preemptible=true` flag and add preemptible worker pools. By default they are all nonpremptible.