### PR TITLE
fix create command

### DIFF
--- a/sdk/src/beta9/cli/machine.py
+++ b/sdk/src/beta9/cli/machine.py
@@ -185,7 +185,7 @@ def create_machine(service: ServiceClient, pool: str):
     if res.agent_upstream_url:
         cmd_args.append(f'--flux-upstream "{res.agent_upstream_url}"')
 
-    if res.agent_upstream_branch:
+    if res.agent_upstream_branch and res.agent_upstream_branch != "main":
         cmd_args.append(f'--flux-branch "{res.agent_upstream_branch}"')
         agent_url += f"-{res.agent_upstream_branch}"
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed the machine creation command to only include the flux branch parameter when it differs from "main". This prevents unnecessary branch specification when using the default main branch.

**Bug Fixes**
- Updated the create_machine function to only add the flux-branch argument when the branch is not "main"

<!-- End of auto-generated description by mrge. -->

