### PR TITLE
feat: check pod status before deleting stale jobs

### DIFF
--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -208,6 +208,11 @@ func (c *WorkerResourceCleaner) deleteStaleJob(ctx context.Context, pod corev1.P
 		return
 	}
 
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded, corev1.PodFailed:
+		return
+	}
+
 	_, err := c.WorkerRepo.GetWorkerById(workerId)
 	if err == nil {
 		return


### PR DESCRIPTION
- Prevents the deletion of jobs where its pods have already completed e.g. completed workers

Resolve BE-2343