### PR TITLE
fix: issue with getting package version for user-agent

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.144"
+version = "0.1.145"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -3,6 +3,7 @@ import sys
 import traceback
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from importlib import metadata
 from typing import Any, Callable, Generator, List, NewType, Optional, Sequence, Tuple, cast
 
 import grpc
@@ -18,7 +19,6 @@ from .config import (
     ConfigContext,
     SDKSettings,
     get_config_context,
-    get_settings,
     load_config,
     prompt_for_config_context,
     save_config,
@@ -36,11 +36,9 @@ def channel_reconnect_event(connect_status: grpc.ChannelConnectivity) -> None:
         terminal.warn("Connection lost, reconnecting...")
 
 
-def get_user_agent() -> str:
-    from importlib import metadata
-
-    package_name = get_settings().name.lower()
-    return f"{package_name}/{metadata.version(package_name)}"
+def get_user_agent() -> Optional[str]:
+    if p := __package__:
+        return f"{p}/{metadata.version(p)}"
 
 
 class Channel(InterceptorChannel):
@@ -59,7 +57,8 @@ class Channel(InterceptorChannel):
             options = []
 
         options = [opt for opt in options if "grpc.secondary_user_agent" not in opt[0]]
-        options.append(("grpc.secondary_user_agent", get_user_agent()))
+        if ua := get_user_agent():
+            options.append(("grpc.secondary_user_agent", ua))
 
         if credentials is not None:
             channel = grpc.secure_channel(addr, credentials)


### PR DESCRIPTION
Fixes adding a user-agent to every gRPC connection. The UA will always be "beta9/x.x.x", even when called from the beam-client.