### PR TITLE
Feat: Add flag to force rebuild of image

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.109"
+version = "0.1.110"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -330,6 +330,7 @@ class RunnerAbstraction(BaseAbstraction):
         func: Optional[Callable] = None,
         stub_type: str,
         force_create_stub: bool = False,
+        force_rebuild: bool = False,
     ) -> bool:
         if called_on_import():
             return False
@@ -345,7 +346,7 @@ class RunnerAbstraction(BaseAbstraction):
         self.cpu = self._parse_cpu_to_millicores(self.cpu)
 
         if not self.image_available:
-            image_build_result: ImageBuildResult = self.image.build()
+            image_build_result: ImageBuildResult = self.image.build(force_rebuild=force_rebuild)
 
             if image_build_result and image_build_result.success:
                 self.image_available = True

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -492,14 +492,14 @@ class _CallableWrapper(DeployableMixin):
         return self.func(*args, **kwargs)
 
     @with_grpc_error_handling
-    def serve(self, timeout: int = 0, url_type: str = ""):
+    def serve(self, timeout: int = 0, url_type: str = "", force_rebuild: bool = False):
         stub_type = ENDPOINT_SERVE_STUB_TYPE
 
         if getattr(self.parent, "is_asgi", None):
             stub_type = ASGI_SERVE_STUB_TYPE
 
         if not self.parent.prepare_runtime(
-            func=self.func, stub_type=stub_type, force_create_stub=True
+            func=self.func, stub_type=stub_type, force_create_stub=True, force_rebuild=force_rebuild
         ):
             return False
 

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -165,11 +165,11 @@ class Image(BaseAbstraction):
 
         return (r.exists, ImageBuildResult(success=r.exists, image_id=r.image_id))
 
-    def build(self) -> ImageBuildResult:
+    def build(self, force_rebuild: bool = False) -> ImageBuildResult:
         terminal.header("Building image")
 
         exists, exists_response = self.exists()
-        if exists:
+        if exists and not force_rebuild:
             terminal.header("Using cached image")
             return ImageBuildResult(success=True, image_id=exists_response.image_id)
 

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -366,6 +366,7 @@ class VLLM(ASGI):
         self,
         name: Optional[str] = None,
         context: Optional[ConfigContext] = None,
+        force_rebuild: bool = False,
         invocation_details_func: Optional[Callable[..., None]] = None,
         **invocation_details_options: Any,
     ) -> bool:
@@ -389,6 +390,7 @@ class VLLM(ASGI):
         if not self.prepare_runtime(
             stub_type=ASGI_DEPLOYMENT_STUB_TYPE,
             force_create_stub=True,
+            force_rebuild=force_rebuild,
         ):
             return False
 
@@ -408,8 +410,10 @@ class VLLM(ASGI):
         return deploy_response.ok
 
     @with_grpc_error_handling
-    def serve(self, timeout: int = 0, url_type: str = ""):
-        if not self.prepare_runtime(stub_type=ASGI_SERVE_STUB_TYPE, force_create_stub=True):
+    def serve(self, timeout: int = 0, url_type: str = "", force_rebuild: bool = False):
+        if not self.prepare_runtime(
+            stub_type=ASGI_SERVE_STUB_TYPE, force_create_stub=True, force_rebuild=force_rebuild
+        ):
             return False
 
         try:

--- a/sdk/src/beta9/abstractions/mixins.py
+++ b/sdk/src/beta9/abstractions/mixins.py
@@ -27,6 +27,7 @@ class DeployableMixin:
         self,
         name: Optional[str] = None,
         context: Optional[ConfigContext] = None,
+        force_rebuild: bool = False,
         invocation_details_func: Optional[Callable[..., None]] = None,
         **invocation_details_options: Any,
     ) -> bool:
@@ -42,7 +43,10 @@ class DeployableMixin:
             self.parent.config_context = context
 
         if not self.parent.prepare_runtime(
-            func=self.func, stub_type=self.deployment_stub_type, force_create_stub=True
+            func=self.func,
+            stub_type=self.deployment_stub_type,
+            force_create_stub=True,
+            force_rebuild=force_rebuild,
         ):
             return False
 

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -175,9 +175,12 @@ class _CallableWrapper(DeployableMixin):
         return self.func(*args, **kwargs)
 
     @with_grpc_error_handling
-    def serve(self, timeout: int = 0, url_type: str = ""):
+    def serve(self, timeout: int = 0, url_type: str = "", force_rebuild: bool = False):
         if not self.parent.prepare_runtime(
-            func=self.func, stub_type=TASKQUEUE_SERVE_STUB_TYPE, force_create_stub=True
+            func=self.func,
+            stub_type=TASKQUEUE_SERVE_STUB_TYPE,
+            force_create_stub=True,
+            force_rebuild=force_rebuild,
         ):
             return False
 

--- a/sdk/src/beta9/cli/deployment.py
+++ b/sdk/src/beta9/cli/deployment.py
@@ -62,9 +62,20 @@ def common(**_):
     help="The type of URL to get back. [default is determined by the server] ",
     type=click.Choice(["host", "path"]),
 )
