### PR TITLE
Feat: Add nanosecond time for serializer time and add app to deployments

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1214,9 +1214,11 @@ func (c *PostgresBackendRepository) listDeploymentsQueryBuilder(filters types.De
 		"d.id, d.external_id, d.name, d.active, d.subdomain, d.workspace_id, d.stub_id, d.stub_type, d.version, d.created_at, d.updated_at, d.deleted_at",
 		"w.external_id AS \"workspace.external_id\"", "w.name AS \"workspace.name\"", "w.created_at AS \"workspace.created_at\"", "w.updated_at AS \"workspace.updated_at\"",
 		"s.external_id AS \"stub.external_id\"", "s.name AS \"stub.name\"", "s.config AS \"stub.config\"", "s.type AS \"stub.type\"", "s.created_at AS \"stub.created_at\"", "s.updated_at AS \"stub.updated_at\"",
+		"a.external_id AS \"app.external_id\"", "a.name AS \"app.name\"", "a.created_at AS \"app.created_at\"", "a.updated_at AS \"app.updated_at\"",
 	).From("deployment d").
 		Join("workspace w ON d.workspace_id = w.id").
 		Join("stub s ON d.stub_id = s.id").
+		Join("app a ON d.app_id = a.id").
 		OrderBy("d.created_at DESC")
 
 	// Apply filters
@@ -1281,7 +1283,6 @@ func (c *PostgresBackendRepository) listDeploymentsQueryBuilder(filters types.De
 	}
 
 	if filters.AppId != "" {
-		qb = qb.Join("app a ON d.app_id = a.id")
 		qb = qb.Where(squirrel.Eq{"a.external_id": filters.AppId})
 	}
 

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -39,7 +39,7 @@ func (t NullTime) Serialize() interface{} {
 		return nil
 	}
 
-	return time.Time(t.Time).Format(time.RFC3339)
+	return time.Time(t.Time).Format(time.RFC3339Nano)
 }
 
 func (t NullTime) Now() NullTime {
@@ -232,9 +232,12 @@ type Deployment struct {
 
 type DeploymentWithRelated struct {
 	Deployment
-	Workspace Workspace `db:"workspace" json:"workspace" serializer:"workspace"`
-	Stub      Stub      `db:"stub" json:"stub" serializer:"stub"`
-	StubId    string    `serializer:"stub_id,source:stub.id"`
+	Workspace   Workspace `db:"workspace" json:"workspace" serializer:"workspace"`
+	Stub        Stub      `db:"stub" json:"stub" serializer:"stub"`
+	App         App       `db:"app" json:"app" serializer:"app"`
+	StubId      string    `serializer:"stub_id,source:stub.id"`
+	AppId       string    `serializer:"app_id,source:app.id"`
+	WorkspaceId string    `serializer:"workspace_id,source:workspace.id"`
 }
 
 // @go2proto

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -17,7 +17,7 @@ type Time struct {
 }
 
 func (t Time) Serialize() string {
-	return t.Time.Format(time.RFC3339)
+	return t.Time.Format(time.RFC3339Nano)
 }
 
 func (t *Time) Scan(value interface{}) error {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated the time serializer to use nanosecond precision, allowing more accurate timestamps.

<!-- End of auto-generated description by mrge. -->

