### PR TITLE
Fix: Copy content fails if user never created stub

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path"
@@ -209,9 +210,11 @@ func (g StubGroup) processStubOverrides(overrideConfig OverrideStubConfig, stub 
 	}
 
 	if overrideConfig.Gpu != nil {
+		log.Println("GPU override:", *overrideConfig.Gpu)
 		if _, ok := types.GPUTypesToMap(types.AllGPUTypes())[*overrideConfig.Gpu]; ok {
-			stubConfig.Runtime.Gpu = types.GpuType(*overrideConfig.Gpu)
+			stubConfig.Runtime.Gpus = []types.GpuType{types.GpuType(*overrideConfig.Gpu)}
 		} else {
+
 			return HTTPBadRequest("Invalid GPU type")
 		}
 	}

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path"
@@ -276,6 +277,13 @@ func (g *StubGroup) copyObjectContents(ctx context.Context, workspace *types.Wor
 	}
 
 	newObjectPath := path.Join(types.DefaultObjectPath, workspace.Name)
+
+	if _, err := os.Stat(newObjectPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(newObjectPath, 0755); err != nil {
+			return 0, err
+		}
+	}
+
 	newObjectFilePath := path.Join(newObjectPath, newObject.ExternalId)
 
 	input, err := os.ReadFile(parentObjectFilePath)
