### PR TITLE
Fix: Pin setuptools to working version for Python versions older than 12

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -68,7 +68,8 @@ apt-get install -y python3.11 python3.11-dev python3.11-distutils
 
 # Get the latest pip version
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
-python3.11 -m pip install --upgrade distlib setuptools pip
+python3.11 -m pip install setuptools==70.3.0
+python3.11 -m pip install --upgrade distlib pip
 python3.11 -m pip install -r /workspace/requirements.txt
 
 # Set default python
@@ -105,7 +106,8 @@ apt-get install -y python3.10 python3.10-dev python3.10-distutils
 
 # Get the latest pip version
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
-python3.10 -m pip install --upgrade distlib setuptools pip
+python3.10 -m pip install setuptools==70.3.0
+python3.10 -m pip install --upgrade distlib pip
 python3.10 -m pip install -r /workspace/requirements.txt
 
 # Set default python
@@ -142,7 +144,8 @@ apt-get install -y python3.9 python3.9-dev python3.9-distutils
 
 # Get the latest pip version
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-python3.9 -m pip install --upgrade distlib setuptools pip
+python3.9 -m pip install setuptools==70.3.0
+python3.9 -m pip install --upgrade distlib pip
 python3.9 -m pip install -r /workspace/requirements.txt
 
 # Set default python
@@ -179,7 +182,8 @@ apt-get install -y python3.8 python3.8-dev python3.8-distutils
 
 # Get the latest pip version
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8
-python3.8 -m pip install --upgrade distlib setuptools pip
+python3.8 -m pip install setuptools==70.3.0
+python3.8 -m pip install --upgrade distlib pip
 python3.8 -m pip install -r /workspace/requirements.txt
 
 # Set default python


### PR DESCRIPTION
Resolve BE-2112

This seems to be a breaking change made to the setuptools library and the maintainer does not seem likely to fix it. 
https://github.com/pypa/setuptools/issues/4483

It feels bad to be pinning an old version, but for now that seems to be the best way of mitigating this problem. 