### PR TITLE
Feat: Support multiple cpu pools

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -260,7 +260,9 @@ func (i *AutoscaledInstance) HandleScalingEvent(desiredContainers int) error {
 		err = i.StopContainersFunc(-containerDelta)
 	}
 
-	go i.handleStubEvents(state.FailedContainers)
+	if len(state.FailedContainers) > 0 {
+		go i.handleStubEvents(state.FailedContainers)
+	}
 
 	return err
 }

--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -100,6 +100,7 @@ func (i *endpointInstance) startContainers(containersToRun int) error {
 			Mounts:            mounts,
 			Stub:              *i.Stub,
 			CheckpointEnabled: checkpointEnabled,
+			Preemptable:       true,
 		}
 
 		// Set initial keepwarm to prevent rapid spin-up/spin-down of containers

--- a/pkg/scheduler/pool_manager.go
+++ b/pkg/scheduler/pool_manager.go
@@ -35,7 +35,8 @@ func (m *WorkerPoolManager) GetPool(name string) (*WorkerPool, bool) {
 type poolFilters struct {
 	GPUType string
 	// Preemptible *bool
-	// TODO: Add other filters here
+	// TODO: add preemptible filter back once we have better ways of handling pool state
+	// (i.e. if a worker is not appearing in a certain pool)
 }
 
 // GetPoolByFilters retrieves all WorkerPools that match the specified filters.

--- a/pkg/scheduler/pool_manager.go
+++ b/pkg/scheduler/pool_manager.go
@@ -33,8 +33,9 @@ func (m *WorkerPoolManager) GetPool(name string) (*WorkerPool, bool) {
 }
 
 type poolFilters struct {
-	GPUType     string
-	Preemptible *bool
+	GPUType string
+	// Preemptible *bool
+	// TODO: Add other filters here
 }
 
 // GetPoolByFilters retrieves all WorkerPools that match the specified filters.
@@ -45,9 +46,8 @@ func (m *WorkerPoolManager) GetPoolByFilters(filters poolFilters) []*WorkerPool 
 
 	m.poolMap.Range(func(key string, value *WorkerPool) bool {
 		gpuMatches := value.Config.GPUType == filters.GPUType
-		isPreemptibilityCompatible := matchesPreemptibility(filters.Preemptible, value.Controller.IsPreemptable())
 
-		if gpuMatches && isPreemptibilityCompatible {
+		if gpuMatches {
 			pools = append(pools, value)
 		}
 
@@ -59,18 +59,6 @@ func (m *WorkerPoolManager) GetPoolByFilters(filters poolFilters) []*WorkerPool 
 	})
 
 	return pools
-}
-
-// matchesPreemptibility determines if a worker pool's preemptibility is compatible
-// with the workload's requirements:
-// - If preemptible is nil, all pools are compatible
-// - Preemptible workloads (preemptible == true) can run on any pool
-// - Non-preemptible workloads (preemptible == false) can only run on non-preemptible pools
-func matchesPreemptibility(requirement *bool, poolPreemptible bool) bool {
-	if requirement == nil || *requirement {
-		return true // No requirement or preemptible workloads can run on any pool
-	}
-	return !poolPreemptible // Non-preemptible workloads need non-preemptible pools
 }
 
 // GetPoolByGPU retrieves a WorkerPool by its GPU type.

--- a/pkg/scheduler/pool_manager.go
+++ b/pkg/scheduler/pool_manager.go
@@ -32,6 +32,36 @@ func (m *WorkerPoolManager) GetPool(name string) (*WorkerPool, bool) {
 	return m.poolMap.Get(name)
 }
 
+type poolFilters struct {
+	GPUType     string
+	Preemptible *bool
+}
+
+// GetPoolByFilters retrieves all WorkerPools that match the specified filters.
+// It returns a slice of WorkerPools that match all specified filters (GPU type and preemptibility),
+// sorted by WorkerPoolConfig.Priority in descending order.
+func (m *WorkerPoolManager) GetPoolByFilters(filters poolFilters) []*WorkerPool {
+	var pools []*WorkerPool
+
+	m.poolMap.Range(func(key string, value *WorkerPool) bool {
+		gpuMatches := value.Config.GPUType == filters.GPUType
+
+		preemptibleMatches := filters.Preemptible == nil ||
+			value.Controller.IsPreemptable() == *filters.Preemptible
+
+		if gpuMatches && preemptibleMatches {
+			pools = append(pools, value)
+		}
+		return true
+	})
+
+	slices.SortFunc(pools, func(a, b *WorkerPool) int {
+		return cmp.Compare(b.Config.Priority, a.Config.Priority)
+	})
+
+	return pools
+}
+
 // GetPoolByGPU retrieves a WorkerPool by its GPU type.
 // It returns the first matching WorkerPool found.
 func (m *WorkerPoolManager) GetPoolByGPU(gpuType string) (*WorkerPool, bool) {

--- a/pkg/scheduler/pool_manager_test.go
+++ b/pkg/scheduler/pool_manager_test.go
@@ -1,10 +1,12 @@
 package scheduler
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 )
 
 func TestGetPoolsByGPU(t *testing.T) {
@@ -54,4 +56,121 @@ func TestGetPoolsByGPU(t *testing.T) {
 	assert.Equal(t, "xyz-t4", t4s[0].Name) // highest priority
 	assert.Equal(t, "gcp-t4", t4s[1].Name)
 	assert.Equal(t, "aws-t4", t4s[2].Name)
+}
+
+func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
+	manager := NewWorkerPoolManager()
+
+	preemptibleCtrl := &LocalWorkerPoolControllerForTest{
+		preemptible: true,
+	}
+	nonPreemptibleCtrl := &LocalWorkerPoolControllerForTest{}
+
+	// Set up test pools with different configurations
+	testPools := []struct {
+		name       string
+		config     types.WorkerPoolConfig
+		controller WorkerPoolController
+	}{
+		{
+			name: "pool1",
+			config: types.WorkerPoolConfig{
+				GPUType:  "",
+				Priority: 100,
+			},
+			controller: preemptibleCtrl,
+		},
+		{
+			name: "pool2",
+			config: types.WorkerPoolConfig{
+				GPUType:  "",
+				Priority: 200,
+			},
+			controller: nonPreemptibleCtrl,
+		},
+		{
+			name: "pool3",
+			config: types.WorkerPoolConfig{
+				GPUType:  "A100-40",
+				Priority: 150,
+			},
+			controller: preemptibleCtrl,
+		},
+	}
+
+	// Add pools to manager
+	for _, pool := range testPools {
+		manager.SetPool(pool.name, pool.config, pool.controller)
+	}
+
+	// Test cases
+	tests := []struct {
+		name    string
+		filters poolFilters
+		want    []string // Expected pool names in order
+		wantLen int
+	}{
+		{
+			name: "filter by GPU type only",
+			filters: poolFilters{
+				GPUType: "A100-40",
+			},
+			want:    []string{"pool3"},
+			wantLen: 1,
+		},
+		{
+			name: "filter by all CPU pools (either preemptible or not)",
+			filters: poolFilters{
+				GPUType: "",
+			},
+			want:    []string{"pool2", "pool1"},
+			wantLen: 2,
+		},
+		{
+			name: "filter by GPU type and preemptible",
+			filters: poolFilters{
+				GPUType:     "A100-40",
+				Preemptible: ptr.To(true),
+			},
+			want:    []string{"pool3"},
+			wantLen: 1,
+		},
+		{
+			name: "no matching GPU type",
+			filters: poolFilters{
+				GPUType: "P100",
+			},
+			want:    []string{},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manager.GetPoolByFilters(tt.filters)
+
+			if len(got) != tt.wantLen {
+				t.Errorf("GetPoolByFilters() returned %d pools, want %d", len(got), tt.wantLen)
+			}
+
+			// Check if pools are returned in correct order
+			gotNames := make([]string, len(got))
+			for i, pool := range got {
+				gotNames[i] = pool.Name
+			}
+
+			if !slices.Equal(gotNames, tt.want) {
+				t.Errorf("GetPoolByFilters() returned pools %v, want %v", gotNames, tt.want)
+			}
+		})
+	}
+}
+
+// Mock pool controller for testing
+type mockPoolController struct {
+	preemptible bool
+}
+
+func (m *mockPoolController) IsPreemptable() bool {
+	return m.preemptible
 }

