### PR TITLE
Fix: add blobcache wait

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
-	github.com/beam-cloud/blobcache-v2 v0.0.0-20241016162020-2ed2e4b47b02
+	github.com/beam-cloud/blobcache-v2 v0.0.0-20241121211215-70c6fb259a62
 	github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88
 	github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170
 	github.com/bsm/redislock v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/blobcache-v2 v0.0.0-20241016162020-2ed2e4b47b02 h1:In8RV/6BTTwhIo87SRh6PQgVXV12sOjl3MRsOEzqfj0=
 github.com/beam-cloud/blobcache-v2 v0.0.0-20241016162020-2ed2e4b47b02/go.mod h1:eK80pNykYLVTKmfjfTVqvrJqX4HKXqeCl1OQt6/F8ZM=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20241121211215-70c6fb259a62 h1:mXlXuiLbIS/uuLLzpi+ir0mUij9+I4/0/w7T35SK1M0=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20241121211215-70c6fb259a62/go.mod h1:eK80pNykYLVTKmfjfTVqvrJqX4HKXqeCl1OQt6/F8ZM=
 github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88 h1:SAzRxbcUKx0fFfqBRfrm39fyh0ixtuPM8/1HNJpnh9U=
 github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -26,9 +26,9 @@ import (
 const (
 	requestProcessingInterval     time.Duration = 100 * time.Millisecond
 	containerStatusUpdateInterval time.Duration = 30 * time.Second
-
-	containerLogsPath          string  = "/var/log/worker"
-	defaultWorkerSpindownTimeS float64 = 300 // 5 minutes
+	blobcacheHostWaitTimeout      time.Duration = 60 * time.Second
+	containerLogsPath             string        = "/var/log/worker"
+	defaultWorkerSpindownTimeS    float64       = 300 // 5 minutes
 )
 
 type Worker struct {
@@ -142,6 +142,11 @@ func NewWorker() (*Worker, error) {
 		cacheClient, err = blobcache.NewBlobCacheClient(context.TODO(), config.BlobCache)
 		if err != nil {
 			log.Printf("[WARNING] Cache unavailable, performance may be degraded: %+v\n", err)
+		}
+
+		err = cacheClient.WaitForHosts(blobcacheHostWaitTimeout)
+		if err != nil {
+			log.Printf("[WARNING] No nearby hosts available, performance may be degraded: %+v\n", err)
 		}
 	}
 


### PR DESCRIPTION
- Adds a blobcache WaitForHosts func that waits until at least one cache is nearby before starting up the worker
  - Prevents workers from becoming available until they have a cache