### PR TITLE
bump sdk

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.188"
+version = "0.1.189"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Incremented the SDK version from 0.1.188 to 0.1.189. This version bump ensures clients can access the latest SDK features and fixes.

**Dependencies**
- Updated the beta9 SDK version to 0.1.189 in pyproject.toml.

<!-- End of auto-generated description by mrge. -->

