### PR TITLE
Fix: check if in.extra is an empty string for backwards compat with older SDKs

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -79,6 +79,10 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		}
 	}
 
+	if in.Extra == "" {
+		in.Extra = "{}"
+	}
+
 	stubConfig := types.StubConfigV1{
 		Runtime: types.Runtime{
 			Cpu:     in.Cpu,


### PR DESCRIPTION
- Handle empty strings from older sdks in `Extra` field