### PR TITLE
Fix: docstrings for volume's list to include cloud bucket

### DIFF
--- a/sdk/src/beta9/abstractions/container.py
+++ b/sdk/src/beta9/abstractions/container.py
@@ -7,7 +7,7 @@ from ..abstractions.base.runner import (
     RunnerAbstraction,
 )
 from ..abstractions.image import Image
-from ..abstractions.volume import Volume
+from ..abstractions.volume import CloudBucket, Volume
 from ..channel import with_grpc_error_handling
 from ..clients.container import (
     CommandExecutionRequest,
@@ -38,8 +38,8 @@ class Container(RunnerAbstraction):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume]]):
-            A list of volumes to be mounted to the container. Default is None.
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of volumes and/or cloud buckets to be mounted to the container. Default is None.
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
         name (Optional[str]):
@@ -67,7 +67,7 @@ class Container(RunnerAbstraction):
         gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
         gpu_count: int = 0,
         image: Image = Image(),
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         callback_url: Optional[str] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,

--- a/sdk/src/beta9/abstractions/container.py
+++ b/sdk/src/beta9/abstractions/container.py
@@ -38,7 +38,7 @@ class Container(RunnerAbstraction):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of volumes and/or cloud buckets to be mounted to the container. Default is None.
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
@@ -67,7 +67,7 @@ class Container(RunnerAbstraction):
         gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
         gpu_count: int = 0,
         image: Image = Image(),
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         callback_url: Optional[str] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -192,8 +192,8 @@ class ASGI(Endpoint):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume]]):
-            A list of volumes to be mounted to the ASGI application. Default is None.
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of volumes and/or cloud buckets to be mounted to the ASGI application. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
             Default is 3600. Set it to -1 to disable the timeout.
@@ -283,7 +283,7 @@ class ASGI(Endpoint):
         max_pending_tasks: int = 100,
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,
@@ -341,8 +341,8 @@ class RealtimeASGI(ASGI):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume]]):
-            A list of volumes to be mounted to the ASGI application. Default is None.
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of volumes and/or cloud buckets to be mounted to the ASGI application. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
             Default is 3600. Set it to -1 to disable the timeout.
@@ -418,7 +418,7 @@ class RealtimeASGI(ASGI):
         max_pending_tasks: int = 100,
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -52,7 +52,7 @@ class Endpoint(RunnerAbstraction):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of volumes and/or cloud buckets to be mounted to the endpoint. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
@@ -127,7 +127,7 @@ class Endpoint(RunnerAbstraction):
         max_pending_tasks: int = 100,
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,
@@ -192,7 +192,7 @@ class ASGI(Endpoint):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of volumes and/or cloud buckets to be mounted to the ASGI application. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
@@ -283,7 +283,7 @@ class ASGI(Endpoint):
         max_pending_tasks: int = 100,
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,
@@ -341,7 +341,7 @@ class RealtimeASGI(ASGI):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of volumes and/or cloud buckets to be mounted to the ASGI application. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
@@ -418,7 +418,7 @@ class RealtimeASGI(ASGI):
         max_pending_tasks: int = 100,
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,

--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -18,7 +18,7 @@ from ..abstractions.base.runner import (
     RunnerAbstraction,
 )
 from ..abstractions.image import Image
-from ..abstractions.volume import Volume
+from ..abstractions.volume import CloudBucket, Volume
 from ..channel import with_grpc_error_handling
 from ..clients.endpoint import (
     EndpointServeKeepAliveRequest,
@@ -52,8 +52,8 @@ class Endpoint(RunnerAbstraction):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume]]):
-            A list of volumes to be mounted to the endpoint. Default is None.
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of volumes and/or cloud buckets to be mounted to the endpoint. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
             Default is 3600. Set it to -1 to disable the timeout.
@@ -127,7 +127,7 @@ class Endpoint(RunnerAbstraction):
         max_pending_tasks: int = 100,
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -15,7 +15,7 @@ from ..abstractions.base.runner import (
     RunnerAbstraction,
 )
 from ..abstractions.image import Image
