### PR TITLE
revert dependabot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.13.0 // indirect
 	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/bsm/redislock v0.9.4 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/beam-cloud/beta9
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.22.10
 
 require (
 	buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-20250123222419-64bf8384f939.1
@@ -78,7 +76,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.31.0
 	go.opentelemetry.io/otel/trace v1.33.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
-	golang.org/x/net v0.36.0
+	golang.org/x/net v0.35.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.30.0
 	golang.org/x/time v0.8.0
@@ -286,7 +284,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.35.0 // indirect
+	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/term v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,16 +87,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250402150505-44ffcea1a2c9 h1:0VJSSeBu2Qyp4ZqgD28ZHk0tivb//ssJYwrwvLEz4Ns=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250402150505-44ffcea1a2c9/go.mod h1:ZjQOwyxSN8Z2b25M0X7FtVCYaS1lyOuRzsMkn2NxQac=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250402205159-7050ba514f13 h1:kiHNmz5Yz2nVNlHOUDsWNKSZ4Vgxxveddi6Z5il2tNE=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250402205159-7050ba514f13/go.mod h1:ZjQOwyxSN8Z2b25M0X7FtVCYaS1lyOuRzsMkn2NxQac=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250404181439-77731be5b69a h1:KMeA3tn2wd57vkVFRPwNt60Kqa3yruubgTxADZjYdH4=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250404181439-77731be5b69a/go.mod h1:ZjQOwyxSN8Z2b25M0X7FtVCYaS1lyOuRzsMkn2NxQac=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250408171712-a24dbf78bc3a h1:KcavR96FQ1F3SNsFCGt+jkPUlelUmPK28PaVqvTP52I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250408171712-a24dbf78bc3a/go.mod h1:ZjQOwyxSN8Z2b25M0X7FtVCYaS1lyOuRzsMkn2NxQac=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250408172911-61aea73a084e h1:vmrcqPR0T23GOS7XUycTQpRbqVYXMnWYhBEYvpEn/c4=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250408172911-61aea73a084e/go.mod h1:ZjQOwyxSN8Z2b25M0X7FtVCYaS1lyOuRzsMkn2NxQac=
 github.com/beam-cloud/blobcache-v2 v0.0.0-20250409191605-4d9739224e40 h1:cLuUCDggvxWVQPudfVm2xAHd2vemV14Y8Vq8ZhXGOqQ=
 github.com/beam-cloud/blobcache-v2 v0.0.0-20250409191605-4d9739224e40/go.mod h1:ZjQOwyxSN8Z2b25M0X7FtVCYaS1lyOuRzsMkn2NxQac=
 github.com/beam-cloud/clip v0.0.0-20250314195126-c4a7a2a7f4ba h1:gkdfRwR9mhyTKspfJVTbbBgbw2PsuH3kZTS+UEhtqpk=

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
-golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
@@ -786,8 +786,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
-golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
+golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
+golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Reverted Go version from 1.23.0 to 1.22.10 and downgraded several dependencies to maintain compatibility. These changes roll back recent Dependabot updates that caused issues.

**Dependencies**
- Downgraded Go from 1.23.0 to 1.22.10
- Removed toolchain go1.24.1 directive
- Reverted golang.org/x/net from 0.36.0 to 0.35.0
- Reverted golang.org/x/crypto from 0.35.0 to 0.33.0
- Removed several intermediate blobcache-v2 dependency versions

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1081: Enhanced change log with LLM](https://github.com/beam-cloud/beta9/pull/1081)
* **[#1094: revert dependabot](https://github.com/beam-cloud/beta9/pull/1094)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/beam-cloud/beta9/pull/1094))

---
<!-- MRGE_STACK_DESCRIPTION_END -->