+@click.option(
+    "--force-rebuild",
+    help="Force a rebuild of the deployment.",
+    is_flag=True,
+)
 @click.pass_context
-def deploy(ctx: click.Context, name: str, entrypoint: str, url_type: str):
-    ctx.invoke(create_deployment, name=name, entrypoint=entrypoint, url_type=url_type)
+def deploy(ctx: click.Context, name: str, entrypoint: str, url_type: str, force_rebuild: bool):
+    ctx.invoke(
+        create_deployment,
+        name=name,
+        entrypoint=entrypoint,
+        url_type=url_type,
+        force_rebuild=force_rebuild,
+    )
 
 
 @click.group(
@@ -103,8 +114,15 @@ def management():
     help="The type of URL to get back. [default is determined by the server] ",
     type=click.Choice(["host", "path"]),
 )
+@click.option(
+    "--force-rebuild",
+    help="Force a rebuild of the deployment.",
+    is_flag=True,
+)
 @extraclick.pass_service_client
-def create_deployment(service: ServiceClient, name: str, entrypoint: str, url_type: str):
+def create_deployment(
+    service: ServiceClient, name: str, entrypoint: str, url_type: str, force_rebuild: bool
+):
     current_dir = os.getcwd()
     if current_dir not in sys.path:
         sys.path.insert(0, current_dir)
@@ -131,7 +149,9 @@ def create_deployment(service: ServiceClient, name: str, entrypoint: str, url_ty
     if hasattr(user_obj, "set_handler"):
         user_obj.set_handler(f"{module_name}:{obj_name}")
 
-    if not user_obj.deploy(name=name, context=service._config, url_type=url_type):  # type: ignore
+    if not user_obj.deploy(
+        name=name, context=service._config, force_rebuild=force_rebuild, url_type=url_type
+    ):  # type: ignore
         terminal.error("Deployment failed ☠️")
 
 

--- a/sdk/src/beta9/cli/serve.py
+++ b/sdk/src/beta9/cli/serve.py
@@ -49,6 +49,11 @@ def common(**_):
     help="The type of URL to get back. [default is determined by the server] ",
     type=click.Choice(["host", "path"]),
 )
+@click.option(
+    "--force-rebuild",
+    help="Force a rebuild of the deployment.",
+    is_flag=True,
+)
 @extraclick.pass_service_client
 @click.pass_context
 def serve(
@@ -57,6 +62,7 @@ def serve(
     entrypoint: str,
     timeout: Optional[int] = None,
     url_type: str = "path",
+    force_rebuild: bool = False,
 ):
     current_dir = os.getcwd()
     if current_dir not in sys.path:
@@ -84,4 +90,4 @@ def serve(
     if hasattr(user_obj, "set_handler"):
         user_obj.set_handler(f"{module_name}:{obj_name}")
 
-    user_obj.serve(timeout=int(timeout), url_type=url_type)  # type:ignore
+    user_obj.serve(timeout=int(timeout), url_type=url_type, force_rebuild=force_rebuild)  # type:ignore


### PR DESCRIPTION
Resolve BE-2022

This PR adds a flag to deploy and serve that allows a user to force the image to be re-built. 

```bash
# WITHOUT
~/Dev/beam/baps/asgi main ❯ beta9 deploy app.py:handler                                                                                                                                                                                                                                                         beta9-py3.12
=> Building image
=> Using cached image
=> Syncing files
Reading .beta9ignore file
Collecting files from /Users/minzi/Dev/beam/baps/asgi
Added /Users/minzi/Dev/beam/baps/asgi/.beamignore
Added /Users/minzi/Dev/beam/baps/asgi/pyproject.toml
Added /Users/minzi/Dev/beam/baps/asgi/app.py
Added /Users/minzi/Dev/beam/baps/asgi/urls.txt
Added /Users/minzi/Dev/beam/baps/asgi/sleep-body.json
Added /Users/minzi/Dev/beam/baps/asgi/poetry.lock
Collected object is 109.27 KB
=> Files already synced
=> Deploying
=> Deployed 🎉

# WITH
~/Dev/beam/baps/asgi main ❯ beta9 deploy app.py:handler --force-rebuild                                                                                                                                                                                                                                         beta9-py3.12
=> Building image
Waiting for build container to start...
Python 3.10.14
... build stuff happening
Saving image, this may take a few minutes...
[==================================================] 100%
=> Build complete 🎉
=> Syncing files
Reading .beta9ignore file
Collecting files from /Users/minzi/Dev/beam/baps/asgi
Added /Users/minzi/Dev/beam/baps/asgi/.beamignore
Added /Users/minzi/Dev/beam/baps/asgi/pyproject.toml
Added /Users/minzi/Dev/beam/baps/asgi/app.py
Added /Users/minzi/Dev/beam/baps/asgi/urls.txt
Added /Users/minzi/Dev/beam/baps/asgi/sleep-body.json
Added /Users/minzi/Dev/beam/baps/asgi/poetry.lock
Collected object is 109.27 KB
=> Files already synced
=> Deploying
=> Deployed 🎉
```
