### PR TITLE
Feat: Add L40S gpu type

### DIFF
--- a/pkg/types/gpu.go
+++ b/pkg/types/gpu.go
@@ -71,13 +71,14 @@ const (
 	GPU_H100    GpuType = "H100"
 	GPU_A6000   GpuType = "A6000"
 	GPU_RTX4090 GpuType = "RTX4090"
+	GPU_L40S    GpuType = "L40S"
 
 	NO_GPU  GpuType = "NO_GPU"
 	GPU_ANY GpuType = "any"
 )
 
 func AllGPUTypes() []GpuType {
-	return []GpuType{GPU_A10G, GPU_A100_40, GPU_A100_80, GPU_L4, GPU_T4, GPU_H100, GPU_A6000, GPU_RTX4090, GPU_ANY}
+	return []GpuType{GPU_A10G, GPU_A100_40, GPU_A100_80, GPU_L4, GPU_T4, GPU_H100, GPU_A6000, GPU_RTX4090, GPU_L40S, GPU_ANY}
 }
 
 func GpuTypesToSlice(gpuTypes []GpuType) []string {

--- a/sdk/src/beta9/type.py
+++ b/sdk/src/beta9/type.py
@@ -97,6 +97,7 @@ class GpuType(str, Enum):
     H100 = "H100"
     A6000 = "A6000"
     RTX4090 = "RTX4090"
+    L40S = "L40S"
 
 
 # Add GpuType str literals. Must copy/paste for now.
@@ -112,6 +113,7 @@ GpuTypeLiteral = Literal[
     "H100",
     "A6000",
     "RTX4090",
+    "L40S",
 ]
 
 GpuTypeAlias = Union[GpuType, GpuTypeLiteral]


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added support for the L40S GPU type across the platform. This enhancement expands our GPU offerings to include NVIDIA's L40S model in both the Go backend and Python SDK.

**New Features**
- Added L40S GPU type constant in the Go backend code.
- Updated the Python SDK to include L40S in the GpuType enum and GpuTypeLiteral list.
- Included L40S in the AllGPUTypes function to make it available throughout the system.

<!-- End of auto-generated description by mrge. -->

