### PR TITLE
Better import for integrations

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.111"
+version = "0.1.112"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/__init__.py
+++ b/sdk/src/beta9/__init__.py
@@ -1,5 +1,5 @@
 from . import env
-from .abstractions import experimental, integrations
+from .abstractions import experimental
 from .abstractions.container import Container
 from .abstractions.endpoint import ASGI as asgi
 from .abstractions.endpoint import Endpoint as endpoint
@@ -33,7 +33,7 @@ __all__ = [
     "Output",
     "QueueDepthAutoscaler",
     "experimental",
+    "integrations",
     "schedule",
     "TaskPolicy",
-    "integrations",
 ]

--- a/sdk/src/beta9/integrations.py
+++ b/sdk/src/beta9/integrations.py
@@ -1,1 +1,3 @@
-from .abstractions.integrations import *
+from .abstractions.integrations import VLLM, VLLMArgs
+
+__all__ = ["VLLM", "VLLMArgs"]

--- a/sdk/src/beta9/integrations.py
+++ b/sdk/src/beta9/integrations.py
@@ -1,0 +1,1 @@
+from .abstractions.integrations import *


### PR DESCRIPTION
This makes it so that we can import like this

```python
from beta9.integrations import VLLM
```

instead of 

```python
from beta9.abstractions.integrations import VLLM
```