### PR TITLE
Fix: Upgrade to Cuda 12.4, use defaults for missing env vars, include more libs

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -94,7 +94,7 @@ RUN go build -o /usr/local/bin/worker ./cmd/worker/main.go
 
 # final image
 # ========================
-FROM nvidia/cuda:12.3.1-base-ubuntu22.04 AS release
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04 AS release
 FROM release AS dev
 
 FROM ${BASE_STAGE} AS final
@@ -108,6 +108,8 @@ RUN apt-get update && \
     curl -fsSL https://nvidia.github.io/nvidia-container-runtime/ubuntu22.04/nvidia-container-runtime.list | tee /etc/apt/sources.list.d/nvidia-container-runtime.list && \
     apt-get update && \
     apt-get install psmisc
+
+RUN apt-get install -y cuda-nvcc-12-4 libnvidia-compute-550 libnvidia-encode-550 libnvidia-decode-550 libnvidia-extra-550 nvidia-utils-550
 
 RUN curl -L https://beam-runner-python-deps.s3.amazonaws.com/juicefs -o /usr/local/bin/juicefs && chmod +x /usr/local/bin/juicefs
 RUN curl -fsSL https://tailscale.com/install.sh | sh

--- a/pkg/worker/nvidia.go
+++ b/pkg/worker/nvidia.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	defaultContainerCudaVersion string   = "12.3"
+	defaultContainerCudaVersion string   = "12.4"
 	defaultContainerPath        []string = []string{"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"}
 	defaultContainerLibrary     []string = []string{"/usr/lib/x86_64-linux-gnu", "/usr/lib/worker/x86_64-linux-gnu", "/usr/local/nvidia/lib64"}
 )
