### PR TITLE
Fix: Add bzip for Mamba and remove distutils for Python 3.12

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN <<EOT
 echo 'Acquire::ForceIPv4 "true";' | tee /etc/apt/apt.conf.d/1000-force-ipv4-transport
 apt-get update
-apt-get install -y software-properties-common curl git gcc python3-dev
+apt-get install -y software-properties-common curl git gcc python3-dev bzip2
 add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 EOT
@@ -27,7 +27,7 @@ RUN <<EOT
 set -eux
 
 # Install python and dependencies
-apt-get install -y python3.12 python3.12-dev python3.12-distutils
+apt-get install -y python3.12 python3.12-dev
 
 # Get the latest pip version
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12


### PR DESCRIPTION
Resolve BE-2125

This is a small change to the runner dockerfiles to fix Mamba builds by adding the bzip dependency and to fix the Python 3.12 build by removing disutils (see below). 

> Of note, the distutils package has been removed from the standard library.

https://docs.python.org/3/whatsnew/3.12.html

