### PR TITLE
Feat: Transition to CDI for adding GPUs to containers

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -36,7 +36,7 @@ RUN apt-get install -y libseccomp-dev
 
 RUN <<EOT
 set -eux
-git clone https://github.com/beam-cloud/runc.git .
+git clone --branch v1.2.4 --depth 1 https://github.com/opencontainers/runc.git .
 make
 make install
 /usr/local/sbin/runc --version
@@ -124,10 +124,27 @@ RUN curl -L https://raw.githubusercontent.com/containers/shortnames/refs/heads/m
 RUN <<EOT
 set -eux
 if [ "$(uname -m)" = "x86_64" ]; then
-    apt-get install -y python3-protobuf libnet1 libnftables1 libnl-3-200 libprotobuf-c1 iptables
-    curl -L -o criu.deb https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_22.04/amd64/criu_4.0-3_amd64.deb
-    dpkg -i criu.deb
-    rm criu.deb
+    apt-get update && apt-get install -y \
+        python3-protobuf \
+        libbsd-dev \
+        libdrm-dev \
+        libnet1-dev \
+        libnl-3-dev \
+        libcap-dev \
+        uuid-dev \
+        gnutls-dev \
+        libnftables-dev \
+        pkg-config \
+        protobuf-c-compiler \
+        protobuf-compiler \
+        libprotobuf-c-dev \
+        git
+    git clone https://github.com/checkpoint-restore/criu.git
+    cd criu
+    make install-lib install-criu install-compel install-amdgpu_plugin install-cuda_plugin PREFIX=/usr SKIP_PIP_INSTALL=1
+    criu --version
+    stat /usr/lib/criu/cuda_plugin.so 
+    cd .. && rm -rf criu
 fi
 EOT
 

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,9 @@ require (
 )
 
 require (
+	github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc // indirect
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
+	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 	buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241203191352-2167379de17d.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210312213058-32f4d319f0d2 // indirect
@@ -272,4 +275,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	tags.cncf.io/container-device-interface v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -468,6 +468,8 @@ github.com/opencontainers/runc v1.1.14/go.mod h1:E4C2z+7BxR7GHXp0hAY53mek+x49X1L
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:d2hUh5O6MRBvStV55MQ8we08t42zSTqBbscoQccWmMc=
+github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
 github.com/opencontainers/umoci v0.4.7 h1:mbIbtMpZ3v9oMpKaLopnWoLykgmnixeLzq51EzAX5nQ=
 github.com/opencontainers/umoci v0.4.7/go.mod h1:lgJ4bnwJezsN1o/5d7t/xdRPvmf8TvBko5kKYJsYvgo=
 github.com/openmeterio/openmeter v1.0.0-beta.47 h1:tZR4QiKLiJMAhPUsA/FXrskYF65wQ/23QNbxeFzWRA0=
@@ -559,6 +561,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tailscale/certstore v0.1.1-0.20231202035212-d3fa0460f47e h1:PtWT87weP5LWHEY//SWsYkSO3RWRZo4OSWagh3YD2vQ=
 github.com/tailscale/certstore v0.1.1-0.20231202035212-d3fa0460f47e/go.mod h1:XrBNfAFN+pwoWuksbFS9Ccxnopa15zJGgXRFN90l3K4=
 github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55 h1:Gzfnfk2TWrk8Jj4P4c1a3CtQyMaTVCznlkLZI++hok4=
@@ -860,5 +864,9 @@ sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+tags.cncf.io/container-device-interface v0.8.0 h1:8bCFo/g9WODjWx3m6EYl3GfUG31eKJbaggyBDxEldRc=
+tags.cncf.io/container-device-interface v0.8.0/go.mod h1:Apb7N4VdILW0EVdEMRYXIDVRZfNJZ+kmEUss2kRRQ6Y=
+tags.cncf.io/container-device-interface/specs-go v0.8.0 h1:QYGFzGxvYK/ZLMrjhvY0RjpUavIn4KcmRmVP/JjdBTA=
+tags.cncf.io/container-device-interface/specs-go v0.8.0/go.mod h1:BhJIkjjPh4qpys+qm4DAYtUyryaTDg9zris+AczXyws=
 tailscale.com v1.72.1 h1:hk82jek36ph2S3Tfsh57NVWKEm/pZ9nfUonvlowpfaA=
 tailscale.com v1.72.1/go.mod h1:v7OHtg0KLAnhOVf81Z8WrjNefj238QbFhgkWJQoKxbs=

--- a/pkg/worker/base_runc_config.json
+++ b/pkg/worker/base_runc_config.json
@@ -12,8 +12,8 @@
 			"/dev/null"
 		],
 		"env": [
-			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH",
-			"LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:$LD_LIBRARY_PATH",
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu",
 			"TERM=xterm",
 			"LAMBDA_TASK_ROOT=/workspace",
 			"MAMBA_ROOT_PREFIX=/micromamba"
@@ -424,17 +424,7 @@
 			]
 		}
 	],
