### PR TITLE
fix: multipart uploads and downloads with empty files

### DIFF
--- a/pkg/abstractions/volume/multipart.go
+++ b/pkg/abstractions/volume/multipart.go
@@ -168,6 +168,11 @@ func (s *GlobalVolumeService) CreateMultipartUpload(ctx context.Context, in *pb.
 	totalParts := math.Ceil(float64(in.FileSize) / float64(in.ChunkSize))
 	uploadParts := make([]*pb.FileUploadPart, int(totalParts))
 
+	// When the file size is 0, we still need to create a part
+	if len(uploadParts) == 0 {
+		uploadParts = make([]*pb.FileUploadPart, 1)
+	}
+
 	for i := range uploadParts {
 		res, err := s.CreatePresignedURL(ctx, &pb.CreatePresignedURLRequest{
 			VolumeName: in.VolumeName,

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.149"
+version = "0.1.150"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/multipart.py
+++ b/sdk/src/beta9/multipart.py
@@ -364,7 +364,7 @@ def _calculate_file_ranges(file_size: int, chunk_size: int) -> List[FileRange]:
     Returns:
         List of byte ranges.
     """
-    ranges = math.ceil(file_size / chunk_size)
+    ranges = math.ceil(file_size / (chunk_size or 1))
     return [
         FileRange(
             number=i + 1,


### PR DESCRIPTION
- When file size is 0, make just 1 presigned url upload part
- When upload is complete, call progress callback at least once to indicate it completed
- Don't send any data to juicefs s3 gateway when chunk is empty
- Fix divide by zero errors with downloads

Resolve BE-2133