### PR TITLE
Fix: Add metadata mode to machine state

### DIFF
--- a/pkg/api/v1/machine.go
+++ b/pkg/api/v1/machine.go
@@ -119,13 +119,14 @@ func (g *MachineGroup) RegisterMachine(ctx echo.Context) error {
 	}
 
 	err = g.providerRepo.RegisterMachine(request.ProviderName, request.PoolName, request.MachineID, &types.ProviderMachineState{
-		MachineId: request.MachineID,
-		Token:     request.Token,
-		HostName:  hostName,
-		Cpu:       cpu,
-		Memory:    memory,
-		GpuCount:  uint32(gpuCount),
-		PrivateIP: request.PrivateIP,
+		MachineId:    request.MachineID,
+		Token:        request.Token,
+		HostName:     hostName,
+		Cpu:          cpu,
+		Memory:       memory,
+		GpuCount:     uint32(gpuCount),
+		PrivateIP:    request.PrivateIP,
+		MetadataMode: g.config.BlobCache.Metadata.Mode,
 	}, &poolConfig)
 	if err != nil {
 		return HTTPInternalServerError("Failed to register machine")

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -182,7 +182,7 @@ type ProviderRepository interface {
 	GetMachine(providerName, poolName, machineId string) (*types.ProviderMachine, error)
 	AddMachine(providerName, poolName, machineId string, machineInfo *types.ProviderMachineState) error
 	RemoveMachine(providerName, poolName, machineId string) error
-	SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, ready bool, metrics *types.ProviderMachineMetrics) error
+	SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, metrics *types.ProviderMachineMetrics) error
 	SetLastWorkerSeen(providerName, poolName, machineId string) error
 	RegisterMachine(providerName, poolName, machineId string, newMachineInfo *types.ProviderMachineState, poolConfig *types.WorkerPoolConfig) error
 	WaitForMachineRegistration(providerName, poolName, machineId string) (*types.ProviderMachineState, error)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -183,7 +183,7 @@ type ProviderRepository interface {
 	AddMachine(providerName, poolName, machineId string, machineInfo *types.ProviderMachineState) error
 	RemoveMachine(providerName, poolName, machineId string) error
 	SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, metrics *types.ProviderMachineMetrics) error
-	SetMachineReady(providerName, poolName, machineId string) error
+	SetMachineStatusReady(providerName, poolName, machineId string) error
 	SetLastWorkerSeen(providerName, poolName, machineId string) error
 	RegisterMachine(providerName, poolName, machineId string, newMachineInfo *types.ProviderMachineState, poolConfig *types.WorkerPoolConfig) error
 	WaitForMachineRegistration(providerName, poolName, machineId string) (*types.ProviderMachineState, error)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -182,7 +182,7 @@ type ProviderRepository interface {
 	GetMachine(providerName, poolName, machineId string) (*types.ProviderMachine, error)
 	AddMachine(providerName, poolName, machineId string, machineInfo *types.ProviderMachineState) error
 	RemoveMachine(providerName, poolName, machineId string) error
-	SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, metrics *types.ProviderMachineMetrics) error
+	SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, ready bool, metrics *types.ProviderMachineMetrics) error
 	SetLastWorkerSeen(providerName, poolName, machineId string) error
 	RegisterMachine(providerName, poolName, machineId string, newMachineInfo *types.ProviderMachineState, poolConfig *types.WorkerPoolConfig) error
 	WaitForMachineRegistration(providerName, poolName, machineId string) (*types.ProviderMachineState, error)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -183,6 +183,7 @@ type ProviderRepository interface {
 	AddMachine(providerName, poolName, machineId string, machineInfo *types.ProviderMachineState) error
 	RemoveMachine(providerName, poolName, machineId string) error
 	SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, metrics *types.ProviderMachineMetrics) error
+	SetMachineReady(providerName, poolName, machineId string) error
 	SetLastWorkerSeen(providerName, poolName, machineId string) error
 	RegisterMachine(providerName, poolName, machineId string, newMachineInfo *types.ProviderMachineState, poolConfig *types.WorkerPoolConfig) error
 	WaitForMachineRegistration(providerName, poolName, machineId string) (*types.ProviderMachineState, error)

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -186,7 +186,7 @@ func (r *ProviderRedisRepository) WaitForMachineRegistration(providerName, poolN
 				return nil, fmt.Errorf("error parsing machine state for %s: %w", machineId, err)
 			}
 
