### PR TITLE
feat: allow draining multiple workers in one go

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.158"
+version = "0.1.159"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [


### PR DESCRIPTION
- `worker drain` can accept multiple worker ids
- `worker drain` can accept from stdin with `-`
- Remove `worker drain` confirmation

Resolve BE-2275