### PR TITLE
Dont limit build logs

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -188,7 +188,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 	outputLogger := slog.New(common.NewChannelHandler(logChan))
 
 	// Handle stdout/stderr
-	go s.containerLogger.CaptureLogs(containerId, logChan, request.IsBuildRequest())
+	go s.containerLogger.CaptureLogs(request, logChan)
 
 	// Attempt to pull image
 	log.Info().Str("container_id", containerId).Msgf("lazy-pulling image: %s", request.ImageId)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -188,7 +188,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 	outputLogger := slog.New(common.NewChannelHandler(logChan))
 
 	// Handle stdout/stderr
-	go s.containerLogger.CaptureLogs(containerId, logChan)
+	go s.containerLogger.CaptureLogs(containerId, logChan, request.IsBuildRequest())
 
 	// Attempt to pull image
 	log.Info().Str("container_id", containerId).Msgf("lazy-pulling image: %s", request.ImageId)

--- a/pkg/worker/logger.go
+++ b/pkg/worker/logger.go
@@ -59,7 +59,7 @@ func (r *ContainerLogger) Log(containerId, stubId string, format string, args ..
 	return nil
 }
 
-func (r *ContainerLogger) CaptureLogs(containerId string, logChan chan common.LogRecord) error {
+func (r *ContainerLogger) CaptureLogs(containerId string, logChan chan common.LogRecord, isBuildRequest bool) error {
 	logFile, err := openLogFile(containerId)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func (r *ContainerLogger) CaptureLogs(containerId string, logChan chan common.Lo
 	rateLimitMessageLogged := false
 
 	for o := range logChan {
-		if !limiter.Allow() {
+		if !isBuildRequest && !limiter.Allow() {
 			if !rateLimitMessageLogged {
 				log.Info().Str("container_id", containerId).Msg(rateLimitMsg)
 				f.WithFields(logrus.Fields{


### PR DESCRIPTION
Resolve BE-2427

The current log limits are imposed to build containers, which might prevent users from seeing critical build logs. 