### PR TITLE
Feat: Add ability to clone stubs

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -209,8 +208,7 @@ func (g *StubGroup) copyObjectContents(ctx context.Context, workspace *types.Wor
 	parentObjectPath := path.Join(types.DefaultObjectPath, stub.Workspace.Name)
 	parentObjectFilePath := path.Join(parentObjectPath, parentObject.ExternalId)
 
-	// TODO: update
-	hash := sha256.Sum256([]byte(parentObject.Hash + "a"))
+	hash := sha256.Sum256([]byte(parentObject.Hash + workspace.ExternalId))
 	hashStr := hex.EncodeToString(hash[:])
 
 	if existingObject, err := g.backendRepo.GetObjectByHash(ctx, hashStr, workspace.Id); err == nil {
@@ -243,7 +241,6 @@ func (g *StubGroup) copyObjectContents(ctx context.Context, workspace *types.Wor
 func (g *StubGroup) cloneStub(ctx context.Context, workspace *types.Workspace, stub *types.StubWithRelated) (*types.Stub, error) {
 	objectId, err := g.copyObjectContents(ctx, workspace, stub)
 	if err != nil {
-		log.Println(err)
 		return nil, HTTPBadRequest("Failed to clone object")
 	}
 

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -837,7 +837,7 @@ func (r *PostgresBackendRepository) UpdateStubConfig(ctx context.Context, stubId
 func (r *PostgresBackendRepository) GetStubByExternalId(ctx context.Context, externalId string, queryFilters ...types.QueryFilter) (*types.StubWithRelated, error) {
 	var stub types.StubWithRelated
 	qb := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).Select(
-		`s.id, s.external_id, s.name, s.type, s.config, s.config_version, s.object_id, s.workspace_id, s.created_at, s.updated_at,
+		`s.id, s.external_id, s.name, s.type, s.config, s.config_version, s.object_id, s.workspace_id, s.created_at, s.updated_at, s.public,
 	    w.id AS "workspace.id", w.external_id AS "workspace.external_id", w.name AS "workspace.name", w.created_at AS "workspace.created_at", w.updated_at AS "workspace.updated_at", w.signing_key AS "workspace.signing_key", w.volume_cache_enabled AS "workspace.volume_cache_enabled", w.multi_gpu_enabled AS "workspace.multi_gpu_enabled",
 	    o.id AS "object.id", o.external_id AS "object.external_id", o.hash AS "object.hash", o.size AS "object.size", o.workspace_id AS "object.workspace_id", o.created_at AS "object.created_at"`,
 	).

--- a/pkg/repository/backend_postgres_migrations/023_add_public_field_to_stub.go
+++ b/pkg/repository/backend_postgres_migrations/023_add_public_field_to_stub.go
@@ -1,0 +1,23 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddFieldStubPublicField, downDropFieldStubPublicField)
+}
+
+func upAddFieldStubPublicField(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`ALTER TABLE stub ADD COLUMN public BOOLEAN DEFAULT FALSE;`)
+
+	return err
+}
+
+func downDropFieldStubPublicField(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`ALTER TABLE stub DROP COLUMN public;`)
+	return err
+}

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -328,6 +328,7 @@ type Stub struct {
 	WorkspaceId   uint      `db:"workspace_id" json:"workspace_id"` // Foreign key to Workspace
 	CreatedAt     time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt     time.Time `db:"updated_at" json:"updated_at"`
+	Public        bool      `db:"public" json:"public"`
 }
 
 func (s *Stub) UnmarshalConfig() (*StubConfigV1, error) {


### PR DESCRIPTION
**Summary**

This PR adds the ability to clone the stub only if it is public. The public field is necessary else user's can just clone any stub that exists.

I make sure to only clone information that can be shared. Secrets are repopulated from the user that is cloning the stub and will fail if the secrets do not exist. I also make sure to clone the object from parent.

**Running the stub**

Since each abstraction has its unique way of running their stub (functions vs pods), I do not try to condense their functionality into a umbrella `Run` method. That means you must call them from their individual invocation endpoints

function: /function/:id/:stubId
pod: /pod/run/:stubId

Notes:
- I assume that the object is free to clone if attached to a public stub
- I skipped cloning onDeploy stubs to simplify the PR