### PR TITLE
Revert endpoint change

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.138"
+version = "0.1.139"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -5,7 +5,7 @@ import signal
 import traceback
 from contextlib import asynccontextmanager
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
@@ -197,10 +197,13 @@ class EndpointManager:
             payload = await request.json()
 
             status_code = HTTPStatus.OK
-            task_lifecycle_data.result = await self._call_function(task_id=task_id, payload=payload)
-
-            if task_lifecycle_data.result.get("error"):
+            task_lifecycle_data.result, err = await self._call_function(
+                task_id=task_id, payload=payload
+            )
+            if err:
                 task_lifecycle_data.status = TaskStatus.Error
+
+            if task_lifecycle_data.status == TaskStatus.Error:
                 status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
             kwargs = payload.get("kwargs", {})
@@ -222,7 +225,8 @@ class EndpointManager:
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 
-    async def _call_function(self, task_id: str, payload: dict) -> Response:
+    async def _call_function(self, task_id: str, payload: dict) -> Tuple[Response, Any]:
+        error = None
         response_body = {}
 
         args = payload.get("args", [])
@@ -257,7 +261,7 @@ class EndpointManager:
             print(exception)
             response_body = {"error": exception}
 
-        return response_body
+        return response_body, error
 
     def shutdown(self, signum=None, frame=None):
         os._exit(self.exit_code)


### PR DESCRIPTION
Temporarily reverting the endpoint status change so that we can give users a longer warning period before making this change. 