### PR TITLE
Add primary tokens

### DIFF
--- a/pkg/api/v1/token.go
+++ b/pkg/api/v1/token.go
@@ -44,7 +44,9 @@ func (g *TokenGroup) CreateWorkspaceToken(ctx echo.Context) error {
 	tokenType := ctx.QueryParam("token_type")
 	if tokenType == "" {
 		tokenType = types.TokenTypeWorkspace
-	} else if tokenType == types.TokenTypeWorkspacePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+	}
+
+	if tokenType == types.TokenTypeWorkspacePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
 		return HTTPBadRequest("Invalid token type")
 	}
 

--- a/pkg/api/v1/token.go
+++ b/pkg/api/v1/token.go
@@ -33,13 +33,22 @@ func NewTokenGroup(g *echo.Group, backendRepo repository.BackendRepository, conf
 }
 
 func (g *TokenGroup) CreateWorkspaceToken(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+
 	workspaceId := ctx.Param("workspaceId")
 	workspace, err := g.backendRepo.GetWorkspaceByExternalId(ctx.Request().Context(), workspaceId)
 	if err != nil {
 		return HTTPBadRequest("Invalid workspace ID")
 	}
 
-	token, err := g.backendRepo.CreateToken(ctx.Request().Context(), workspace.Id, types.TokenTypeWorkspace, true)
+	tokenType := ctx.QueryParam("token_type")
+	if tokenType == "" {
+		tokenType = types.TokenTypeWorkspace
+	} else if tokenType == types.TokenTypePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+		return HTTPBadRequest("Invalid token type")
+	}
+
+	token, err := g.backendRepo.CreateToken(ctx.Request().Context(), workspace.Id, tokenType, true)
 	if err != nil {
 		return HTTPInternalServerError("Unable to create token")
 	}
@@ -112,14 +121,25 @@ func (g *TokenGroup) ToggleWorkspaceToken(ctx echo.Context) error {
 }
 
 func (g *TokenGroup) DeleteWorkspaceToken(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
 	workspaceId := ctx.Param("workspaceId")
 	workspace, err := g.backendRepo.GetWorkspaceByExternalId(ctx.Request().Context(), workspaceId)
 	if err != nil {
 		return HTTPBadRequest("Invalid workspace ID")
 	}
 
-	extTokenId := ctx.Param("tokenId")
-	err = g.backendRepo.DeleteToken(ctx.Request().Context(), workspace.Id, extTokenId)
+	tokenId := ctx.Param("tokenId")
+
+	token, err := g.backendRepo.GetTokenByExternalId(ctx.Request().Context(), workspace.Id, tokenId)
+	if err != nil {
+		return HTTPBadRequest("Invalid token ID")
+	}
+
+	if token.TokenType == types.TokenTypePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+		return HTTPBadRequest("Cannot delete primary token")
+	}
+
+	err = g.backendRepo.DeleteToken(ctx.Request().Context(), workspace.Id, tokenId)
 	if err != nil {
 		return HTTPInternalServerError("Failed to delete token")
 	}

--- a/pkg/api/v1/token.go
+++ b/pkg/api/v1/token.go
@@ -44,7 +44,7 @@ func (g *TokenGroup) CreateWorkspaceToken(ctx echo.Context) error {
 	tokenType := ctx.QueryParam("token_type")
 	if tokenType == "" {
 		tokenType = types.TokenTypeWorkspace
-	} else if tokenType == types.TokenTypePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+	} else if tokenType == types.TokenTypeWorkspacePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
 		return HTTPBadRequest("Invalid token type")
 	}
 
@@ -135,7 +135,7 @@ func (g *TokenGroup) DeleteWorkspaceToken(ctx echo.Context) error {
 		return HTTPBadRequest("Invalid token ID")
 	}
 
-	if token.TokenType == types.TokenTypePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+	if token.TokenType == types.TokenTypeWorkspacePrimary && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
 		return HTTPBadRequest("Cannot delete primary token")
 	}
 

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -328,6 +328,18 @@ func (r *PostgresBackendRepository) ListTokens(ctx context.Context, workspaceId 
 	return tokens, nil
 }
 
