### PR TITLE
Add fields for monitoring ingestion config

### DIFF
--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -447,9 +447,12 @@ type MonitoringConfig struct {
 }
 
 type VictoriaMetricsConfig struct {
-	PushURL   string `key:"pushURL" json:"push_url"`
-	AuthToken string `key:"authToken" json:"auth_token"`
-	PushSecs  int    `key:"pushSecs" json:"push_secs"`
+	PushURL       string `key:"pushURL" json:"push_url"`
+	AuthToken     string `key:"authToken" json:"auth_token"`
+	PushSecs      int    `key:"pushSecs" json:"push_secs"`
+	WriteURL      string `key:"writeURL" json:"write_url"`
+	WriteUsername string `key:"writeUsername" json:"write_username"`
+	WritePassword string `key:"writePassword" json:"write_password"`
 }
 
 type PrometheusConfig struct {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added new configuration fields to support alternative authentication methods for Victoria Metrics monitoring. These fields will enable cleaner implementation of monitoring ingestion in the agent.

**New Features**
- Added three new fields to VictoriaMetricsConfig: WriteURL, WriteUsername, and WritePassword.
- Maintained backward compatibility with existing PushURL, AuthToken, and PushSecs fields.

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1081: Enhanced change log with LLM](https://github.com/beam-cloud/beta9/pull/1081)
* **[#1088: Add fields for monitoring ingestion config](https://github.com/beam-cloud/beta9/pull/1088)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/beam-cloud/beta9/pull/1088))

---
<!-- MRGE_STACK_DESCRIPTION_END -->





Will use these new fields to clean this up: https://github.com/beam-cloud/beta9-agent/pull/38/files#diff-93fded10dbfe86b56e1de652621f5533e990108ec562dbb01f31e40e22a058e9R291-R303