@@ -296,6 +304,7 @@ func (g *StubGroup) copyObjectContents(ctx context.Context, workspace *types.Wor
 func (g *StubGroup) cloneStub(ctx context.Context, workspace *types.Workspace, stub *types.StubWithRelated) (*types.Stub, error) {
 	objectId, err := g.copyObjectContents(ctx, workspace, stub)
 	if err != nil {
+		log.Println("Failed to copy object contents:", err)
 		return nil, HTTPBadRequest("Failed to clone object")
 	}
 

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -174,7 +174,12 @@ func (g *StubGroup) CloneStubPublic(ctx echo.Context) error {
 		return HTTPBadRequest("Invalid stub ID")
 	}
 
-	if err := g.processStubOverrides(ctx, stub); err != nil {
+	var overrideConfig OverrideStubConfig
+	if err := ctx.Bind(&overrideConfig); err != nil {
+		return HTTPBadRequest("Failed to process overrides")
+	}
+
+	if err := g.processStubOverrides(overrideConfig, stub); err != nil {
 		return err
 	}
 
@@ -186,13 +191,7 @@ func (g *StubGroup) CloneStubPublic(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, newStub)
 }
 
-func (g StubGroup) processStubOverrides(ctx echo.Context, stub *types.StubWithRelated) error {
-	var overrideConfig OverrideStubConfig
-
-	if err := ctx.Bind(&overrideConfig); err != nil {
-		return HTTPBadRequest("Failed to process overrides")
-	}
-
+func (g StubGroup) processStubOverrides(overrideConfig OverrideStubConfig, stub *types.StubWithRelated) error {
 	var stubConfig types.StubConfigV1
 	if err := json.Unmarshal([]byte(stub.Config), &stubConfig); err != nil {
 		return HTTPBadRequest("Failed to process overrides")

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -181,7 +180,6 @@ func (g *StubGroup) CloneStubPublic(ctx echo.Context) error {
 
 	newStub, err := g.cloneStub(ctx.Request().Context(), cc.AuthInfo.Workspace, stub)
 	if err != nil {
-		log.Println(err)
 		return err
 	}
 
@@ -295,7 +293,6 @@ func (g *StubGroup) copyObjectContents(ctx context.Context, workspace *types.Wor
 func (g *StubGroup) cloneStub(ctx context.Context, workspace *types.Workspace, stub *types.StubWithRelated) (*types.Stub, error) {
 	objectId, err := g.copyObjectContents(ctx, workspace, stub)
 	if err != nil {
-		log.Println(err)
 		return nil, HTTPBadRequest("Failed to clone object")
 	}
 
@@ -343,7 +340,6 @@ func (g *StubGroup) cloneStub(ctx context.Context, workspace *types.Workspace, s
 
 	newStub, err := g.backendRepo.GetOrCreateStub(ctx, stub.Name, string(stub.Type), *stubConfig, objectId, workspace.Id, true)
 	if err != nil {
-		log.Println(err)
 		return nil, HTTPInternalServerError("Failed to clone stub")
 	}
 

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -210,7 +209,6 @@ func (g StubGroup) processStubOverrides(overrideConfig OverrideStubConfig, stub 
 	}
 
 	if overrideConfig.Gpu != nil {
-		log.Println("GPU override:", *overrideConfig.Gpu)
 		if _, ok := types.GPUTypesToMap(types.AllGPUTypes())[*overrideConfig.Gpu]; ok {
 			stubConfig.Runtime.Gpus = []types.GpuType{types.GpuType(*overrideConfig.Gpu)}
 		} else {

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -304,7 +303,6 @@ func (g *StubGroup) copyObjectContents(ctx context.Context, workspace *types.Wor
 func (g *StubGroup) cloneStub(ctx context.Context, workspace *types.Workspace, stub *types.StubWithRelated) (*types.Stub, error) {
 	objectId, err := g.copyObjectContents(ctx, workspace, stub)
 	if err != nil {
-		log.Println("Failed to copy object contents:", err)
 		return nil, HTTPBadRequest("Failed to clone object")
 	}
 

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -1,0 +1,88 @@
+package apiv1
+
+import (
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/labstack/echo/v4"
+	"k8s.io/utils/ptr"
+)
+
+func NewStubGroupForTest() *StubGroup {
+	backendRepo, err := repository.NewBackendPostgresRepositoryForTest()
+	if err != nil {
+		panic(err)
+	}
+
+	config := types.AppConfig{}
+
+	e := echo.New()
+
+	return NewStubGroup(
+		e.Group("/stubs"),
+		backendRepo,
+		config,
+	)
+}
+
+func generateDefaultStubWithConfig() *types.Stub {
+	return &types.Stub{
+		Name:   "Test Stub",
+		Config: `{"runtime":{"cpu":1000,"gpu":"","gpu_count":0,"memory":1000,"image_id":"","gpus":[]},"handler":"","on_start":"","on_deploy":"","on_deploy_stub_id":"","python_version":"python3","keep_warm_seconds":600,"max_pending_tasks":100,"callback_url":"","task_policy":{"max_retries":3,"timeout":3600,"expires":"0001-01-01T00:00:00Z","ttl":0},"workers":1,"concurrent_requests":1,"authorized":false,"volumes":null,"autoscaler":{"type":"queue_depth","max_containers":1,"tasks_per_container":1,"min_containers":0},"extra":{},"checkpoint_enabled":false,"work_dir":"","entry_point":["sleep 100"],"ports":[]}`,
+	}
+}
+
+func TestProcessStubOverrides(t *testing.T) {
+	stubGroup := NewStubGroupForTest()
+
+	tests := []struct {
+		name     string
+		cpu      *int64
+		memory   *int64
+		gpu      *string
+		gpuCount *uint32
+	}{
+		{
+			name: "Test with CPU override",
+			cpu:  ptr.To(int64(2000)),
+		},
+		{
+			name:   "Test with Memory override",
+			memory: ptr.To(int64(4096)),
+		},
+		{
+			name: "Test with GPU override",
+			gpu:  ptr.To(string(types.GPU_A10G)),
+		},
+		{
+			name:     "Test with GPU Count override",
+			gpuCount: ptr.To(uint32(2)),
+		},
+		{
+			name:     "Test with all overrides",
+			cpu:      ptr.To(int64(2000)),
+			memory:   ptr.To(int64(4096)),
+			gpu:      ptr.To(string(types.GPU_A10G)),
+			gpuCount: ptr.To(uint32(2)),
+		},
+		{
+			name: "Test with no overrides",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := stubGroup.processStubOverrides(OverrideStubConfig{
+				Cpu:      tt.cpu,
+				Memory:   tt.memory,
+				Gpu:      tt.gpu,
+				GpuCount: tt.gpuCount,
+			}, &types.StubWithRelated{Stub: *generateDefaultStubWithConfig()})
+			if err != nil {
+				t.Errorf("processStubOverrides() error = %v", err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
If a user never created a stub from any sort of command, they won't have an existing folder `/data/objects/{workspace_name}`
