### PR TITLE
Fix: Add option for force path style to be passed to clip

### DIFF
--- a/deploy/charts/beta9/values.local.yaml
+++ b/deploy/charts/beta9/values.local.yaml
@@ -46,6 +46,7 @@ manifests:
           #!/bin/bash
           awslocal s3 mb s3://juicefs
           awslocal s3 mb s3://logs
+          awslocal s3 mb s3://beta9-images
         persistence:
           enabled: true
           storageClass: local-path

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4
 	github.com/beam-cloud/blobcache-v2 v0.0.0-20250204202524-80d61da9a0f8
-	github.com/beam-cloud/clip v0.0.0-20250109221532-5d9d7744594d
+	github.com/beam-cloud/clip v0.0.0-20250226231934-32af21a743cd
 	github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
 	github.com/cedana/cedana v0.9.240

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/beam-cloud/blobcache-v2 v0.0.0-20250204202524-80d61da9a0f8 h1:lwuVDUF
 github.com/beam-cloud/blobcache-v2 v0.0.0-20250204202524-80d61da9a0f8/go.mod h1:6cJ/j/kpxdVnpZaLri99cg/7QRmRQ8d6yvv6UFBBOUE=
 github.com/beam-cloud/clip v0.0.0-20250109221532-5d9d7744594d h1:EEWoW32RCi3i9/PWkvrPMDIo4j2attsKkMXxwZQRKt4=
 github.com/beam-cloud/clip v0.0.0-20250109221532-5d9d7744594d/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
+github.com/beam-cloud/clip v0.0.0-20250226231934-32af21a743cd h1:UU7oR8KdNUn0cBplumOYjvwjmtMrWMnl9leO/aLMfDo=
+github.com/beam-cloud/clip v0.0.0-20250226231934-32af21a743cd/go.mod h1:FO7taXHUAqgx33PjeB6LbSLpKob3Ceyo9Po64nq5TR0=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170 h1:KYVz18kobBGU8URM9Srn++2tcL9e0PcwYyH0Z4GYicM=
 github.com/beam-cloud/go-runc v0.0.0-20231222221338-b89899f33170/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=

--- a/manifests/k3d/localstack.yaml
+++ b/manifests/k3d/localstack.yaml
@@ -17,6 +17,7 @@ spec:
       #!/bin/bash
       awslocal s3 mb s3://juicefs
       awslocal s3 mb s3://logs
+      awslocal s3 mb s3://beta9-images
     persistence:
       enabled: true
       storageClass: local-path

--- a/manifests/kustomize/components/localstack/helm-chart-generator.yaml
+++ b/manifests/kustomize/components/localstack/helm-chart-generator.yaml
@@ -19,6 +19,7 @@ valuesInline:
     #!/bin/bash
     awslocal s3 mb s3://juicefs
     awslocal s3 mb s3://logs
+    awslocal s3 mb s3://beta9-images
   persistence:
     enabled: true
     storageClass: local-path

--- a/pkg/common/registry.go
+++ b/pkg/common/registry.go
@@ -85,7 +85,11 @@ func NewS3Store(config types.S3ImageRegistryConfig) (*S3Store, error) {
 	}
 
 	return &S3Store{
-		client: s3.NewFromConfig(cfg),
+		client: s3.NewFromConfig(cfg, func(o *s3.Options) {
+			if config.ForcePathStyle {
+				o.UsePathStyle = true
+			}
+		}),
 		config: config,
 	}, nil
 }

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -161,11 +161,12 @@ type DockerImageRegistryConfig struct {
 }
 
 type S3ImageRegistryConfig struct {
-	BucketName string `key:"bucketName" json:"bucket_name"`
-	AccessKey  string `key:"accessKey" json:"access_key"`
-	SecretKey  string `key:"secretKey" json:"secret_key"`
-	Region     string `key:"region" json:"region"`
-	Endpoint   string `key:"endpoint" json:"endpoint"`
+	BucketName     string `key:"bucketName" json:"bucket_name"`
+	AccessKey      string `key:"accessKey" json:"access_key"`
+	SecretKey      string `key:"secretKey" json:"secret_key"`
+	Region         string `key:"region" json:"region"`
+	Endpoint       string `key:"endpoint" json:"endpoint"`
+	ForcePathStyle bool   `key:"forcePathStyle" json:"force_path_style"`
 }
 
 type RunnerConfig struct {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -430,10 +430,11 @@ func (c *ImageClient) Archive(ctx context.Context, bundlePath string, imageId st
 			},
 			ProgressChan: progressChan,
 		}, &clipCommon.S3StorageInfo{
-			Bucket:   c.config.ImageService.Registries.S3.BucketName,
-			Region:   c.config.ImageService.Registries.S3.Region,
-			Endpoint: c.config.ImageService.Registries.S3.Endpoint,
-			Key:      fmt.Sprintf("%s.clip", imageId),
+			Bucket:         c.config.ImageService.Registries.S3.BucketName,
+			Region:         c.config.ImageService.Registries.S3.Region,
+			Endpoint:       c.config.ImageService.Registries.S3.Endpoint,
+			Key:            fmt.Sprintf("%s.clip", imageId),
+			ForcePathStyle: c.config.ImageService.Registries.S3.ForcePathStyle,
 		})
 	case common.LocalImageRegistryStore:
 		err = clip.CreateArchive(clip.CreateOptions{


### PR DESCRIPTION
This will allow us to mount localstack s3 buckets, which is useful for testing blobcache behavior, etc locally.

It requires [clip#16](https://github.com/beam-cloud/clip/pull/16) to be merged first. 

It is also related to [blobcache-v2#27](https://github.com/beam-cloud/blobcache-v2/pull/27)