@@ -205,15 +205,15 @@ func minor(dev uint64) uint64 {
 
 func (c *ContainerNvidiaManager) InjectEnvVars(env []string, options *ContainerOptions) ([]string, bool) {
 	existingCudaFound := false
-	cudaEnvVarNames := []string{
-		"NVIDIA_DRIVER_CAPABILITIES",
-		"NVIDIA_REQUIRE_CUDA",
-		"NVARCH",
-		"NV_CUDA_COMPAT_PACKAGE",
-		"NV_CUDA_CUDART_VERSION",
-		"CUDA_VERSION",
-		"GPU_TYPE",
-		"CUDA_HOME",
+	cudaEnvVarDefaults := map[string]string{
+		"NVIDIA_DRIVER_CAPABILITIES": "all",
+		"NVIDIA_REQUIRE_CUDA":        "",
+		"NVARCH":                     "",
+		"NV_CUDA_COMPAT_PACKAGE":     "",
+		"NV_CUDA_CUDART_VERSION":     "",
+		"CUDA_VERSION":               "",
+		"GPU_TYPE":                   "",
+		"CUDA_HOME":                  "/usr/local/cuda-12.4",
 	}
 
 	initialEnvVars := make(map[string]string)
@@ -251,7 +251,7 @@ func (c *ContainerNvidiaManager) InjectEnvVars(env []string, options *ContainerO
 	}
 
 	var cudaEnvVars []string
-	for _, key := range cudaEnvVarNames {
+	for key, defaultValue := range cudaEnvVarDefaults {
 		cudaEnvVarValue := os.Getenv(key)
 
 		if existingCudaFound {
@@ -260,6 +260,10 @@ func (c *ContainerNvidiaManager) InjectEnvVars(env []string, options *ContainerO
 			} else {
 				continue
 			}
+		}
+
+		if cudaEnvVarValue == "" {
+			cudaEnvVarValue = defaultValue
 		}
 
 		cudaEnvVars = append(cudaEnvVars, fmt.Sprintf("%s=%s", key, cudaEnvVarValue))

--- a/pkg/worker/nvidia.go
+++ b/pkg/worker/nvidia.go
@@ -213,7 +213,7 @@ func (c *ContainerNvidiaManager) InjectEnvVars(env []string, options *ContainerO
 		"NV_CUDA_CUDART_VERSION":     "",
 		"CUDA_VERSION":               "",
 		"GPU_TYPE":                   "",
-		"CUDA_HOME":                  "/usr/local/cuda-12.4",
+		"CUDA_HOME":                  fmt.Sprintf("/usr/local/cuda-%s", defaultContainerCudaVersion),
 	}
 
 	initialEnvVars := make(map[string]string)

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"syscall"
 	"testing"
 
@@ -65,6 +66,11 @@ func TestInjectNvidiaEnvVarsNoCudaInImage(t *testing.T) {
 			Process: &specs.Process{},
 		},
 	})
+
+	// Sort both slices before comparison
+	sort.Strings(expectedEnv)
+	sort.Strings(resultEnv)
+
 	if !reflect.DeepEqual(expectedEnv, resultEnv) {
 		t.Errorf("Expected %v, got %v", expectedEnv, resultEnv)
 	}

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -44,7 +44,7 @@ func TestInjectNvidiaEnvVarsNoCudaInImage(t *testing.T) {
 	// Set some environment variables to simulate NVIDIA settings
 	os.Setenv("NVIDIA_DRIVER_CAPABILITIES", "all")
 	os.Setenv("NVIDIA_REQUIRE_CUDA", "cuda>=9.0")
-	os.Setenv("CUDA_HOME", "/usr/local/cuda-12.3")
+	os.Setenv("CUDA_HOME", "/usr/local/cuda-12.4")
 
 	expectedEnv := []string{
 		"INITIAL=1",
@@ -55,9 +55,9 @@ func TestInjectNvidiaEnvVarsNoCudaInImage(t *testing.T) {
 		"NV_CUDA_CUDART_VERSION=",
 		"CUDA_VERSION=",
 		"GPU_TYPE=",
-		"CUDA_HOME=/usr/local/cuda-12.3",
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/cuda-12.3/bin:$PATH",
-		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-12.3/targets/x86_64-linux/lib:$LD_LIBRARY_PATH",
+		"CUDA_HOME=/usr/local/cuda-12.4",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/cuda-12.4/bin:$PATH",
+		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-12.4/targets/x86_64-linux/lib:$LD_LIBRARY_PATH",
 	}
 
 	resultEnv, _ := manager.InjectEnvVars(initialEnv, &ContainerOptions{
@@ -77,7 +77,7 @@ func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
 	// Set some environment variables to simulate NVIDIA settings
 	os.Setenv("NVIDIA_DRIVER_CAPABILITIES", "all")
 	os.Setenv("NVIDIA_REQUIRE_CUDA", "cuda>=9.0")
-	os.Setenv("CUDA_VERSION", "12.3")
+	os.Setenv("CUDA_VERSION", "12.4")
 
 	expectedEnv := []string{
 		"INITIAL=1",

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -99,6 +99,9 @@ func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
 		},
 	})
 
+	sort.Strings(expectedEnv)
+	sort.Strings(resultEnv)
+
 	assert.Equal(t, expectedEnv, resultEnv)
 }
 

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/tj/assert"
 )
 
 type GPUInfoClientForTest struct {
@@ -82,8 +82,8 @@ func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
 	expectedEnv := []string{
 		"INITIAL=1",
 		"NVIDIA_REQUIRE_CUDA=",
-		"CUDA_VERSION=11.8.2",
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/cuda-11.8/bin:$PATH",
+		"CUDA_VERSION=12.4.1",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/cuda-12.4/bin:$PATH",
 		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-11.8/targets/x86_64-linux/lib:$LD_LIBRARY_PATH",
 	}
 
@@ -93,15 +93,7 @@ func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
 		},
 	})
 
-	expectedEnvStr := strings.Join(expectedEnv, "")
-	resultEnvStr := strings.Join(resultEnv, "")
-
-	expectedEnvStr = strings.ReplaceAll(expectedEnvStr, " ", "")
-	resultEnvStr = strings.ReplaceAll(resultEnvStr, " ", "")
-
-	if expectedEnvStr != resultEnvStr {
-		t.Errorf("Expected %v, got %v", expectedEnv, resultEnv)
-	}
+	assert.Equal(t, expectedEnv, resultEnv)
 }
 
 func TestInjectNvidiaMounts(t *testing.T) {

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -84,12 +84,12 @@ func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
 		"NVIDIA_REQUIRE_CUDA=",
 		"CUDA_VERSION=12.4.1",
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/cuda-12.4/bin:$PATH",
-		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-11.8/targets/x86_64-linux/lib:$LD_LIBRARY_PATH",
+		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-12.4/targets/x86_64-linux/lib:$LD_LIBRARY_PATH",
 	}
 
 	resultEnv, _ := manager.InjectEnvVars(initialEnv, &ContainerOptions{
 		InitialSpec: &specs.Spec{
-			Process: &specs.Process{Env: []string{"NVIDIA_REQUIRE_CUDA=", "CUDA_VERSION=11.8.2"}},
+			Process: &specs.Process{Env: []string{"NVIDIA_REQUIRE_CUDA=", "CUDA_VERSION=12.4.1"}},
 		},
 	})
 


### PR DESCRIPTION
Resolve BE-2270

This PR does three things 

1. It upgrades the worker to CUDA 12.4.
2. If CUDA_HOME is not set or provided anywhere, use a default location for CUDA 12.4
3. Install encode, decode, nvcc, compute, utils, etc in worker. This all ends up available through mounts so runner size/cold start will not be impacted. 

WARNING: Do not release until A10G cuda version/driver is updated