### PR TITLE
Fix: Improve exit code logging

### DIFF
--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -137,7 +137,7 @@ func (i *endpointInstance) stopContainers(containersToStop int) error {
 		idx := rnd.Intn(len(containerIds))
 		containerId := containerIds[idx]
 
-		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId})
+		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Reason: types.StopContainerReasonScheduler})
 		if err != nil {
 			log.Error().Str("instance_name", i.Name).Err(err).Msg("unable to stop container")
 			return err

--- a/pkg/abstractions/endpoint/serve.go
+++ b/pkg/abstractions/endpoint/serve.go
@@ -69,7 +69,7 @@ func (es *HttpEndpointService) StartEndpointServe(in *pb.StartEndpointServeReque
 		output := "\nContainer was stopped."
 		if exitCode != 0 {
 			output = fmt.Sprintf("Container failed with exit code %d", exitCode)
-			if exitCode == types.WorkerContainerExitCodeOomKill {
+			if types.ContainerExitCode(exitCode) == types.ContainerExitCodeOomKill {
 				output = "Container was killed due to an out-of-memory error"
 			}
 		}

--- a/pkg/abstractions/experimental/bot/http.go
+++ b/pkg/abstractions/experimental/bot/http.go
@@ -163,7 +163,7 @@ func (g *botGroup) BotOpenSession(ctx echo.Context) error {
 			}
 
 			for _, containerId := range containersBySessionId[sessionId] {
-				err := instance.scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId})
+				err := instance.scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Reason: types.StopContainerReasonScheduler})
 				if err != nil {
 					log.Error().Str("container_id", containerId).Err(err).Msg("failed to stop bot container")
 				}

--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -334,9 +334,9 @@ func (b *Builder) Build(ctx context.Context, opts *BuildOpts, outputChan chan co
 
 			exitCode, err := b.containerRepo.GetContainerExitCode(containerId)
 			if err == nil && exitCode != 0 {
-				msg, ok := types.WorkerContainerExitCodes[exitCode]
+				msg, ok := types.WorkerContainerExitCodes[types.ContainerExitCode(exitCode)]
 				if !ok {
-					msg = types.WorkerContainerExitCodes[types.WorkerContainerExitCodeUnknownError]
+					msg = types.WorkerContainerExitCodes[types.ContainerExitCodeUnknownError]
 				}
 
 				// Wait for any final logs to get sent before returning

--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -232,6 +232,7 @@ func (is *RuncImageService) monitorImageContainers(ctx context.Context) {
 						is.builder.scheduler.Stop(&types.StopContainerArgs{
 							ContainerId: containerId,
 							Force:       true,
+							Reason:      types.StopContainerReasonTtl,
 						})
 					}
 				}
@@ -241,6 +242,7 @@ func (is *RuncImageService) monitorImageContainers(ctx context.Context) {
 					is.builder.scheduler.Stop(&types.StopContainerArgs{
 						ContainerId: containerId,
 						Force:       true,
+						Reason:      types.StopContainerReasonTtl,
 					})
 				}
 			}

--- a/pkg/abstractions/pod/instance.go
+++ b/pkg/abstractions/pod/instance.go
@@ -116,7 +116,7 @@ func (i *podInstance) stopContainers(containersToStop int) error {
 		idx := rnd.Intn(len(containerIds))
 		containerId := containerIds[idx]
 
-		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Force: true})
+		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Force: true, Reason: types.StopContainerReasonScheduler})
 		if err != nil {
 			log.Error().Str("instance_name", i.Name).Err(err).Msg("unable to stop container")
 			return err

--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -120,6 +120,7 @@ func (ss *SSHShellService) handleTTLEvents() {
 						ss.scheduler.Stop(&types.StopContainerArgs{
 							ContainerId: containerId,
 							Force:       true,
+							Reason:      types.StopContainerReasonTtl,
 						})
 					}
 				}
@@ -131,6 +132,7 @@ func (ss *SSHShellService) handleTTLEvents() {
 				ss.scheduler.Stop(&types.StopContainerArgs{
 					ContainerId: containerId,
 					Force:       true,
+					Reason:      types.StopContainerReasonTtl,
 				})
 			}
 		case <-ss.ctx.Done():
