### PR TITLE
Copy custom images to disk instead of memory before unpacking

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -30,7 +30,7 @@ const (
 	defaultImageBuildGracefulShutdownS               = 5 * time.Second
 	defaultBuildContainerCpu           int64         = 1000
 	defaultBuildContainerMemory        int64         = 1024
-	defaultContainerSpinupTimeout      time.Duration = 360 * time.Second
+	defaultContainerSpinupTimeout      time.Duration = 600 * time.Second
 
 	pipCommandType        string = "pip"
 	shellCommandType      string = "shell"
@@ -219,7 +219,6 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 	case opts.Dockerfile != "":
 		opts.addPythonRequirements()
 		dockerfile = &opts.Dockerfile
-		containerSpinupTimeout = 600 * time.Second
 	case opts.ExistingImageUri != "":
 		err := b.handleCustomBaseImage(opts, outputChan)
 		if err != nil {

--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -30,7 +30,7 @@ const (
 	defaultImageBuildGracefulShutdownS               = 5 * time.Second
 	defaultBuildContainerCpu           int64         = 1000
 	defaultBuildContainerMemory        int64         = 1024
-	defaultContainerSpinupTimeout      time.Duration = 180 * time.Second
+	defaultContainerSpinupTimeout      time.Duration = 360 * time.Second
 
 	pipCommandType        string = "pip"
 	shellCommandType      string = "shell"
@@ -332,8 +332,8 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 		}
 
 		if time.Since(start) > containerSpinupTimeout {
-			outputChan <- common.OutputMsg{Done: true, Success: false, Msg: "Timeout: container not running after 180 seconds.\n"}
-			return errors.New("timeout: container not running after 180 seconds")
+			outputChan <- common.OutputMsg{Done: true, Success: false, Msg: fmt.Sprintf("Timeout: container not running after %d seconds.\n", containerSpinupTimeout)}
+			return errors.New(fmt.Sprintf("timeout: container not running after %d seconds", containerSpinupTimeout))
 		}
 
 		time.Sleep(100 * time.Millisecond)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -246,7 +246,7 @@ func (s *Worker) buildOrPullImage(request *types.ContainerRequest, containerId s
 	case request.BuildOptions.SourceImage != nil:
 		log.Info().Str("container_id", containerId).Msgf("lazy-pull failed, pulling source image: %s", *request.BuildOptions.SourceImage)
 
-		if err := s.imageClient.PullAndArchiveImage(context.TODO(), *request.BuildOptions.SourceImage, request.ImageId, request.BuildOptions.SourceImageCreds); err != nil {
+		if err := s.imageClient.PullAndArchiveImage(context.TODO(), outputLogger, *request.BuildOptions.SourceImage, request.ImageId, request.BuildOptions.SourceImageCreds); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Resolve BE-2204

This PR adds additional logging to custom base image builds, increases the spin up timeout for build containers, and copies images to disk instead of memory with skopeo. The biggest change is the copying location. This change has little to no impact on the time it takes to copy/unpack custom images from what I've measured. It is a change worth making because it decreases the memory required by the worker for custom base images. For example, as things are, `docker.io/pytorch/pytorch:2.2.2-cuda12.1-cudnn8-devel` will cause the worker to OOM. With this change, that image can be used without any problems. 