### PR TITLE
fix: juicefs does not exit when the worker is oomkilled

### DIFF
--- a/pkg/common/proc.go
+++ b/pkg/common/proc.go
@@ -1,0 +1,114 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+var (
+	ErrInvalidScore = errors.New("oom score must be between -1000 and 1000")
+)
+
+type PID interface {
+	int | int32 | uint32
+}
+
+func MatchParentOOMScoreAdj[T PID](pid T) error {
+	score, err := GetOOMScoreAdj(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	procs, err := FindProcesses(pid)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, p := range procs {
+		if err := SetOOMScoreAdj(int(p.Pid), score); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func GetOOMScoreAdj[T PID](pid T) (int, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid pid: %d", pid)
+	}
+
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read oom_score_adj: %v", err)
+	}
+
+	score, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse oom_score_adj: %v", err)
+	}
+
+	return score, nil
+}
+
+func SetOOMScoreAdj(pid, score int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid pid: %d", pid)
+	}
+	if score < -1000 || score > 1000 {
+		return ErrInvalidScore
+	}
+
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	if err := os.WriteFile(path, []byte(strconv.Itoa(score)), 0644); err != nil {
+		return fmt.Errorf("failed to set oom_score_adj: %v", err)
+	}
+
+	return nil
+}
+
+func FindProcesses[T PID](pid T) ([]*process.Process, error) {
+	processes, err := process.Processes()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range processes {
+		if p.Pid == int32(pid) {
+			return append(FindChildProcesses(p), p), nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find processes for pid %v", pid)
+}
+
+func FindChildProcesses(p *process.Process) []*process.Process {
+	children, err := p.Children()
+	if err != nil {
+		// An error will occur when there are no children (pgrep -P <pid>)
+		return nil
+	}
+
+	processes := []*process.Process{}
+	processes = append(processes, children...)
+
+	for _, child := range children {
+		grandChildren := FindChildProcesses(child)
+		if grandChildren == nil {
+			continue
+		}
+		processes = append(processes, grandChildren...)
+	}
+
+	return processes
+}

--- a/pkg/storage/juicefs.go
+++ b/pkg/storage/juicefs.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/cenkalti/backoff"
 	"github.com/rs/zerolog/log"
@@ -44,7 +45,6 @@ func (s *JuiceFsStorage) Mount(localPath string) error {
 		"mount",
 		s.config.RedisURI,
 		localPath,
-		"-d",
 		"--bucket", s.config.AWSS3Bucket,
 		"--cache-size", cacheSize,
 		"--prefetch", prefetch,
@@ -52,7 +52,7 @@ func (s *JuiceFsStorage) Mount(localPath string) error {
 		"--no-usage-report",
 	)
 
-	// Start the mount command in the background
+	// Start and run the mount command in the background
 	go func() {
 		output, err := s.mountCmd.CombinedOutput()
 		if err != nil {
@@ -82,6 +82,11 @@ func (s *JuiceFsStorage) Mount(localPath string) error {
 	// Wait for confirmation or timeout
 	if !<-done {
 		return fmt.Errorf("failed to mount JuiceFS filesystem to: '%s'", localPath)
+	}
+
+	// Set the OOM score adjustment to the same as the parent process
+	if err := common.MatchParentOOMScoreAdj(s.mountCmd.Process.Pid); err != nil {
+		log.Error().Err(err).Int("pid", s.mountCmd.Process.Pid).Msg("failed to match parent oom_score_adj")
 	}
 
 	log.Info().Str("local_path", localPath).Msg("juicefs filesystem mounted")


### PR DESCRIPTION
When resource limits/requests are configured, the worker gets a oom_score_adj of -997 (or not -1000), but all juicefs processes get -1000 which means they are not oom-killable. 

This is mentioned in the [oom_score_adj](https://man7.org/linux/man-pages/man5/proc_pid_oom_score_adj.5.html) man page. 

> The value of oom_score_adj is added to the badness score
> before it is used to determine which task to kill.
> Acceptable values range from -1000 (OOM_SCORE_ADJ_MIN) to
> +1000 (OOM_SCORE_ADJ_MAX).  This allows user space to
> control the preference for OOM-killing, ranging from always
> preferring a certain task or completely disabling it from
> OOM-killing.  The lowest possible value, -1000, is
> equivalent to disabling OOM-killing entirely for that task,
> since it will always report a badness score of 0.

Changes to fix this:

- Match parent's oom_score_adj for all juicefs processes. This value is dynamically adjusted based on a pod's QoS which is based on resources limits/requests. This ensures juicefs gets the same oom_score_adj as the worker.
- Don't use daemon mode for juicefs because it immediately creates a defunct process since it's started in a goroutine anyway

Resolve BE-2334