### PR TITLE
Fix: Allow cluster admins to stop all containers

### DIFF
--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -107,7 +107,7 @@ func (gws GatewayService) StopContainer(ctx context.Context, in *pb.StopContaine
 		}, nil
 	}
 
-	if state.WorkspaceId != workspaceId && authInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+	if isAdmin, _ := isClusterAdmin(ctx); state.WorkspaceId != workspaceId && !isAdmin {
 		return &pb.StopContainerResponse{
 			Ok:       false,
 			ErrorMsg: fmt.Sprintf("Container not found: %s", in.ContainerId),

--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -107,7 +107,7 @@ func (gws GatewayService) StopContainer(ctx context.Context, in *pb.StopContaine
 		}, nil
 	}
 
-	if state.WorkspaceId != workspaceId {
+	if state.WorkspaceId != workspaceId && authInfo.Token.TokenType != types.TokenTypeClusterAdmin {
 		return &pb.StopContainerResponse{
 			Ok:       false,
 			ErrorMsg: fmt.Sprintf("Container not found: %s", in.ContainerId),

--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -12,7 +12,6 @@ import (
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -116,7 +115,6 @@ func (gws GatewayService) StopContainer(ctx context.Context, in *pb.StopContaine
 
 	err = gws.scheduler.Stop(&types.StopContainerArgs{ContainerId: in.ContainerId, Reason: types.StopContainerReasonUser})
 	if err != nil {
-		log.Error().Err(err).Msg("unable to stop container")
 		return &pb.StopContainerResponse{
 			Ok:       false,
 			ErrorMsg: fmt.Sprintf("Unable to stop container: %s", in.ContainerId),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Cluster admins can now stop any container, regardless of workspace, fixing a permissions issue.

<!-- End of auto-generated description by mrge. -->

