### PR TITLE
Fix: When build context is cancelled subsequent spawns should stop

### DIFF
--- a/pkg/common/events.go
+++ b/pkg/common/events.go
@@ -49,10 +49,6 @@ const (
 	EventTypeReloadInstance EventType = "RELOAD_INSTANCE"
 )
 
-func StopBuildEventType(containerId string) EventType {
-	return EventType("stop-build-" + containerId)
-}
-
 // Send an event over the bus
 func (eb *EventBus) Send(event *Event) (string, error) {
 	serializedEvent, err := eb.serialize(event)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -139,7 +139,7 @@ func (s *Scheduler) getConcurrencyLimit(request *types.ContainerRequest) (*types
 }
 
 func (s *Scheduler) Stop(stopArgs *types.StopContainerArgs) error {
-	log.Info().Interface("stop_args", stopArgs).Msg("received stop request")
+	log.Info().Interface("stop_args", stopArgs).Msg("scheduler received stop request")
 
 	err := s.containerRepo.UpdateContainerStatus(stopArgs.ContainerId, types.ContainerStatusStopping, types.ContainerStateTtlSWhilePending)
 	if err != nil {

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -238,7 +238,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 		return ctx.Err()
 	default:
 		// Start the container
-		go s.spawn(request, spec, outputLogger, opts)
+		go s.spawn(ctx, request, spec, outputLogger, opts)
 	}
 
 	log.Info().Str("container_id", containerId).Msg("spawned successfully")
@@ -445,8 +445,8 @@ func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, option
 }
 
 // spawn a container using runc binary
-func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, outputLogger *slog.Logger, opts *ContainerOptions) {
-	ctx, cancel := context.WithCancel(s.ctx)
+func (s *Worker) spawn(ctx context.Context, request *types.ContainerRequest, spec *specs.Spec, outputLogger *slog.Logger, opts *ContainerOptions) {
+	ctx, cancel := context.WithCancel(ctx)
 
 	s.workerRepo.AddContainerToWorker(s.workerId, request.ContainerId)
 	defer s.workerRepo.RemoveContainerFromWorker(s.workerId, request.ContainerId)
@@ -577,7 +577,7 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 	}
 
 	// Invoke runc process (launch the container)
-	_, err = s.runcHandle.Run(s.ctx, containerId, opts.BundlePath, &runc.CreateOpts{
+	_, err = s.runcHandle.Run(ctx, containerId, opts.BundlePath, &runc.CreateOpts{
 		Detach:        true,
 		ConsoleSocket: consoleWriter,
 		ConfigPath:    configPath,


### PR DESCRIPTION
There is an edge case in which the build is cancelled between the container setup completing and the container starting. In this case, since the setup is complete, the context cancellation currently has no effect. The container will launch, but the build on the gateway side is terminated, so it will hang. 

To fix this, we should start the container with the context that can be canceled. It is derived from the worker's context, so it will still be cancelled if the worker is being drained. Since it uses the cancelable RunContainer context it will be stopped on a stop build event. 
<img width="1255" alt="Screenshot 2025-01-29 at 13 15 31" src="https://github.com/user-attachments/assets/51688b05-50dd-4edd-a5bc-3d1d9e276611" />
