### PR TITLE
Fix: Remove instance spec from exec env

### DIFF
--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -111,7 +111,7 @@ func (s *RunCServer) RunCExec(ctx context.Context, in *pb.RunCExecRequest) (*pb.
 	if !exists {
 		return &pb.RunCExecResponse{Ok: false}, nil
 	}
-	process.Env = append(process.Env, instance.Spec.Process.Env...)
+	// process.Env = append(process.Env, instance.Spec.Process.Env...)
 	if instance.Request.IsBuildRequest() {
 		process.Env = append(process.Env, instance.Request.BuildOptions.BuildSecrets...)
 	}

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -111,7 +111,6 @@ func (s *RunCServer) RunCExec(ctx context.Context, in *pb.RunCExecRequest) (*pb.
 	if !exists {
 		return &pb.RunCExecResponse{Ok: false}, nil
 	}
-	// process.Env = append(process.Env, instance.Spec.Process.Env...)
 	if instance.Request.IsBuildRequest() {
 		process.Env = append(process.Env, instance.Request.BuildOptions.BuildSecrets...)
 	}


### PR DESCRIPTION
For some reason this was causing our base requirement installation to fail. I suspect it might have been duplicating some of the env vars from the base spec, which might have been causing issues. We should investigate adding the vars not already included and see if that still causes issues. For now, this seems to fix the problem. 