### PR TITLE
Use geese fork with fixed symlinks

### DIFF
--- a/bin/k3d.sh
+++ b/bin/k3d.sh
@@ -13,6 +13,9 @@ check_gpu_linux() {
 }
 
 k3d_up() {
+  mkdir -p .k3d/storage
+  chmod 777 .k3d/storage
+  
   os_type="$(uname)"
   case "$os_type" in
     Linux*)

--- a/bin/k3d.sh
+++ b/bin/k3d.sh
@@ -13,9 +13,6 @@ check_gpu_linux() {
 }
 
 k3d_up() {
-  mkdir -p .k3d/storage
-  chmod 777 .k3d/storage
-  
   os_type="$(uname)"
   case "$os_type" in
     Linux*)

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -56,6 +56,18 @@ make install
 /usr/local/bin/skopeo --version
 EOT
 
+# build geesefs fork
+# ========================
+FROM golang AS geesefs
+
+WORKDIR /workspace
+
+RUN <<EOT
+git clone https://github.com/beam-cloud/geesefs.git
+cd geesefs
+make build
+EOT
+
 # nvidia-container-toolkit
 # ========================
 FROM golang:1.23-bookworm AS nvidia-container-toolkit
@@ -158,14 +170,6 @@ RUN MOUNT_S3_URL=$(if [ "$TARGETARCH" = "arm64" ]; then echo $MOUNT_S3_URL_ARM64
 RUN curl -L https://github.com/NVIDIA/cuda-checkpoint/raw/refs/heads/main/bin/x86_64_Linux/cuda-checkpoint -o /usr/local/bin/cuda-checkpoint && \
     chmod +x /usr/local/bin/cuda-checkpoint
 
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
-    curl -L https://github.com/yandex-cloud/geesefs/releases/download/v0.42.4/geesefs-linux-amd64 -o /usr/local/bin/geesefs && \
-    chmod +x /usr/local/bin/geesefs; \
-    elif [ "$(uname -m)" = "aarch64" ]; then \
-    curl -L https://github.com/yandex-cloud/geesefs/releases/download/v0.42.4/geesefs-linux-amd64 -o /usr/local/bin/geesefs && \
-    chmod +x /usr/local/bin/geesefs; \
-    fi
-
 RUN apt-get remove -y curl && \
     apt-get clean && apt-get autoremove -y && apt-get autopurge -y && \
     rm -rf /var/lib/apt/lists/* /var/log/*
@@ -178,6 +182,7 @@ COPY --from=runc /usr/local/bin/buildah /usr/local/bin/buildah
 COPY --from=runc /usr/local/bin/skopeo /usr/local/bin/skopeo
 COPY --from=runc /workspace/skopeo/default-policy.json /etc/containers/policy.json
 COPY --from=nvidia-container-toolkit /workspace/nvidia-container-runtime* /usr/bin/
+COPY --from=geesefs /workspace/geesefs/geesefs /usr/local/bin/geesefs
 
 COPY ./bin/volume_cache_x86.so /usr/local/lib/volume_cache_x86.so
 COPY ./bin/volume_cache_arm.so /usr/local/lib/volume_cache_arm.so

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -63,8 +63,10 @@ FROM golang AS geesefs
 WORKDIR /workspace
 
 RUN <<EOT
+set -eux
 git clone https://github.com/beam-cloud/geesefs.git
 cd geesefs
+git checkout 02ebd066ad8aad5faad4198e1a07f8ded0384713
 make build
 EOT
 

--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -60,6 +60,7 @@ func (s *GeeseStorage) Mount(localPath string) error {
 	if s.config.EndpointUrl != "" {
 		args = append(args, fmt.Sprintf("--endpoint=%s", s.config.EndpointUrl))
 	}
+	args = append(args, "--symlink-zeroed")
 
 	// Add bucket and mount path
 	args = append(args, s.config.BucketName, localPath)


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Switched to a custom geesefs fork with fixed symlink handling and enabled the --symlink-zeroed option for mounts.

- **Dependencies**
  - Build geesefs from the beam-cloud fork instead of downloading the upstream release.
  - Add --symlink-zeroed flag to geesefs mount command.

<!-- End of auto-generated description by mrge. -->

