### PR TITLE
Fix: Write response headers from copy of internal response's headers

### DIFF
--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -468,8 +468,15 @@ func (rb *RequestBuffer) handleHttpRequest(req *request, c container) {
 
 	defer resp.Body.Close()
 
-	// Write response headers
+	responseHeaders := make(http.Header)
 	for key, values := range resp.Header {
+		for _, value := range values {
+			responseHeaders.Add(key, value)
+		}
+	}
+
+	// Write response headers
+	for key, values := range responseHeaders {
 		for _, value := range values {
 			req.ctx.Response().Writer.Header().Add(key, value)
 		}


### PR DESCRIPTION
Instead of directly writing the headers into the final response, make a copy and then write from the copy. 

> fatal error: concurrent map iteration and map write