### PR TITLE
Fix: Endpoint returns internal service error on exception

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.136"
+version = "0.1.137"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [


### PR DESCRIPTION
Resolve BE-2148

Previously, if the handler raised an exception it would be returned with status 200 and the task would be marked complete. With this change, the exception is returned with status 500 and the task is marked as errored. 