### PR TITLE
Fix: Receive up to 16mb payloads for taskqueue

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -39,8 +39,8 @@ gateway:
     externalPort: 1993
     tls: false
     port: 1993
-    maxRecvMsgSize: 1024
-    maxSendMsgSize: 1024
+    maxRecvMsgSize: 16
+    maxSendMsgSize: 16
   http:
     externalHost: localhost
     externalPort: 1994

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -25,6 +25,8 @@ from .config import (
 from .env import is_remote
 from .exceptions import RunnerException
 
+GRPC_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+
 
 def channel_reconnect_event(connect_status: grpc.ChannelConnectivity) -> None:
     if connect_status not in (
@@ -50,8 +52,8 @@ class Channel(InterceptorChannel):
     ):
         if options is None:
             options = [
-                ("grpc.max_receive_message_length", 1024 * 1024 * 1024),
-                ("grpc.max_send_message_length", 1024 * 1024 * 1024),
+                ("grpc.max_receive_message_length", GRPC_MAX_MESSAGE_SIZE),
+                ("grpc.max_send_message_length", GRPC_MAX_MESSAGE_SIZE),
             ]
 
         if credentials is not None:

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -49,14 +49,17 @@ class Channel(InterceptorChannel):
         ),
     ):
         if options is None:
-            options = []
+            options = [
+                ("grpc.max_receive_message_length", 1024 * 1024 * 1024),
+                ("grpc.max_send_message_length", 1024 * 1024 * 1024),
+            ]
 
         if credentials is not None:
-            channel = grpc.secure_channel(addr, credentials)
+            channel = grpc.secure_channel(addr, credentials, options=options)
         elif addr.endswith("443"):
-            channel = grpc.secure_channel(addr, grpc.ssl_channel_credentials())
+            channel = grpc.secure_channel(addr, grpc.ssl_channel_credentials(), options=options)
         else:
-            channel = grpc.insecure_channel(addr)
+            channel = grpc.insecure_channel(addr, options=options)
 
         # NOTE: we observed that in a multiprocessing context, this
         # retry mechanism did not work as expected. We're not sure why,

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -183,8 +183,8 @@ class TaskQueueWorker:
                 args=task["args"],
                 kwargs=task["kwargs"],
             )
-        except (grpc.RpcError, OSError) as e:
-            print("Failed to retrieve task due to unexpected error", e)
+        except (grpc.RpcError, OSError):
+            print("Failed to retrieve task due to unexpected error", traceback.format_exc())
             return None
 
     def _monitor_task(

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -184,7 +184,7 @@ class TaskQueueWorker:
                 kwargs=task["kwargs"],
             )
         except (grpc.RpcError, OSError) as e:
-            print("Failed to pop task", e)
+            print("Failed to retrieve task due to unexpected error", e)
             return None
 
     def _monitor_task(

--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -183,7 +183,8 @@ class TaskQueueWorker:
                 args=task["args"],
                 kwargs=task["kwargs"],
             )
-        except (grpc.RpcError, OSError):
+        except (grpc.RpcError, OSError) as e:
+            print("Failed to pop task", e)
             return None
 
     def _monitor_task(


### PR DESCRIPTION
Previously this would fail:
```python
from beta9 import task_queue


@task_queue(
    cpu=1.0,
    memory=128,
    name="big-payload",
)
def big_payload(input):
    print("hello!")
    # result = inputs["x"] * 2
    # print the first 100 characters of the string
    print(input["x"][:100])
    return {"result": "ok"}


if __name__ == "__main__":
    print("starting...")
    # create 10mb string
    data = "a" * 10 * 1024 * 1024
    big_payload.put({"x": data})
```

With this change it wont