### PR TITLE
feat: allow cordon/uncordon multiple workers in one go

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.159"
+version = "0.1.160"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/cli/worker.py
+++ b/sdk/src/beta9/cli/worker.py
@@ -178,10 +178,10 @@ def uncordon_worker(service: ServiceClient, worker_id: str):
 
         # Drain multiple workers
         {cli_name} worker drain 675a65c3 9c1b7bae 4c89436cs
-        \b
 
-        # Drain workers from stdin (useful for piping), and force the operation
-        {cli_name} worker list --format=json | jq -r '.[].id' | beta9 worker drain -
+        # Drain workers from stdin (useful for piping)
+        {cli_name} worker list --format=json | jq -r '.[].id' | {cli_name} worker drain -
+        \b
     """,
 )
 @click.argument(

--- a/sdk/src/beta9/cli/worker.py
+++ b/sdk/src/beta9/cli/worker.py
@@ -157,22 +157,37 @@ def cordon_worker(service: ServiceClient, worker_ids: List[str]):
     epilog="""
       Examples:
 
+        # Uncordon a worker
         {cli_name} worker uncordon 675a65c3
+
+        # Uncordon multiple workers
+        {cli_name} worker uncordon 675a65c3 9c1b7bae 4c89436cs
+
+        # Uncordon workers from stdin (useful for piping)
+        {cli_name} worker list --format=json | jq -r '.[] | select(.status=="disabled") | .id' | {cli_name} worker uncordon -
         \b
     """,
 )
 @click.argument(
-    "worker_id",
-    nargs=1,
+    "worker_ids",
+    nargs=-1,
     required=True,
 )
 @extraclick.pass_service_client
-def uncordon_worker(service: ServiceClient, worker_id: str):
-    res = service.gateway.uncordon_worker(UncordonWorkerRequest(worker_id=worker_id))
-    if not res.ok:
-        return terminal.error(f"Failed to uncordon worker: {res.err_msg}")
+def uncordon_worker(service: ServiceClient, worker_ids: List[str]):
+    if worker_ids and worker_ids[0] == "-":
+        worker_ids = click.get_text_stream("stdin").read().strip().split()
 
-    terminal.success(f"Worker {worker_id} has been uncordoned.")
+    if not worker_ids:
+        return terminal.error("Must provide at least one worker ID.")
+
+    for worker_id in worker_ids:
+        res = service.gateway.uncordon_worker(UncordonWorkerRequest(worker_id=worker_id))
+        if not res.ok:
+            text = res.err_msg.capitalize()
+            terminal.warn(text)
+        else:
+            terminal.success(f"Worker {worker_id} has been uncordon.")
 
 
 @management.command(


### PR DESCRIPTION
- `worker cordon/uncordon` can accept multiple worker ids
- `worker cordon/uncordon` can accept from stdin with `-`
- Fix `worker drain` docs

Resolve BE-2275