### PR TITLE
fix: improve beam shell connectivity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ proxy:
 
 runner:
 	for target in py312 py311 py310 py39 py38; do \
-		docker build . --target $$target --platform=linux/arm64 -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:$$target-$(runnerTag); \
+		docker build . --target $$target --platform=linux/arm64 -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:$$target-$(runnerTag) --progress=plain; \
 		docker push localhost:5001/beta9-runner:$$target-$(runnerTag); \
 	done
 	for version in "3.12" "3.11" "3.10" "3.9" "3.8"; do \
-		docker build . --build-arg PYTHON_VERSION=$$version --target micromamba --platform=linux/arm64 -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:micromamba$$version-$(runnerTag); \
+		docker build . --build-arg PYTHON_VERSION=$$version --target micromamba --platform=linux/arm64 -f ./docker/Dockerfile.runner -t localhost:5001/beta9-runner:micromamba$$version-$(runnerTag) --progress=plain; \
 		docker push localhost:5001/beta9-runner:micromamba$$version-$(runnerTag); \
 	done
 

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.6
-FROM ubuntu:22.04 as base
+FROM ubuntu:22.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -14,7 +14,7 @@ EOT
 
 # Python 3.12
 # ========================
-FROM base as py312
+FROM base AS py312
 
 WORKDIR /workspace
 
@@ -51,7 +51,7 @@ VOLUME ["/volumes", "/snapshot"]
 
 # Python 3.11
 # ========================
-FROM base as py311
+FROM base AS py311
 
 WORKDIR /workspace
 
@@ -89,7 +89,7 @@ VOLUME ["/volumes", "/snapshot"]
 
 # Python 3.10
 # ========================
-FROM base as py310
+FROM base AS py310
 
 WORKDIR /workspace
 
@@ -127,7 +127,7 @@ VOLUME ["/volumes", "/snapshot"]
 
 # Python 3.9
 # ========================
-FROM base as py39
+FROM base AS py39
 
 WORKDIR /workspace
 
@@ -165,7 +165,7 @@ VOLUME ["/volumes", "/snapshot"]
 
 # Python 3.8
 # ========================
-FROM base as py38
+FROM base AS py38
 
 WORKDIR /workspace
 
@@ -202,7 +202,7 @@ VOLUME ["/volumes", "/snapshot"]
 
 # Micromamba-base
 # ========================
-FROM base as micromamba-base
+FROM base AS micromamba-base
 
 WORKDIR /workspace
 

