### PR TITLE
Add logging and temporary force update of container status

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -445,8 +445,12 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 			}
 		}
 
+		log.Printf("<%s> - updating container status to running\n", containerId)
 		// Update container status to running
-		s.containerRepo.UpdateContainerStatus(containerId, types.ContainerStatusRunning, time.Duration(types.ContainerStateTtlS)*time.Second)
+		err := s.containerRepo.UpdateContainerStatus(containerId, types.ContainerStatusRunning, time.Duration(types.ContainerStateTtlS)*time.Second)
+		if err != nil {
+			log.Printf("<%s> failed to update container status to running: %v", containerId, err)
+		}
 	}()
 
 	// Setup container overlay filesystem

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -326,6 +326,12 @@ func (s *Worker) updateContainerStatus(request *types.ContainerRequest) error {
 
 			log.Printf("<%s> - container still running: %s\n", request.ContainerId, request.ImageId)
 
+			// TODO: remove this hotfix
+			if state.Status == types.ContainerStatusPending {
+				log.Printf("<%s> - forcing container status to running\n", request.ContainerId)
+				state.Status = types.ContainerStatusRunning
+			}
+
 			err = s.containerRepo.UpdateContainerStatus(request.ContainerId, state.Status, time.Duration(types.ContainerStateTtlS)*time.Second)
 			if err != nil {
 				log.Printf("<%s> - unable to update container state: %v\n", request.ContainerId, err)


### PR DESCRIPTION
Adds some logs around potential causes of the PENDING container bug. Also, adds a forced update to the container status for now to make sure it at least gets cleaned up. 