### PR TITLE
Chore: Sanitize container requests and add stub id to container events

### DIFF
--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -111,7 +111,8 @@ func (t *TCPEventClientRepo) PushContainerRequestedEvent(request *types.Containe
 		types.EventContainerStatusRequestedSchemaVersion,
 		types.EventContainerStatusRequestedSchema{
 			ContainerID: request.ContainerId,
-			Request:     *request,
+			Request:     sanitizeContainerRequest(request),
+			StubID:      request.StubId,
 			Status:      types.EventContainerLifecycleRequested,
 		},
 	)
@@ -124,7 +125,8 @@ func (t *TCPEventClientRepo) PushContainerScheduledEvent(containerID string, wor
 		types.EventContainerLifecycleSchema{
 			ContainerID: containerID,
 			WorkerID:    workerID,
-			Request:     *request,
+			Request:     sanitizeContainerRequest(request),
+			StubID:      request.StubId,
 			Status:      types.EventContainerLifecycleScheduled,
 		},
 	)
@@ -137,7 +139,8 @@ func (t *TCPEventClientRepo) PushContainerStartedEvent(containerID string, worke
 		types.EventContainerLifecycleSchema{
 			ContainerID: containerID,
 			WorkerID:    workerID,
-			Request:     *request,
+			Request:     sanitizeContainerRequest(request),
+			StubID:      request.StubId,
 			Status:      types.EventContainerLifecycleStarted,
 		},
 	)
@@ -150,7 +153,8 @@ func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, worke
 		types.EventContainerLifecycleSchema{
 			ContainerID: containerID,
 			WorkerID:    workerID,
-			Request:     *request,
+			Request:     sanitizeContainerRequest(request),
+			StubID:      request.StubId,
 			Status:      types.EventContainerLifecycleStopped,
 		},
 	)
@@ -294,4 +298,14 @@ func (t *TCPEventClientRepo) PushStubStateUnhealthy(workspaceId string, stubId s
 			FailedContainers: failedContainers,
 		},
 	)
+}
+
+func sanitizeContainerRequest(request *types.ContainerRequest) types.ContainerRequest {
+	requestCopy := *request
+	requestCopy.Env = nil
+	requestCopy.EntryPoint = nil
+	requestCopy.Stub = types.StubWithRelated{}
+	requestCopy.Mounts = nil
+	requestCopy.PoolSelector = ""
+	return requestCopy
 }

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -57,11 +57,12 @@ var (
 
 // Schema versions should be in ISO 8601 format
 
-var EventContainerLifecycleSchemaVersion = "1.0"
+var EventContainerLifecycleSchemaVersion = "1.1"
 
 type EventContainerLifecycleSchema struct {
 	ContainerID string           `json:"container_id"`
 	WorkerID    string           `json:"worker_id"`
+	StubID      string           `json:"stub_id"`
 	Status      string           `json:"status"`
 	Request     ContainerRequest `json:"request"`
 }
@@ -95,11 +96,12 @@ type EventContainerMetricsData struct {
 	GPUType            string  `json:"gpu_type"`
 }
 
-var EventContainerStatusRequestedSchemaVersion = "1.0"
+var EventContainerStatusRequestedSchemaVersion = "1.1"
 
 type EventContainerStatusRequestedSchema struct {
 	ContainerID string           `json:"container_id"`
 	Request     ContainerRequest `json:"request"`
+	StubID      string           `json:"stub_id"`
 	Status      string           `json:"status"`
 }
 


### PR DESCRIPTION
1. Sanitize container requests before sending data to events so that events don't leak vital information
2. Add stub_id directly into `container.lifecycle` events for easier filtering