### PR TITLE
Fix: Use heartbeats to correct for request token drift

### DIFF
--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -271,7 +271,7 @@ func (es *HttpEndpointService) getOrCreateEndpointInstance(ctx context.Context, 
 		instance.isASGI = true
 	}
 
-	instance.buffer = NewRequestBuffer(autoscaledInstance.Ctx, es.rdb, &stub.Workspace, stubId, requestBufferSize, es.containerRepo, stubConfig, es.tailscale, es.config.Tailscale, instance.isASGI)
+	instance.buffer = NewRequestBuffer(autoscaledInstance.Ctx, es.rdb, &stub.Workspace, stubId, requestBufferSize, es.containerRepo, es.keyEventManager, stubConfig, es.tailscale, es.config.Tailscale, instance.isASGI)
 
 	// Embed autoscaled instance struct
 	instance.AutoscaledInstance = autoscaledInstance
@@ -313,7 +313,7 @@ var (
 	endpointKeepWarmLock     string = "endpoint:%s:%s:keep_warm_lock:%s"
 	endpointInstanceLock     string = "endpoint:%s:%s:instance_lock"
 	endpointRequestTokens    string = "endpoint:%s:%s:request_tokens:%s"
-	endpointRequestHeartbeat string = "endpoint:%s:%s:request_heartbeat:%s"
+	endpointRequestHeartbeat string = "endpoint:%s:%s:request_heartbeat:%s:%s"
 	endpointServeLock        string = "endpoint:%s:%s:serve_lock"
 )
 
@@ -329,8 +329,8 @@ func (k *keys) endpointRequestTokens(workspaceName, stubId, containerId string) 
 	return fmt.Sprintf(endpointRequestTokens, workspaceName, stubId, containerId)
 }
 
-func (k *keys) endpointRequestHeartbeat(workspaceName, stubId, taskId string) string {
-	return fmt.Sprintf(endpointRequestHeartbeat, workspaceName, stubId, taskId)
+func (k *keys) endpointRequestHeartbeat(workspaceName, stubId, taskId, containerId string) string {
+	return fmt.Sprintf(endpointRequestHeartbeat, workspaceName, stubId, taskId, containerId)
 }
 
 func (k *keys) endpointServeLock(workspaceName, stubId string) string {

--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -74,10 +74,15 @@ func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellation
 }
 
 func (t *EndpointTask) HeartBeat(ctx context.Context) (bool, error) {
-	heartbeatKey := Keys.endpointRequestHeartbeat(t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId)
-	exists, err := t.es.rdb.Exists(ctx, heartbeatKey).Result()
+	task, err := t.es.backendRepo.GetTask(ctx, t.msg.TaskId)
 	if err != nil {
-		return false, fmt.Errorf("failed to retrieve endpoint heartbeat key <%v>: %w", heartbeatKey, err)
+		return false, err
+	}
+
+	key := Keys.endpointRequestHeartbeat(t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId, task.ContainerId)
+	exists, err := t.es.rdb.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("failed to check existence of endpoint heartbeat key <%v>: %w", key, err)
 	}
 
 	return exists > 0, nil

--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -79,10 +79,10 @@ func (t *EndpointTask) HeartBeat(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	key := Keys.endpointRequestHeartbeat(t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId, task.ContainerId)
-	exists, err := t.es.rdb.Exists(ctx, key).Result()
+	heartbeatKey := Keys.endpointRequestHeartbeat(t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId, task.ContainerId)
+	exists, err := t.es.rdb.Exists(ctx, heartbeatKey).Result()
 	if err != nil {
-		return false, fmt.Errorf("failed to check existence of endpoint heartbeat key <%v>: %w", key, err)
+		return false, fmt.Errorf("failed to retrieve endpoint heartbeat key <%v>: %w", heartbeatKey, err)
 	}
 
 	return exists > 0, nil


### PR DESCRIPTION
- Uses key events + request heartbeats to correct for token drift after a particular gateway crashed unexpectedly

The consequence of this is that if a gateway that was actively handling a request crashes or is forcibly terminated, there will be a 30 delay before any active containers that were handling requests have the token count incremented. This should fix "bricked" containers that had an inaccurately low token count.