### PR TITLE
Fetch and unpack stub code from s3

### DIFF
--- a/pkg/common/object.go
+++ b/pkg/common/object.go
@@ -1,10 +1,18 @@
 package common
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/mholt/archiver/v3"
+	"github.com/rs/zerolog/log"
 )
 
 func ExtractObjectFile(ctx context.Context, objectPath, destPath string) error {
@@ -23,6 +31,63 @@ func ExtractObjectFile(ctx context.Context, objectPath, destPath string) error {
 	zip := archiver.NewZip()
 	if err := zip.Unarchive(objectPath, destPath); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func UnzipBytesToPath(destPath string, objBytes []byte, request *types.ContainerRequest) error {
+	if _, err := os.Stat(destPath); !os.IsNotExist(err) {
+		return nil
+	}
+
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		return err
+	}
+
+	zipReader, err := zip.NewReader(bytes.NewReader(objBytes), int64(len(objBytes)))
+	if err != nil {
+		log.Error().Str("container_id", request.ContainerId).Err(err).Msg("error creating zip reader")
+		return err
+	}
+
+	// Extract each file
+	for _, zipFile := range zipReader.File {
+		filePath := filepath.Join(destPath, zipFile.Name)
+
+		if !strings.HasPrefix(filePath, filepath.Clean(destPath)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", filePath)
+		}
+
+		if zipFile.FileInfo().IsDir() {
+			if err := os.MkdirAll(filePath, zipFile.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return err
+		}
+
+		destFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, zipFile.Mode())
+		if err != nil {
+			return err
+		}
+
+		srcFile, err := zipFile.Open()
+		if err != nil {
+			destFile.Close()
+			return err
+		}
+
+		_, err = io.Copy(destFile, srcFile)
+		srcFile.Close()
+		destFile.Close()
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -300,9 +300,6 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 	return nil
 }
 
-func (s *Worker) prepareMntCode(request *types.ContainerRequest) {
-}
-
 func (s *Worker) buildOrPullBaseImage(ctx context.Context, request *types.ContainerRequest, containerId string, outputLogger *slog.Logger) error {
 	switch {
 	case request.BuildOptions.Dockerfile != nil:

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -245,7 +245,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 		InitialSpec:  initialBundleSpec,
 	}
 
-	err = s.containerMountManager.SetupContainerMounts(request, outputLogger)
+	err = s.containerMountManager.SetupContainerMounts(ctx, request, outputLogger)
 	if err != nil {
 		s.containerLogger.Log(request.ContainerId, request.StubId, "failed to setup container mounts: %v", err)
 	}
@@ -298,6 +298,9 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 
 	log.Info().Str("container_id", containerId).Msg("spawned successfully")
 	return nil
+}
+
+func (s *Worker) prepareMntCode(request *types.ContainerRequest) {
 }
 
 func (s *Worker) buildOrPullBaseImage(ctx context.Context, request *types.ContainerRequest, containerId string, outputLogger *slog.Logger) error {

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -40,7 +40,7 @@ func (c *ContainerMountManager) SetupContainerMounts(ctx context.Context, reques
 					return err
 				}
 			} else {
-				if err := getMntCodeAndExtract(ctx, request); err != nil {
+				if err := getAndExtractStubCode(ctx, request); err != nil {
 					return err
 				}
 			}
@@ -127,8 +127,8 @@ func checkpointSignalDir(containerId string) string {
 	return fmt.Sprintf("/tmp/%s/criu", containerId)
 }
 
-// getMntCodeAndExtract downloads the object from storage and extracts it to the temp location that will be mounted
-func getMntCodeAndExtract(ctx context.Context, request *types.ContainerRequest) error {
+// getAndExtractStubCode downloads the object from storage and extracts it to the temp location that will be mounted
+func getAndExtractStubCode(ctx context.Context, request *types.ContainerRequest) error {
 	storageClient, err := clients.NewStorageClient(ctx, request.Workspace.Name, request.Workspace.Storage)
 	if err != nil {
 		log.Error().Str("container_id", request.ContainerId).Str("workspace_id", request.Workspace.ExternalId).Err(err).Msg("unable to instantiate storage client")

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -40,7 +40,7 @@ func (c *ContainerMountManager) SetupContainerMounts(ctx context.Context, reques
 
 			if !request.StorageAvailable() {
 				objectPath := path.Join(types.DefaultObjectPath, request.Workspace.Name, request.Stub.Object.ExternalId)
-				err := common.ExtractObjectFile(context.TODO(), objectPath, m.LocalPath)
+				err := common.ExtractObjectFile(ctx, objectPath, m.LocalPath)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Improved container code fetching by directly downloading stub code from S3 instead of relying on GeeseFS. This change avoids eventual consistency issues and provides a more reliable way to access container code.

**Refactors**
- Added direct S3 download functionality to fetch stub code objects instead of using the filesystem.
- Implemented zip extraction logic to unpack code directly from memory to the container workspace.
- Updated the container mount setup function to accept a context parameter for proper cancellation support.

**Bug Fixes**
- Fixed potential eventual consistency issues when accessing code through GeeseFS.
- Added path validation to prevent zip slip vulnerabilities during extraction.

<!-- End of auto-generated description by mrge. -->

To avoid eventual consistency problems with GeeseFS, we go direct to object storage for the stub object.