### PR TITLE
fix: liveness probe success threshold

### DIFF
--- a/deploy/charts/beta9/templates/_helpers.tpl
+++ b/deploy/charts/beta9/templates/_helpers.tpl
@@ -65,7 +65,7 @@ controllers:
             custom: true
             spec:
               initialDelaySeconds: 10
-              successThreshold: 2
+              successThreshold: 1
               failureThreshold: 10
               periodSeconds: 3
               timeoutSeconds: 1

--- a/manifests/kustomize/components/beta9-gateway/deployment.yaml
+++ b/manifests/kustomize/components/beta9-gateway/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             port: 1993
         livenessProbe:
           initialDelaySeconds: 10
-          successThreshold: 2
+          successThreshold: 1
           failureThreshold: 10
           periodSeconds: 3
           timeoutSeconds: 1


### PR DESCRIPTION
Fixes helm upgrades. Should prevent this error.

```
Error: UPGRADE FAILED: cannot patch "beta9-gateway" with kind Deployment: Deployment.apps "beta9-gateway" is invalid: spec.template.spec.containers[0].livenessProbe.successThreshold: Invalid value: 2: must be 1
```

Kustomize seems unaffected and will just correct successThreshold to 1.

Resolve BE-2386