### PR TITLE
fix worker metrics gpu reporting

### DIFF
--- a/pkg/worker/usage.go
+++ b/pkg/worker/usage.go
@@ -17,12 +17,14 @@ type WorkerUsageMetrics struct {
 	metricsRepo         repo.UsageMetricsRepository
 	ctx                 context.Context
 	containerCostClient *clients.ContainerCostClient
+	gpuType             string
 }
 
 func NewWorkerUsageMetrics(
 	ctx context.Context,
 	workerId string,
 	config types.MonitoringConfig,
+	gpuType string,
 ) (*WorkerUsageMetrics, error) {
 	metricsRepo, err := usage.NewUsageMetricsRepository(config, string(usage.MetricsSourceWorker))
 	if err != nil {
@@ -34,6 +36,7 @@ func NewWorkerUsageMetrics(
 	return &WorkerUsageMetrics{
 		ctx:                 ctx,
 		workerId:            workerId,
+		gpuType:             gpuType,
 		metricsRepo:         metricsRepo,
 		containerCostClient: containerCostClient,
 	}, nil
@@ -74,6 +77,7 @@ func (wm *WorkerUsageMetrics) EmitContainerUsage(ctx context.Context, request *t
 	ticker := time.NewTicker(types.ContainerDurationEmissionInterval)
 	defer ticker.Stop()
 
+	request.Gpu = wm.gpuType
 	wm.addContainerCostPerMs(request)
 
 	for {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -205,7 +205,7 @@ func NewWorker() (*Worker, error) {
 		return nil, err
 	}
 
-	workerMetrics, err := NewWorkerUsageMetrics(ctx, workerId, config.Monitoring)
+	workerMetrics, err := NewWorkerUsageMetrics(ctx, workerId, config.Monitoring, gpuType)
 	if err != nil {
 		cancel()
 		return nil, err


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed GPU reporting in worker metrics by adding GPU type to container usage requests, ensuring accurate resource tracking and cost calculations.

<!-- End of auto-generated description by mrge. -->

