### PR TITLE
feat: Use gRPC Health Check server

### DIFF
--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -53,14 +53,24 @@ controllers:
             enabled: true
             custom: true
             spec:
-              successThreshold: 1
-              failureThreshold: 3
               initialDelaySeconds: 5
-              periodSeconds: 5
+              successThreshold: 2
+              failureThreshold: 2
+              periodSeconds: 3
               timeoutSeconds: 1
-              httpGet:
-                path: /api/v1/health
-                port: 1994
+              grpc:
+                port: 1993
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              initialDelaySeconds: 10
+              successThreshold: 2
+              failureThreshold: 10
+              periodSeconds: 3
+              timeoutSeconds: 1
+              grpc:
+                port: 1993
         securityContext:
           privileged: true
     hostNetwork: true

--- a/manifests/kustomize/components/beta9-gateway/deployment.yaml
+++ b/manifests/kustomize/components/beta9-gateway/deployment.yaml
@@ -43,13 +43,21 @@ spec:
         image: registry.localhost:5000/beta9-gateway:latest
         name: main
         readinessProbe:
-          failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 2
-          httpGet:
-            path: /api/v1/health
-            port: 1994
+          successThreshold: 2
+          failureThreshold: 2
+          periodSeconds: 3
+          timeoutSeconds: 1
+          grpc:
+            port: 1993
+        livenessProbe:
+          initialDelaySeconds: 10
+          successThreshold: 2
+          failureThreshold: 10
+          periodSeconds: 3
+          timeoutSeconds: 1
+          grpc:
+            port: 1993
         resources:
           limits:
             cpu: 4000m

--- a/pkg/auth/grpc.go
+++ b/pkg/auth/grpc.go
@@ -31,19 +31,20 @@ type AuthInterceptor struct {
 	workspaceRepo          repository.WorkspaceRepository
 }
 
-func NewAuthInterceptor(backendRepo repository.BackendRepository, workspaceRepo repository.WorkspaceRepository) *AuthInterceptor {
+func NewAuthInterceptor(config types.AppConfig, backendRepo repository.BackendRepository, workspaceRepo repository.WorkspaceRepository) *AuthInterceptor {
 	return &AuthInterceptor{
 		backendRepo:   backendRepo,
 		workspaceRepo: workspaceRepo,
 		unauthenticatedMethods: map[string]bool{
-			"/gateway.GatewayService/Authorize": true,
+			"/gateway.GatewayService/Authorize":                         true,
+			"/grpc.health.v1.Health/Check":                              true,
+			"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo": config.DebugMode,
 		},
 	}
 }
 
 func (ai *AuthInterceptor) isAuthRequired(method string) bool {
-	_, ok := ai.unauthenticatedMethods[method]
-	return !ok
+	return !ai.unauthenticatedMethods[method]
 }
 
 func (ai *AuthInterceptor) validateToken(md metadata.MD) (*AuthInfo, bool) {


### PR DESCRIPTION
**Changes**

- Replaces HTTP health check with gRPC
- Enables gRPC reflection when in debug mode
- Configures aggressive readiness and liveness probes

**Summary**

This adds a new [gRPC health](https://grpc.io/docs/guides/health-checking/) endpoint. 

The new readiness probe values basically say the pod will _stop receiving traffic_ if the gRPC health endpoint fails for 6s (2s * 3s). It also runs every 3 seconds. Alternatively, this starts sending the pod traffic after 6s of successful checks.

The new liveness probe values basically say the pod will _restart_ if the gRPC health endpoint fails for 30s (10s * 3s). It also runs every 3 seconds. Alternatively, this will not restart the pod after 6s of successful checks.

Because the liveness checks take no more than 30s, the shutdown timeout will no longer be relevant when it is larger than the liveness check's failure threshold.

Resolve BE-2386