### PR TITLE
Fix: Set container request status to failed if scheduler can't find a worker

### DIFF
--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -15,6 +15,7 @@ var (
 	schedulerContainerState          string = "scheduler:container:state:%s"
 	schedulerContainerAddress        string = "scheduler:container:container_addr:%s"
 	schedulerContainerAddressMap     string = "scheduler:container:container_addr_map:%s"
+	schedulerContainerRequestStatus  string = "scheduler:container:request_status:%s"
 	schedulerContainerIndex          string = "scheduler:container:index:%s"
 	schedulerContainerWorkerIndex    string = "scheduler:container:worker:index:%s"
 	schedulerContainerWorkspaceIndex string = "scheduler:container:workspace:index:%s"
@@ -145,6 +146,10 @@ func (rk *redisKeys) SchedulerContainerAddress(containerId string) string {
 
 func (rk *redisKeys) SchedulerContainerAddressMap(containerId string) string {
 	return fmt.Sprintf(schedulerContainerAddressMap, containerId)
+}
+
+func (rk *redisKeys) SchedulerContainerRequestStatus(containerId string) string {
+	return fmt.Sprintf(schedulerContainerRequestStatus, containerId)
 }
 
 func (rk *redisKeys) SchedulerWorkerAddress(containerId string) string {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -48,6 +48,7 @@ type ContainerRepository interface {
 	UpdateContainerStatus(string, types.ContainerStatus, int64) error
 	UpdateAssignedContainerGPU(string, string) error
 	DeleteContainerState(containerId string) error
+	SetContainerRequestStatus(containerId string, status types.ContainerRequestStatus) error
 	SetWorkerAddress(containerId string, addr string) error
 	GetWorkerAddress(ctx context.Context, containerId string) (string, error)
 	SetContainerAddressMap(containerId string, addressMap map[int32]string) error

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -294,13 +293,20 @@ func (cr *ContainerRedisRepository) GetWorkerAddress(ctx context.Context, contai
 		select {
 		case <-ctx.Done():
 			if ctx.Err() == context.DeadlineExceeded {
-				return "", errors.New("timeout reached while trying to get worker addr")
+				return "", fmt.Errorf("failed to schedule container, container id: %s", containerId)
 			}
-			return "", errors.New("context cancelled while trying to get worker addr")
+			return "", fmt.Errorf("context cancelled while trying to get worker addr, container id: %s", containerId)
 		case <-ticker.C:
 			hostname, err = cr.rdb.Get(ctx, common.RedisKeys.SchedulerWorkerAddress(containerId)).Result()
 			if err == nil {
 				return hostname, nil
+			}
+
+			requestStatus, err := cr.GetContainerRequestStatus(containerId)
+			if err == nil {
+				if requestStatus == types.ContainerRequestStatusFailed {
+					return "", fmt.Errorf("failed to schedule container, container id: %s", containerId)
+				}
 			}
 		}
 	}
@@ -537,4 +543,17 @@ func (cr *ContainerRedisRepository) SetStubState(stubId, state string) error {
 func (cr *ContainerRedisRepository) DeleteStubState(stubId string) error {
 	stateKey := common.RedisKeys.SchedulerStubState(stubId)
 	return cr.rdb.Del(context.TODO(), stateKey).Err()
+}
+
+func (cr *ContainerRedisRepository) SetContainerRequestStatus(containerId string, status types.ContainerRequestStatus) error {
+	return cr.rdb.Set(context.TODO(), common.RedisKeys.SchedulerContainerRequestStatus(containerId), status, 0).Err()
+}
+
+func (cr *ContainerRedisRepository) GetContainerRequestStatus(containerId string) (types.ContainerRequestStatus, error) {
+	status, err := cr.rdb.Get(context.TODO(), common.RedisKeys.SchedulerContainerRequestStatus(containerId)).Result()
+	if err != nil {
+		return "", err
+	}
+
+	return types.ContainerRequestStatus(status), nil
 }

--- a/pkg/types/scheduler.go
+++ b/pkg/types/scheduler.go
@@ -29,6 +29,12 @@ const (
 	StubStateHealthy  = "healthy"
 )
 
+type ContainerRequestStatus string
+
+const (
+	ContainerRequestStatusFailed ContainerRequestStatus = "failed"
+)
+
 // @go2proto
 type Worker struct {
 	Id                   string       `json:"id" redis:"id"`


### PR DESCRIPTION
Currently, users see something like this
```
error timeout reached while trying to get worker addr
```
This is confusing.

After this change they will see a message like the one below: 
![Screenshot 2025-03-11 at 16 45 02](https://github.com/user-attachments/assets/9e22c5c1-ef63-4c1f-8b3b-fadf4dc7b21d)

If the issue is unrelated to scheduling the default message is now 
```
failed to schedule container, container id:
```