--- a/pkg/scheduler/pool_manager_test.go
+++ b/pkg/scheduler/pool_manager_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 )
 
 func TestGetPoolsByGPU(t *testing.T) {
@@ -61,10 +60,9 @@ func TestGetPoolsByGPU(t *testing.T) {
 func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 	manager := NewWorkerPoolManager()
 
-	preemptibleCtrl := &LocalWorkerPoolControllerForTest{
+	controller := &LocalWorkerPoolControllerForTest{
 		preemptible: true,
 	}
-	nonPreemptibleCtrl := &LocalWorkerPoolControllerForTest{}
 
 	// Set up test pools with different configurations
 	testPools := []struct {
@@ -78,7 +76,7 @@ func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 				GPUType:  "",
 				Priority: 100,
 			},
-			controller: preemptibleCtrl,
+			controller: controller,
 		},
 		{
 			name: "pool2",
@@ -86,7 +84,7 @@ func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 				GPUType:  "",
 				Priority: 200,
 			},
-			controller: nonPreemptibleCtrl,
+			controller: controller,
 		},
 		{
 			name: "pool3",
@@ -94,7 +92,7 @@ func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 				GPUType:  "A100-40",
 				Priority: 150,
 			},
-			controller: preemptibleCtrl,
+			controller: controller,
 		},
 	}
 