+func (r *PostgresBackendRepository) GetTokenByExternalId(ctx context.Context, workspaceId uint, extTokenId string) (*types.Token, error) {
+	query := `SELECT id, external_id, key, created_at, updated_at, active, token_type, reusable, workspace_id FROM token WHERE external_id = $1 AND workspace_id = $2;`
+
+	var token types.Token
+	err := r.client.GetContext(ctx, &token, query, extTokenId, workspaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &token, nil
+}
+
 func (r *PostgresBackendRepository) ToggleToken(ctx context.Context, workspaceId uint, extTokenId string) (types.Token, error) {
 	query := `
 	UPDATE token

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -334,6 +335,9 @@ func (r *PostgresBackendRepository) GetTokenByExternalId(ctx context.Context, wo
 	var token types.Token
 	err := r.client.GetContext(ctx, &token, query, extTokenId, workspaceId)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errors.New("token not found")
+		}
 		return nil, err
 	}
 

--- a/pkg/repository/backend_postgres_migrations/025_add_workspace_primary_token.go
+++ b/pkg/repository/backend_postgres_migrations/025_add_workspace_primary_token.go
@@ -1,0 +1,44 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(addWorkspacePrimaryToken, downRemoveWorkspacePrimaryToken)
+}
+
+func addWorkspacePrimaryToken(ctx context.Context, tx *sql.Tx) error {
+	newTokenTypes := []string{"primary"}
+
+	for _, tokenType := range newTokenTypes {
+		addEnumSQL := fmt.Sprintf(`
+DO $$
+BEGIN
+   IF NOT EXISTS (
+      SELECT 1 FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+      JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public' AND t.typname = 'token_type' AND e.enumlabel = '%s'
+   ) THEN
+      EXECUTE 'ALTER TYPE token_type ADD VALUE ' || quote_literal('%s');
+   END IF;
+END
+$$;`, tokenType, tokenType)
+
+		if _, err := tx.Exec(addEnumSQL); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downRemoveWorkspacePrimaryToken(ctx context.Context, tx *sql.Tx) error {
+	// PostgreSQL doesn't support removing values from an ENUM directly
+	return nil
+}

--- a/pkg/repository/backend_postgres_migrations/025_add_workspace_primary_token.go
+++ b/pkg/repository/backend_postgres_migrations/025_add_workspace_primary_token.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 func addWorkspacePrimaryToken(ctx context.Context, tx *sql.Tx) error {
-	newTokenTypes := []string{"primary"}
+	newTokenTypes := []string{"workspace_primary"}
 
 	for _, tokenType := range newTokenTypes {
 		addEnumSQL := fmt.Sprintf(`

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -106,6 +106,7 @@ type BackendRepository interface {
 	CreateToken(ctx context.Context, workspaceId uint, tokenType string, reusable bool) (types.Token, error)
 	AuthorizeToken(ctx context.Context, tokenKey string) (*types.Token, *types.Workspace, error)
 	RetrieveActiveToken(ctx context.Context, workspaceId uint) (*types.Token, error)
+	GetTokenByExternalId(ctx context.Context, workspaceId uint, extTokenId string) (*types.Token, error)
 	ListTokens(ctx context.Context, workspaceId uint) ([]types.Token, error)
 	UpdateTokenAsClusterAdmin(ctx context.Context, tokenId string, disabled bool) error
 	ToggleToken(ctx context.Context, workspaceId uint, extTokenId string) (types.Token, error)

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -139,11 +139,11 @@ func (w *WorkspaceStorage) ToProto() *pb.WorkspaceStorage {
 }
 
 const (
-	TokenTypeClusterAdmin string = "admin"
-	TokenTypePrimary      string = "primary"
-	TokenTypeWorkspace    string = "workspace"
-	TokenTypeWorker       string = "worker"
-	TokenTypeMachine      string = "machine"
+	TokenTypeClusterAdmin     string = "admin"
+	TokenTypeWorkspacePrimary string = "workspace_primary"
+	TokenTypeWorkspace        string = "workspace"
+	TokenTypeWorker           string = "worker"
+	TokenTypeMachine          string = "machine"
 )
 
 type Token struct {

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -140,6 +140,7 @@ func (w *WorkspaceStorage) ToProto() *pb.WorkspaceStorage {
 
 const (
 	TokenTypeClusterAdmin string = "admin"
+	TokenTypePrimary      string = "primary"
 	TokenTypeWorkspace    string = "workspace"
 	TokenTypeWorker       string = "worker"
 	TokenTypeMachine      string = "machine"


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added support for primary workspace tokens with appropriate authorization controls. This enhancement allows creating a special token type with restricted access permissions.

**New Features**
- Added a new primary token type for workspaces
- Created database migration to add the primary token type to the enum
- Added endpoint to create primary tokens (restricted to cluster admins)

**Refactors**
- Enhanced token management with proper permission checks
- Added GetTokenByExternalId method to retrieve tokens by external ID
- Updated token deletion to prevent non-admin users from removing primary tokens

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1081: Enhanced change log with LLM](https://github.com/beam-cloud/beta9/pull/1081)
* **[#1090: Add primary tokens](https://github.com/beam-cloud/beta9/pull/1090)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/beam-cloud/beta9/pull/1090))

---
<!-- MRGE_STACK_DESCRIPTION_END -->







