### PR TITLE
Fix: Dont coalesce pip install commands if they contain flags

### DIFF
--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -229,6 +229,18 @@ func TestParseBuildSteps(t *testing.T) {
 				"micromamba3.10 -m pip install --root-user-action=ignore --no-deps trl peft accelerate bitsandbytes",
 			},
 		},
+		{
+			steps: []BuildStep{
+				{Type: micromambaCommandType, Command: "torch"},
+				{Type: pipCommandType, Command: "--no-deps trl peft accelerate bitsandbytes"},
+				{Type: pipCommandType, Command: "unsloth[colab-new] @ git+https://github.com/unslothai/unsloth.git"},
+			},
+			want: []string{
+				"micromamba install -y -n beta9 \"torch\"",
+				"micromamba3.10 -m pip install --root-user-action=ignore --no-deps trl peft accelerate bitsandbytes",
+				"micromamba3.10 -m pip install --root-user-action=ignore \"unsloth[colab-new] @ git+https://github.com/unslothai/unsloth.git\"",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -217,6 +217,18 @@ func TestParseBuildSteps(t *testing.T) {
 			},
 			want: []string{"echo 'hello'", "micromamba3.10 -m pip install --root-user-action=ignore \"numpy\" \"pandas\"", "micromamba install -y -n beta9 \"torch\" \"vllm\"", "apt install -y ffmpeg", "micromamba install -y -n beta9 \"ffmpeg\""},
 		},
+		{
+			steps: []BuildStep{
+				{Type: micromambaCommandType, Command: "torch"},
+				{Type: pipCommandType, Command: "unsloth[colab-new] @ git+https://github.com/unslothai/unsloth.git"},
+				{Type: pipCommandType, Command: "--no-deps trl peft accelerate bitsandbytes"},
+			},
+			want: []string{
+				"micromamba install -y -n beta9 \"torch\"",
+				"micromamba3.10 -m pip install --root-user-action=ignore \"unsloth[colab-new] @ git+https://github.com/unslothai/unsloth.git\"",
+				"micromamba3.10 -m pip install --root-user-action=ignore --no-deps trl peft accelerate bitsandbytes",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
If we have an image like the following, we should not combing the python package installs because of the `--no-deps` flag. It will break the prior packages install unintentionally. This PR flushes any commands if a flag command is encountered and flushes flag commands immediately. 

```
image = (
    Image(python_version="python3.11")
    .micromamba()
    .add_micromamba_packages(["pytorch-cuda=12.1", "pytorch", "cudatoolkit", "xformers", "numpy"], ["pytorch", "nvidia", "xformers", "conda-forge"])
    .add_python_packages(["unsloth[colab-new] @ git+https://github.com/unslothai/unsloth.git", "--no-deps trl peft accelerate bitsandbytes"])
)
```
