### PR TITLE
Fix: Race condition when adding workers on remote nodes

### DIFF
--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -36,7 +36,7 @@ var (
 	workerNetworkLock            string = "worker:network:%s:lock"
 	workerNetworkIpIndex         string = "worker:network:%s:ip_index"
 	workerNetworkContainerIp     string = "worker:network:%s:container_ip:%s"
-	workerPoolSizerLock          string = "worker:poolsizer:%s:lock"
+	workerPoolSizerLock          string = "worker:pool_sizer:%s:lock"
 )
 
 var (

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -36,6 +36,7 @@ var (
 	workerNetworkLock            string = "worker:network:%s:lock"
 	workerNetworkIpIndex         string = "worker:network:%s:ip_index"
 	workerNetworkContainerIp     string = "worker:network:%s:container_ip:%s"
+	workerPoolSizerLock          string = "worker:poolsizer:%s:lock"
 )
 
 var (
@@ -47,11 +48,6 @@ var (
 	taskClaim       string = "task:%s:%s:%s:claim"
 	taskCancel      string = "task:%s:%s:%s:cancel"
 	taskRetryLock   string = "task:%s:%s:%s:retry_lock"
-)
-
-var (
-	workerPoolLock  string = "workerpool:lock:%s"
-	workerPoolState string = "workerpool:state:%s"
 )
 
 var (
@@ -242,12 +238,8 @@ func (rl *redisKeys) WorkspaceAuthorizedToken(token string) string {
 }
 
 // WorkerPool keys
-func (rk *redisKeys) WorkerPoolLock(poolName string) string {
-	return fmt.Sprintf(workerPoolLock, poolName)
-}
-
-func (rk *redisKeys) WorkerPoolState(poolName string) string {
-	return fmt.Sprintf(workerPoolState, poolName)
+func (rk *redisKeys) WorkerPoolSizerLock(poolName string) string {
+	return fmt.Sprintf(workerPoolSizerLock, poolName)
 }
 
 // Tailscale keys

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -35,6 +35,8 @@ type WorkerRepository interface {
 	GetContainerIps(networkPrefix string) ([]string, error)
 	SetNetworkLock(networkPrefix string, ttl, retries int) error
 	RemoveNetworkLock(networkPrefix string) error
+	SetWorkerPoolSizerLock(controllerName string) error
+	RemoveWorkerPoolSizerLock(controllerName string) error
 }
 
 type ContainerRepository interface {

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -364,6 +364,19 @@ func (r *WorkerRedisRepository) UpdateWorkerCapacity(worker *types.Worker, reque
 	return nil
 }
 
+func (r *WorkerRedisRepository) SetWorkerPoolSizerLock(poolName string) error {
+	err := r.lock.Acquire(context.TODO(), common.RedisKeys.WorkerPoolSizerLock(poolName), common.RedisLockOptions{TtlS: 3, Retries: 0})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *WorkerRedisRepository) RemoveWorkerPoolSizerLock(poolName string) error {
+	return r.lock.Release(common.RedisKeys.WorkerPoolSizerLock(poolName))
+}
+
 func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, request *types.ContainerRequest) error {
 	// Serialize the ContainerRequest -> JSON
 	requestJSON, err := json.Marshal(request)


### PR DESCRIPTION
- Add lock by pool name when adding workers in occupyAvailableMachines func. This prevents multiple instances of gateway from adding workers to the same pool at the same time

Resolve BE-2045