### PR TITLE
fix: task queue tasks should error when they raise an exception

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.132"
+version = "0.1.133"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/__init__.py
+++ b/sdk/src/beta9/__init__.py
@@ -1,5 +1,5 @@
 from . import env
-from .abstractions import experimental
+from .abstractions import experimental, integrations
 from .abstractions.container import Container
 from .abstractions.endpoint import ASGI as asgi
 from .abstractions.endpoint import Endpoint as endpoint

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -66,8 +66,6 @@ class Function(RunnerAbstraction):
         task_policy (TaskPolicy):
             The task policy for the function. This helps manage the lifecycle of an individual task.
             Setting values here will override timeout and retries.
-        retry_for (Optional[List[BaseException]]):
-            A list of exceptions that will trigger a retry.
     Example:
         ```python
         from beta9 import function, Image
@@ -101,7 +99,6 @@ class Function(RunnerAbstraction):
         secrets: Optional[List[str]] = None,
         name: Optional[str] = None,
         task_policy: TaskPolicy = TaskPolicy(),
-        retry_for: Optional[List[Exception]] = None,
     ) -> None:
         super().__init__(
             cpu=cpu,
@@ -120,7 +117,6 @@ class Function(RunnerAbstraction):
 
         self._function_stub: Optional[FunctionServiceStub] = None
         self.syncer: FileSyncer = FileSyncer(self.gateway_stub)
-        self.retry_for = retry_for
 
     def __call__(self, func):
         return _CallableWrapper(func, self)

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -1,7 +1,7 @@
 import json
 import os
 import threading
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional, Type, Union
 
 from .. import terminal
 from ..abstractions.base.runner import (
@@ -131,7 +131,7 @@ class TaskQueue(RunnerAbstraction):
         autoscaler: Autoscaler = QueueDepthAutoscaler(),
         task_policy: TaskPolicy = TaskPolicy(),
         checkpoint_enabled: bool = False,
-        retry_for: Optional[List[BaseException]] = None,
+        retry_for: Optional[List[Type[Exception]]] = None,
     ) -> None:
         super().__init__(
             cpu=cpu,
@@ -155,7 +155,7 @@ class TaskQueue(RunnerAbstraction):
             checkpoint_enabled=checkpoint_enabled,
         )
         self._taskqueue_stub: Optional[TaskQueueServiceStub] = None
-        self.retry_for = retry_for
+        self.retry_for = retry_for or []
 
     @property
     def taskqueue_stub(self) -> TaskQueueServiceStub:


### PR DESCRIPTION
- Fix tasks being marked as completed when they raise an exception and retry_for is not explicitly set
- Fix type hinting for retry_for in task_queue decorator
- Fix potential scoping issues with args and kwargs
- Remove unimplemented retry_for parameter from functions

Resolve BE-2128