-			if state.Status == types.MachineStatusPending || !state.Ready {
+			if state.Status != types.MachineStatusReady {
 				log.Info().Msgf("waiting for machine to be ready: %s", machineId)
 				continue
 			}
@@ -225,7 +225,7 @@ func (r *ProviderRedisRepository) AddMachine(providerName, poolName, machineId s
 	return nil
 }
 
-func (r *ProviderRedisRepository) SetMachineReady(providerName, poolName, machineId string) error {
+func (r *ProviderRedisRepository) SetMachineStatusReady(providerName, poolName, machineId string) error {
 	stateKey := common.RedisKeys.ProviderMachineState(providerName, poolName, machineId)
 
 	machineState, err := r.getMachineStateFromKey(stateKey)
@@ -233,7 +233,7 @@ func (r *ProviderRedisRepository) SetMachineReady(providerName, poolName, machin
 		return fmt.Errorf("failed to get machine state <%v>: %w", stateKey, err)
 	}
 
-	machineState.Ready = true
+	machineState.Status = types.MachineStatusReady
 
 	err = r.rdb.HSet(context.TODO(), stateKey, common.ToSlice(machineState)).Err()
 	if err != nil {

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -224,7 +224,7 @@ func (r *ProviderRedisRepository) AddMachine(providerName, poolName, machineId s
 	return nil
 }
 
-func (r *ProviderRedisRepository) SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, ready bool, metrics *types.ProviderMachineMetrics) error {
+func (r *ProviderRedisRepository) SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, metrics *types.ProviderMachineMetrics) error {
 	stateKey := common.RedisKeys.ProviderMachineState(providerName, poolName, machineId)
 	metricsKey := common.RedisKeys.ProviderMachineMetrics(providerName, poolName, machineId)
 
@@ -236,7 +236,6 @@ func (r *ProviderRedisRepository) SetMachineKeepAlive(providerName, poolName, ma
 	// Update the LastKeepalive with the current Unix timestamp
 	machineState.LastKeepalive = fmt.Sprintf("%d", time.Now().Unix())
 	machineState.AgentVersion = agentVersion
-	machineState.Ready = ready
 
 	err = r.rdb.HSet(context.TODO(), stateKey, common.ToSlice(machineState)).Err()
 	if err != nil {

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -224,7 +224,7 @@ func (r *ProviderRedisRepository) AddMachine(providerName, poolName, machineId s
 	return nil
 }
 
-func (r *ProviderRedisRepository) SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, metrics *types.ProviderMachineMetrics) error {
+func (r *ProviderRedisRepository) SetMachineKeepAlive(providerName, poolName, machineId, agentVersion string, ready bool, metrics *types.ProviderMachineMetrics) error {
 	stateKey := common.RedisKeys.ProviderMachineState(providerName, poolName, machineId)
 	metricsKey := common.RedisKeys.ProviderMachineMetrics(providerName, poolName, machineId)
 
@@ -236,6 +236,7 @@ func (r *ProviderRedisRepository) SetMachineKeepAlive(providerName, poolName, ma
 	// Update the LastKeepalive with the current Unix timestamp
 	machineState.LastKeepalive = fmt.Sprintf("%d", time.Now().Unix())
 	machineState.AgentVersion = agentVersion
+	machineState.Ready = ready
 
 	err = r.rdb.HSet(context.TODO(), stateKey, common.ToSlice(machineState)).Err()
 	if err != nil {

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -351,6 +351,7 @@ func (r *ProviderRedisRepository) RegisterMachine(providerName, poolName, machin
 	machineInfo.Memory = newMachineInfo.Memory
 	machineInfo.GpuCount = newMachineInfo.GpuCount
 	machineInfo.PrivateIP = newMachineInfo.PrivateIP
+	machineInfo.MetadataMode = newMachineInfo.MetadataMode
 
 	err = r.rdb.HSet(context.TODO(), stateKey, common.ToSlice(machineInfo)).Err()
 	if err != nil {

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog/log"
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -186,7 +187,7 @@ func (r *ProviderRedisRepository) WaitForMachineRegistration(providerName, poolN
 			}
 
 			if state.Status == types.MachineStatusPending || !state.Ready {
-				// Still waiting for machine registration
+				log.Info().Msgf("waiting for machine to be ready: %s", machineId)
 				continue
 			}
 

--- a/pkg/repository/provider_redis.go
+++ b/pkg/repository/provider_redis.go
@@ -185,7 +185,7 @@ func (r *ProviderRedisRepository) WaitForMachineRegistration(providerName, poolN
 				return nil, fmt.Errorf("error parsing machine state for %s: %w", machineId, err)
 			}
 
-			if state.Status == types.MachineStatusPending {
+			if state.Status == types.MachineStatusPending || !state.Ready {
 				// Still waiting for machine registration
 				continue
 			}

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -248,7 +248,7 @@ func (wpc *ExternalWorkerPoolController) attemptToAssignWorkerToMachine(workerId
 		remainingMachineGpuCount -= uint32(worker.TotalGpuCount)
 	}
 
-	if !machine.State.Ready {
+	if machine.State.Status != types.MachineStatusReady {
 		return nil, errors.New("machine not ready")
 	}
 

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -248,7 +248,11 @@ func (wpc *ExternalWorkerPoolController) attemptToAssignWorkerToMachine(workerId
 		remainingMachineGpuCount -= uint32(worker.TotalGpuCount)
 	}
 
-	if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount && machine.State.Ready {
+	if !machine.State.Ready {
+		return nil, errors.New("machine not ready")
+	}
+
+	if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount {
 		log.Info().Str("machine_id", machine.State.MachineId).Str("hostname", machine.State.HostName).Msg("using existing machine")
 
 		// If there is only one GPU available on the machine, give the worker access to everything

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -248,7 +248,7 @@ func (wpc *ExternalWorkerPoolController) attemptToAssignWorkerToMachine(workerId
 		remainingMachineGpuCount -= uint32(worker.TotalGpuCount)
 	}
 
-	if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount {
+	if remainingMachineCpu >= int64(cpu) && remainingMachineMemory >= int64(memory) && machine.State.Gpu == gpuType && remainingMachineGpuCount >= gpuCount && machine.State.Ready {
 		log.Info().Str("machine_id", machine.State.MachineId).Str("hostname", machine.State.HostName).Msg("using existing machine")
 
 		// If there is only one GPU available on the machine, give the worker access to everything

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -132,6 +132,7 @@ func (s *WorkerPoolSizer) occupyAvailableMachines() error {
 
 		worker, err := s.controller.AddWorkerToMachine(cpu, memory, gpuType, gpuCount, m.State.MachineId)
 		if err != nil {
+			log.Error().Str("pool_name", s.controller.Name()).Err(err).Msg("failed to add worker to machine")
 			continue
 		}
 

--- a/pkg/types/provider.go
+++ b/pkg/types/provider.go
@@ -9,6 +9,7 @@ import (
 const (
 	MachineStatusRegistered          MachineStatus = "registered"
 	MachineStatusPending             MachineStatus = "pending"
+	MachineStatusReady               MachineStatus = "ready"
 	MachinePendingExpirationS        int           = 3600 // 1 hour
 	MachineKeepaliveExpirationS      int           = 300  // 5 minutes
 	MachineEmptyConsolidationPeriodM time.Duration = 10 * time.Minute
@@ -62,7 +63,6 @@ type ProviderMachineState struct {
 	AutoConsolidate   bool                            `json:"auto_consolidate" redis:"auto_consolidate"`
 	AgentVersion      string                          `json:"agent_version" redis:"agent_version"`
 	MetadataMode      blobcache.BlobCacheMetadataMode `json:"metadata_mode" redis:"metadata_mode"`
-	Ready             bool                            `json:"ready" redis:"ready"`
 }
 
 type ProviderNotImplemented struct {

--- a/pkg/types/provider.go
+++ b/pkg/types/provider.go
@@ -61,7 +61,6 @@ type ProviderMachineState struct {
 	LastKeepalive     string                          `json:"last_keepalive" redis:"last_keepalive"`
 	AutoConsolidate   bool                            `json:"auto_consolidate" redis:"auto_consolidate"`
 	AgentVersion      string                          `json:"agent_version" redis:"agent_version"`
-	Ready             bool                            `json:"ready" redis:"ready"`
 	MetadataMode      blobcache.BlobCacheMetadataMode `json:"metadata_mode" redis:"metadata_mode"`
 }
 

--- a/pkg/types/provider.go
+++ b/pkg/types/provider.go
@@ -62,6 +62,7 @@ type ProviderMachineState struct {
 	AutoConsolidate   bool                            `json:"auto_consolidate" redis:"auto_consolidate"`
 	AgentVersion      string                          `json:"agent_version" redis:"agent_version"`
 	MetadataMode      blobcache.BlobCacheMetadataMode `json:"metadata_mode" redis:"metadata_mode"`
+	Ready             bool                            `json:"ready" redis:"ready"`
 }
 
 type ProviderNotImplemented struct {

--- a/pkg/types/provider.go
+++ b/pkg/types/provider.go
@@ -1,6 +1,10 @@
 package types
 
-import "time"
+import (
+	"time"
+
+	blobcache "github.com/beam-cloud/blobcache-v2/pkg"
+)
 
 const (
 	MachineStatusRegistered          MachineStatus = "registered"
@@ -41,22 +45,24 @@ type ProviderMachineMetrics struct {
 }
 
 type ProviderMachineState struct {
-	MachineId         string        `json:"machine_id" redis:"machine_id"`
-	PoolName          string        `json:"pool_name" redis:"pool_name"`
-	Status            MachineStatus `json:"status" redis:"status"`
-	HostName          string        `json:"hostname" redis:"hostname"`
-	Token             string        `json:"token" redis:"token"`
-	Cpu               int64         `json:"cpu" redis:"cpu"`
-	Memory            int64         `json:"memory" redis:"memory"`
-	Gpu               string        `json:"gpu" redis:"gpu"`
-	GpuCount          uint32        `json:"gpu_count" redis:"gpu_count"`
-	RegistrationToken string        `json:"registration_token" redis:"registration_token"`
-	PrivateIP         string        `json:"private_ip" redis:"private_ip"`
-	Created           string        `json:"created" redis:"created"`
-	LastWorkerSeen    string        `json:"last_worker_seen" redis:"last_worker_seen"`
-	LastKeepalive     string        `json:"last_keepalive" redis:"last_keepalive"`
-	AutoConsolidate   bool          `json:"auto_consolidate" redis:"auto_consolidate"`
-	AgentVersion      string        `json:"agent_version" redis:"agent_version"`
+	MachineId         string                          `json:"machine_id" redis:"machine_id"`
+	PoolName          string                          `json:"pool_name" redis:"pool_name"`
+	Status            MachineStatus                   `json:"status" redis:"status"`
+	HostName          string                          `json:"hostname" redis:"hostname"`
+	Token             string                          `json:"token" redis:"token"`
+	Cpu               int64                           `json:"cpu" redis:"cpu"`
+	Memory            int64                           `json:"memory" redis:"memory"`
+	Gpu               string                          `json:"gpu" redis:"gpu"`
+	GpuCount          uint32                          `json:"gpu_count" redis:"gpu_count"`
+	RegistrationToken string                          `json:"registration_token" redis:"registration_token"`
+	PrivateIP         string                          `json:"private_ip" redis:"private_ip"`
+	Created           string                          `json:"created" redis:"created"`
+	LastWorkerSeen    string                          `json:"last_worker_seen" redis:"last_worker_seen"`
+	LastKeepalive     string                          `json:"last_keepalive" redis:"last_keepalive"`
+	AutoConsolidate   bool                            `json:"auto_consolidate" redis:"auto_consolidate"`
+	AgentVersion      string                          `json:"agent_version" redis:"agent_version"`
+	Ready             bool                            `json:"ready" redis:"ready"`
+	MetadataMode      blobcache.BlobCacheMetadataMode `json:"metadata_mode" redis:"metadata_mode"`
 }
 
 type ProviderNotImplemented struct {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added machine readiness and metadata mode to improve worker scheduling and connection management. These changes help the scheduler determine if a machine is ready for workers and prevent non-local node connections from using the sentinel connection.

**New Features**
- Added `Ready` boolean flag to machine state to indicate scheduling availability.
- Added `MetadataMode` field to control sentinel connection behavior for non-local nodes.

**Refactors**
- Updated `SetMachineKeepAlive` function signature to include the readiness parameter.
- Modified repository interfaces to support the new machine state properties.

<!-- End of auto-generated description by mrge. -->

This PR adds readiness and metadata mode to the machine state. Readiness will be used by the scheduler to determine if a machine is ready to have workers scheduled. The metadata mode will be used to avoid piggy backing the sentinel connection off of non-local nodes