### PR TITLE
fix: show terminal cursor after multipart error

### DIFF
--- a/sdk/src/beta9/cli/volume.py
+++ b/sdk/src/beta9/cli/volume.py
@@ -293,6 +293,8 @@ def cp(
         terminal.warn("\rCancelled")
     except Exception as e:
         terminal.error(f"\rFailed: {e}")
+    finally:
+        terminal.reset_terminal()
 
 
 @common.command(


### PR DESCRIPTION
- Fixes some edge cases when cancelling during a copy - resets the terminal cursor so it is shown even after an error

Resolve BE-2133