### PR TITLE
Redirect to presigned deployment package

### DIFF
--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -17,7 +17,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 )
 
-const presignedURLExpiration = 10 * 60
+const presignedURLExpirationSec = 10 * 60
 
 type DeploymentGroup struct {
 	routerGroup   *echo.Group
@@ -241,7 +241,7 @@ func (g *DeploymentGroup) DownloadDeploymentPackage(ctx echo.Context) error {
 		if err != nil {
 			return HTTPInternalServerError("Failed to get object")
 		}
-		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), fmt.Sprintf("%s/%s", types.DefaultObjectPrefix, object.ExternalId), presignedURLExpiration)
+		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), fmt.Sprintf("%s/%s", types.DefaultObjectPrefix, object.ExternalId), presignedURLExpirationSec)
 		if err != nil {
 			return HTTPInternalServerError("Failed to generate presigned URL")
 		}

--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -1,6 +1,7 @@
 package apiv1
 
 import (
+	"fmt"
 	"net/http"
 	"path"
 	"time"
@@ -240,7 +241,7 @@ func (g *DeploymentGroup) DownloadDeploymentPackage(ctx echo.Context) error {
 		if err != nil {
 			return HTTPInternalServerError("Failed to get object")
 		}
-		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), "objects/"+object.ExternalId, presignedURLExpiration)
+		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), fmt.Sprintf("%s/%s", types.DefaultObjectPrefix, object.ExternalId), presignedURLExpiration)
 		if err != nil {
 			return HTTPInternalServerError("Failed to generate presigned URL")
 		}

--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -17,7 +17,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 )
 
-const presignedURLExpirationSec = 10 * 60
+const presignedURLExpirationS = 10 * 60
 
 type DeploymentGroup struct {
 	routerGroup   *echo.Group

--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -9,11 +9,14 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/clients"
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/scheduler"
 	"github.com/beam-cloud/beta9/pkg/types"
 )
+
+const presignedURLExpiration = 10 * 60
 
 type DeploymentGroup struct {
 	routerGroup   *echo.Group
@@ -231,8 +234,21 @@ func (g *DeploymentGroup) DownloadDeploymentPackage(ctx echo.Context) error {
 	if err != nil {
 		return HTTPInternalServerError("Failed to get object")
 	}
-	path := getPackagePath(workspace.Name, object.ExternalId)
 
+	if workspaceStorage, err := g.backendRepo.GetWorkspaceStorage(ctx.Request().Context(), workspace.Id); err == nil {
+		storageClient, err := clients.NewStorageClient(ctx.Request().Context(), workspace.Name, workspaceStorage)
+		if err != nil {
+			return HTTPInternalServerError("Failed to get object")
+		}
+		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), "objects/"+object.ExternalId, presignedURLExpiration)
+		if err != nil {
+			return HTTPInternalServerError("Failed to generate presigned URL")
+		}
+
+		return ctx.Redirect(http.StatusTemporaryRedirect, presignedURL)
+	}
+
+	path := getPackagePath(workspace.Name, object.ExternalId)
 	return ctx.File(path)
 }
 

--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -241,7 +241,7 @@ func (g *DeploymentGroup) DownloadDeploymentPackage(ctx echo.Context) error {
 		if err != nil {
 			return HTTPInternalServerError("Failed to get object")
 		}
-		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), fmt.Sprintf("%s/%s", types.DefaultObjectPrefix, object.ExternalId), presignedURLExpirationSec)
+		presignedURL, err := storageClient.GeneratePresignedGetURL(ctx.Request().Context(), fmt.Sprintf("%s/%s", types.DefaultObjectPrefix, object.ExternalId), presignedURLExpirationS)
 		if err != nil {
 			return HTTPInternalServerError("Failed to generate presigned URL")
 		}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added redirect to presigned URLs for deployment package downloads. This improves performance and security by using temporary authorized links instead of direct file serving.

**New Features**
- Added support for generating presigned URLs with a 10-minute expiration for deployment package downloads.
- Implemented HTTP redirect (307) to the presigned URL when a storage client is available.

**Refactors**
- Modified the DownloadDeploymentPackage handler to first attempt using presigned URLs before falling back to direct file serving.

<!-- End of auto-generated description by mrge. -->

