### PR TITLE
Add extra logging and tweak logic

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -541,9 +541,7 @@ func (s *Worker) watchOOMEvents(ctx context.Context, containerId string, output 
 
 	ch, err := s.runcHandle.Events(ctx, containerId, time.Second)
 	if err != nil {
-		output <- common.OutputMsg{
-			Msg: fmt.Sprintf("[WARNING] Failed to open runc events channel %s.", err),
-		}
+		log.Printf("<%s> failed to open runc events channel: %v", containerId, err)
 		return
 	}
 
@@ -557,9 +555,7 @@ func (s *Worker) watchOOMEvents(ctx context.Context, containerId string, output 
 		case event, ok := <-ch:
 			if !ok { // If the channel is closed, try to re-open it
 				if tries == maxTries-1 {
-					output <- common.OutputMsg{
-						Msg: fmt.Sprintln("[WARNING] Unable to watch for OOM events."),
-					}
+					log.Printf("<%s> failed to watch for OOM events.", containerId)
 					return
 				}
 
@@ -570,9 +566,7 @@ func (s *Worker) watchOOMEvents(ctx context.Context, containerId string, output 
 				case <-time.After(time.Second):
 					ch, err = s.runcHandle.Events(ctx, containerId, time.Second)
 					if err != nil {
-						output <- common.OutputMsg{
-							Msg: fmt.Sprintf("[WARNING] Failed to open runc events channel %s.", err),
-						}
+						log.Printf("<%s> failed to open runc events channel: %v", containerId, err)
 					}
 				}
 				continue


### PR DESCRIPTION

I have not been able to reproduce this issue locally, which has made finding a solution difficult. As a result, I am proposing adding additional logs to get a better sense of what is actually happening here. 

My original guess was that we were leaking the routine. This would explain the failure to watch as it the process its watching wouldn't exist. 

I based it off of the following logs, which I've annotated with `worker-1` and `worker-2` for clarity. 

```bash
worker-1 2024-11-04T18:18:19.850004286Z:[1;36m(VllmWorkerProcess pid=50)[0;0m
Loading safetensors checkpoint shards:  50% Completed | 1/2 [02:34<02:34, 154.37s/it]
worker-1 2024-11-04T18:19:02.434508425Z:[2024-11-04 18:19:02 +0000] [1] [INFO] Handling signal: term
worker-2 2024-11-04T18:19:19.246985322Z:Loading image: 2ad21c04ade2c364
worker-2 2024-11-04T18:19:19.247029214Z:Loaded image <2ad21c04ade2c364>, took: 1.40979ms
worker-1 2024-11-04T18:19:20.241518420Z:[WARNING] Unable to watch for OOM events.
worker-1 2024-11-04T18:19:32.457570399Z:[2024-11-04 18:19:32 +0000] [1] [INFO] Shutting down: Master
worker-2 2024-11-04T18:22:40.226597887Z:[2024-11-04 18:22:40 +0000] [1] [INFO] Starting gunicorn 20.1.0
```

Anyway, this PR contains the following changes: 
* add more logs to OOM watch method
* read events as case
* use time.After+select instead of time.sleep so that we can check context before trying to re-open the events channel. 