### PR TITLE
Fix: prevent stream exit from messing with function runs

### DIFF
--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -61,7 +61,7 @@ class Channel(InterceptorChannel):
         if options is None:
             options = []
 
-        # options.extend(CHANNEL_OPTIONS)  # add gRPC keepalive options
+        options.extend(CHANNEL_OPTIONS)  # add gRPC keepalive options
 
         if credentials is not None:
             channel = grpc.secure_channel(addr, credentials)

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -36,16 +36,6 @@ def channel_reconnect_event(connect_status: grpc.ChannelConnectivity) -> None:
         terminal.warn("Connection lost, reconnecting...")
 
 
-CHANNEL_OPTIONS = [
-    ("grpc.keepalive_time_ms", 10000),  # send keepalive ping every 10 seconds
-    (
-        "grpc.keepalive_timeout_ms",
-        5000,
-    ),  # wait 5 seconds for ping ack before considering the connection dead
-    ("grpc.keepalive_permit_without_calls", 1),  # allow pings when there are no calls
-]
-
-
 class Channel(InterceptorChannel):
     def __init__(
         self,
@@ -60,8 +50,6 @@ class Channel(InterceptorChannel):
     ):
         if options is None:
             options = []
-
-        options.extend(CHANNEL_OPTIONS)  # add gRPC keepalive options
 
         if credentials is not None:
             channel = grpc.secure_channel(addr, credentials)

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -61,7 +61,7 @@ class Channel(InterceptorChannel):
         if options is None:
             options = []
 
-        options.extend(CHANNEL_OPTIONS)  # add gRPC keepalive options
+        # options.extend(CHANNEL_OPTIONS)  # add gRPC keepalive options
 
         if credentials is not None:
             channel = grpc.secure_channel(addr, credentials)

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -36,6 +36,16 @@ def channel_reconnect_event(connect_status: grpc.ChannelConnectivity) -> None:
         terminal.warn("Connection lost, reconnecting...")
 
 
+CHANNEL_OPTIONS = [
+    ("grpc.keepalive_time_ms", 10000),  # send keepalive ping every 10 seconds
+    (
+        "grpc.keepalive_timeout_ms",
+        5000,
+    ),  # wait 5 seconds for ping ack before considering the connection dead
+    ("grpc.keepalive_permit_without_calls", 1),  # allow pings when there are no calls
+]
+
+
 class Channel(InterceptorChannel):
     def __init__(
         self,
@@ -50,6 +60,8 @@ class Channel(InterceptorChannel):
     ):
         if options is None:
             options = []
+
+        options.extend(CHANNEL_OPTIONS)  # add gRPC keepalive options
 
         if credentials is not None:
             channel = grpc.secure_channel(addr, credentials)

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -138,6 +138,7 @@ def _monitor_task(
                     os.kill(parent_pid, signal.SIGABRT)
                     return
 
+                print(f"Lost connection to task monitor, retrying... {retry}")
                 time.sleep(backoff)
                 backoff *= 2
                 retry += 1

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -89,6 +89,8 @@ def _monitor_task(
                         container_id=function_context.container_id,
                     )
                 ):
+                    print(f"Received monitor response: {response}")
+
                     response: FunctionMonitorResponse
                     if response.cancelled:
                         print(f"Task cancelled: {function_context.task_id}")

--- a/sdk/src/beta9/runner/function.py
+++ b/sdk/src/beta9/runner/function.py
@@ -148,6 +148,8 @@ def _monitor_task(
                 os.kill(parent_pid, signal.SIGABRT)
                 return
 
+        print("Task monitor stream ended")
+
 
 def _handle_sigterm(*args: Any, **kwargs: Any) -> None:
     os._exit(TaskExitCode.Success)


### PR DESCRIPTION
The issue here is that during a rollout restart, the stream exits with no errors (since the function service context causes the stream to exit). So in those cases, we stop setting heartbearts and create "ghost tasks". The solution is to embed the monitor task into an outer loop, and if we encounter an interruption of the stream without any errors, just restart the monitor_task stream. You can see this reflected in the logs below, after a rollout restart, the loop restarts:

```Response(ok=True)"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:16Z","message":"Received monitor response: FunctionMonitorResponse(ok=True)"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:17Z","message":"Received monitor response: FunctionMonitorResponse(ok=True)"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:18Z","message":"Task monitor stream ended"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:18Z","message":"Monitor stream ended naturally, restarting monitor stream"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:18Z","message":"Received monitor response: FunctionMonitorResponse(ok=True)"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:19Z","message":"Received monitor response: FunctionMonitorResponse(ok=True)"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:20Z","message":"Received monitor response: FunctionMonitorResponse(ok=True)"}
{"level":"info","container_id":"function-d6c67c57-e539-48ed-83bd-3b1d73c72fdd-ca6d2830","task_id":"d6c67c57-e539-48ed-83bd-3b1d73c72fdd","time":"2025-02-02T18:05:21Z","message":"Received monitor response:```