### PR TITLE
Add full request to es oom event

### DIFF
--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -177,7 +177,7 @@ type EventRepository interface {
 	PushContainerScheduledEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerStartedEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerStoppedEvent(containerID string, workerID string, request *types.ContainerRequest)
-	PushContainerOOMEvent(containerID string, workerID string, stubId string)
+	PushContainerOOMEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerResourceMetricsEvent(workerID string, request *types.ContainerRequest, metrics types.EventContainerMetricsData)
 	PushWorkerStartedEvent(workerID string)
 	PushWorkerStoppedEvent(workerID string)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -160,14 +160,15 @@ func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, worke
 	)
 }
 
-func (t *TCPEventClientRepo) PushContainerOOMEvent(containerID string, workerID string, stubId string) {
+func (t *TCPEventClientRepo) PushContainerOOMEvent(containerID string, workerID string, request *types.ContainerRequest) {
 	t.pushEvent(
 		types.EventContainerLifecycle,
 		types.EventContainerLifecycleSchemaVersion,
 		types.EventContainerLifecycleSchema{
 			ContainerID: containerID,
 			WorkerID:    workerID,
-			StubID:      stubId,
+			StubID:      request.StubId,
+			Request:     sanitizeContainerRequest(request),
 			Status:      types.EventContainerLifecycleOOM,
 		},
 	)

--- a/pkg/worker/cr.go
+++ b/pkg/worker/cr.go
@@ -187,8 +187,8 @@ func (s *Worker) waitForRestoredContainer(ctx context.Context, containerId strin
 		return exitCode
 	}
 
-	go s.collectAndSendContainerMetrics(ctx, request, spec, pid)        // Capture resource usage (cpu/mem/gpu)
-	go s.watchOOMEvents(ctx, containerId, request.StubId, outputLogger) // Watch for OOM events
+	go s.collectAndSendContainerMetrics(ctx, request, spec, pid) // Capture resource usage (cpu/mem/gpu)
+	go s.watchOOMEvents(ctx, request, outputLogger)              // Watch for OOM events
 
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -604,8 +604,8 @@ func (s *Worker) wait(ctx context.Context, containerId string, startedChan chan 
 	pid := state.Pid
 
 	// Start monitoring the container
-	go s.collectAndSendContainerMetrics(ctx, request, spec, pid)        // Capture resource usage (cpu/mem/gpu)
-	go s.watchOOMEvents(ctx, containerId, request.StubId, outputLogger) // Watch for OOM events
+	go s.collectAndSendContainerMetrics(ctx, request, spec, pid) // Capture resource usage (cpu/mem/gpu)
+	go s.watchOOMEvents(ctx, request, outputLogger)              // Watch for OOM events
 
 	process, err := os.FindProcess(pid)
 	if err != nil {
@@ -637,12 +637,13 @@ func (s *Worker) createOverlay(request *types.ContainerRequest, bundlePath strin
 	return common.NewContainerOverlay(request.ContainerId, rootPath, overlayPath)
 }
 
-func (s *Worker) watchOOMEvents(ctx context.Context, containerId string, stubId string, outputLogger *slog.Logger) {
+func (s *Worker) watchOOMEvents(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger) {
 	var (
-		seenEvents = make(map[string]struct{})
-		ch         <-chan *runc.Event
-		err        error
-		ticker     = time.NewTicker(time.Second)
+		seenEvents  = make(map[string]struct{})
+		ch          <-chan *runc.Event
+		err         error
+		ticker      = time.NewTicker(time.Second)
+		containerId = request.ContainerId
 	)
 
 	defer ticker.Stop()
@@ -693,7 +694,7 @@ func (s *Worker) watchOOMEvents(ctx context.Context, containerId string, stubId 
 
 			if event.Type == "oom" {
 				outputLogger.Error("A process in the container was killed due to out-of-memory conditions.")
-				s.eventRepo.PushContainerOOMEvent(containerId, s.workerId, stubId)
+				s.eventRepo.PushContainerOOMEvent(containerId, s.workerId, request)
 			}
 		}
 	}


### PR DESCRIPTION
This is a small change to add the request to the es oom event we publish. We need this to be able to properly scope the oom event manager to the workspace on the frontend. 