-from ..abstractions.volume import Volume
+from ..abstractions.volume import CloudBucket, Volume
 from ..channel import with_grpc_error_handling
 from ..clients.function import (
     FunctionInvokeRequest,
@@ -56,8 +56,8 @@ class Function(RunnerAbstraction):
             The maximum number of times a task will be retried if the container crashes. Default is 3.
         callback_url (Optional[str]):
             An optional URL to send a callback to when a task is completed, timed out, or cancelled.
-        volumes (Optional[List[Volume]]):
-            A list of storage volumes to be associated with the function. Default is [].
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of storage volumes and/or cloud buckets to be associated with the function. Default is [].
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
         env (Optional[Dict[str, str]]):
@@ -99,7 +99,7 @@ class Function(RunnerAbstraction):
         timeout: int = 3600,
         retries: int = 3,
         callback_url: Optional[str] = None,
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,
@@ -284,7 +284,7 @@ class ScheduleWrapper(_CallableWrapper):
             next_run_utc = cron_utc.get_next(datetime)
             terminal.print(
                 (
-                    f"  [bright_white]{i+1}.[/bright_white] {next_run_utc:%Y-%m-%d %H:%M:%S %Z} "
+                    f"  [bright_white]{i + 1}.[/bright_white] {next_run_utc:%Y-%m-%d %H:%M:%S %Z} "
                     f"({next_run:%Y-%m-%d %H:%M:%S} {local_tz})"
                 )
             )

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -56,7 +56,7 @@ class Function(RunnerAbstraction):
             The maximum number of times a task will be retried if the container crashes. Default is 3.
         callback_url (Optional[str]):
             An optional URL to send a callback to when a task is completed, timed out, or cancelled.
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of storage volumes and/or cloud buckets to be associated with the function. Default is [].
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
@@ -99,7 +99,7 @@ class Function(RunnerAbstraction):
         timeout: int = 3600,
         retries: int = 3,
         callback_url: Optional[str] = None,
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,
@@ -318,8 +318,8 @@ class Schedule(Function):
             The maximum number of times a task will be retried if the container crashes. Default is 3.
         callback_url (Optional[str]):
             An optional URL to send a callback to when a task is completed, timed out, or cancelled.
-        volumes (Optional[List[Volume]]):
-            A list of storage volumes to be associated with the function. Default is [].
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
+            A list of storage volumes and/or cloud buckets to be associated with the function. Default is [].
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
         env (Optional[Dict[str, str]]):
@@ -359,7 +359,7 @@ class Schedule(Function):
         timeout: int = 3600,
         retries: int = 3,
         callback_url: Optional[str] = None,
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -172,7 +172,7 @@ class VLLM(ASGI):
             Whether the endpoints require authorization. Default is True.
         name (str):
             The name of the container. Default is none, which means you must provide it during deployment.
-        volumes (List[Volume, CloudBucket]):
+        volumes (List[Union[Volume, CloudBucket]]):
             The volumes and/or cloud buckets to mount into the container. Default is a single volume named "vllm_cache" mounted to "./vllm_cache".
             It is used as the download directory for vLLM models.
         secrets (List[str]):
@@ -208,7 +208,7 @@ class VLLM(ASGI):
         timeout: int = 3600,
         authorized: bool = True,
         name: Optional[str] = None,
-        volumes: Optional[List[Volume, CloudBucket]] = [],
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = [],
         secrets: Optional[List[str]] = None,
         autoscaler: Autoscaler = QueueDepthAutoscaler(),
         vllm_args: VLLMArgs = VLLMArgs(),

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -8,7 +8,7 @@ from ... import terminal
 from ...abstractions.base.runner import ASGI_DEPLOYMENT_STUB_TYPE, ASGI_SERVE_STUB_TYPE
 from ...abstractions.endpoint import ASGI
 from ...abstractions.image import Image
-from ...abstractions.volume import Volume
+from ...abstractions.volume import CloudBucket, Volume
 from ...channel import with_grpc_error_handling
 from ...clients.endpoint import (
     EndpointServeKeepAliveRequest,
@@ -172,8 +172,8 @@ class VLLM(ASGI):
             Whether the endpoints require authorization. Default is True.
         name (str):
             The name of the container. Default is none, which means you must provide it during deployment.
-        volumes (List[Volume]):
-            The volumes to mount into the container. Default is a single volume named "vllm_cache" mounted to "./vllm_cache".
+        volumes (List[Volume, CloudBucket]):
+            The volumes and/or cloud buckets to mount into the container. Default is a single volume named "vllm_cache" mounted to "./vllm_cache".
             It is used as the download directory for vLLM models.
         secrets (List[str]):
             The secrets to pass to the container. If you need huggingface authentication to download models, you should set HF_TOKEN in the secrets.
@@ -208,7 +208,7 @@ class VLLM(ASGI):
         timeout: int = 3600,
         authorized: bool = True,
         name: Optional[str] = None,
-        volumes: Optional[List[Volume]] = [],
+        volumes: Optional[List[Volume, CloudBucket]] = [],
         secrets: Optional[List[str]] = None,
         autoscaler: Autoscaler = QueueDepthAutoscaler(),
         vllm_args: VLLMArgs = VLLMArgs(),

--- a/sdk/src/beta9/abstractions/pod.py
+++ b/sdk/src/beta9/abstractions/pod.py
@@ -93,7 +93,7 @@ class Pod(RunnerAbstraction):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of volumes and/or cloud buckets to be mounted to the pod. Default is None.
         secrets (Optional[List[str]):
             A list of secrets that are injected into the pod as environment variables. Default is [].
@@ -129,7 +129,7 @@ class Pod(RunnerAbstraction):
         gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
         gpu_count: int = 0,
         image: Image = Image(),
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         keep_warm_seconds: int = 600,

--- a/sdk/src/beta9/abstractions/pod.py
+++ b/sdk/src/beta9/abstractions/pod.py
@@ -12,7 +12,7 @@ from ..abstractions.base.runner import (
     RunnerAbstraction,
 )
 from ..abstractions.image import Image
-from ..abstractions.volume import Volume
+from ..abstractions.volume import CloudBucket, Volume
 from ..channel import with_grpc_error_handling
 from ..clients.gateway import (
     DeployStubRequest,
@@ -93,8 +93,8 @@ class Pod(RunnerAbstraction):
             specified but this value is set to 0, it will be automatically updated to 1.
         image (Union[Image, dict]):
             The container image used for the task execution. Default is [Image](#image).
-        volumes (Optional[List[Volume]]):
-            A list of volumes to be mounted to the pod. Default is None.
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of volumes and/or cloud buckets to be mounted to the pod. Default is None.
         secrets (Optional[List[str]):
             A list of secrets that are injected into the pod as environment variables. Default is [].
         env (Optional[Dict[str, str]]):
@@ -129,7 +129,7 @@ class Pod(RunnerAbstraction):
         gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
         gpu_count: int = 0,
         image: Image = Image(),
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         keep_warm_seconds: int = 600,

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -73,7 +73,7 @@ class TaskQueue(RunnerAbstraction):
             loading models, or anything else computationally expensive.
         callback_url (Optional[str]):
             An optional URL to send a callback to when a task is completed, timed out, or cancelled.
-        volumes (Optional[List[Volume, CloudBucket]]):
+        volumes (Optional[List[Union[Volume, CloudBucket]]]):
             A list of storage volumes and/or cloud buckets to be associated with the taskqueue. Default is [].
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
@@ -127,7 +127,7 @@ class TaskQueue(RunnerAbstraction):
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
         callback_url: Optional[str] = None,
-        volumes: Optional[List[Volume, CloudBucket]] = None,
+        volumes: Optional[List[Union[Volume, CloudBucket]]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -12,7 +12,7 @@ from ..abstractions.base.runner import (
     RunnerAbstraction,
 )
 from ..abstractions.image import Image
-from ..abstractions.volume import Volume
+from ..abstractions.volume import CloudBucket, Volume
 from ..channel import with_grpc_error_handling
 from ..clients.taskqueue import (
     StartTaskQueueServeRequest,
@@ -73,8 +73,8 @@ class TaskQueue(RunnerAbstraction):
             loading models, or anything else computationally expensive.
         callback_url (Optional[str]):
             An optional URL to send a callback to when a task is completed, timed out, or cancelled.
-        volumes (Optional[List[Volume]]):
-            A list of storage volumes to be associated with the taskqueue. Default is [].
+        volumes (Optional[List[Volume, CloudBucket]]):
+            A list of storage volumes and/or cloud buckets to be associated with the taskqueue. Default is [].
         secrets (Optional[List[str]):
             A list of secrets that are injected into the container as environment variables. Default is [].
         env (Optional[Dict[str, str]]):
@@ -127,7 +127,7 @@ class TaskQueue(RunnerAbstraction):
         on_start: Optional[Callable] = None,
         on_deploy: Optional[AbstractCallableWrapper] = None,
         callback_url: Optional[str] = None,
-        volumes: Optional[List[Volume]] = None,
+        volumes: Optional[List[Volume, CloudBucket]] = None,
         secrets: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = {},
         name: Optional[str] = None,

--- a/sdk/src/beta9/abstractions/volume.py
+++ b/sdk/src/beta9/abstractions/volume.py
@@ -85,9 +85,9 @@ class CloudBucketConfig:
         read_only (bool):
             Whether the volume is read-only.
         access_key (str):
-            The S3 access key for the external provider.
+            The name of the beam secret containing the S3 access key for the external provider.
         secret_key (str):
-            The S3 secret key for the external provider.
+            The name of the beam secret containing the S3 secret key for the external provider.
         endpoint (Optional[str]):
             The S3 endpoint for the external provider.
         region (Optional[str]):


### PR DESCRIPTION
Resolve BE-2426

Adds cloudbucket to volumes docstring for a variety of abstractions. 