### PR TITLE
Fix: Add nested venv in ignore

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.112"
+version = "0.1.113"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/sync.py
+++ b/sdk/src/beta9/sync.py
@@ -69,6 +69,7 @@ drive/MyDrive
 **/__pycache__/
 **/.pytest_cache/
 **/node_modules/
+**/.venv/
 *.pyc
 .next/
 .circleci


### PR DESCRIPTION
Adds nested .venv to the default ignore list