### PR TITLE
use external id for storage bucket

### DIFF
--- a/pkg/api/v1/workspace.go
+++ b/pkg/api/v1/workspace.go
@@ -172,7 +172,7 @@ func (g *WorkspaceGroup) CreateWorkspaceStorage(ctx echo.Context) error {
 		return err
 	}
 
-	bucketName := types.WorkspaceBucketName(workspace.Id)
+	bucketName := types.WorkspaceBucketName(workspace.ExternalId)
 	accessKey := g.config.Storage.WorkspaceStorage.DefaultAccessKey
 	secretKey := g.config.Storage.WorkspaceStorage.DefaultSecretKey
 	endpointUrl := g.config.Storage.WorkspaceStorage.DefaultEndpointUrl

--- a/pkg/types/storage.go
+++ b/pkg/types/storage.go
@@ -2,6 +2,6 @@ package types
 
 import "fmt"
 
-func WorkspaceBucketName(workspaceId uint) string {
-	return fmt.Sprintf("workspace-%d", workspaceId)
+func WorkspaceBucketName(workspaceExternalId string) string {
+	return fmt.Sprintf("workspace-%s", workspaceExternalId)
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Updated workspace storage bucket naming to use external IDs instead of internal numeric IDs. This change provides more stable and meaningful bucket names that won't change if internal IDs are regenerated.

**Refactors**
- Changed `WorkspaceBucketName` function to accept external ID (string) instead of internal ID (uint)
- Updated bucket name format from `workspace-{id}` to `workspace-{externalId}`
- Modified workspace storage creation to use external ID when generating bucket names

<!-- End of auto-generated description by mrge. -->

