### PR TITLE
Fix: mount sdk to opt conda path

### DIFF
--- a/pkg/worker/base_runc_config.json
+++ b/pkg/worker/base_runc_config.json
@@ -188,457 +188,229 @@
 			"destination": "/usr/local/lib/python3.8/dist-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.8/dist-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.9/dist-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.9/dist-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.10/dist-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.10/dist-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.11/dist-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.11/dist-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.12/dist-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.12/dist-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.8/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.8/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.9/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.9/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.10/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.10/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.11/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.11/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.12/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/usr/local/lib/python3.12/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.8/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.8/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.9/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.9/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.10/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.10/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.11/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.11/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.12/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/micromamba/envs/beta9/lib/python3.12/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.9/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.9/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.10/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.10/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.11/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.11/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.12/site-packages/beta9",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		},
 		{
 			"destination": "/opt/conda/lib/python3.12/site-packages/beam",
 			"type": "bind",
 			"source": "/workspace/sdk",
-			"options": [
-				"ro",
-				"rbind",
-				"rprivate",
-				"nosuid",
-				"nodev"
-			]
+			"options": ["ro", "rbind", "rprivate", "nosuid", "nodev"]
 		}
 	],
 	"hooks": {

--- a/pkg/worker/base_runc_config.json
+++ b/pkg/worker/base_runc_config.json
@@ -543,6 +543,102 @@
 				"nosuid",
 				"nodev"
 			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.9/site-packages/beta9",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.9/site-packages/beam",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.10/site-packages/beta9",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.10/site-packages/beam",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.11/site-packages/beta9",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.11/site-packages/beam",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.12/site-packages/beta9",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/opt/conda/lib/python3.12/site-packages/beam",
+			"type": "bind",
+			"source": "/workspace/sdk",
+			"options": [
+				"ro",
+				"rbind",
+				"rprivate",
+				"nosuid",
+				"nodev"
+			]
 		}
 	],
 	"hooks": {


### PR DESCRIPTION
We should mount the sdk to the `opt/conda` path. This is used for a lot of images that use Anaconda like [pytorch](https://github.com/pytorch/pytorch/blob/main/Dockerfile#L24) and the [official anaconda image](https://github.com/anaconda/docker-images/blob/main/anaconda3/debian/Dockerfile#L4)