### PR TITLE
Fix: Claiming a task and prevent process crashes

### DIFF
--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -283,7 +283,7 @@ func (tq *RedisTaskQueue) TaskQueuePop(ctx context.Context, in *pb.TaskQueuePopR
 
 	err = tq.taskDispatcher.Claim(ctx, authInfo.Workspace.Name, task.Stub.ExternalId, task.ExternalId, in.ContainerId)
 	if err != nil {
-		return nil, err
+		return &pb.TaskQueuePopResponse{Ok: false}, nil
 	}
 
 	task.ContainerId = in.ContainerId
@@ -406,7 +406,7 @@ func (tq *RedisTaskQueue) TaskQueueMonitor(req *pb.TaskQueueMonitorRequest, stre
 	} else if leftoverTimeoutSeconds <= 0 {
 		err := timeoutCallback()
 		if err != nil {
-			log.Printf("error timing out task: %v", err)
+			log.Printf("Error timing out task: %v\n", err)
 			return err
 		}
 
@@ -426,7 +426,7 @@ func (tq *RedisTaskQueue) TaskQueueMonitor(req *pb.TaskQueueMonitorRequest, stre
 				case <-timeoutChan:
 					err := timeoutCallback()
 					if err != nil {
-						log.Printf("task timeout err: %v", err)
+						log.Printf("Task timeout err: %v\n", err)
 					}
 					timeoutFlag <- true
 					return
@@ -442,7 +442,7 @@ func (tq *RedisTaskQueue) TaskQueueMonitor(req *pb.TaskQueueMonitorRequest, stre
 
 				case err := <-errs:
 					if err != nil {
-						log.Printf("monitor task subscription err: %v", err)
+						log.Printf("Monitor task subscription err: %v\n", err)
 						break retry
 					}
 				}

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -339,5 +339,8 @@ def is_asgi3(app: Any) -> bool:
 
 class ThreadPoolExecutorOverride(ThreadPoolExecutor):
     def __exit__(self, *_, **__):
-        # cancel_futures added in 3.9
-        self.shutdown(cancel_futures=True)
+        try:
+            # cancel_futures added in 3.9
+            self.shutdown(cancel_futures=True)
+        except Exception:
+            pass


### PR DESCRIPTION
In TaskQueuePop we claim a task and then update the "task running lock" TTL. When the task cannot be claimed, we return a nil/None object to the Python runner when its expecting a TaskQueuePopResponse object. This causes the spawned Python process to crash. In this scenario, TaskQueueComplete is never called which is also an issue because the "keep warm lock" TTL is never updated. 

For the AutoscaledInstance of a task queue, the StopContainersFunc has a pointer to stopContainers which calls stoppableContainers. In stoppableContainers, a container is considered stoppable when there is no "keep warm" or "task running" locks. THIS is why a container that should keep running is ultimately stopped.

A side affect of the Python process crashing is that the monitor_task function thread keeps running. This is why we see the "Task process did not join within the timeout. Terminating..." message.

Changes

- Use the correct response type when we cannot claim a task
- Fix custom thread pool class exit functionality for Python 3.8
- Fix a few print statements

Resolve BE-1990