### PR TITLE
Check for config.yaml and set env in okteto if it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ runner:
 	done
 
 start:
-	cd hack && okteto up --file okteto.yaml
+	@if [ -f config.yaml ]; then \
+		cd hack && okteto up --file okteto.yaml --env CONFIG_PATH=/workspace/config.yaml; \
+	else \
+		cd hack && okteto up --file okteto.yaml; \
+	fi
 
 stop:
 	cd hack && okteto down --file okteto.yaml


### PR DESCRIPTION
Its annoying to add the env var to the okteto.yaml file and then pick around that file when committing.