### PR TITLE
feat: improve multipart error messages

### DIFF
--- a/pkg/abstractions/volume/multipart.go
+++ b/pkg/abstractions/volume/multipart.go
@@ -3,6 +3,7 @@ package volume
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"path/filepath"
 	"time"
@@ -147,7 +148,7 @@ func (s *GlobalVolumeService) CreateMultipartUpload(ctx context.Context, in *pb.
 	if err != nil {
 		return &pb.CreateMultipartUploadResponse{
 			Ok:     false,
-			ErrMsg: err.Error(),
+			ErrMsg: fmt.Sprintf("Volume '%s' not found\n", in.VolumeName),
 		}, nil
 	}
 
@@ -219,7 +220,7 @@ func (s *GlobalVolumeService) CompleteMultipartUpload(ctx context.Context, in *p
 	if err != nil {
 		return &pb.CompleteMultipartUploadResponse{
 			Ok:     false,
-			ErrMsg: err.Error(),
+			ErrMsg: fmt.Sprintf("Volume '%s' not found\n", in.VolumeName),
 		}, nil
 	}
 
@@ -261,7 +262,7 @@ func (s *GlobalVolumeService) AbortMultipartUpload(ctx context.Context, in *pb.A
 	if err != nil {
 		return &pb.AbortMultipartUploadResponse{
 			Ok:     false,
-			ErrMsg: err.Error(),
+			ErrMsg: fmt.Sprintf("Volume '%s' not found\n", in.VolumeName),
 		}, nil
 	}
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beta9"
-version = "0.1.170"
+version = "0.1.171"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [

--- a/sdk/src/beta9/exceptions.py
+++ b/sdk/src/beta9/exceptions.py
@@ -75,3 +75,17 @@ class GetFileSizeError(RuntimeError):
         self.message = message
         self.status_code = status_code
         super().__init__(f"Unable to get file size: {status_code=} {message=}")
+
+
+class ListPathError(RuntimeError):
+    def __init__(self, path: str, message: str):
+        self.message = message.capitalize() if message else ""
+        self.path = path
+        super().__init__(f"Unable to list path: {path=} {message=}")
+
+
+class StatPathError(RuntimeError):
+    def __init__(self, path: str, message: str):
+        self.message = message.capitalize() if message else ""
+        self.path = path
+        super().__init__(f"Unable to stat path: {path=} {message=}")

--- a/sdk/src/beta9/multipart.py
+++ b/sdk/src/beta9/multipart.py
@@ -54,7 +54,9 @@ from .exceptions import (
     CreatePresignedUrlError,
     DownloadChunkError,
     GetFileSizeError,
+    ListPathError,
     RetryableError,
+    StatPathError,
     UploadPartError,
 )
 from .terminal import CustomProgress
@@ -617,7 +619,7 @@ class Beta9Handler(RemoteHandler):
 
         res = self.service.list_path(ListPathRequest(path=path))
         if not res.ok:
-            raise RuntimeError(f"{remote_path} ({res.err_msg})")
+            raise ListPathError(remote_path.path, res.err_msg)
 
         return [
             RemotePath(remote_path.scheme, remote_path.volume_name, p.path, is_dir=p.is_dir)
@@ -630,7 +632,7 @@ class Beta9Handler(RemoteHandler):
 
         res = self.service.stat_path(StatPathRequest(path=remote_path.path))
         if not res.ok:
-            raise RuntimeError(f"{remote_path} ({res.err_msg})")
+            raise StatPathError(remote_path.path, res.err_msg)
 
         return res.path_info.is_dir if not res.err_msg else False
 


### PR DESCRIPTION
- Return user-friendly error message when volume is not found during creating, completing, or aborting a multipart upload
- List and Stat path errors get their own error classes in order to differentiate between them

Resolve BE-2333