### PR TITLE
fix: revert worker fatal err message

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -39,6 +39,6 @@ func main() {
 			return
 		}
 
-		log.Fatal().Err(err).Msgf("worker failed to run: %v\n", err)
+		log.Fatal().Err(err).Msg("worker failed to run")
 	}
 }


### PR DESCRIPTION
According to the zerolog docs

> Err adds the field "error" with serialized err to the *Event context. If err is nil, no field is added.

So we don't actually need to printf the error. This reverts the change.