### PR TITLE
 Feat: Add authorized flag to bots to allow public bot pages

### DIFF
--- a/pkg/abstractions/experimental/bot/bot.go
+++ b/pkg/abstractions/experimental/bot/bot.go
@@ -114,6 +114,19 @@ func (pbs *PetriBotService) botTaskFactory(ctx context.Context, msg types.TaskMe
 	}, nil
 }
 
+func (pbs *PetriBotService) isPublic(stubId string) (*types.Workspace, error) {
+	instance, err := pbs.getOrCreateBotInstance(stubId)
+	if err != nil {
+		return nil, err
+	}
+
+	if instance.botConfig.Authorized {
+		return nil, errors.New("unauthorized")
+	}
+
+	return instance.workspace, nil
+}
+
 func (pbs *PetriBotService) handleBotContainerEvents(ctx context.Context) {
 	for {
 		select {

--- a/pkg/abstractions/experimental/bot/http.go
+++ b/pkg/abstractions/experimental/bot/http.go
@@ -39,6 +39,7 @@ func registerBotRoutes(g *echo.Group, pbs *PetriBotService) *botGroup {
 	g.GET("/:deploymentName", auth.WithAuth(group.BotOpenSession))
 	g.GET("/:deploymentName/latest", auth.WithAuth(group.BotOpenSession))
 	g.GET("/:deploymentName/v:version", auth.WithAuth(group.BotOpenSession))
+	g.GET("/public/:stubId", auth.WithAssumedStubAuth(group.BotOpenSession, group.pbs.isPublic))
 	g.DELETE("/:stubId/:sessionId", auth.WithAuth(group.BotDeleteSession))
 	g.GET("/:stubId/:sessionId", auth.WithAuth(group.BotGetSession))
 	g.GET("/:stubId/sessions", auth.WithAuth(group.BotListSessions))

--- a/pkg/abstractions/experimental/bot/types.go
+++ b/pkg/abstractions/experimental/bot/types.go
@@ -156,6 +156,7 @@ type BotConfig struct {
 	Locations   map[string]BotLocationConfig   `json:"locations" redis:"locations"`
 	Transitions map[string]BotTransitionConfig `json:"transitions" redis:"transitions"`
 	ApiKey      string                         `json:"api_key" redis:"api_key"`
+	Authorized  bool                           `json:"authorized" redis:"authorized"`
 }
 
 func (b *BotConfig) FormatLocations() string {

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -74,7 +74,7 @@ class Endpoint(RunnerAbstraction):
         name (Optional[str]):
             An optional name for this endpoint, used during deployment. If not specified, you must specify the name
             at deploy time with the --name argument
-        authorized (Optional[bool]):
+        authorized (bool):
             If false, allows the endpoint to be invoked without an auth token.
             Default is True.
         autoscaler (Optional[Autoscaler]):
@@ -205,7 +205,7 @@ class ASGI(Endpoint):
         name (Optional[str]):
             An optional name for this ASGI application, used during deployment. If not specified, you must
             specify the name at deploy time with the --name argument
-        authorized (Optional[str]):
+        authorized (bool):
             If false, allows the ASGI application to be invoked without an auth token.
             Default is True.
         autoscaler (Optional[Autoscaler]):
@@ -334,7 +334,7 @@ class RealtimeASGI(ASGI):
         name (Optional[str]):
             An optional name for this ASGI application, used during deployment. If not specified, you must
             specify the name at deploy time with the --name argument
-        authorized (Optional[str]):
+        authorized (bool):
             If false, allows the ASGI application to be invoked without an auth token.
             Default is True.
         autoscaler (Optional[Autoscaler]):

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -74,7 +74,7 @@ class Endpoint(RunnerAbstraction):
         name (Optional[str]):
             An optional name for this endpoint, used during deployment. If not specified, you must specify the name
             at deploy time with the --name argument
-        authorized (Optional[str]):
+        authorized (Optional[bool]):
             If false, allows the endpoint to be invoked without an auth token.
             Default is True.
         autoscaler (Optional[Autoscaler]):

--- a/sdk/src/beta9/abstractions/experimental/bot/bot.py
+++ b/sdk/src/beta9/abstractions/experimental/bot/bot.py
@@ -234,7 +234,7 @@ class Bot(RunnerAbstraction, DeployableMixin):
             A description of the bot. Default is None.
         volumes (Optional[List[Volume]]):
             A list of volumes to mount in bot transitions. Default is None.
-        authorized (Optional[bool]):
+        authorized (bool):
             If false, allows the bot to be invoked without an auth token.
             Default is True.
     """

--- a/sdk/src/beta9/abstractions/experimental/bot/bot.py
+++ b/sdk/src/beta9/abstractions/experimental/bot/bot.py
@@ -234,6 +234,9 @@ class Bot(RunnerAbstraction, DeployableMixin):
             A description of the bot. Default is None.
         volumes (Optional[List[Volume]]):
             A list of volumes to mount in bot transitions. Default is None.
+        authorized (Optional[bool]):
+            If false, allows the bot to be invoked without an auth token.
+            Default is True.
     """
 
     deployment_stub_type = BOT_DEPLOYMENT_STUB_TYPE
@@ -257,6 +260,7 @@ class Bot(RunnerAbstraction, DeployableMixin):
         locations: List[BotLocation] = [],
         description: Optional[str] = None,
         volumes: Optional[List[Volume]] = None,
+        authorized: bool = True,
     ) -> None:
         super().__init__(volumes=volumes)
 
@@ -279,6 +283,7 @@ class Bot(RunnerAbstraction, DeployableMixin):
         self.extra["locations"] = {}
         self.extra["description"] = description
         self.extra["api_key"] = api_key
+        self.extra["authorized"] = authorized
 
         for location in self.locations:
             location_config = location.to_dict()

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -77,7 +77,7 @@ class TaskQueue(RunnerAbstraction):
         name (Optional[str]):
             An optional name for this task_queue, used during deployment. If not specified, you must specify the name
             at deploy time with the --name argument
-        authorized (Optional[str]):
+        authorized (bool):
             If false, allows the endpoint to be invoked without an auth token.
             Default is True.
         autoscaler (Autoscaler):


### PR DESCRIPTION
Same process as the other abstractions - use with assumed stub auth to allow unauthorized access to bots.

Used like this:

```
bot = Bot(
    model="gpt-4o",
    api_key="sk-proj-....",
    locations=[
        BotLocation(marker=HostLocation),
    ],
    description="Scan hosts and determine what services are running on them",
    authorized=False,
)
```