### PR TITLE
Fix: Nvidia container toolkit needs 1.23 to build

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -58,7 +58,7 @@ EOT
 
 # nvidia-container-toolkit
 # ========================
-FROM golang AS nvidia-container-toolkit
+FROM golang:1.23-bookworm AS nvidia-container-toolkit
 
 WORKDIR /workspace
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Updated the Golang base image for nvidia-container-toolkit to version 1.23-bookworm. This fixes build issues with the nvidia-container-toolkit component in the worker Dockerfile.

**Bug Fixes**
- Updated the Golang base image from unspecified version to 1.23-bookworm for the nvidia-container-toolkit build stage.

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1081: Enhanced change log with LLM](https://github.com/beam-cloud/beta9/pull/1081)
* **[#1092: Fix: Nvidia container toolkit needs 1.23 to build](https://github.com/beam-cloud/beta9/pull/1092)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/beam-cloud/beta9/pull/1092))

---
<!-- MRGE_STACK_DESCRIPTION_END -->

