### PR TITLE
Fix: fix task cancellation status bug

### DIFF
--- a/pkg/abstractions/taskqueue/task.go
+++ b/pkg/abstractions/taskqueue/task.go
@@ -70,6 +70,11 @@ func (t *TaskQueueTask) Cancel(ctx context.Context, reason types.TaskCancellatio
 		return err
 	}
 
+	// Don't update tasks that are already in a terminal state
+	if task.Status.IsCompleted() {
+		return nil
+	}
+
 	switch reason {
 	case types.TaskExpired:
 		task.Status = types.TaskStatusExpired


### PR DESCRIPTION
In some cases, for a very long running task queue task the dispatcher can accidentally move a task to "Expired", even though it is actually completed. This happens because the task is finished, and there is a race condition in the dispatcher trying to "expire" the task and the task claim release.