### PR TITLE
Fix: don't overwrite /root in containers

### DIFF
--- a/pkg/worker/base_runc_config.json
+++ b/pkg/worker/base_runc_config.json
@@ -93,16 +93,6 @@
       "options": ["rw", "nosuid", "noexec", "nodev"]
 		},
 		{
-			"destination": "/root",
-			"type": "tmpfs",
-			"source": "tmpfs",
-			"options": [
-				"nosuid",
-				"strictatime",
-				"mode=755"
-			]
-		},
-		{
 			"destination": "/volumes",
 			"type": "tmpfs",
 			"source": "tmpfs",


### PR DESCRIPTION
Certain images install stuff into /root. We currently overwrite this path with a tmpfs on container startup. I don't think this is needed, because we are already adding a r/w overlay on top of the user container that allows them to modify the contents. For example, this should work:

```
from beta9 import Image, endpoint


@endpoint(
    cpu=1,
    memory=128,
    image=Image(
        python_version="python3.10",
    ).add_commands(
        [
            "touch /root/hello.txt",
            "touch /something.txt",
        ]
    ),
)
def handler():
    with open("/root/hello.txt", "r") as f:
        print(f.read())

    with open("/root/something_else.txt", "w") as f:
        f.write("Hello, World!")

    return "Hello, World!"
```