### PR TITLE
Fix: Add unknown exit code to message for clarity

### DIFF
--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -183,7 +183,7 @@ func (gws *GatewayService) AttachToContainer(stream pb.GatewayService_AttachToCo
 	}
 
 	exitCallback := func(exitCode int32) error {
-		output := "\nContainer was stopped."
+		output := fmt.Sprintf("\nContainer was stopped.\n\nExit code: %d", exitCode)
 		if exitCode != 0 {
 			exitCodeMessage, ok := types.ExitCodeMessages[types.ContainerExitCode(exitCode)]
 			if ok {


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added exit code information to container stop messages for better debugging. This change helps users identify what went wrong when their container stops unexpectedly.

**Bug Fixes**
- Updated container stop message to include the actual exit code value.
- Improved error clarity by showing numeric exit codes alongside any existing exit code messages.

<!-- End of auto-generated description by mrge. -->

When we encounter an unexpected exit code we should log what it was. This exit code could from the user app and give them necessary information about what went wrong.  