### PR TITLE
feat: Install streaming support + enable metrics for Cedana

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -120,7 +120,7 @@ RUN mkdir -p /etc/containers/registries.conf.d
 RUN curl -L https://raw.githubusercontent.com/containers/shortnames/refs/heads/main/shortnames.conf \
     -o /etc/containers/registries.conf.d/shortnames.conf
 
-ARG CEDANA_VERSION=0.9.238-pre
+ARG CEDANA_VERSION=0.9.239
 ARG CEDANA_BASE_URL=""
 ARG CEDANA_TOKEN=""
 RUN <<EOT
@@ -131,7 +131,7 @@ if [ "$(uname -m)" = "x86_64" ] && [ ! -z "${CEDANA_BASE_URL}" ] && [ ! -z "${CE
     tar -xzf cedana.tar.gz cedana
     mv cedana /usr/local/bin/cedana
     rm cedana.tar.gz
-    CEDANA_URL=${CEDANA_BASE_URL} CEDANA_AUTH_TOKEN=${CEDANA_TOKEN} cedana plugin install criu runc gpu
+    CEDANA_URL=${CEDANA_BASE_URL} CEDANA_AUTH_TOKEN=${CEDANA_TOKEN} cedana plugin install criu runc gpu streamer
 fi
 EOT
 

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -217,6 +217,9 @@ worker:
       db:
         # Use remote DB on the cedana endpoint
         remote: true
+      metrics:
+        # Let cedana collect C/R metrics for improvements
+        otel: true
       profiling:
         # Receive profiling info in the gRPC trailer
         enabled: false


### PR DESCRIPTION
Install the `streamer` plugin, which is ready to use for streaming to/from checkpoints with low overhead.

Also enables metrics, that allows the daemon to send metrics to the specified Cedana endpoint (e.g. beam.cedana.ai). This helps us make improvements, by monitoring failures, and performance.