### PR TITLE
Fix: handle cache discovery properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
-	github.com/beam-cloud/blobcache-v2 v0.0.0-20241130031721-a8b98f6da3eb
+	github.com/beam-cloud/blobcache-v2 v0.0.0-20241130154900-a300eab4a8f1
 	github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88
 	github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170
 	github.com/bsm/redislock v0.9.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
-	github.com/beam-cloud/blobcache-v2 v0.0.0-20241130154900-a300eab4a8f1
+	github.com/beam-cloud/blobcache-v2 v0.0.0-20241130174455-2909e9e10c53
 	github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88
 	github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170
 	github.com/bsm/redislock v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZ
 github.com/aws/smithy-go v1.20.0 h1:6+kZsCXZwKxZS9RfISnPc4EXlHoyAkm2hPuM8X2BrrQ=
 github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe7dklGc=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20241130031721-a8b98f6da3eb h1:UHKz0uthIJ8zJWkoG3Ks837Q6MU8Kv8/8hmrpwZg+iU=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20241130031721-a8b98f6da3eb/go.mod h1:eK80pNykYLVTKmfjfTVqvrJqX4HKXqeCl1OQt6/F8ZM=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20241130154900-a300eab4a8f1 h1:lo+QNQZRFHCVLq99ooeyhE4DfwlyjmPz2uE+8gFUWhM=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20241130154900-a300eab4a8f1/go.mod h1:eK80pNykYLVTKmfjfTVqvrJqX4HKXqeCl1OQt6/F8ZM=
 github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88 h1:SAzRxbcUKx0fFfqBRfrm39fyh0ixtuPM8/1HNJpnh9U=
 github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZ
 github.com/aws/smithy-go v1.20.0 h1:6+kZsCXZwKxZS9RfISnPc4EXlHoyAkm2hPuM8X2BrrQ=
 github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe7dklGc=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20241130154900-a300eab4a8f1 h1:lo+QNQZRFHCVLq99ooeyhE4DfwlyjmPz2uE+8gFUWhM=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20241130154900-a300eab4a8f1/go.mod h1:eK80pNykYLVTKmfjfTVqvrJqX4HKXqeCl1OQt6/F8ZM=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20241130174455-2909e9e10c53 h1:iKrOAJQQznDc9Dxxc/33nCeOf6JzUPWsEFScOWWynKQ=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20241130174455-2909e9e10c53/go.mod h1:eK80pNykYLVTKmfjfTVqvrJqX4HKXqeCl1OQt6/F8ZM=
 github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88 h1:SAzRxbcUKx0fFfqBRfrm39fyh0ixtuPM8/1HNJpnh9U=
 github.com/beam-cloud/clip v0.0.0-20240826223025-899feb184e88/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -144,6 +144,8 @@ func (c *ImageClient) PullLazy(request *types.ContainerRequest) error {
 			if err == nil {
 				localCachePath = baseBlobFsContentPath
 			}
+
+			c.logger.Log(request.ContainerId, request.StubId, "unable to cache image nearby <%s>: %v\n", imageId, err)
 		}
 	}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -27,8 +27,9 @@ const (
 	requestProcessingInterval     time.Duration = 100 * time.Millisecond
 	containerStatusUpdateInterval time.Duration = 30 * time.Second
 
-	containerLogsPath          string  = "/var/log/worker"
-	defaultWorkerSpindownTimeS float64 = 300 // 5 minutes
+	containerLogsPath          string        = "/var/log/worker"
+	defaultWorkerSpindownTimeS float64       = 300 // 5 minutes
+	defaultCacheWaitTime       time.Duration = 30 * time.Second
 )
 
 type Worker struct {
@@ -140,6 +141,10 @@ func NewWorker() (*Worker, error) {
 	var cacheClient *blobcache.BlobCacheClient = nil
 	if config.Worker.BlobCacheEnabled {
 		cacheClient, err = blobcache.NewBlobCacheClient(context.TODO(), config.BlobCache)
+		if err == nil {
+			err = cacheClient.WaitForHosts(defaultCacheWaitTime)
+		}
+
 		if err != nil {
 			log.Printf("[WARNING] Cache unavailable, performance may be degraded: %+v\n", err)
 		}

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -312,11 +312,12 @@ class TaskQueueWorker:
 
                         result = handler(context, *args, **kwargs)
                     except BaseException as e:
+                        print(traceback.format_exc())
+
                         if type(e) in handler.parent_abstraction.retry_for:
                             caught_exception = e.__class__.__name__
                             task_status = TaskStatus.Retry
                         else:
-                            print(traceback.format_exc())
                             task_status = TaskStatus.Error
                     finally:
                         duration = time.time() - start_time


### PR DESCRIPTION
- Fix a bug where cache discovery wasn't properly handling new hosts
- Always print exception during retries
- Wait for at least a single blobcache host