### PR TITLE
Fix: Check for available hosts before attempting to cache

### DIFF
--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -162,7 +162,6 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	imageId := request.ImageId
 	isBuildContainer := strings.HasPrefix(request.ContainerId, types.BuildContainerPrefix)
 
-	c.logger.Log(request.ContainerId, request.StubId, "Loading image: %s", imageId)
 	localCachePath := fmt.Sprintf("%s/%s.cache", c.imageCachePath, imageId)
 	if !c.config.ImageService.LocalCacheEnabled && !isBuildContainer {
 		localCachePath = ""
@@ -181,7 +180,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 		baseBlobFsContentPath := fmt.Sprintf("%s/%s", baseFileCachePath, sourcePath)
 		if _, err := os.Stat(baseBlobFsContentPath); err == nil && c.cacheClient.IsPathCachedNearby(ctx, "/"+sourcePath) {
 			localCachePath = baseBlobFsContentPath
-		} else {
+		} else if c.cacheClient.HostsAvailable() {
 			pullStartTime := time.Now()
 			outputLogger.Info(fmt.Sprintf("Image <%s> not found in worker region, caching nearby\n", imageId))
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed an issue where the system attempts to cache images when no hosts are available. This change prevents unnecessary caching attempts by checking host availability first.

**Bug Fixes**
- Added a check for available hosts before attempting to cache images
- Removed redundant logging message for image loading

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1081: Enhanced change log with LLM](https://github.com/beam-cloud/beta9/pull/1081)
* **[#1087: Fix: Check for available hosts before attempting to cache](https://github.com/beam-cloud/beta9/pull/1087)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/beam-cloud/beta9/pull/1087))

---
<!-- MRGE_STACK_DESCRIPTION_END -->

