### PR TITLE
fix bug with retry for causing taskqueue to spin down 

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.126"
+version = "0.1.127"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -340,19 +340,22 @@ class TaskQueueWorker:
                                 print("hello")
                                 raise RunnerException("Unable to end task")
 
-                            if task_status != TaskStatus.Retry:
-                                print(f"Task completed <{task.id}>, took {duration}s")
-                                send_callback(
-                                    gateway_stub=gateway_stub,
-                                    context=context,
-                                    payload=result or {},
-                                    task_status=task_status,
-                                    override_callback_url=kwargs.get("callback_url"),
-                                )  # Send callback to callback_url, if defined
-                            else:
-                                print(
-                                    f"Retrying task <{task.id}> after {caught_exception} exception"
+                            if task_status == TaskStatus.Retry:
+                                message = (
+                                    complete_task_response.message
+                                    or f"Retrying task <{task.id}> after {caught_exception} exception"
                                 )
+                                print(message)
+                                continue
+
+                            print(f"Task completed <{task.id}>, took {duration}s")
+                            send_callback(
+                                gateway_stub=gateway_stub,
+                                context=context,
+                                payload=result or {},
+                                task_status=task_status,
+                                override_callback_url=kwargs.get("callback_url"),
+                            )
 
                         except BaseException:
                             print(traceback.format_exc())

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -337,22 +337,22 @@ class TaskQueueWorker:
                                 )
                             )
                             if not complete_task_response.ok:
+                                print("hello")
                                 raise RunnerException("Unable to end task")
 
                             if task_status == TaskStatus.Retry:
                                 print(
                                     f"Retrying task <{task.id}> after {caught_exception} exception"
                                 )
-                                return
-
-                            print(f"Task completed <{task.id}>, took {duration}s")
-                            send_callback(
-                                gateway_stub=gateway_stub,
-                                context=context,
-                                payload=result or {},
-                                task_status=task_status,
-                                override_callback_url=kwargs.get("callback_url"),
-                            )  # Send callback to callback_url, if defined
+                            else:
+                                print(f"Task completed <{task.id}>, took {duration}s")
+                                send_callback(
+                                    gateway_stub=gateway_stub,
+                                    context=context,
+                                    payload=result or {},
+                                    task_status=task_status,
+                                    override_callback_url=kwargs.get("callback_url"),
+                                )  # Send callback to callback_url, if defined
 
                         except BaseException:
                             print(traceback.format_exc())

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -340,11 +340,7 @@ class TaskQueueWorker:
                                 print("hello")
                                 raise RunnerException("Unable to end task")
 
-                            if task_status == TaskStatus.Retry:
-                                print(
-                                    f"Retrying task <{task.id}> after {caught_exception} exception"
-                                )
-                            else:
+                            if task_status != TaskStatus.Retry:
                                 print(f"Task completed <{task.id}>, took {duration}s")
                                 send_callback(
                                     gateway_stub=gateway_stub,
@@ -353,6 +349,10 @@ class TaskQueueWorker:
                                     task_status=task_status,
                                     override_callback_url=kwargs.get("callback_url"),
                                 )  # Send callback to callback_url, if defined
+                            else:
+                                print(
+                                    f"Retrying task <{task.id}> after {caught_exception} exception"
+                                )
 
                         except BaseException:
                             print(traceback.format_exc())


### PR DESCRIPTION
The early return caused `monitor_task.cancel()` not to be called which would snowball into the taskqueue shutting down early and the task never getting retried. 