### PR TITLE
Fix: Increase connectionReadTimeout to 5min for Pod Proxy

### DIFF
--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -25,7 +25,7 @@ const (
 	containerDialTimeoutDurationS time.Duration = time.Second * 30
 	connectionBufferSize          int           = 1024 * 4 // 4KB
 	connectionKeepAliveInterval   time.Duration = time.Second * 1
-	connectionReadTimeout         time.Duration = time.Second * 10
+	connectionReadTimeout         time.Duration = time.Minute * 5
 	containerAvailableTimeout     time.Duration = time.Second * 2
 )
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Increased the connection read timeout for Pod Proxy from 10 seconds to 5 minutes. This change helps prevent timeouts during longer-running operations when proxying to containers.

**Bug Fixes**
- Extended the `connectionReadTimeout` constant from 10 seconds to 5 minutes in the pod proxy implementation.

<!-- End of auto-generated description by mrge. -->

Increases `connectionReadTimeout` from 10s to 5mins