### PR TITLE
Feat: Add warm up endpoint to both endpoints and taskqueues

### DIFF
--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -434,6 +434,9 @@ func (rb *RequestBuffer) handleHttpRequest(req *request, c container) {
 	}
 
 	containerUrl := fmt.Sprintf("http://%s/%s", c.address, req.ctx.Param("subPath"))
+	if req.task.msg.NoOp {
+		containerUrl = fmt.Sprintf("http://%s/beta9/warmup", c.address)
+	}
 
 	// Forward query params to the container if ASGI
 	if rb.isASGI {

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -164,6 +164,7 @@ func (es *HttpEndpointService) forwardRequest(
 	ctx echo.Context,
 	authInfo *auth.AuthInfo,
 	stubId string,
+	noOp bool,
 ) error {
 	instance, err := es.getOrCreateEndpointInstance(ctx.Request().Context(), stubId)
 	if err != nil {
@@ -204,6 +205,7 @@ func (es *HttpEndpointService) forwardRequest(
 		MaxRetries: 0,
 		Timeout:    instance.StubConfig.TaskPolicy.Timeout,
 		Expires:    time.Now().Add(time.Duration(ttl) * time.Second),
+		NoOp:       noOp,
 	})
 	if err != nil {
 		return err

--- a/pkg/abstractions/taskqueue/http.go
+++ b/pkg/abstractions/taskqueue/http.go
@@ -26,12 +26,6 @@ func registerTaskQueueRoutes(g *echo.Group, tq *RedisTaskQueue) *taskQueueGroup 
 	g.POST("/:deploymentName/v:version", auth.WithAuth(group.TaskQueuePut))
 	g.POST("/public/:stubId", auth.WithAssumedStubAuth(group.TaskQueuePut, group.tq.isPublic))
 
-	/*
-		g.POST("/id/:stubId/warmup", auth.WithAuth(group.warmUpEndpoint))
-		g.POST("/:deploymentName/warmup", auth.WithAuth(group.warmUpEndpoint))
-		g.POST("/:deploymentName/latest/warmup", auth.WithAuth(group.warmUpEndpoint))
-		g.POST("/:deploymentName/v:version/warmup", auth.WithAuth(group.warmUpEndpoint))
-	*/
 	g.POST("/id/:stubId/warmup", auth.WithAuth(group.TaskQueueWarmUp))
 	g.POST("/:deploymentName/warmup", auth.WithAuth(group.TaskQueueWarmUp))
 	g.POST("/:deploymentName/latest/warmup", auth.WithAuth(group.TaskQueueWarmUp))

--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -81,6 +81,7 @@ func (d *Dispatcher) Send(ctx context.Context, executor string, authInfo *auth.A
 	taskMessage.Kwargs = payload.Kwargs
 	taskMessage.Policy = policy
 	taskMessage.Timestamp = time.Now().Unix()
+	taskMessage.NoOp = policy.NoOp
 
 	taskFactory, exists := d.executors.Get(executor)
 	if !exists {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -61,6 +61,7 @@ type TaskMessage struct {
 	Policy        TaskPolicy             `json:"policy" redis:"policy"`
 	Retries       uint                   `json:"retries" redis:"retries"`
 	Timestamp     int64                  `json:"timestamp" redis:"timestamp"`
+	NoOp          bool                   `json:"no_op" redis:"no_op"`
 }
 
 func (tm *TaskMessage) Reset() {
@@ -119,6 +120,7 @@ type TaskPolicy struct {
 	Timeout    int       `json:"timeout" redis:"timeout"`
 	Expires    time.Time `json:"expires" redis:"expires"`
 	TTL        uint32    `json:"ttl" redis:"ttl"`
+	NoOp       bool      `json:"no_op" redis:"no_op"`
 }
 
 type ErrExceededTaskLimit struct {

--- a/sdk/src/beta9/runner/endpoint.py
+++ b/sdk/src/beta9/runner/endpoint.py
@@ -212,6 +212,14 @@ class EndpointManager:
 
             return self._create_response(body=task_lifecycle_data.result, status_code=status_code)
 
+        @self.app.post("/beta9/warmup")
+        async def warmup(
+            request: Request,
+        ):
+            payload = await request.json()
+            task_id = payload.get("task_id")
+            return self._create_response(body=task_id, status_code=HTTPStatus.OK)
+
     def _create_response(self, *, body: Any, status_code: int = HTTPStatus.OK) -> Response:
         if isinstance(body, Response):
             return body


### PR DESCRIPTION
Added a new variable `NoOp` to the `TaskMessage` data model which only exists in Redis. If this variable is detected to be true in a task, the idea is that the task handler will detect it and run it as a fake task just so it can complete and start up the timer for the keep warm.