### PR TITLE
fix: attempt to disable gRPC absl logs

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.154"
+version = "0.1.155"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -1,4 +1,7 @@
 import os
+
+os.environ["GRPC_VERBOSITY"] = os.getenv("GRPC_VERBOSITY") or "NONE"
+
 import sys
 from abc import ABC
 from dataclasses import dataclass

--- a/sdk/src/beta9/cli/main.py
+++ b/sdk/src/beta9/cli/main.py
@@ -1,4 +1,7 @@
 import os
+
+os.environ["GRPC_VERBOSITY"] = os.getenv("GRPC_VERBOSITY") or "NONE"
+
 import shutil
 from types import ModuleType
 from typing import Any, Optional
@@ -25,8 +28,6 @@ from . import (
 from .extraclick import CLICK_CONTEXT_SETTINGS, ClickCommonGroup, CommandGroupCollection
 
 click.formatting.FORCED_WIDTH = shutil.get_terminal_size().columns
-
-os.environ["GRPC_VERBOSITY"] = os.getenv("GRPC_VERBOSITY") or "NONE"
 
 
 class CLI:


### PR DESCRIPTION
Prevent these logs from showing up when running a function.

```python
#!/usr/bin/env python

from beam import function


@function(name="func-test", cpu=3, memory="16Gi")
def handler():
    return {}


if __name__ == "__main__":
    handler.remote()
```


```sh
python app.py
...
=> Function complete <99f6ef8f-749a-43e2-a1e6-e9e55c794f0d>

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1737223352.040854 11801855 init.cc:232] grpc_wait_for_shutdown_with_timeout() timed out.
```

Resolve BE-2262