-	"hooks": {
-		"prestart": [
-			{
-				"path": "/usr/bin/nvidia-container-runtime-hook",
-				"args": [
-					"/usr/bin/nvidia-container-runtime-hook",
-					"-ociconfig"
-				]
-			}
-		]
-	},
+	"hooks": {},
 	"linux": {
 		"resources": {
 			"devices": [

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/storage"
 	types "github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 
 	runc "github.com/beam-cloud/go-runc"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -27,6 +28,7 @@ const (
 	defaultContainerDirectory string        = "/mnt/code"
 	specBaseName              string        = "config.json"
 	initialSpecBaseName       string        = "initial_config.json"
+	nvidiaVendorPrefix        string        = "nvidia.com/gpu"
 	runcEventsInterval        time.Duration = 5 * time.Second
 	containerInnerPort        int           = 8001 // Use a fixed port inside the container
 )
@@ -306,7 +308,6 @@ func (s *Worker) readBundleConfig(imageId string, isBuildRequest bool) (*specs.S
 // Generate a runc spec from a given request
 func (s *Worker) specFromRequest(request *types.ContainerRequest, options *ContainerOptions) (*specs.Spec, error) {
 	os.MkdirAll(filepath.Join(baseConfigPath, request.ContainerId), os.ModePerm)
-	configPath := filepath.Join(baseConfigPath, request.ContainerId, specBaseName)
 
 	spec, err := s.newSpecTemplate()
 	if err != nil {
@@ -325,36 +326,15 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 
 	env := s.getContainerEnvironment(request, options)
 	if request.Gpu != "" {
-		spec.Hooks.Prestart[0].Args = append(spec.Hooks.Prestart[0].Args, configPath, "prestart")
-
-		existingCudaFound := false
-		env, existingCudaFound = s.containerCudaManager.InjectEnvVars(env)
-		if !existingCudaFound {
-			// If the container image does not have cuda libraries installed, mount cuda libs from the host
-			spec.Mounts = s.containerCudaManager.InjectMounts(spec.Mounts)
-		}
-
-		// Assign n-number of GPUs to a container
-		assignedGpus, err := s.containerCudaManager.AssignGPUDevices(request.ContainerId, request.GpuCount)
-		if err != nil {
-			return nil, err
-		}
-		env = append(env, fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", assignedGpus.String()))
-
-		spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, assignedGpus.devices...)
-
-	} else {
-		spec.Hooks.Prestart = nil
+		env = s.containerCudaManager.InjectEnvVars(env)
 	}
+	spec.Process.Env = append(spec.Process.Env, env...)
 
 	// We need to modify the spec to support Cedana C/R if enabled
 	if s.IsCRIUAvailable() && request.CheckpointEnabled {
 		containerHostname := fmt.Sprintf("%s:%d", s.podAddr, options.BindPort)
 		s.cedanaClient.PrepareContainerSpec(spec, request.ContainerId, containerHostname, request.RequiresGPU())
 	}
-
-	spec.Process.Env = append(spec.Process.Env, env...)
-	spec.Root.Readonly = false
 
 	var volumeCacheMap map[string]string = make(map[string]string)
 
@@ -542,6 +522,7 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 	}
 	defer containerInstance.Overlay.Cleanup()
 
+	spec.Root.Readonly = false
 	spec.Root.Path = containerInstance.Overlay.TopLayerPath()
 
 	// Setup container network namespace / devices
@@ -558,15 +539,43 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 		return
 	}
 
+	if request.Gpu != "" {
+		// Assign n-number of GPUs to a container
+		assignedDevices, err := s.containerCudaManager.AssignGPUDevices(request.ContainerId, request.GpuCount)
+		if err != nil {
+			log.Error().Str("container_id", request.ContainerId).Msgf("failed to assign GPUs: %v", err)
+			return
+		}
+
+		cdiCache := cdi.GetDefaultCache()
+
+		var devicesToInject []string
+		for _, device := range assignedDevices {
+			devicePath := fmt.Sprintf("%s=%d", nvidiaVendorPrefix, device)
+			devicesToInject = append(devicesToInject, devicePath)
+		}
+
+		unresolvable, err := cdiCache.InjectDevices(spec, devicesToInject...)
+		if err != nil {
+			log.Error().Str("container_id", request.ContainerId).Msgf("failed to inject devices: %v", err)
+			return
+		}
+		if len(unresolvable) > 0 {
+			log.Error().Str("container_id", request.ContainerId).Msgf("unresolvable devices: %v", unresolvable)
+			return
+		}
+	}
+
 	// Write runc config spec to disk
 	configContents, err := json.MarshalIndent(spec, "", " ")
 	if err != nil {
 		return
 	}
 
-	configPath := filepath.Join(baseConfigPath, containerId, specBaseName)
+	configPath := filepath.Join(spec.Root.Path, specBaseName)
 	err = os.WriteFile(configPath, configContents, 0644)
 	if err != nil {
+		log.Error().Str("container_id", containerId).Msgf("failed to write runc config: %v", err)
 		return
 	}
 
@@ -606,10 +615,10 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 	}
 
 	// Invoke runc process (launch the container)
-	_, err = s.runcHandle.Run(s.ctx, containerId, opts.BundlePath, &runc.CreateOpts{
+	bundlePath := filepath.Dir(configPath)
+	_, err = s.runcHandle.Run(s.ctx, containerId, bundlePath, &runc.CreateOpts{
 		Detach:        true,
 		ConsoleSocket: consoleWriter,
-		ConfigPath:    configPath,
 		Started:       startedChan,
 	})
 	if err != nil {
@@ -623,7 +632,6 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 // Wait for a container to exit and return the exit code
 func (s *Worker) wait(ctx context.Context, containerId string, startedChan chan int, outputLogger *slog.Logger, request *types.ContainerRequest, spec *specs.Spec) int {
 	<-startedChan
-
 	// Clean up runc container state and send final output message
 	cleanup := func(exitCode int, err error) int {
 		log.Info().Str("container_id", containerId).Msgf("container has exited with code: %d", exitCode)

--- a/pkg/worker/nvidia.go
+++ b/pkg/worker/nvidia.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"slices"
 	"strings"
 	"syscall"
@@ -21,10 +22,10 @@ var (
 )
 
 type GPUManager interface {
-	AssignGPUDevices(containerId string, gpuCount uint32) (*AssignedGpuDevices, error)
+	AssignGPUDevices(containerId string, gpuCount uint32) ([]int, error)
 	GetContainerGPUDevices(containerId string) []int
 	UnassignGPUDevices(containerId string)
-	InjectEnvVars(env []string) ([]string, bool)
+	InjectEnvVars(env []string) []string
 	InjectMounts(mounts []specs.Mount) []specs.Mount
 }
 
@@ -37,6 +38,13 @@ type ContainerNvidiaManager struct {
 }
 
 func NewContainerNvidiaManager(gpuCount uint32) GPUManager {
+	if gpuCount > 0 {
+		err := exec.Command("nvidia-ctk", "cdi", "generate", "--output", "/etc/cdi/nvidia.yaml").Run()
+		if err != nil {
+			log.Error().Msgf("failed to generate cdi config: %v", err)
+		}
+	}
+
 	return &ContainerNvidiaManager{
 		gpuAllocationMap: common.NewSafeMap[[]int](),
 		gpuCount:         gpuCount,
@@ -47,79 +55,18 @@ func NewContainerNvidiaManager(gpuCount uint32) GPUManager {
 }
 
 type AssignedGpuDevices struct {
-	devices []specs.LinuxDeviceCgroup
-	visible string // Visible devices (for NVIDIA_VISIBLE_DEVICES env var)
-}
-
-func (d *AssignedGpuDevices) String() string {
-	return d.visible
 }
 
 func (c *ContainerNvidiaManager) UnassignGPUDevices(containerId string) {
 	c.gpuAllocationMap.Delete(containerId)
 }
 
-func (c *ContainerNvidiaManager) AssignGPUDevices(containerId string, gpuCount uint32) (*AssignedGpuDevices, error) {
+func (c *ContainerNvidiaManager) AssignGPUDevices(containerId string, gpuCount uint32) ([]int, error) {
 	gpuIds, err := c.chooseDevices(containerId, gpuCount)
 	if err != nil {
 		return nil, err
 	}
-
-	// Device cgroup rules for the specific GPUs
-	var devices []specs.LinuxDeviceCgroup
-	var visibleGPUs []string // To collect the IDs for NVIDIA_VISIBLE_DEVICES
-
-	for _, gpuId := range gpuIds {
-		gpuDeviceNode := fmt.Sprintf("/dev/nvidia%d", gpuId)
-
-		majorNum, err := c.getDeviceMajorNumber(gpuDeviceNode)
-		if err != nil {
-			return nil, err
-		}
-
-		minorNum, err := c.getDeviceMinorNumber(gpuDeviceNode)
-		if err != nil {
-			return nil, err
-		}
-
-		// Add the specific GPU device node
-		devices = append(devices, specs.LinuxDeviceCgroup{
-			Allow:  true,
-			Type:   "c",
-			Major:  majorNum,
-			Minor:  minorNum,
-			Access: "rwm",
-		})
-
-		// Collect GPU IDs for NVIDIA_VISIBLE_DEVICES
-		visibleGPUs = append(visibleGPUs, fmt.Sprintf("%d", gpuId))
-	}
-
-	// Assuming control and UVM devices are shared across all GPUs and required
-	majorNum, err := c.getDeviceMajorNumber("/dev/nvidiactl")
-	if err != nil {
-		return nil, err
-	}
-
-	minorNum, err := c.getDeviceMinorNumber("/dev/nvidiactl")
-	if err != nil {
-		return nil, err
-	}
-	devices = append(devices, specs.LinuxDeviceCgroup{
-		Allow:  true,
-		Type:   "c",
-		Major:  majorNum,
-		Minor:  minorNum,
-		Access: "rwm",
-	})
-
-	// Join the GPU IDs with commas for the NVIDIA_VISIBLE_DEVICES variable
-	visible := strings.Join(visibleGPUs, ",")
-
-	return &AssignedGpuDevices{
-		visible: visible,
-		devices: devices,
-	}, nil
+	return gpuIds, nil
 }
 
 func (c *ContainerNvidiaManager) GetContainerGPUDevices(containerId string) []int {
@@ -173,40 +120,7 @@ func (c *ContainerNvidiaManager) chooseDevices(containerId string, requestedGpuC
 	return devicesToAllocate, nil
 }
 
-// getDeviceMajorNumber returns the major device number for the given device node path
-func (c *ContainerNvidiaManager) getDeviceMajorNumber(devicePath string) (*int64, error) {
-	stat := syscall.Stat_t{}
-	if err := c.statFunc(devicePath, &stat); err != nil {
-		return nil, err
-	}
-
-	major := int64(major(uint64(stat.Rdev))) // Extract major number
-	return &major, nil
-}
-
-// getDeviceMinorNumber returns the minor device number for the given device node path
-func (c *ContainerNvidiaManager) getDeviceMinorNumber(devicePath string) (*int64, error) {
-	stat := syscall.Stat_t{}
-	if err := c.statFunc(devicePath, &stat); err != nil {
-		return nil, err
-	}
-
-	minor := int64(minor(uint64(stat.Rdev))) // Extract minor number
-	return &minor, nil
-}
-
-// major extracts the major device number from the raw device number
-func major(dev uint64) uint64 {
-	return (dev >> 8) & 0xfff
-}
-
-// minor extracts the minor device number from the raw device number
-func minor(dev uint64) uint64 {
-	return (dev & 0xff) | ((dev >> 12) & 0xfff00)
-}
-
-func (c *ContainerNvidiaManager) InjectEnvVars(env []string) ([]string, bool) {
-	existingCudaFound := false
+func (c *ContainerNvidiaManager) InjectEnvVars(env []string) []string {
 	cudaEnvVarDefaults := map[string]string{
 		"NVIDIA_DRIVER_CAPABILITIES": "compute,utility,graphics,ngx,video",
 		"NVIDIA_REQUIRE_CUDA":        "",
@@ -267,7 +181,7 @@ func (c *ContainerNvidiaManager) InjectEnvVars(env []string) ([]string, bool) {
 		modifiedEnv = append(modifiedEnv, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	return modifiedEnv, existingCudaFound
+	return modifiedEnv
 }
 
 func mergePaths(pathName string, initEnv map[string]string, mergeIn []string) {

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -5,13 +5,17 @@ import (
 	"math/rand"
 	"os"
 	"sort"
-	"sync"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	common "github.com/beam-cloud/beta9/pkg/common"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/tj/assert"
+
+	"gvisor.dev/gvisor/pkg/sync"
 )
 
 type GPUInfoClientForTest struct {
@@ -19,8 +23,14 @@ type GPUInfoClientForTest struct {
 }
 
 func NewContainerNvidiaManagerForTest(gpuCount int) GPUManager {
-	manager := NewContainerNvidiaManager(uint32(gpuCount))
-	gpuManager := manager.(*ContainerNvidiaManager)
+	gpuManager := &ContainerNvidiaManager{
+		gpuAllocationMap: common.NewSafeMap[[]int](),
+		gpuCount:         uint32(gpuCount),
+		mu:               sync.Mutex{},
+		statFunc:         syscall.Stat,
+		infoClient:       &NvidiaInfoClient{},
+	}
+
 	gpuManager.infoClient = &GPUInfoClientForTest{GpuCount: gpuCount}
 	gpuManager.statFunc = mockStat
 
@@ -64,14 +74,14 @@ func TestInjectNvidiaEnvVarsNoCudaInImage(t *testing.T) {
 		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-12.4/targets/x86_64-linux/lib",
 	}
 
-	resultEnv, _ := manager.InjectEnvVars(initialEnv)
+	resultEnv := manager.InjectEnvVars(initialEnv)
 	sort.Strings(expectedEnv)
 	sort.Strings(resultEnv)
 	assert.Equal(t, expectedEnv, resultEnv)
 }
 
 func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
-	manager := NewContainerNvidiaManager(4)
+	manager := NewContainerNvidiaManagerForTest(4)
 	initialEnv := []string{"INITIAL=1", "CUDA_VERSION=12.4"}
 
 	// Set some environment variables to simulate NVIDIA settings
@@ -95,14 +105,14 @@ func TestInjectNvidiaEnvVarsExistingCudaInImage(t *testing.T) {
 		"LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib/worker/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda-12.4/targets/x86_64-linux/lib",
 	}
 
-	resultEnv, _ := manager.InjectEnvVars(initialEnv)
+	resultEnv := manager.InjectEnvVars(initialEnv)
 	sort.Strings(expectedEnv)
 	sort.Strings(resultEnv)
 	assert.Equal(t, expectedEnv, resultEnv)
 }
 
 func TestInjectNvidiaMounts(t *testing.T) {
-	manager := NewContainerNvidiaManager(4)
+	manager := NewContainerNvidiaManagerForTest(4)
 	initialMounts := []specs.Mount{{Type: "bind", Source: "/src", Destination: "/dst"}}
 
 	resultMounts := manager.InjectMounts(initialMounts)
@@ -130,12 +140,12 @@ func TestAssignAndUnassignGPUDevices(t *testing.T) {
 	}
 
 	// Verify that 2 GPUs are assigned and the visible string is correct
-	if len(assignedDevices.devices) != gpuCount+1 {
-		t.Errorf("Expected 2 GPUs to be assigned, got %d", len(assignedDevices.devices))
+	if len(assignedDevices) != gpuCount {
+		t.Errorf("Expected 2 GPUs to be assigned, got %d", len(assignedDevices))
 	}
 
-	if assignedDevices.visible != "0,1" && assignedDevices.visible != "1,0" { // Order might vary
-		t.Errorf("Expected visible GPUs to be '0,1' or '1,0', got '%s'", assignedDevices.visible)
+	if assignedDevices[0] != 0 && assignedDevices[1] != 1 { // Order might vary
+		t.Errorf("Expected visible GPUs to be '0,1' or '1,0', got '%d'", assignedDevices)
 	}
 
 	// Unassign the GPUs from the container
@@ -181,22 +191,6 @@ func TestAssignGPUsToMultipleContainers(t *testing.T) {
 	}
 }
 
-func TestAssignGPUsStatFail(t *testing.T) {
-	manager := NewContainerNvidiaManagerForTest(4)
-	gpuManager := manager.(*ContainerNvidiaManager)
-	// Override syscall.Stat to simulate failure
-
-	gpuManager.statFunc = func(path string, stat *syscall.Stat_t) error {
-		return fmt.Errorf("mock stat error")
-	}
-
-	// Attempt to assign GPUs should fail due to statFunc error
-	_, err := manager.AssignGPUDevices("container1", 2)
-	if err == nil {
-		t.Errorf("Expected error due to stat failure, but got none")
-	}
-}
-
 func TestConcurrentlyAssignGPUDevices(t *testing.T) {
 	manager := NewContainerNvidiaManagerForTest(4)
 	numContainers := 4
@@ -226,11 +220,11 @@ func TestConcurrentlyAssignGPUDevices(t *testing.T) {
 				// retry up to maxRetries times
 				maxRetries := 3
 				attempt := 0
-				var assignedRes *AssignedGpuDevices
+				var key string
 				var err error
 
 				for {
-					assignedRes, err = manager.AssignGPUDevices(id, uint32(gpusPerContainer))
+					assignedDevices, err := manager.AssignGPUDevices(id, uint32(gpusPerContainer))
 					if err != nil {
 						attempt++
 
@@ -243,8 +237,11 @@ func TestConcurrentlyAssignGPUDevices(t *testing.T) {
 						continue
 					}
 
-					// Use assignedRes.String() to check for duplicate GPU assignment
-					key := assignedRes.String()
+					nums := make([]string, len(assignedDevices))
+					for i, num := range assignedDevices {
+						nums[i] = strconv.Itoa(num)
+					}
+					key = strings.Join(nums, ",")
 					currentlyAssignedGPUsMu.Lock()
 					if owner, exists := currentlyAssignedGPUs[key]; exists {
 						errCh <- fmt.Errorf("GPU assignment %s is already assigned to container %s, but was also assigned to container %s", key, owner, id)
@@ -260,13 +257,6 @@ func TestConcurrentlyAssignGPUDevices(t *testing.T) {
 				}
 				if err != nil {
 					// move on to the next iteration if we couldn't get an assignment
-					continue
-				}
-
-				// validate that the NVIDIA_VISIBLE_DEVICES string isn't empty
-				if assignedRes.visible == "" {
-					errCh <- fmt.Errorf("empty NVIDIA_VISIBLE_DEVICES for container %s on iteration %d", id, iter)
-					manager.UnassignGPUDevices(id)
 					continue
 				}
 
@@ -286,7 +276,7 @@ func TestConcurrentlyAssignGPUDevices(t *testing.T) {
 
 				// Unmark GPUs as assigned
 				currentlyAssignedGPUsMu.Lock()
-				delete(currentlyAssignedGPUs, assignedRes.String())
+				delete(currentlyAssignedGPUs, key)
 				currentlyAssignedGPUsMu.Unlock()
 			}
 		}(containerID)


### PR DESCRIPTION
Resolve BE-2357

This PR makes large changes to how we add Nvidia devices to containers. It makes use of the nvidia container toolkit's ability to generate a [CDI spec](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html) for the devices available to the worker. Using this spec, we can leverage the package`tags.cncf.io/container-device-interface/pkg/cdi` to parse the spec and apply the required edits directly to the `spec.Spec` object. This greatly simplifies things on our end. 

Additionally, instead of using the original bundle mounted at (`/images/mnt`) this PR makes a change to use the merged layer in `tmp`. The benefit to this change is that we can write the spec to disk directly next to the bundle. This means we no longer need to use a custom runc build that supports a custom config path. 