### PR TITLE
Fix: Output useful example command when deploying or serving realtime app

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.107"
+version = "0.1.108"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -158,6 +158,17 @@ class RunnerAbstraction(BaseAbstraction):
             ),
             "-d '{}'",
         ]
+
+        if self.is_websocket:
+            commands = [
+                f"websocat '{res.url.replace('http://', 'ws://').replace('https://', 'wss://')}' \\",
+                *(
+                    [f"-H 'Authorization: Bearer {self.config_context.token}'"]
+                    if self.authorized
+                    else []
+                ),
+            ]
+
         terminal.print("\n".join(commands), crop=False, overflow="ignore")
 
     def _parse_memory(self, memory_str: str) -> int:

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -396,6 +396,7 @@ class RealtimeASGI(ASGI):
             callback_url=callback_url,
             concurrent_requests=concurrent_requests,
         )
+        self.is_websocket = True
 
     def __call__(self, func):
         import asyncio


### PR DESCRIPTION
Resolve BE-2020

Instead of `curl`, we will now output a command that uses `websocat`. We do this by checking for a `websocket` flag set on the parent. 


```bash
~/Dev/be/baps/realtime main ❯ beta9 serve app.py:handler                                                          28s   beta9-py3.12
=> Building image
=> Using cached image
=> Syncing files
Reading .beta9ignore file
Collecting files from /Users/minzi/Dev/beam/baps/realtime
Added /Users/minzi/Dev/beam/baps/realtime/app.py
Collected object is 405.00 B
=> Files already synced
=> Invocation details
websocat 'ws://localhost:1994/asgi/id/ba11d9f7-7c2a-4396-8dd2-094f9c592301' \
-H 'Authorization: Bearer TOKEN'
=> Watching '/Users/minzi/Dev/beam/baps/realtime' for changes...
[2024-11-04 20:21:01 +0000] [10] [INFO] Starting gunicorn 20.1.0
[2024-11-04 20:21:01 +0000] [10] [INFO] Listening at: http://[::]:37151 (10)
[2024-11-04 20:21:01 +0000] [10] [INFO] Using worker: uvicorn.workers.UvicornWorker
[2024-11-04 20:21:01 +0000] [11] [INFO] Booting worker with pid: 11
Running on_start func: app:load_model
on_start func complete, took: 0.0005667209625244141s
[2024-11-04 20:21:02 +0000] [11] [INFO] Started server process [11]
[2024-11-04 20:21:02 +0000] [11] [INFO] Waiting for application startup.
[2024-11-04 20:21:02 +0000] [11] [INFO] Application startup complete.
Received task <504082a2-f47a-415c-8573-34ff4be3806b>
[2024-11-04 20:21:13 +0000] [11] [INFO] ('::ffff:10.42.0.226', 58748) - "WebSocket /" [accepted]
[2024-11-04 20:21:13 +0000] [11] [INFO] connection open
my_model
my_model
Task <504082a2-f47a-415c-8573-34ff4be3806b> finished
[2024-11-04 20:21:18 +0000] [11] [INFO] connection closed
=> Stopping serve container
Goodbye 👋
```