### PR TITLE
Fix: Dont init multiprocessing Value unless it will be used

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.130"
+version = "0.1.131"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -163,12 +163,8 @@ class FunctionContext:
 
 
 workers_ready = None
-
-
-def initialize_workers_ready():
-    global workers_ready
-    if workers_ready is None:
-        workers_ready = Value("i", 0)
+if is_remote():
+    workers_ready = Value("i", 0)
 
 
 class FunctionHandler:
@@ -397,8 +393,6 @@ CHECKPOINT_CONTAINER_HOSTNAME_FILE = "/cedana/CONTAINER_HOSTNAME"
 
 
 def wait_for_checkpoint():
-    initialize_workers_ready()
-
     def _reload_config():
         # Once we have set the checkpoint signal file, wait for checkpoint to be complete before reloading the config
         while not Path(CHECKPOINT_COMPLETE_FILE).exists():

--- a/sdk/src/beta9/runner/common.py
+++ b/sdk/src/beta9/runner/common.py
@@ -162,7 +162,13 @@ class FunctionContext:
         )
 
 
-workers_ready = Value("i", 0)
+workers_ready = None
+
+
+def initialize_workers_ready():
+    global workers_ready
+    if workers_ready is None:
+        workers_ready = Value("i", 0)
 
 
 class FunctionHandler:
@@ -391,6 +397,8 @@ CHECKPOINT_CONTAINER_HOSTNAME_FILE = "/cedana/CONTAINER_HOSTNAME"
 
 
 def wait_for_checkpoint():
+    initialize_workers_ready()
+
     def _reload_config():
         # Once we have set the checkpoint signal file, wait for checkpoint to be complete before reloading the config
         while not Path(CHECKPOINT_COMPLETE_FILE).exists():


### PR DESCRIPTION
It seems `Value` is responsible for leaking the semaphore. Even though it is not used in the serve, the value is initialized on import because it is global. This tweak fixes the leak. 

Before
```
=> Stopping serve container
Goodbye 👋
/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```
After
```
=> Stopping serve container
Goodbye 👋
```