### PR TITLE
Fix: Remove task running lock scan

### DIFF
--- a/pkg/abstractions/taskqueue/client.go
+++ b/pkg/abstractions/taskqueue/client.go
@@ -75,6 +75,11 @@ func (qc *taskQueueClient) Pop(ctx context.Context, workspaceName, stubId, conta
 		return nil, err
 	}
 
+	err = qc.rdb.SAdd(ctx, Keys.taskQueueTaskRunningLockIndex(workspaceName, stubId, containerId), tm.TaskId).Err()
+	if err != nil {
+		return nil, err
+	}
+
 	// Set a lock to prevent spin-down during decoding (decoding can take a long time for larger payloads)
 	err = qc.rdb.SetEx(ctx, Keys.taskQueueTaskRunningLock(workspaceName, stubId, containerId, tm.TaskId), 1, time.Duration(defaultTaskRunningExpiration)*time.Second).Err()
 	if err != nil {

--- a/pkg/abstractions/taskqueue/instance.go
+++ b/pkg/abstractions/taskqueue/instance.go
@@ -186,6 +186,9 @@ func (i *taskQueueInstance) stoppableContainers() ([]string, error) {
 		}
 
 		tasksRunning := false
+
+		// Check if any tasks are currently running on this container
+		// We do this by checking for the presence of "taskQueueTaskRunningLock" keys
 		for _, taskId := range containerTasks {
 			_, err = i.Rdb.Get(context.TODO(), Keys.taskQueueTaskRunningLock(i.Workspace.Name, i.Stub.ExternalId, container.ContainerId, taskId)).Result()
 			if err != nil && err != redis.Nil {

--- a/pkg/abstractions/taskqueue/keys.go
+++ b/pkg/abstractions/taskqueue/keys.go
@@ -4,15 +4,16 @@ import "fmt"
 
 // Redis keys
 var (
-	taskQueueList                string = "taskqueue:%s:%s"
-	taskQueueServeLock           string = "taskqueue:%s:%s:serve_lock"
-	taskQueueInstanceLock        string = "taskqueue:%s:%s:instance_lock"
-	taskQueueTaskDuration        string = "taskqueue:%s:%s:task_duration"
-	taskQueueAverageTaskDuration string = "taskqueue:%s:%s:avg_task_duration"
-	taskQueueTaskHeartbeat       string = "taskqueue:%s:%s:task:heartbeat:%s"
-	taskQueueProcessingLock      string = "taskqueue:%s:%s:processing_lock:%s"
-	taskQueueKeepWarmLock        string = "taskqueue:%s:%s:keep_warm_lock:%s"
-	taskQueueTaskRunningLock     string = "taskqueue:%s:%s:task_running:%s:%s"
+	taskQueueList                 string = "taskqueue:%s:%s"
+	taskQueueServeLock            string = "taskqueue:%s:%s:serve_lock"
+	taskQueueInstanceLock         string = "taskqueue:%s:%s:instance_lock"
+	taskQueueTaskDuration         string = "taskqueue:%s:%s:task_duration"
+	taskQueueAverageTaskDuration  string = "taskqueue:%s:%s:avg_task_duration"
+	taskQueueTaskHeartbeat        string = "taskqueue:%s:%s:task:heartbeat:%s"
+	taskQueueProcessingLock       string = "taskqueue:%s:%s:processing_lock:%s"
+	taskQueueKeepWarmLock         string = "taskqueue:%s:%s:keep_warm_lock:%s"
+	taskQueueTaskRunningLockIndex string = "taskqueue:%s:%s:task_running:%s:index"
+	taskQueueTaskRunningLock      string = "taskqueue:%s:%s:task_running:%s:%s"
 )
 
 var Keys = &keys{}
@@ -41,6 +42,10 @@ func (k *keys) taskQueueTaskDuration(workspaceName, stubId string) string {
 
 func (k *keys) taskQueueAverageTaskDuration(workspaceName, stubId string) string {
 	return fmt.Sprintf(taskQueueAverageTaskDuration, workspaceName, stubId)
+}
+
+func (k *keys) taskQueueTaskRunningLockIndex(workspaceName, stubId, containerId string) string {
+	return fmt.Sprintf(taskQueueTaskRunningLockIndex, workspaceName, stubId, containerId)
 }
 
 func (k *keys) taskQueueTaskRunningLock(workspaceName, stubId, containerId, taskId string) string {

--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -269,6 +269,7 @@ func (tq *RedisTaskQueue) TaskQueuePop(ctx context.Context, in *pb.TaskQueuePopR
 
 			if t.Status.IsCompleted() {
 				instance.client.rdb.Del(ctx, Keys.taskQueueTaskRunningLock(authInfo.Workspace.Name, in.StubId, in.ContainerId, t.ExternalId))
+				instance.client.rdb.SRem(ctx, Keys.taskQueueTaskRunningLockIndex(authInfo.Workspace.Name, in.StubId, in.ContainerId), t.ExternalId)
 				continue
 			}
 
@@ -289,6 +290,13 @@ func (tq *RedisTaskQueue) TaskQueuePop(ctx context.Context, in *pb.TaskQueuePopR
 	task.ContainerId = in.ContainerId
 	task.StartedAt = sql.NullTime{Time: time.Now(), Valid: true}
 	task.Status = types.TaskStatusRunning
+
+	err = tq.rdb.SAdd(ctx, Keys.taskQueueTaskRunningLockIndex(authInfo.Workspace.Name, in.StubId, in.ContainerId), task.ExternalId).Err()
+	if err != nil {
+		return &pb.TaskQueuePopResponse{
+			Ok: false,
+		}, nil
+	}
 
 	err = tq.rdb.SetEx(context.TODO(), Keys.taskQueueTaskRunningLock(authInfo.Workspace.Name, in.StubId, in.ContainerId, task.ExternalId), 1, time.Duration(defaultTaskRunningExpiration)*time.Second).Err()
 	if err != nil {
@@ -326,6 +334,13 @@ func (tq *RedisTaskQueue) TaskQueueComplete(ctx context.Context, in *pb.TaskQueu
 				Ok: false,
 			}, nil
 		}
+	}
+
+	err = tq.rdb.SRem(ctx, Keys.taskQueueTaskRunningLockIndex(authInfo.Workspace.Name, in.StubId, in.ContainerId), in.TaskId).Err()
+	if err != nil {
+		return &pb.TaskQueueCompleteResponse{
+			Ok: false,
+		}, nil
 	}
 
 	err = tq.rdb.Del(ctx, Keys.taskQueueTaskRunningLock(authInfo.Workspace.Name, in.StubId, in.ContainerId, in.TaskId)).Err()


### PR DESCRIPTION
Not the most elegant approach, but this index will remove the scan (which locks redis). It should make us less susceptible to CPU spikes.

- Remove the last major redis key scan we perform in the beta9 repo (outside of maps)