### PR TITLE
Write restore logs to tmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 tag := latest
 workerTag := latest
 runnerTag := latest
-runnerPlatform := linux/arm64
+runnerPlatform := linux/amd64
 
 setup:
 	bash bin/setup.sh
@@ -54,6 +54,10 @@ start:
 	else \
 		cd hack && okteto up --file okteto.yaml; \
 	fi
+
+clear-ports:
+	@echo "Killing processes on ports 1993, 1994, and 8008..."
+	@lsof -t -i :1993,1994,8008 | xargs -r sudo kill -9 2>/dev/null || true
 
 stop:
 	cd hack && okteto down --file okteto.yaml

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -186,8 +186,13 @@ func (c *NvidiaCRIUManager) cacheDir(containerId, checkpointPath string) error {
 	}))
 
 	wg.Wait() // Wait for all tasks to finish
-	log.Info().Str("container_id", containerId).Msgf("cached checkpoint: %s", checkpointPath)
-	return storeContentErr.ErrorOrNil()
+	err = storeContentErr.ErrorOrNil()
+	if err != nil {
+		log.Error().Str("container_id", containerId).Msgf("error caching checkpoint: %v", err)
+	} else {
+		log.Info().Str("container_id", containerId).Msgf("cached checkpoint: %s", checkpointPath)
+	}
+	return err
 }
 
 // getNvidiaDriverVersion returns the NVIDIA driver version as an integer

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -67,7 +67,6 @@ func (c *NvidiaCRIUManager) CreateCheckpoint(ctx context.Context, request *types
 func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *RestoreOpts) (int, error) {
 	bundlePath := filepath.Dir(opts.configPath)
 	imagePath := filepath.Join(c.cpStorageConfig.MountPath, opts.request.StubId)
-	originalImagePath := imagePath
 	workDir := filepath.Join("/tmp", imagePath)
 	err := c.setupRestoreWorkDir(workDir)
 	if err != nil {


### PR DESCRIPTION
* Changes the base working directory for restores to `/tmp` to avoid write issues with the cache/mountpoint-s3 filesystems. 