### PR TITLE
Feat: Add more client logs

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -303,7 +303,7 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 	}()
 	defer client.Kill(containerId) // Kill and remove container after the build completes
 
-	outputChan <- common.OutputMsg{Done: false, Success: success.Load(), Msg: "Waiting for build container to start...\n"}
+	outputChan <- common.OutputMsg{Done: false, Success: success.Load(), Msg: "Setting up build container...\n"}
 	start := time.Now()
 	buildContainerRunning := false
 
@@ -834,7 +834,7 @@ func tagOrDigest(digest string, tag string) string {
 
 func (b *Builder) calculateImageArchiveDuration(ctx context.Context, opts *BuildOpts) time.Duration {
 	sourceImage := getSourceImage(opts)
-	imageMetadata, err := b.skopeoClient.Inspect(ctx, sourceImage, opts.BaseImageCreds)
+	imageMetadata, err := b.skopeoClient.Inspect(ctx, sourceImage, opts.BaseImageCreds, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to inspect image")
 		return defaultContainerSpinupTimeout

--- a/pkg/common/io.go
+++ b/pkg/common/io.go
@@ -90,3 +90,12 @@ func (w *ZerologIOWriter) Write(p []byte) (n int, err error) {
 	w.LogFn().Msg(strings.TrimSpace(string(p)))
 	return len(p), nil
 }
+
+type ExecWriter struct {
+	*slog.Logger
+}
+
+func (c *ExecWriter) Write(p []byte) (n int, err error) {
+	c.Info(string(p))
+	return len(p), nil
+}

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -104,12 +104,11 @@ func NewImageClient(config types.AppConfig, workerId string, workerRepoClient pb
 	return c, nil
 }
 
-func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequest) error {
+func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger) (time.Duration, error) {
 	imageId := request.ImageId
 	isBuildContainer := strings.HasPrefix(request.ContainerId, types.BuildContainerPrefix)
 
 	c.logger.Log(request.ContainerId, request.StubId, "Loading image: %s", imageId)
-
 	localCachePath := fmt.Sprintf("%s/%s.cache", c.imageCachePath, imageId)
 	if !c.config.ImageService.LocalCacheEnabled && !isBuildContainer {
 		localCachePath = ""
@@ -129,14 +128,15 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 		if _, err := os.Stat(baseBlobFsContentPath); err == nil && c.cacheClient.IsPathCachedNearby(ctx, "/"+sourcePath) {
 			localCachePath = baseBlobFsContentPath
 		} else {
-			c.logger.Log(request.ContainerId, request.StubId, "image <%s> not found in cache, caching nearby", imageId)
+			c.logger.Log(request.ContainerId, request.StubId, "Image <%s> not found in worker's region, caching nearby", imageId)
 
 			// Otherwise, lets cache it in a nearby blobcache host
 			_, err := c.cacheClient.StoreContentFromSource(sourcePath, sourceOffset)
 			if err == nil {
 				localCachePath = baseBlobFsContentPath
+				c.logger.Log(request.ContainerId, request.StubId, "Image <%s> cached in worker's region", imageId)
 			} else {
-				c.logger.Log(request.ContainerId, request.StubId, "unable to cache image nearby <%s>: %v\n", imageId, err)
+				c.logger.Log(request.ContainerId, request.StubId, "Failed to cache image in worker's region <%s>: %v", imageId, err)
 			}
 		}
 	}
@@ -148,7 +148,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	if _, err := os.Stat(remoteArchivePath); err != nil {
 		err = c.registry.Pull(context.TODO(), remoteArchivePath, imageId)
 		if err != nil {
-			return err
+			return elapsed, err
 		}
 	}
 
@@ -170,7 +170,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	// Check if a fuse server exists for this imageId
 	_, mounted := c.mountedFuseServers.Get(imageId)
 	if mounted {
-		return nil
+		return elapsed, nil
 	}
 
 	// Get lock on image mount
@@ -179,7 +179,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 		ImageId:  imageId,
 	}))
 	if err != nil {
-		return err
+		return elapsed, err
 	}
 	defer handleGRPCResponse(c.workerRepoClient.RemoveImagePullLock(context.Background(), &pb.RemoveImagePullLockRequest{
 		WorkerId: c.workerId,
@@ -189,16 +189,16 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 
 	startServer, _, server, err := clip.MountArchive(*mountOptions)
 	if err != nil {
-		return err
+		return elapsed, err
 	}
 
 	err = startServer()
 	if err != nil {
-		return err
+		return elapsed, err
 	}
 
 	c.mountedFuseServers.Set(imageId, server)
-	return nil
+	return elapsed, nil
 }
 
 func (c *ImageClient) Cleanup() error {
@@ -220,7 +220,7 @@ func (c *ImageClient) Cleanup() error {
 }
 
 func (c *ImageClient) inspectAndVerifyImage(ctx context.Context, request *types.ContainerRequest) error {
-	imageMetadata, err := c.skopeoClient.Inspect(ctx, *request.BuildOptions.SourceImage, request.BuildOptions.SourceImageCreds)
+	imageMetadata, err := c.skopeoClient.Inspect(ctx, *request.BuildOptions.SourceImage, request.BuildOptions.SourceImageCreds, nil)
 	if err != nil {
 		return err
 	}
@@ -238,16 +238,6 @@ func (c *ImageClient) inspectAndVerifyImage(ctx context.Context, request *types.
 	}
 
 	return nil
-}
-
-// Will be replaced when structured logging is merged
-type ExecWriter struct {
-	outputLogger *slog.Logger
-}
-
-func (c *ExecWriter) Write(p []byte) (n int, err error) {
-	c.outputLogger.Info(string(p))
-	return len(p), nil
 }
 
 func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *slog.Logger, request *types.ContainerRequest) error {
@@ -279,16 +269,16 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 	os.MkdirAll(ociPath, 0755)
 
 	cmd := exec.CommandContext(ctx, "buildah", "--root", imagePath, "bud", "-f", tempDockerFile, "-t", request.ImageId+":latest", buildCtxPath)
-	cmd.Stdout = &ExecWriter{outputLogger: outputLogger}
-	cmd.Stderr = &ExecWriter{outputLogger: outputLogger}
+	cmd.Stdout = &common.ExecWriter{Logger: outputLogger}
+	cmd.Stderr = &common.ExecWriter{Logger: outputLogger}
 	err = cmd.Run()
 	if err != nil {
 		return err
 	}
 
 	cmd = exec.CommandContext(ctx, "buildah", "--root", imagePath, "push", request.ImageId+":latest", "oci:"+ociPath+":latest")
-	cmd.Stdout = &ExecWriter{outputLogger: outputLogger}
-	cmd.Stderr = &ExecWriter{outputLogger: outputLogger}
+	cmd.Stdout = &common.ExecWriter{Logger: outputLogger}
+	cmd.Stderr = &common.ExecWriter{Logger: outputLogger}
 	err = cmd.Run()
 	if err != nil {
 		return err
@@ -332,7 +322,7 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 		return err
 	}
 
-	outputLogger.Info("Inspecting image name and verifying architecture...\n")
+	outputLogger.Info("Inspecting image name and verifying architecture...\n", "header", true)
 	if err := c.inspectAndVerifyImage(ctx, request); err != nil {
 		return err
 	}
@@ -345,13 +335,13 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 
 	dest := fmt.Sprintf("oci:%s:%s", baseImage.Repo, baseImage.Tag)
 
-	outputLogger.Info("Copying image...\n")
-	err = c.skopeoClient.Copy(ctx, *request.BuildOptions.SourceImage, dest, request.BuildOptions.SourceImageCreds)
+	outputLogger.Info("Pulling image...\n", "header", true)
+	err = c.skopeoClient.Copy(ctx, *request.BuildOptions.SourceImage, dest, request.BuildOptions.SourceImageCreds, outputLogger)
 	if err != nil {
 		return err
 	}
 
-	outputLogger.Info("Unpacking image...\n")
+	outputLogger.Info("Unpacking image...\n", "header", true)
 	tmpBundlePath := filepath.Join(baseTmpBundlePath, request.ImageId)
 	err = c.unpack(ctx, baseImage.Repo, baseImage.Tag, tmpBundlePath)
 	if err != nil {
@@ -361,7 +351,7 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 	defer os.RemoveAll(baseTmpBundlePath)
 	defer os.RemoveAll(copyDir)
 
-	outputLogger.Info("Archiving base image...\n")
+	outputLogger.Info("Archiving base image...\n", "header", true)
 	return c.Archive(ctx, tmpBundlePath, request.ImageId, nil)
 }
 

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -128,21 +128,20 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 		if _, err := os.Stat(baseBlobFsContentPath); err == nil && c.cacheClient.IsPathCachedNearby(ctx, "/"+sourcePath) {
 			localCachePath = baseBlobFsContentPath
 		} else {
-			c.logger.Log(request.ContainerId, request.StubId, "Image <%s> not found in worker's region, caching nearby", imageId)
+			outputLogger.Info("Image <%s> not found in worker's region, caching nearby", imageId)
 
 			// Otherwise, lets cache it in a nearby blobcache host
 			_, err := c.cacheClient.StoreContentFromSource(sourcePath, sourceOffset)
 			if err == nil {
 				localCachePath = baseBlobFsContentPath
-				c.logger.Log(request.ContainerId, request.StubId, "Image <%s> cached in worker's region", imageId)
+				outputLogger.Info("Image <%s> cached in worker's region", imageId)
 			} else {
-				c.logger.Log(request.ContainerId, request.StubId, "Failed to cache image in worker's region <%s>: %v", imageId, err)
+				outputLogger.Info("Failed to cache image in worker's region <%s>: %v", imageId, err)
 			}
 		}
 	}
 
 	elapsed := time.Since(startTime)
-	c.logger.Log(request.ContainerId, request.StubId, "Loaded image <%s>, took: %s", imageId, elapsed)
 
 	remoteArchivePath := fmt.Sprintf("%s/%s.%s", c.imageCachePath, imageId, c.registry.ImageFileExtension)
 	if _, err := os.Stat(remoteArchivePath); err != nil {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -322,7 +322,7 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 		return err
 	}
 
-	outputLogger.Info("Inspecting image name and verifying architecture...\n", "header", true)
+	outputLogger.Info("Inspecting image name and verifying architecture...\n")
 	if err := c.inspectAndVerifyImage(ctx, request); err != nil {
 		return err
 	}
@@ -335,13 +335,13 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 
 	dest := fmt.Sprintf("oci:%s:%s", baseImage.Repo, baseImage.Tag)
 
-	outputLogger.Info("Pulling image...\n", "header", true)
+	outputLogger.Info("Pulling image...\n")
 	err = c.skopeoClient.Copy(ctx, *request.BuildOptions.SourceImage, dest, request.BuildOptions.SourceImageCreds, outputLogger)
 	if err != nil {
 		return err
 	}
 
-	outputLogger.Info("Unpacking image...\n", "header", true)
+	outputLogger.Info("Unpacking image...\n")
 	tmpBundlePath := filepath.Join(baseTmpBundlePath, request.ImageId)
 	err = c.unpack(ctx, baseImage.Repo, baseImage.Tag, tmpBundlePath)
 	if err != nil {
@@ -351,7 +351,7 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 	defer os.RemoveAll(baseTmpBundlePath)
 	defer os.RemoveAll(copyDir)
 
-	outputLogger.Info("Archiving base image...\n", "header", true)
+	outputLogger.Info("Archiving base image...\n")
 	return c.Archive(ctx, tmpBundlePath, request.ImageId, nil)
 }
 

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -128,15 +128,15 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 		if _, err := os.Stat(baseBlobFsContentPath); err == nil && c.cacheClient.IsPathCachedNearby(ctx, "/"+sourcePath) {
 			localCachePath = baseBlobFsContentPath
 		} else {
-			outputLogger.Info("Image <%s> not found in worker's region, caching nearby", imageId)
+			outputLogger.Info(fmt.Sprintf("Image <%s> not found in worker's region, caching nearby", imageId))
 
 			// Otherwise, lets cache it in a nearby blobcache host
 			_, err := c.cacheClient.StoreContentFromSource(sourcePath, sourceOffset)
 			if err == nil {
 				localCachePath = baseBlobFsContentPath
-				outputLogger.Info("Image <%s> cached in worker's region", imageId)
+				outputLogger.Info(fmt.Sprintf("Image <%s> cached in worker's region", imageId))
 			} else {
-				outputLogger.Info("Failed to cache image in worker's region <%s>: %v", imageId, err)
+				outputLogger.Info(fmt.Sprintf("Failed to cache image in worker's region <%s>: %v", imageId, err))
 			}
 		}
 	}

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -128,7 +128,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 		if _, err := os.Stat(baseBlobFsContentPath); err == nil && c.cacheClient.IsPathCachedNearby(ctx, "/"+sourcePath) {
 			localCachePath = baseBlobFsContentPath
 		} else {
-			outputLogger.Info(fmt.Sprintf("Image <%s> not found in worker's region, caching nearby", imageId))
+			outputLogger.Info(fmt.Sprintf("Image <%s> not found in worker region, caching nearby", imageId))
 
 			// Otherwise, lets cache it in a nearby blobcache host
 			_, err := c.cacheClient.StoreContentFromSource(sourcePath, sourceOffset)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -188,7 +188,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 	outputLogger := slog.New(common.NewChannelHandler(logChan))
 
 	// Handle stdout/stderr
-	go s.containerLogger.CaptureLogs(containerId, logChan, request.IsBuildRequest())
+	go s.containerLogger.CaptureLogs(request, logChan)
 
 	// Attempt to pull image
 	log.Info().Str("container_id", containerId).Msgf("lazy-pulling image: %s", request.ImageId)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -211,7 +211,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 			}
 		}
 	}