@@ -277,6 +279,7 @@ func (ss *SSHShellService) CreateShell(ctx context.Context, in *pb.CreateShellRe
 		ss.scheduler.Stop(&types.StopContainerArgs{
 			ContainerId: containerId,
 			Force:       true,
+			Reason:      types.StopContainerReasonTtl,
 		})
 
 		return &pb.CreateShellResponse{

--- a/pkg/abstractions/taskqueue/instance.go
+++ b/pkg/abstractions/taskqueue/instance.go
@@ -130,7 +130,7 @@ func (i *taskQueueInstance) stopContainers(containersToStop int) error {
 		idx := rnd.Intn(len(containerIds))
 		containerId := containerIds[idx]
 
-		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId})
+		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Reason: types.StopContainerReasonScheduler})
 		if err != nil {
 			log.Error().Str("instance_name", i.Name).Err(err).Msg("unable to stop container")
 			return err

--- a/pkg/abstractions/taskqueue/serve.go
+++ b/pkg/abstractions/taskqueue/serve.go
@@ -60,7 +60,7 @@ func (tq *RedisTaskQueue) StartTaskQueueServe(in *pb.StartTaskQueueServeRequest,
 		output := "\nContainer was stopped."
 		if exitCode != 0 {
 			output = fmt.Sprintf("Container failed with exit code %d", exitCode)
-			if exitCode == types.WorkerContainerExitCodeOomKill {
+			if types.ContainerExitCode(exitCode) == types.ContainerExitCodeOomKill {
 				output = "Container was killed due to an out-of-memory error"
 			}
 		}

--- a/pkg/common/skopeo.go
+++ b/pkg/common/skopeo.go
@@ -81,7 +81,7 @@ func (p *skopeoClient) Inspect(ctx context.Context, sourceImage string, creds st
 	output, err := exec.CommandContext(ctx, p.pullCommand, args...).Output()
 	if err != nil {
 		return imageMetadata, &types.ExitCodeError{
-			ExitCode: types.WorkerContainerExitCodeInvalidCustomImage,
+			ExitCode: types.ContainerExitCodeInvalidCustomImage,
 		}
 	}
 

--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -113,7 +113,7 @@ func (gws GatewayService) StopContainer(ctx context.Context, in *pb.StopContaine
 		}, nil
 	}
 
-	err = gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: in.ContainerId})
+	err = gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: in.ContainerId, Reason: types.StopContainerReasonUser})
 	if err != nil {
 		log.Error().Err(err).Msg("unable to stop container")
 		return &pb.StopContainerResponse{
@@ -151,9 +151,9 @@ func (gws *GatewayService) AttachToContainer(in *pb.AttachToContainerRequest, st
 	exitCallback := func(exitCode int32) error {
 		output := "\nContainer was stopped."
 		if exitCode != 0 {
-			output = fmt.Sprintf("Container failed with exit code %d", exitCode)
-			if exitCode == types.WorkerContainerExitCodeOomKill {
-				output = "Container was killed due to an out-of-memory error"
+			exitCodeMessage, ok := types.ExitCodeMessages[exitCode]
+			if ok {
+				output = exitCodeMessage
 			}
 		}
 

--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -151,7 +151,7 @@ func (gws *GatewayService) AttachToContainer(in *pb.AttachToContainerRequest, st
 	exitCallback := func(exitCode int32) error {
 		output := "\nContainer was stopped."
 		if exitCode != 0 {
-			exitCodeMessage, ok := types.ExitCodeMessages[exitCode]
+			exitCodeMessage, ok := types.ExitCodeMessages[types.ContainerExitCode(exitCode)]
 			if ok {
 				output = exitCodeMessage
 			}

--- a/pkg/gateway/services/deployment.go
+++ b/pkg/gateway/services/deployment.go
@@ -249,7 +249,7 @@ func (gws *GatewayService) stopDeployments(deployments []types.DeploymentWithRel
 		containers, err := gws.containerRepo.GetActiveContainersByStubId(deployment.Stub.ExternalId)
 		if err == nil {
 			for _, container := range containers {
-				gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId})
+				gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId, Reason: types.StopContainerReasonUser})
 			}
 		}
 

--- a/pkg/gateway/services/worker.go
+++ b/pkg/gateway/services/worker.go
@@ -185,7 +185,7 @@ func (gws *GatewayService) DrainWorker(ctx context.Context, in *pb.DrainWorkerRe
 	var group errgroup.Group
 	for _, container := range containers {
 		group.Go(func() error {
-			return gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId})
+			return gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: container.ContainerId, Reason: types.StopContainerReasonAdmin})
 		})
 	}
 	if err := group.Wait(); err != nil {

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -406,7 +405,7 @@ func (cr *ContainerRedisRepository) GetFailedContainersByStubId(stubId string) (
 		}
 
 		// Check if the exit code is non-zero
-		if !slices.Contains(types.AllowedExitCodes, exitCode) {
+		if types.ContainerExitCode(exitCode).IsFailed() {
 			failedContainerIds = append(failedContainerIds, containerId)
 		}
 	}

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -405,7 +406,7 @@ func (cr *ContainerRedisRepository) GetFailedContainersByStubId(stubId string) (
 		}
 
 		// Check if the exit code is non-zero
-		if exitCode != 0 && exitCode != types.WorkerContainerExitCodeOomKill {
+		if !slices.Contains(types.AllowedExitCodes, exitCode) {
 			failedContainerIds = append(failedContainerIds, containerId)
 		}
 	}

--- a/pkg/types/scheduler.go
+++ b/pkg/types/scheduler.go
@@ -525,23 +525,25 @@ func (e *ErrCheckpointNotFound) Error() string {
 	return fmt.Sprintf("checkpoint state not found: %s", e.CheckpointId)
 }
 
+type StopContainerReason string
+
 const (
 	// StopContainerReasonTtl is used when a container is stopped due to some TTL expiration
-	StopContainerReasonTtl = "TTL"
+	StopContainerReasonTtl StopContainerReason = "TTL"
 	// StopContainerReasonUser is used when a container is stopped by a user request
-	StopContainerReasonUser = "USER"
+	StopContainerReasonUser StopContainerReason = "USER"
 	// StopContainerReasonScheduler is used when a container is stopped by the scheduler
-	StopContainerReasonScheduler = "SCHEDULER"
+	StopContainerReasonScheduler StopContainerReason = "SCHEDULER"
 	// StopContainerReasonAdmin is used when a container is stopped by an admin request (i.e. draining a worker)
-	StopContainerReasonAdmin = "ADMIN"
+	StopContainerReasonAdmin StopContainerReason = "ADMIN"
 
-	StopContainerReasonUnknown = "UNKNOWN"
+	StopContainerReasonUnknown StopContainerReason = "UNKNOWN"
 )
 
 type StopContainerArgs struct {
-	ContainerId string `json:"container_id"`
-	Force       bool   `json:"force"`
-	Reason      string `json:"reason"`
+	ContainerId string              `json:"container_id"`
+	Force       bool                `json:"force"`
+	Reason      StopContainerReason `json:"reason"`
 }
 
 func (a StopContainerArgs) ToMap() (map[string]any, error) {

--- a/pkg/types/scheduler.go
+++ b/pkg/types/scheduler.go
@@ -525,9 +525,23 @@ func (e *ErrCheckpointNotFound) Error() string {
 	return fmt.Sprintf("checkpoint state not found: %s", e.CheckpointId)
 }
 
+const (
+	// StopContainerReasonTtl is used when a container is stopped due to some TTL expiration
+	StopContainerReasonTtl = "TTL"
+	// StopContainerReasonUser is used when a container is stopped by a user request
+	StopContainerReasonUser = "USER"
+	// StopContainerReasonScheduler is used when a container is stopped by the scheduler
+	StopContainerReasonScheduler = "SCHEDULER"
+	// StopContainerReasonAdmin is used when a container is stopped by an admin request (i.e. draining a worker)
+	StopContainerReasonAdmin = "ADMIN"
+
+	StopContainerReasonUnknown = "UNKNOWN"
+)
+
 type StopContainerArgs struct {
 	ContainerId string `json:"container_id"`
 	Force       bool   `json:"force"`
+	Reason      string `json:"reason"`
 }
 
 func (a StopContainerArgs) ToMap() (map[string]any, error) {

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -88,7 +88,27 @@ const (
 	WorkerContainerExitCodeSuccess            = 0
 	WorkerContainerExitCodeOomKill            = 137 // 128 + 9 (base value + SIGKILL), used to indicate OOM kill
 	WorkerContainerExitCodeSigterm            = 143 // 128 + 15 (base value + SIGTERM), used to indicate a graceful termination
+	WorkerContainerExitCodeScheduler          = 558
+	WorkerContainerExitCodeTtl                = 559
+	WorkerContainerExitCodeUser               = 560
+	WorkerContainerExitCodeAdmin              = 561
 )
+
+const (
+	WorkerContainerExitCodeOomKillMessage   = "Container was killed due to an out-of-memory error"
+	WorkerContainerExitCodeSchedulerMessage = "Container was stopped by the scheduler"
+	WorkerContainerExitCodeTtlMessage       = "Container was stopped due to TTL expiration"
+	WorkerContainerExitCodeUserMessage      = "Container was stopped by the user"
+	WorkerContainerExitCodeAdminMessage     = "Container was stopped by the admin"
+)
+
+var ExitCodeMessages = map[int32]string{
+	WorkerContainerExitCodeOomKill:   WorkerContainerExitCodeOomKillMessage,
+	WorkerContainerExitCodeScheduler: WorkerContainerExitCodeSchedulerMessage,
+	WorkerContainerExitCodeTtl:       WorkerContainerExitCodeTtlMessage,
+	WorkerContainerExitCodeUser:      WorkerContainerExitCodeUserMessage,
+	WorkerContainerExitCodeAdmin:     WorkerContainerExitCodeAdminMessage,
+}
 
 var WorkerContainerExitCodes = map[int]string{
 	WorkerContainerExitCodeSuccess:            "Success",

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -94,9 +94,18 @@ const (
 	WorkerContainerExitCodeAdmin              = 561
 )
 
+var AllowedExitCodes = []int{
+	WorkerContainerExitCodeSuccess,
+	WorkerContainerExitCodeOomKill,
+	WorkerContainerExitCodeScheduler,
+	WorkerContainerExitCodeTtl,
+	WorkerContainerExitCodeUser,
+	WorkerContainerExitCodeAdmin,
+}
+
 const (
 	WorkerContainerExitCodeOomKillMessage   = "Container killed due to an out-of-memory error"
-	WorkerContainerExitCodeSchedulerMessage = "Container stopped by scheduler"
+	WorkerContainerExitCodeSchedulerMessage = "Container stopped"
 	WorkerContainerExitCodeTtlMessage       = "Container stopped due to TTL expiration"
 	WorkerContainerExitCodeUserMessage      = "Container stopped by user"
 	WorkerContainerExitCodeAdminMessage     = "Container stopped by admin"

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"runtime"
+	"slices"
 	"time"
 
 	pb "github.com/beam-cloud/beta9/proto"
@@ -73,35 +74,42 @@ func NewMountFromProto(in *pb.Mount) *Mount {
 }
 
 type ExitCodeError struct {
-	ExitCode int
+	ExitCode ContainerExitCode
 }
 
 func (e *ExitCodeError) Error() string {
 	return fmt.Sprintf("exit code error: %s", WorkerContainerExitCodes[e.ExitCode])
 }
 
-const (
-	WorkerContainerExitCodeInvalidCustomImage = 555
-	WorkerContainerExitCodeIncorrectImageArch = 556
-	WorkerContainerExitCodeIncorrectImageOs   = 557
-	WorkerContainerExitCodeUnknownError       = 1
-	WorkerContainerExitCodeSuccess            = 0
-	WorkerContainerExitCodeOomKill            = 137 // 128 + 9 (base value + SIGKILL), used to indicate OOM kill
-	WorkerContainerExitCodeSigterm            = 143 // 128 + 15 (base value + SIGTERM), used to indicate a graceful termination
-	WorkerContainerExitCodeScheduler          = 558
-	WorkerContainerExitCodeTtl                = 559
-	WorkerContainerExitCodeUser               = 560
-	WorkerContainerExitCodeAdmin              = 561
-)
+type ContainerExitCode int
 
-var AllowedExitCodes = []int{
-	WorkerContainerExitCodeSuccess,
-	WorkerContainerExitCodeOomKill,
-	WorkerContainerExitCodeScheduler,
-	WorkerContainerExitCodeTtl,
-	WorkerContainerExitCodeUser,
-	WorkerContainerExitCodeAdmin,
+func (c ContainerExitCode) IsFailed() bool {
+	return !slices.Contains(
+		[]ContainerExitCode{
+			ContainerExitCodeSuccess,
+			ContainerExitCodeOomKill,
+			ContainerExitCodeScheduler,
+			ContainerExitCodeTtl,
+			ContainerExitCodeUser,
+			ContainerExitCodeAdmin,
+		},
+		c,
+	)
 }
+
+const (
+	ContainerExitCodeInvalidCustomImage ContainerExitCode = 555
+	ContainerExitCodeIncorrectImageArch ContainerExitCode = 556
+	ContainerExitCodeIncorrectImageOs   ContainerExitCode = 557
+	ContainerExitCodeUnknownError       ContainerExitCode = 1
+	ContainerExitCodeSuccess            ContainerExitCode = 0
+	ContainerExitCodeOomKill            ContainerExitCode = 137 // 128 + 9 (base value + SIGKILL), used to indicate OOM kill
+	ContainerExitCodeSigterm            ContainerExitCode = 143 // 128 + 15 (base value + SIGTERM), used to indicate a graceful termination
+	ContainerExitCodeScheduler          ContainerExitCode = 558
+	ContainerExitCodeTtl                ContainerExitCode = 559
+	ContainerExitCodeUser               ContainerExitCode = 560
+	ContainerExitCodeAdmin              ContainerExitCode = 561
+)
 
 const (
 	WorkerContainerExitCodeOomKillMessage   = "Container killed due to an out-of-memory error"
@@ -111,20 +119,20 @@ const (
 	WorkerContainerExitCodeAdminMessage     = "Container stopped by admin"
 )
 
-var ExitCodeMessages = map[int32]string{
-	WorkerContainerExitCodeOomKill:   WorkerContainerExitCodeOomKillMessage,
-	WorkerContainerExitCodeScheduler: WorkerContainerExitCodeSchedulerMessage,
-	WorkerContainerExitCodeTtl:       WorkerContainerExitCodeTtlMessage,
-	WorkerContainerExitCodeUser:      WorkerContainerExitCodeUserMessage,
-	WorkerContainerExitCodeAdmin:     WorkerContainerExitCodeAdminMessage,
+var ExitCodeMessages = map[ContainerExitCode]string{
+	ContainerExitCodeOomKill:   WorkerContainerExitCodeOomKillMessage,
+	ContainerExitCodeScheduler: WorkerContainerExitCodeSchedulerMessage,
+	ContainerExitCodeTtl:       WorkerContainerExitCodeTtlMessage,
+	ContainerExitCodeUser:      WorkerContainerExitCodeUserMessage,
+	ContainerExitCodeAdmin:     WorkerContainerExitCodeAdminMessage,
 }
 
-var WorkerContainerExitCodes = map[int]string{
-	WorkerContainerExitCodeSuccess:            "Success",
-	WorkerContainerExitCodeUnknownError:       "UnknownError: An unknown error occurred.",
-	WorkerContainerExitCodeIncorrectImageArch: "InvalidArch: Image must be built for the " + runtime.GOARCH + " architecture.",
-	WorkerContainerExitCodeInvalidCustomImage: "InvalidCustomImage: Custom image not found. Check your image reference and registry credentials.",
-	WorkerContainerExitCodeIncorrectImageOs:   "InvalidOS: Image must be built for Linux.",
+var WorkerContainerExitCodes = map[ContainerExitCode]string{
+	ContainerExitCodeSuccess:            "Success",
+	ContainerExitCodeUnknownError:       "UnknownError: An unknown error occurred.",
+	ContainerExitCodeIncorrectImageArch: "InvalidArch: Image must be built for the " + runtime.GOARCH + " architecture.",
+	ContainerExitCodeInvalidCustomImage: "InvalidCustomImage: Custom image not found. Check your image reference and registry credentials.",
+	ContainerExitCodeIncorrectImageOs:   "InvalidOS: Image must be built for Linux.",
 }
 
 const (

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -95,11 +95,11 @@ const (
 )
 
 const (
-	WorkerContainerExitCodeOomKillMessage   = "Container was killed due to an out-of-memory error"
-	WorkerContainerExitCodeSchedulerMessage = "Container was stopped by the scheduler"
-	WorkerContainerExitCodeTtlMessage       = "Container was stopped due to TTL expiration"
-	WorkerContainerExitCodeUserMessage      = "Container was stopped by the user"
-	WorkerContainerExitCodeAdminMessage     = "Container was stopped by the admin"
+	WorkerContainerExitCodeOomKillMessage   = "Container killed due to an out-of-memory error"
+	WorkerContainerExitCodeSchedulerMessage = "Container stopped by scheduler"
+	WorkerContainerExitCodeTtlMessage       = "Container stopped due to TTL expiration"
+	WorkerContainerExitCodeUserMessage      = "Container stopped by user"
+	WorkerContainerExitCodeAdminMessage     = "Container stopped by admin"
 )
 
 var ExitCodeMessages = map[int32]string{

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -226,13 +226,13 @@ func (c *ImageClient) inspectAndVerifyImage(ctx context.Context, request *types.
 
 	if imageMetadata.Architecture != runtime.GOARCH {
 		return &types.ExitCodeError{
-			ExitCode: types.WorkerContainerExitCodeIncorrectImageArch,
+			ExitCode: types.ContainerExitCodeIncorrectImageArch,
 		}
 	}
 
 	if imageMetadata.Os != runtime.GOOS {
 		return &types.ExitCodeError{
-			ExitCode: types.WorkerContainerExitCodeIncorrectImageOs,
+			ExitCode: types.ContainerExitCodeIncorrectImageOs,
 		}
 	}
 

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -54,8 +54,10 @@ func (s *Worker) handleStopContainerEvent(event *common.Event) bool {
 		return false
 	}
 
-	if _, exists := s.containerInstances.Get(stopArgs.ContainerId); exists {
+	if containerInstance, exists := s.containerInstances.Get(stopArgs.ContainerId); exists {
 		log.Info().Str("container_id", stopArgs.ContainerId).Msg("received stop container event")
+		containerInstance.StopReason = stopArgs.Reason
+		s.containerInstances.Set(stopArgs.ContainerId, containerInstance)
 		s.stopContainerChan <- stopContainerEvent{ContainerId: stopArgs.ContainerId, Kill: stopArgs.Force}
 	}
 
@@ -564,7 +566,7 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 				log.Info().Str("container_id", containerId).Msg("container state not found, returning")
 				return
 			}
-		} else if err == nil && resp.State.Status == string(types.ContainerStatusStopping) {
+		} else if resp.State.Status == string(types.ContainerStatusStopping) {
 			log.Info().Str("container_id", containerId).Msg("container should be stopping, force killing")
 			s.stopContainer(containerId, true)
 			return
@@ -690,20 +692,33 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 		go s.watchOOMEvents(ctx, request, outputLogger, &isOOMKilled) // Watch for OOM events
 	}()
 
-	exitCode, containerId, err = s.runContainer(ctx, request, configPath, outputWriter, startedChan, checkpointPIDChan)
-	if err != nil {
-		return
+	exitCode, containerId, _ = s.runContainer(ctx, request, configPath, outputWriter, startedChan, checkpointPIDChan)
+
+	stopReason := types.StopContainerReasonUnknown
+	containerInstance, exists = s.containerInstances.Get(containerId)
+	if exists {
+		stopReason = containerInstance.StopReason
 	}
 
-	if isOOMKilled.Load() {
-		exitCode = types.WorkerContainerExitCodeOomKill
-	} else if exitCode == -1 {
-		// If the container exited with a code of -1 and was not OOM killed, set the exit code to 0
-		// since the container was likely terminated by a SIGTERM/SIGKILL
-		exitCode = 0
+	switch stopReason {
+	case types.StopContainerReasonScheduler:
+		exitCode = types.WorkerContainerExitCodeScheduler
+	case types.StopContainerReasonTtl:
+		exitCode = types.WorkerContainerExitCodeTtl
+	case types.StopContainerReasonUser:
+		exitCode = types.WorkerContainerExitCodeUser
+	case types.StopContainerReasonAdmin:
+		exitCode = types.WorkerContainerExitCodeAdmin
+	default:
+		if isOOMKilled.Load() {
+			exitCode = types.WorkerContainerExitCodeOomKill
+		} else if exitCode == types.WorkerContainerExitCodeOomKill || exitCode == -1 {
+			// Exit code will match OOM kill exit code, but container was not OOM killed so override it
+			exitCode = 0
+		}
 	}
 
-	log.Info().Str("container_id", containerId).Msgf("container has exited with code: %d", exitCode)
+	log.Info().Str("container_id", containerId).Msgf("container has exited with code: %d, stop reason: %s", exitCode, stopReason)
 	outputLogger.Info("", "done", true, "success", exitCode == 0)
 	if containerId != "" {
 		err = s.runcHandle.Delete(s.ctx, containerId, &runc.DeleteOpts{Force: true})
@@ -720,7 +735,12 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		if err == nil {
 			return exitCode, containerId, err
 		}
-		log.Error().Str("container_id", request.ContainerId).Msgf("failed to run container with checkpoint/restore got exit code %d: %v, attempting to run container from bundle", exitCode, err)
+
+		if exitCode == types.WorkerContainerExitCodeOomKill {
+			log.Warn().Str("container_id", request.ContainerId).Msg("container was killed")
+		} else {
+			log.Error().Str("container_id", request.ContainerId).Msgf("failed to run container with checkpoint/restore got exit code %d: %v, attempting to run container from bundle", exitCode, err)
+		}
 	}
 
 	bundlePath := filepath.Dir(configPath)
@@ -729,7 +749,11 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		Started:      startedChan,
 	})
 	if err != nil {
-		log.Error().Str("container_id", request.ContainerId).Msgf("failed to run container: %v", err)
+		if exitCode == types.WorkerContainerExitCodeOomKill {
+			log.Warn().Str("container_id", request.ContainerId).Msg("container was killed")
+		} else {
+			log.Error().Str("container_id", request.ContainerId).Msgf("failed to run container: %v", err)
+		}
 	}
 	return exitCode, request.ContainerId, err
 }

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -95,7 +95,7 @@ func (s *Worker) finalizeContainer(containerId string, request *types.ContainerR
 
 	if *exitCode < 0 {
 		*exitCode = 1
-	} else if *exitCode == types.WorkerContainerExitCodeSigterm {
+	} else if *exitCode == int(types.ContainerExitCodeSigterm) {
 		*exitCode = 0
 	}
 
@@ -697,22 +697,22 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 	stopReason := types.StopContainerReasonUnknown
 	containerInstance, exists = s.containerInstances.Get(containerId)
 	if exists {
-		stopReason = containerInstance.StopReason
+		stopReason = types.StopContainerReason(containerInstance.StopReason)
 	}
 
 	switch stopReason {
 	case types.StopContainerReasonScheduler:
-		exitCode = types.WorkerContainerExitCodeScheduler
+		exitCode = int(types.ContainerExitCodeScheduler)
 	case types.StopContainerReasonTtl:
-		exitCode = types.WorkerContainerExitCodeTtl
+		exitCode = int(types.ContainerExitCodeTtl)
 	case types.StopContainerReasonUser:
-		exitCode = types.WorkerContainerExitCodeUser
+		exitCode = int(types.ContainerExitCodeUser)
 	case types.StopContainerReasonAdmin:
-		exitCode = types.WorkerContainerExitCodeAdmin
+		exitCode = int(types.ContainerExitCodeAdmin)
 	default:
 		if isOOMKilled.Load() {
-			exitCode = types.WorkerContainerExitCodeOomKill
-		} else if exitCode == types.WorkerContainerExitCodeOomKill || exitCode == -1 {
+			exitCode = int(types.ContainerExitCodeOomKill)
+		} else if exitCode == int(types.ContainerExitCodeOomKill) || exitCode == -1 {
 			// Exit code will match OOM kill exit code, but container was not OOM killed so override it
 			exitCode = 0
 		}

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -735,12 +735,7 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		if err == nil {
 			return exitCode, containerId, err
 		}
-
-		if exitCode == types.WorkerContainerExitCodeOomKill {
-			log.Warn().Str("container_id", request.ContainerId).Msg("container was killed")
-		} else {
-			log.Error().Str("container_id", request.ContainerId).Msgf("failed to run container with checkpoint/restore got exit code %d: %v, attempting to run container from bundle", exitCode, err)
-		}
+		log.Warn().Str("container_id", request.ContainerId).Err(err).Msgf("error running container from checkpoint/restore, exit code %d", exitCode)
 	}
 
 	bundlePath := filepath.Dir(configPath)
@@ -749,11 +744,7 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		Started:      startedChan,
 	})
 	if err != nil {
-		if exitCode == types.WorkerContainerExitCodeOomKill {
-			log.Warn().Str("container_id", request.ContainerId).Msg("container was killed")
-		} else {
-			log.Error().Str("container_id", request.ContainerId).Msgf("failed to run container: %v", err)
-		}
+		log.Warn().Err(err).Msgf("error running container from bundle, exit code %d", exitCode)
 	}
 	return exitCode, request.ContainerId, err
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -81,6 +81,7 @@ type ContainerInstance struct {
 	OutputWriter *common.OutputWriter
 	LogBuffer    *common.LogBuffer
 	Request      *types.ContainerRequest
+	StopReason   string
 }
 
 type ContainerOptions struct {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -81,7 +81,7 @@ type ContainerInstance struct {
 	OutputWriter *common.OutputWriter
 	LogBuffer    *common.LogBuffer
 	Request      *types.ContainerRequest
-	StopReason   string
+	StopReason   types.StopContainerReason
 }
 
 type ContainerOptions struct {
@@ -318,7 +318,7 @@ func (s *Worker) handleContainerRequest(request *types.ContainerRequest) {
 
 			serr, ok := err.(*types.ExitCodeError)
 			if ok {
-				exitCode = serr.ExitCode
+				exitCode = int(serr.ExitCode)
 			}
 
 			_, err = handleGRPCResponse(s.containerRepoClient.SetContainerExitCode(ctx, &pb.SetContainerExitCodeRequest{

--- a/sdk/src/beta9/cli/container.py
+++ b/sdk/src/beta9/cli/container.py
@@ -156,11 +156,11 @@ def _attach_to_container(service: ServiceClient, container_id: str):
 
     r = None
     for r in stream:
-        if r.output != "":
-            terminal.detail(r.output, end="")
-
         if r.done or r.exit_code != 0:
             break
+
+        if r.output != "":
+            terminal.detail(r.output, end="")
 
     if r is None:
         return terminal.error("Container failed ❌")


### PR DESCRIPTION
Container stopped by scheduler because keep warm expired.
<img width="1138" alt="Screenshot 2025-03-11 at 13 49 51" src="https://github.com/user-attachments/assets/be57ba89-fe5c-4b0a-b715-c1c54fe3e8f5" />

Stopping container with `beta9 container stop`
<img width="1431" alt="Screenshot 2025-03-11 at 13 50 14" src="https://github.com/user-attachments/assets/66157fad-2103-4638-9edc-e3b88757b306" />

In the future it would be nice to send even more information along with scheduler stops. 