### PR TITLE
Fix: Dont timeout during dockerfile builds

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -329,7 +329,7 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 			return errors.New(fmt.Sprintf("container exited with error: %s\n", msg))
 		}
 
-		if time.Since(start) > defaultContainerSpinupTimeout && opts.Dockerfile != "" {
+		if time.Since(start) > defaultContainerSpinupTimeout && opts.Dockerfile == "" {
 			outputChan <- common.OutputMsg{Done: true, Success: false, Msg: "Timeout: container not running after 180 seconds.\n"}
 			return errors.New("timeout: container not running after 180 seconds")
 		}

--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -210,14 +210,16 @@ func (i *BaseImage) String() string {
 // Build user image
 func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan common.OutputMsg) error {
 	var (
-		dockerfile  *string
-		authInfo, _ = auth.AuthInfoFromContext(ctx)
+		dockerfile             *string
+		authInfo, _            = auth.AuthInfoFromContext(ctx)
+		containerSpinupTimeout = defaultContainerSpinupTimeout
 	)
 
 	switch {
 	case opts.Dockerfile != "":
 		opts.addPythonRequirements()
 		dockerfile = &opts.Dockerfile
+		containerSpinupTimeout = 600 * time.Second
 	case opts.ExistingImageUri != "":
 		err := b.handleCustomBaseImage(opts, outputChan)
 		if err != nil {
@@ -329,7 +331,7 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 			return errors.New(fmt.Sprintf("container exited with error: %s\n", msg))
 		}
 
-		if time.Since(start) > defaultContainerSpinupTimeout && opts.Dockerfile == "" {
+		if time.Since(start) > containerSpinupTimeout {
 			outputChan <- common.OutputMsg{Done: true, Success: false, Msg: "Timeout: container not running after 180 seconds.\n"}
 			return errors.New("timeout: container not running after 180 seconds")
 		}

--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -329,7 +329,7 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 			return errors.New(fmt.Sprintf("container exited with error: %s\n", msg))
 		}
 
-		if time.Since(start) > defaultContainerSpinupTimeout {
+		if time.Since(start) > defaultContainerSpinupTimeout && opts.Dockerfile != "" {
 			outputChan <- common.OutputMsg{Done: true, Success: false, Msg: "Timeout: container not running after 180 seconds.\n"}
 			return errors.New("timeout: container not running after 180 seconds")
 		}


### PR DESCRIPTION
At the moment, we will timeout after 3 minutes with the message 

```
Build failed: Timeout: container not running after 180 seconds.
```

This makes sense if we are pulling an image, but some dockerfile builds will take longer than this.