### PR TITLE
Fix: Runc exec should use running container's env vars

### DIFF
--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -103,7 +103,6 @@ func (s *RunCServer) RunCExec(ctx context.Context, in *pb.RunCExecRequest) (*pb.
 	}
 
 	process := s.baseConfigSpec.Process
-	process.Env = append(process.Env, "DEBIAN_FRONTEND=noninteractive")
 	process.Args = parsedCmd
 	process.Cwd = defaultWorkingDirectory
 
@@ -111,6 +110,10 @@ func (s *RunCServer) RunCExec(ctx context.Context, in *pb.RunCExecRequest) (*pb.
 	if !exists {
 		return &pb.RunCExecResponse{Ok: false}, nil
 	}
+
+	instanceSpec := instance.Spec.Process
+	process.Env = append(instanceSpec.Env, "DEBIAN_FRONTEND=noninteractive")
+
 	if instance.Request.IsBuildRequest() {
 		/*
 			For some reason, if the process that is spun up from this (e.g. `runc exec --process /tmp/runc-process839505971 build-128a153e`)


### PR DESCRIPTION
Resolve BE-2274

This did not fix unsloth issues, but is generally important for GPU builds. It will also be important for custom image builds once we start propagating their environment variables as well. 