### PR TITLE
Fix: Clean up logging around scheduling workers

### DIFF
--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -236,7 +236,7 @@ func (wpc *ExternalWorkerPoolController) attemptToAssignWorkerToMachine(workerId
 	}
 
 	if machine.State.Status != types.MachineStatusReady {
-		return nil, errors.New("machine not ready")
+		return nil, nil
 	}
 
 	remainingMachineCpu := machine.State.Cpu
@@ -268,7 +268,7 @@ func (wpc *ExternalWorkerPoolController) attemptToAssignWorkerToMachine(workerId
 		return worker, nil
 	}
 
-	return nil, errors.New("machine out of capacity")
+	return nil, nil
 }
 
 func (wpc *ExternalWorkerPoolController) createWorkerOnMachine(workerId, machineId string, machineState *types.ProviderMachineState, cpu int64, memory int64, gpuType string, gpuCount uint32) (*types.Worker, error) {

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -135,6 +135,10 @@ func (s *WorkerPoolSizer) occupyAvailableMachines() error {
 			log.Error().Str("pool_name", s.controller.Name()).Err(err).Msg("failed to add worker to machine")
 			continue
 		}
+		// When there is no capacity of the machine is not ready the worker will be nil with no error
+		if worker == nil {
+			continue
+		}
 
 		log.Info().Str("pool_name", s.controller.Name()).Interface("worker", worker).Msg("added new worker to occupy existing machine")
 	}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Reduced excessive error logging when scheduling workers by returning nil instead of errors for common conditions. This change prevents log spam when machines are not ready or out of capacity.

**Bug Fixes**
- Changed error returns to nil returns when machines are not ready or out of capacity
- Added handling for nil worker returns in the worker pool sizer
- Preserved the same functional behavior while eliminating unnecessary error logs

<!-- End of auto-generated description by mrge. -->

Currently it spams machine not ready and out of capacity