### PR TITLE
Feat: Use python-build-standalone over apt packages

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -293,7 +293,7 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 	checkPythonVersionCmd := fmt.Sprintf("%s --version", opts.PythonVersion)
 	if resp, err := client.Exec(containerId, checkPythonVersionCmd); (err != nil || !resp.Ok) && !micromambaEnv {
 		outputChan <- common.OutputMsg{Done: false, Success: false, Msg: fmt.Sprintf("%s not detected, installing it for you...\n", opts.PythonVersion)}
-		installCmd, err := getPythonStandaloneInstallCommand(b.config.ImageService.Runner.StandalonePython, opts.PythonVersion)
+		installCmd, err := getPythonStandaloneInstallCommand(b.config.ImageService.Runner.PythonStandalone, opts.PythonVersion)
 		if err != nil {
 			outputChan <- common.OutputMsg{Done: true, Success: false, Msg: err.Error() + "\n"}
 			return err
@@ -500,8 +500,8 @@ func getPythonInstallCommand(pythonVersion string) string {
 	return fmt.Sprintf("%s && add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -q -y %s && %s", baseCmd, installCmd, postInstallCmd)
 }
 
-// StandalonePythonTemplate is used to render the standalone python install script
-type StandalonePythonTemplate struct {
+// PythonStandaloneTemplate is used to render the standalone python install script
+type PythonStandaloneTemplate struct {
 	PythonVersion string
 
 	// Architecture, OS, and Vendor are determined at runtime
@@ -510,7 +510,7 @@ type StandalonePythonTemplate struct {
 	Vendor       string
 }
 
-func getPythonStandaloneInstallCommand(config types.StandalonePythonConfig, pythonVersion string) (string, error) {
+func getPythonStandaloneInstallCommand(config types.PythonStandaloneConfig, pythonVersion string) (string, error) {
 	var arch string
 	switch runtime.GOARCH {
 	case "amd64":
@@ -537,7 +537,7 @@ func getPythonStandaloneInstallCommand(config types.StandalonePythonConfig, pyth
 	}
 
 	var output bytes.Buffer
-	if err := tmpl.Execute(&output, StandalonePythonTemplate{
+	if err := tmpl.Execute(&output, PythonStandaloneTemplate{
 		PythonVersion: config.Versions[pythonVersion],
 		Architecture:  arch,
 		OS:            os,

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -78,6 +78,25 @@ imageService:
       micromamba3.10: micromamba3.10-latest
       micromamba3.11: micromamba3.11-latest
       micromamba3.12: micromamba3.12-latest
+    standalonePython:
+      versions:
+        python3.8: 3.8.20
+        python3.9: 3.9.20
+        python3.10: 3.10.5
+        python3.11: 3.11.10
+        python3.12: 3.12.7
+      installScriptTemplate: |
+        apt-get update -q && \
+        apt-get install -q -y build-essential curl git && \
+        curl -fsSL -o python.tgz 'https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-{{.PythonVersion}}+20241016-{{.Architecture}}-{{.Vendor}}-{{.OS}}-gnu-install_only.tar.gz' && \
+        tar -xzf python.tgz -C /usr/local --strip-components 1 && \
+        rm -f python.tgz && \
+        rm -f /usr/bin/python && \
+        rm -f /usr/bin/python3 && \
+        ln -s /usr/local/bin/python3 /usr/bin/python && \
+        ln -s /usr/local/bin/python3 /usr/bin/python3 && \
+        ln -s /usr/local/bin/pip3 /usr/bin/pip && \
+        ln -s /usr/local/bin/pip3 /usr/bin/pip3
 worker:
   pools:
     default:

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -78,7 +78,7 @@ imageService:
       micromamba3.10: micromamba3.10-latest
       micromamba3.11: micromamba3.11-latest
       micromamba3.12: micromamba3.12-latest
-    standalonePython:
+    pythonStandalone:
       versions:
         python3.8: 3.8.20
         python3.9: 3.9.20

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -132,9 +132,15 @@ type S3ImageRegistryConfig struct {
 }
 
 type RunnerConfig struct {
-	BaseImageName     string            `key:"baseImageName" json:"base_image_name"`
-	BaseImageRegistry string            `key:"baseImageRegistry" json:"base_image_registry"`
-	Tags              map[string]string `key:"tags" json:"tags"`
+	BaseImageName     string                 `key:"baseImageName" json:"base_image_name"`
+	BaseImageRegistry string                 `key:"baseImageRegistry" json:"base_image_registry"`
+	Tags              map[string]string      `key:"tags" json:"tags"`
+	StandalonePython  StandalonePythonConfig `key:"standalonePython" json:"standalone_python"`
+}
+
+type StandalonePythonConfig struct {
+	Versions              map[string]string `key:"versions" json:"versions"`
+	InstallScriptTemplate string            `key:"installScriptTemplate" json:"install_script_template"`
 }
 
 type StorageConfig struct {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -135,10 +135,10 @@ type RunnerConfig struct {
 	BaseImageName     string                 `key:"baseImageName" json:"base_image_name"`
 	BaseImageRegistry string                 `key:"baseImageRegistry" json:"base_image_registry"`
 	Tags              map[string]string      `key:"tags" json:"tags"`
-	StandalonePython  StandalonePythonConfig `key:"standalonePython" json:"standalone_python"`
+	PythonStandalone  PythonStandaloneConfig `key:"pythonStandalone" json:"python_standalone"`
 }
 
-type StandalonePythonConfig struct {
+type PythonStandaloneConfig struct {
 	Versions              map[string]string `key:"versions" json:"versions"`
 	InstallScriptTemplate string            `key:"installScriptTemplate" json:"install_script_template"`
 }


### PR DESCRIPTION
- Use python-build-standalone as a drop-in replacement for custom images without python
- Template the install script, python versions, and a few other runtime variables

Resolve BE-1974