### PR TITLE
Fix: Cleaner handling when cancelling a function during build stage

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.166"
+version = "0.1.167"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -151,17 +151,20 @@ class _CallableWrapper(DeployableMixin):
         if not is_local():
             return self.local(*args, **kwargs)
 
-        if not self.parent.prepare_runtime(
-            func=self.func,
-            stub_type=self.base_stub_type,
-        ):
-            return
+        try:
+            if not self.parent.prepare_runtime(
+                func=self.func,
+                stub_type=self.base_stub_type,
+            ):
+                return
+        except KeyboardInterrupt:
+            terminal.error("Exiting shell. Your build was stopped.")
 
         try:
             with terminal.progress("Working..."):
                 return self._call_remote(*args, **kwargs)
         except KeyboardInterrupt:
-            terminal.error("Exiting Shell. Your function will continue running remotely.")
+            terminal.error("Exiting shell. Your function will continue running remotely.")
 
     @with_grpc_error_handling
     def _call_remote(self, *args, **kwargs) -> Any:


### PR DESCRIPTION
Right now its not handled at all.

```bash
~/Dev/beta9/t/custom-image main M:1 ❯ python app.py                                                           ✘ INT 2m 17s   beta9-py3.12   system minzi@nobara
=> Building image 
Using custom base image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
Exiting shell, stopped build.
```