### PR TITLE
fix: image build error messaging

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -495,9 +495,6 @@ func (b *Builder) handleCustomBaseImage(opts *BuildOpts, outputChan chan common.
 	}
 
 	opts.addPythonRequirements()
-	if outputChan != nil {
-		outputChan <- common.OutputMsg{Done: false, Success: false, Msg: "Custom base image is valid.\n"}
-	}
 	return nil
 }
 

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 )
 
@@ -55,10 +56,10 @@ const (
 
 var WorkerContainerExitCodes = map[int]string{
 	WorkerContainerExitCodeSuccess:            "Success",
-	WorkerContainerExitCodeUnknownError:       "UnknownError",
-	WorkerContainerExitCodeIncorrectImageArch: "InvalidArch: Image is not amd64/x86_64",
-	WorkerContainerExitCodeInvalidCustomImage: "InvalidCustomImage: Could not find custom image",
-	WorkerContainerExitCodeIncorrectImageOs:   "InvalidOs: Image is not built for linux",
+	WorkerContainerExitCodeUnknownError:       "UnknownError: An unknown error occurred.",
+	WorkerContainerExitCodeIncorrectImageArch: "InvalidArch: Image must be built for the " + runtime.GOARCH + " architecture.",
+	WorkerContainerExitCodeInvalidCustomImage: "InvalidCustomImage: Custom image not found. Check your image reference and registry credentials.",
+	WorkerContainerExitCodeIncorrectImageOs:   "InvalidOS: Image must be built for Linux.",
 }
 
 const (

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.161"
+version = "0.1.162"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -394,7 +394,7 @@ class RunnerAbstraction(BaseAbstraction):
                 self.image_available = True
                 self.image_id = image_build_result.image_id
             else:
-                terminal.error("Image build failed", exit=False)
+                terminal.error("Image build failed ❌", exit=False)
                 return False
 
         if not self.files_synced:

--- a/sdk/src/beta9/abstractions/experimental/bot/bot.py
+++ b/sdk/src/beta9/abstractions/experimental/bot/bot.py
@@ -160,9 +160,7 @@ class BotTransition:
 
         self.config["image_id"] = self.image_id
 
-    def _build_image_for_transition(
-        self,
-    ) -> bool:
+    def _build_image_for_transition(self) -> Optional[bool]:
         if not self.image_available:
             terminal.detail(f"Building image for transition: {self.image}")
 

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -80,7 +80,7 @@ ImageCredentials = Union[
     DockerHubCredentials,
     GCPCredentials,
     NGCCredentials,
-    ImageCredentialKeys,
+    List[ImageCredentialKeys],
 ]
 
 
@@ -440,7 +440,7 @@ class Image(BaseAbstraction):
                     gpu=self.gpu,
                 )
             ):
-                if r.msg != "":
+                if r.msg != "" and not r.done:
                     terminal.detail(r.msg, end="")
 
                 if r.done:
@@ -448,7 +448,7 @@ class Image(BaseAbstraction):
                     break
 
         if not last_response.success:
-            terminal.error(f"Build failed: {last_response.msg} ❌")
+            terminal.error(str(last_response.msg).rstrip(), exit=False)
             return ImageBuildResult(success=False)
 
         terminal.header("Build complete 🎉")


### PR DESCRIPTION
- Remove "is valid" message since we already print an error if the build options fail
- More descriptive container exit code errors
- Improve build image error rendering
- Print image build error message once
- Fix some type hinting

Resolve BE-2219