### PR TITLE
Send oom event to es

### DIFF
--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -177,6 +177,7 @@ type EventRepository interface {
 	PushContainerScheduledEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerStartedEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerStoppedEvent(containerID string, workerID string, request *types.ContainerRequest)
+	PushContainerOOMEvent(containerID string, workerID string, stubId string)
 	PushContainerResourceMetricsEvent(workerID string, request *types.ContainerRequest, metrics types.EventContainerMetricsData)
 	PushWorkerStartedEvent(workerID string)
 	PushWorkerStoppedEvent(workerID string)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -160,6 +160,19 @@ func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, worke
 	)
 }
 
+func (t *TCPEventClientRepo) PushContainerOOMEvent(containerID string, workerID string, stubId string) {
+	t.pushEvent(
+		types.EventContainerLifecycle,
+		types.EventContainerLifecycleSchemaVersion,
+		types.EventContainerLifecycleSchema{
+			ContainerID: containerID,
+			WorkerID:    workerID,
+			StubID:      stubId,
+			Status:      types.EventContainerLifecycleOOM,
+		},
+	)
+}
+
 func (t *TCPEventClientRepo) PushWorkerStartedEvent(workerID string) {
 	t.pushEvent(
 		types.EventWorkerLifecycle,

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -47,6 +47,7 @@ var (
 	EventContainerLifecycleScheduled = "scheduled"
 	EventContainerLifecycleStarted   = "started"
 	EventContainerLifecycleStopped   = "stopped"
+	EventContainerLifecycleOOM       = "oom"
 	EventContainerLifecycleFailed    = "failed"
 )
 

--- a/pkg/worker/cr.go
+++ b/pkg/worker/cr.go
@@ -187,8 +187,8 @@ func (s *Worker) waitForRestoredContainer(ctx context.Context, containerId strin
 		return exitCode
 	}
 
-	go s.collectAndSendContainerMetrics(ctx, request, spec, pid) // Capture resource usage (cpu/mem/gpu)
-	go s.watchOOMEvents(ctx, containerId, outputLogger)          // Watch for OOM events
+	go s.collectAndSendContainerMetrics(ctx, request, spec, pid)        // Capture resource usage (cpu/mem/gpu)
+	go s.watchOOMEvents(ctx, containerId, request.StubId, outputLogger) // Watch for OOM events
 
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
Partially resolve BE-2141

This PR makes a small addition to the OOM watching logic. It adds an additional `PushContainerOOMEvent` to the elastic search event repo. It is called when OOMs occur. In the frontend, we can use the container ID and stub ID to alert users that one of their containers has OOM issues. 