### PR TITLE
Fix: worker hangs on shutdown

### DIFF
--- a/bin/delete_workers.sh
+++ b/bin/delete_workers.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-echo "Deleting worker jobs..."
-kubectl delete job --now --cascade=foreground -l run.beam.cloud/role=worker
-
-echo "Deleting scheduler keys..."
+echo "Deleting redis keys..."
 if kubectl get sts redis-master &> /dev/null; then
   replicas=$(kubectl get sts redis-master -o jsonpath='{.spec.replicas}')
   for i in $(seq 0 $((replicas-1))); do
@@ -15,5 +12,10 @@ if kubectl get sts redis-master &> /dev/null; then
     kubectl exec redis-master-$i -- bash -c 'for k in $(redis-cli keys worker:*); do redis-cli -c del $k; done' &
   done
 fi
+
+# Workers now handle deleting themselves from redis on shutdown. This will happen faster than when
+# the redis keys are deleted.
+echo "Deleting worker jobs..."
+kubectl delete job -l run.beam.cloud/role=worker
 
 wait

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -59,3 +59,12 @@ var WorkerContainerExitCodes = map[int]string{
 	WorkerContainerExitCodeInvalidCustomImage: "InvalidCustomImage: Could not find custom image",
 	WorkerContainerExitCodeIncorrectImageOs:   "InvalidOs: Image is not built for linux",
 }
+
+const (
+	// Used specifically for runc states.
+	// Not the same as the scheduler container states.
+	RuncContainerStatusCreated string = "created"
+	RuncContainerStatusRunning string = "running"
+	RuncContainerStatusPaused  string = "paused"
+	RuncContainerStatusStopped string = "stopped"
+)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -56,7 +56,8 @@ func (s *Worker) handleStopContainerEvent(event *common.Event) bool {
 func (s *Worker) stopContainer(containerId string, kill bool) error {
 	log.Printf("<%s> - stopping container.\n", containerId)
 
-	if _, exists := s.containerInstances.Get(containerId); !exists {
+	_, exists := s.containerInstances.Get(containerId)
+	if !exists {
 		log.Printf("<%s> - container not found.\n", containerId)
 		return nil
 	}
@@ -64,8 +65,6 @@ func (s *Worker) stopContainer(containerId string, kill bool) error {
 	signal := int(syscall.SIGTERM)
 	if kill {
 		signal = int(syscall.SIGKILL)
-		s.containerRepo.DeleteContainerState(containerId)
-		defer s.containerInstances.Delete(containerId)
 	}
 
 	err := s.runcHandle.Kill(context.Background(), containerId, signal, &runc.KillOpts{All: true})
@@ -98,10 +97,10 @@ func (s *Worker) finalizeContainer(containerId string, request *types.ContainerR
 		log.Printf("<%s> - failed to set exit code: %v\n", containerId, err)
 	}
 
-	s.clearContainer(containerId, request, time.Duration(s.config.Worker.TerminationGracePeriod)*time.Second, *exitCode)
+	s.clearContainer(containerId, request, *exitCode)
 }
 
-func (s *Worker) clearContainer(containerId string, request *types.ContainerRequest, delay time.Duration, exitCode int) {
+func (s *Worker) clearContainer(containerId string, request *types.ContainerRequest, exitCode int) {
 	s.containerLock.Lock()
 
 	// De-allocate GPU devices so they are available for new containers
@@ -128,7 +127,14 @@ func (s *Worker) clearContainer(containerId string, request *types.ContainerRequ
 	go func() {
 		// Allow for some time to pass before clearing the container. This way we can handle some last
 		// minute logs or events or if the user wants to inspect the container before it's cleared.
-		time.Sleep(delay)
+		select {
+		case <-time.After(time.Duration(s.config.Worker.TerminationGracePeriod) * time.Second):
+		case <-s.ctx.Done():
+		}
+
+		if err := s.stopContainer(containerId, false); err != nil {
+			log.Printf("<%s> - failed to stop container: %v\n", containerId, err)
+		}
 
 		s.containerInstances.Delete(containerId)
 		err := s.containerRepo.DeleteContainerState(containerId)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -134,7 +134,7 @@ func (s *Worker) clearContainer(containerId string, request *types.ContainerRequ
 
 		// If the container is still running, stop it. This happens when a sigterm is detected.
 		container, err := s.runcHandle.State(context.TODO(), containerId)
-		if err == nil && container.Status == "running" {
+		if err == nil && container.Status == types.RuncContainerStatusRunning {
 			if err := s.stopContainer(containerId, false); err != nil {
 				log.Printf("<%s> - failed to stop container: %v\n", containerId, err)
 			}

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -18,6 +18,7 @@ import (
 	pb "github.com/beam-cloud/beta9/proto"
 
 	common "github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/beam-cloud/go-runc"
 	"github.com/google/shlex"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -125,7 +126,7 @@ func (s *RunCServer) RunCStatus(ctx context.Context, in *pb.RunCStatusRequest) (
 	}
 
 	return &pb.RunCStatusResponse{
-		Running: state.Status == "running",
+		Running: state.Status == types.RuncContainerStatusRunning,
 	}, nil
 }
 
@@ -170,7 +171,7 @@ func (s *RunCServer) RunCArchive(req *pb.RunCArchiveRequest, stream pb.RunCServi
 		return stream.Send(&pb.RunCArchiveResponse{Done: true, Success: false, ErrorMsg: "Container not found"})
 	}
 
-	if state.Status != "running" {
+	if state.Status != types.RuncContainerStatusRunning {
 		return stream.Send(&pb.RunCArchiveResponse{Done: true, Success: false, ErrorMsg: "Container not running"})
 	}
 


### PR DESCRIPTION
- Don't delete container state or instance in stopContainer func
- Don't stop all containers in shutdown func
- Call stopContainer in clearContainer func right before delete container state is called only if the container is still running. This allows the container to terminate when the global context is cancelled and finish executing the finalizeContainer and clearContainer functions. Also, this is needed when there is a sigterm, but not when the container stops normally.
- Don't use time.Sleep to delete container state and instance. Instead use a select statement that waits for either the graceful timeout or for the global context to cancel.
- Enable runc debug mode when global debug is enabled
- Revert delete worker changes

Resolve BE-2038