--- a/pkg/abstractions/shell/http.go
+++ b/pkg/abstractions/shell/http.go
@@ -1,10 +1,10 @@
 package shell
 
 import (
-	"context"
 	"io"
+	"net"
 	"net/http"
-	"sync"
+	"time"
 
 	apiv1 "github.com/beam-cloud/beta9/pkg/api/v1"
 	"github.com/beam-cloud/beta9/pkg/auth"
@@ -20,7 +20,7 @@ type shellGroup struct {
 
 func registerShellRoutes(g *echo.Group, ss *SSHShellService) *shellGroup {
 	group := &shellGroup{routerGroup: g, ss: ss}
-	g.CONNECT("/id/:stubId/:containerId", auth.WithAuth(group.ShellConnect))
+	g.GET("/id/:stubId/:containerId", auth.WithAuth(group.ShellConnect))
 	return group
 }
 
@@ -47,13 +47,8 @@ func (g *shellGroup) ShellConnect(ctx echo.Context) error {
 
 	// Channel to signal when either connection is closed
 	done := make(chan struct{})
-	var once sync.Once
 
 	go g.ss.keepAlive(ctx.Request().Context(), containerId, done)
-
-	// Send a 200 OK before hijacking
-	ctx.Response().WriteHeader(http.StatusOK)
-	ctx.Response().Flush()
 
 	// Hijack the connection
 	hijacker, ok := ctx.Response().Writer.(http.Hijacker)
@@ -66,6 +61,7 @@ func (g *shellGroup) ShellConnect(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, "Failed to create tunnel")
 	}
 	defer conn.Close()
+	setConnOptions(conn)
 
 	// Dial ssh server in the container
 	containerConn, err := network.ConnectToHost(ctx.Request().Context(), containerAddress, containerDialTimeoutDurationS, g.ss.tailscale, g.ss.config.Tailscale)
@@ -73,35 +69,37 @@ func (g *shellGroup) ShellConnect(ctx echo.Context) error {
 		return ctx.String(http.StatusBadGateway, "Failed to connect to container")
 	}
 	defer containerConn.Close()
+	setConnOptions(containerConn)
 
-	// Create a context that will be canceled when the client disconnects
-	clientCtx, clientCancel := context.WithCancel(ctx.Request().Context())
-	defer clientCancel()
+	// Tell the client to proceed now that everything is set up
+	if _, err = conn.Write([]byte("OK")); err != nil {
+		return ctx.String(http.StatusBadGateway, "Failed to send OK to client")
+	}
 
-	defer func() {
-		containerConn.Close()
-		conn.Close()
-	}()
+	// Start bidirectional proxy
+	go proxyConn(containerConn, conn, done)
+	go proxyConn(conn, containerConn, done)
 
-	go func() {
-		buf := make([]byte, shellProxyBufferSizeKb)
-		_, _ = io.CopyBuffer(containerConn, conn, buf)
-		once.Do(func() { close(done) })
-	}()
-
-	go func() {
-		buf := make([]byte, shellProxyBufferSizeKb)
-		_, _ = io.CopyBuffer(conn, containerConn, buf)
-		once.Do(func() { close(done) })
-	}()
-
-	// Wait for either connection to close
 	select {
 	case <-done:
 		return nil
-	case <-clientCtx.Done():
+	case <-ctx.Request().Context().Done():
 		return nil
 	case <-g.ss.ctx.Done():
 		return nil
+	}
+}
+
+func proxyConn(dst io.Writer, src io.Reader, done chan<- struct{}) {
+	buf := make([]byte, shellProxyBufferSizeKb)
+	io.CopyBuffer(dst, src, buf)
+	done <- struct{}{}
+}
+
+func setConnOptions(conn net.Conn) {
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetKeepAlive(true)
+		tcpConn.SetKeepAlivePeriod(shellKeepAliveIntervalS)
+		tcpConn.SetDeadline(time.Time{})
 	}
 }