-	outputLogger.Info(fmt.Sprintf("Loaded image <%s>, took: %s\n", request.ImageId, elapsed), "header", true)
+	outputLogger.Info(fmt.Sprintf("Loaded image <%s>, took: %s\n", request.ImageId, elapsed))
 
 	// Determine how many ports we need to expose
 	portsToExpose := len(request.Ports)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -188,7 +188,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 	outputLogger := slog.New(common.NewChannelHandler(logChan))
 
 	// Handle stdout/stderr
-	go s.containerLogger.CaptureLogs(containerId, logChan)
+	go s.containerLogger.CaptureLogs(containerId, logChan, request.IsBuildRequest())
 
 	// Attempt to pull image
 	log.Info().Str("container_id", containerId).Msgf("lazy-pulling image: %s", request.ImageId)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -192,7 +192,8 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 
 	// Attempt to pull image
 	log.Info().Str("container_id", containerId).Msgf("lazy-pulling image: %s", request.ImageId)
-	if err := s.imageClient.PullLazy(ctx, request); err != nil {
+	elapsed, err := s.imageClient.PullLazy(ctx, request, outputLogger)
+	if err != nil {
 		if !request.IsBuildRequest() {
 			return err
 		}
@@ -204,8 +205,13 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 			if err := s.buildOrPullBaseImage(ctx, request, containerId, outputLogger); err != nil {
 				return err
 			}
+			elapsed, err = s.imageClient.PullLazy(ctx, request, outputLogger)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	outputLogger.Info(fmt.Sprintf("Loaded image <%s>, took: %s\n", request.ImageId, elapsed), "header", true)
 
 	// Determine how many ports we need to expose
 	portsToExpose := len(request.Ports)
@@ -304,8 +310,7 @@ func (s *Worker) buildOrPullBaseImage(ctx context.Context, request *types.Contai
 		}
 	}
 
-	// Try pull again after building or pulling the source image
-	return s.imageClient.PullLazy(ctx, request)
+	return nil
 }
 
 func (s *Worker) readBundleConfig(imageId string, isBuildRequest bool) (*specs.Spec, error) {

--- a/pkg/worker/logger.go
+++ b/pkg/worker/logger.go
@@ -59,7 +59,7 @@ func (r *ContainerLogger) Log(containerId, stubId string, format string, args ..
 	return nil
 }
 
-func (r *ContainerLogger) CaptureLogs(containerId string, logChan chan common.LogRecord) error {
+func (r *ContainerLogger) CaptureLogs(containerId string, logChan chan common.LogRecord, isBuildRequest bool) error {
 	logFile, err := openLogFile(containerId)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func (r *ContainerLogger) CaptureLogs(containerId string, logChan chan common.Lo
 	rateLimitMessageLogged := false
 
 	for o := range logChan {
-		if !limiter.Allow() {
+		if !isBuildRequest && !limiter.Allow() {
 			if !rateLimitMessageLogged {
 				log.Info().Str("container_id", containerId).Msg(rateLimitMsg)
 				f.WithFields(logrus.Fields{


### PR DESCRIPTION
Added log that shows image load time when running container. 
<img width="403" alt="Screenshot 2025-03-03 at 20 25 27" src="https://github.com/user-attachments/assets/bbbe0ecc-2b3d-4279-b91e-4176cffe40ac" />

Optionally stream the output of skopeo copy and inspect 
<img width="639" alt="Screenshot 2025-03-03 at 20 26 19" src="https://github.com/user-attachments/assets/5f15c78f-ef3f-4c4b-ab45-88a7016e93dd" />
