### PR TITLE
Fix: Patch volume nil workspace reference

### DIFF
--- a/pkg/abstractions/volume/http.go
+++ b/pkg/abstractions/volume/http.go
@@ -135,13 +135,16 @@ func (g *volumeGroup) UploadFile(ctx echo.Context) error {
 }
 
 func (g *volumeGroup) DownloadFileWithToken(ctx echo.Context) error {
-	cc, _ := ctx.(*auth.HttpAuthContext)
-
 	workspaceId := ctx.Param("workspaceId")
 	volumePath := ctx.Param("volumePath*")
 	decodedVolumePath, err := url.QueryUnescape(volumePath)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid volume path")
+	}
+
+	workspace, err := g.gvs.backendRepo.GetWorkspaceByExternalId(ctx.Request().Context(), workspaceId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid workspace ID")
 	}
 
 	token := ctx.QueryParam("token")
@@ -156,7 +159,7 @@ func (g *volumeGroup) DownloadFileWithToken(ctx echo.Context) error {
 	if path, err := g.gvs.getFilePath(
 		ctx.Request().Context(),
 		decodedVolumePath,
-		cc.AuthInfo.Workspace,
+		&workspace,
 	); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to download file %v", err))
 	} else {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a bug in the file download endpoint where workspace references could be nil. This change properly fetches the workspace by ID before using it in the download process.

**Bug Fixes**
- Fixed potential nil pointer dereference by retrieving workspace information directly from the database
- Replaced dependency on auth context with explicit workspace lookup
- Added proper error handling when workspace ID is invalid

<!-- End of auto-generated description by mrge. -->

