### PR TITLE
Add missing l40s location

### DIFF
--- a/pkg/scheduler/utils.go
+++ b/pkg/scheduler/utils.go
@@ -95,6 +95,8 @@ func ParseGPUType(gpu interface{}) (types.GpuType, error) {
 		return types.GPU_A6000, nil
 	case string(types.GPU_RTX4090):
 		return types.GPU_RTX4090, nil
+	case string(types.GPU_L40S):
+		return types.GPU_L40S, nil
 	default:
 		return types.GpuType(""), errors.New("invalid gpu type")
 	}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added support for L40S GPU type in the scheduler's GPU parsing function. This change ensures the system can properly recognize and handle L40S GPUs when they're specified.

**Bug Fixes**
- Added missing case for L40S GPU type in the ParseGPUType function.

<!-- End of auto-generated description by mrge. -->

