### PR TITLE
Fix: Dont try to load empty result

### DIFF
--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -212,6 +212,8 @@ class _CallableWrapper(DeployableMixin):
             return
 
         terminal.header(f"Function complete <{last_response.task_id}>")
+        if last_response.result == "":
+            return None
         return cloudpickle.loads(last_response.result)
 
     def local(self, *args, **kwargs) -> Any:

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -212,7 +212,8 @@ class _CallableWrapper(DeployableMixin):
             return
 
         terminal.header(f"Function complete <{last_response.task_id}>")
-        if last_response.result == "":
+        # Sometimes the result is empty (task timed out)
+        if not last_response.result:
             return None
         return cloudpickle.loads(last_response.result)
 


### PR DESCRIPTION
If a function times out, the sdk blows up on the user because it tries to load an empty result. 

Long term, we should add an exit code and render a warning in the terminal, but this will do for now. 
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a bug where the SDK would crash if it tried to load an empty result after a function timeout.

<!-- End of auto-generated description by mrge. -->