--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -28,6 +28,7 @@ const (
 	shellContainerPrefix          string        = "shell"
 	shellContainerTtlS            int           = 30 // 30 seconds
 	shellProxyBufferSizeKb        int           = 32 * 1024
+	shellKeepAliveIntervalS       time.Duration = 60 * time.Second
 	defaultContainerCpu           int64         = 100
 	defaultContainerMemory        int64         = 128
 	containerDialTimeoutDurationS time.Duration = 300 * time.Second

--- a/sdk/src/beta9/abstractions/mixins.py
+++ b/sdk/src/beta9/abstractions/mixins.py
@@ -118,6 +118,9 @@ class DeployableMixin:
         container_id = create_shell_response.container_id
         ssh_token = create_shell_response.token
 
+        if not proxy_port:
+            proxy_port = 443 if parsed_url.scheme == "https" else 80
+
         with SSHShell(
             host=proxy_host,
             port=proxy_port,

--- a/sdk/src/beta9/abstractions/shell.py
+++ b/sdk/src/beta9/abstractions/shell.py
@@ -40,18 +40,14 @@ def create_socket(
 
 
 def wait_for_ok(sock: socket.socket, max_retries: int = 10, delay: float = 0.25):
-    tries = 0
-    while tries < max_retries:
-        try:
-            data = sock.recv(4096).decode()
+    """
+    Wait until 'OK' is received from a socket.
+    """
+    for _ in range(max_retries):
+        if data := sock.recv(4096).decode():
             if "OK" in data:
                 return
-        except (socket.timeout, socket.error) as e:
-            print(e)
-            break
-
         time.sleep(delay)
-        tries += 1
 
     raise ConnectionError(f"Failed to setup socket after {max_retries} retries")
 

--- a/sdk/src/beta9/abstractions/shell.py
+++ b/sdk/src/beta9/abstractions/shell.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import ssl
 import struct
 import sys
 import time
@@ -14,44 +15,45 @@ if is_local():
     import paramiko
 
 
-def create_connect_tunnel(
-    proxy_host: str, proxy_port: int, path: str, stub_id: str, container_id: str, auth_token: str
+def create_socket(
+    proxy_host: str, proxy_port: int, path: str, container_id: str, auth_token: str
 ) -> socket.socket:
     """
-    1. Connect to the proxy_host:proxy_port over TCP.
-    2. Send an HTTP CONNECT request for the correct path.
-    3. If we get a 200 response, return the socket as a raw tunnel.
+    Create a socket connection to the server and authenticate with the given token.
     """
+    sock = socket.create_connection((proxy_host, proxy_port), timeout=60)
+    if proxy_port == 443:
+        sock = ssl.create_default_context().wrap_socket(sock=sock, server_hostname=proxy_host)
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((proxy_host, proxy_port))
-
-    # Construct the correct CONNECT request path
-    connect_path = f"{path}/{container_id}"
-
-    connect_req = (
-        f"CONNECT {connect_path} HTTP/1.1\r\n"
-        f"Host: {proxy_host}:{proxy_port}\r\n"
-        f"Proxy-Connection: Keep-Alive\r\n"
+    request = (
+        f"GET {path}/{container_id} HTTP/1.1\r\n"
+        f"Host: {proxy_host}\r\n"
         f"Authorization: Bearer {auth_token}\r\n"
-        f"\r\n"
+        "\r\n"
     )
-    s.sendall(connect_req.encode("ascii"))
 
-    response = b""
-    while b"\r\n\r\n" not in response:
-        chunk = s.recv(4096)
-        if not chunk:
+    sock.sendall(request.encode())
+
+    wait_for_ok(sock)
+
+    return sock
+
+
+def wait_for_ok(sock: socket.socket, max_retries: int = 10, delay: float = 0.25):
+    tries = 0
+    while tries < max_retries:
+        try:
+            data = sock.recv(4096).decode()
+            if "OK" in data:
+                return
+        except (socket.timeout, socket.error) as e:
+            print(e)
             break
-        response += chunk
 
-    response_str = response.decode("ascii", errors="replace")
-    if "200 OK" not in response_str:
-        s.close()
-        raise ConnectionError(f"CONNECT failed. Response:\n{response_str}")
+        time.sleep(delay)
+        tries += 1
 
-    # If we reach here, we have a raw TCP tunnel to "container_id"
-    return s
+    raise ConnectionError(f"Failed to setup socket after {max_retries} retries")
 
 
 @dataclass
@@ -73,23 +75,18 @@ class SSHShell:
         self.channel: Optional["paramiko.Channel"] = None
 
         try:
-            self.socket = create_connect_tunnel(
+            self.socket = create_socket(
                 self.host,
                 self.port,
                 self.path,
-                self.stub_id,
                 self.container_id,
                 self.auth_token,
             )
-        except BaseException:
-            terminal.error("Failed to establish ssh tunnel")
+        except BaseException as e:
+            return terminal.error(f"Failed to establish ssh tunnel: {e}")
 
-        self.transport = paramiko.Transport(
-            self.socket
-        )  # Initialize a transport with the tunnel socket
-
-        self.transport.start_client()
-        self.transport.auth_password(self.username, self.password)
+        self.transport = paramiko.Transport(self.socket)
+        self.transport.connect(username=self.username, password=self.password)
         self.channel = self.transport.open_session()
 
         # Get terminal size - https://stackoverflow.com/a/943921


### PR DESCRIPTION
- Use GET over CONNECT since CONNECT is a tunnel
- Use newer paramiko method to authenticate with
- Add https support to endpoint
- Set keepalive and remove any deadlines on proxied shell connnections
- Notify SDK when to proceed with establishing Paramiko SSH connection after connection to container has been established
- Syntax updates to runner dockerfile
- Use plain console logs when building images for runners

Resolve BE-2267