### PR TITLE
Fix: Prevent logging lock not obtained messages

### DIFF
--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -1,12 +1,13 @@
 package scheduler
 
 import (
+	"errors"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/bsm/redislock"
 )
 
 const poolMonitoringInterval = 1 * time.Second
@@ -67,7 +68,7 @@ func (s *WorkerPoolSizer) Start() {
 			// Handle case where we want to make sure all available manually provisioned nodes have available workers
 			if s.workerPoolConfig.Mode == types.PoolModeExternal {
 				err := s.occupyAvailableMachines()
-				if err != nil && !strings.Contains(err.Error(), "redislock: not obtained") {
+				if err != nil && !errors.Is(err, redislock.ErrNotObtained) {
 					log.Printf("<pool %s> Failed to list machines in external pool: %+v\n", s.controller.Name(), err)
 				}
 			}

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"log"
+	"strings"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/repository"
@@ -66,7 +67,7 @@ func (s *WorkerPoolSizer) Start() {
 			// Handle case where we want to make sure all available manually provisioned nodes have available workers
 			if s.workerPoolConfig.Mode == types.PoolModeExternal {
 				err := s.occupyAvailableMachines()
-				if err != nil {
+				if err != nil && !strings.Contains(err.Error(), "redislock: not obtained") {
 					log.Printf("<pool %s> Failed to list machines in external pool: %+v\n", s.controller.Name(), err)
 				}
 			}


### PR DESCRIPTION
These log messages just mean that another gateway or goroutine is working on this. They're emitted every second x N workers running so it creates a bunch of noise.

Resolve BE-2045