@@ -119,7 +117,7 @@ func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 			wantLen: 1,
 		},
 		{
-			name: "filter by all CPU pools (either preemptible or not)",
+			name: "filter by all CPU pools",
 			filters: poolFilters{
 				GPUType: "",
 			},
@@ -127,10 +125,9 @@ func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 			wantLen: 2,
 		},
 		{
-			name: "filter by GPU type and preemptible",
+			name: "filter by GPU type",
 			filters: poolFilters{
-				GPUType:     "A100-40",
-				Preemptible: ptr.To(true),
+				GPUType: "A100-40",
 			},
 			want:    []string{"pool3"},
 			wantLen: 1,

--- a/pkg/scheduler/pool_manager_test.go
+++ b/pkg/scheduler/pool_manager_test.go
@@ -165,12 +165,3 @@ func TestWorkerPoolManager_GetPoolByFilters(t *testing.T) {
 		})
 	}
 }
-
-// Mock pool controller for testing
-type mockPoolController struct {
-	preemptible bool
-}
-
-func (m *mockPoolController) IsPreemptable() bool {
-	return m.preemptible
-}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -175,12 +175,13 @@ func (s *Scheduler) getControllers(request *types.ContainerRequest) ([]WorkerPoo
 		controllers = append(controllers, wp.Controller)
 
 	} else if !request.RequiresGPU() {
-		wp, ok := s.workerPoolManager.GetPool(types.DefaultCPUWorkerPoolName)
-		if !ok {
-			return nil, errors.New("no controller found for request")
+		pools := s.workerPoolManager.GetPoolByFilters(poolFilters{
+			GPUType:     "",
+			Preemptible: nil,
+		})
+		for _, pool := range pools {
+			controllers = append(controllers, pool.Controller)
 		}
-		controllers = append(controllers, wp.Controller)
-
 	} else {
 		for _, gpu := range request.GpuRequest {
 			pools := s.workerPoolManager.GetPoolsByGPU(gpu)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -177,7 +177,7 @@ func (s *Scheduler) getControllers(request *types.ContainerRequest) ([]WorkerPoo
 	} else if !request.RequiresGPU() {
 		pools := s.workerPoolManager.GetPoolByFilters(poolFilters{
 			GPUType:     "",
-			Preemptible: nil,
+			Preemptible: &request.Preemptable,
 		})
 		for _, pool := range pools {
 			controllers = append(controllers, pool.Controller)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -176,8 +176,7 @@ func (s *Scheduler) getControllers(request *types.ContainerRequest) ([]WorkerPoo
 
 	} else if !request.RequiresGPU() {
 		pools := s.workerPoolManager.GetPoolByFilters(poolFilters{
-			GPUType:     "",
-			Preemptible: &request.Preemptable,
+			GPUType: "",
 		})
 		for _, pool := range pools {
 			controllers = append(controllers, pool.Controller)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -73,10 +73,11 @@ func NewSchedulerForTest() (*Scheduler, error) {
 }
 
 type LocalWorkerPoolControllerForTest struct {
-	ctx        context.Context
-	name       string
-	config     types.AppConfig
-	workerRepo repo.WorkerRepository
+	ctx         context.Context
+	name        string
+	config      types.AppConfig
+	workerRepo  repo.WorkerRepository
+	preemptible bool
 }
 
 func (wpc *LocalWorkerPoolControllerForTest) Context() context.Context {
@@ -84,7 +85,7 @@ func (wpc *LocalWorkerPoolControllerForTest) Context() context.Context {
 }
 
 func (wpc *LocalWorkerPoolControllerForTest) IsPreemptable() bool {
-	return false
+	return wpc.preemptible
 }
 
 func (wpc *LocalWorkerPoolControllerForTest) generateWorkerId() string {


### PR DESCRIPTION
- Add the ability to select multiple CPU pools in the scheduler

**NOTE**: technically GetPoolsByGPU is redundant with these changes, but to minimize scheduling changes I left it in use for GPU workloads.