### PR TITLE
Feat: Push container exit code to events

### DIFF
--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -206,7 +206,7 @@ type EventRepository interface {
 	PushContainerRequestedEvent(request *types.ContainerRequest)
 	PushContainerScheduledEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerStartedEvent(containerID string, workerID string, request *types.ContainerRequest)
-	PushContainerStoppedEvent(containerID string, workerID string, request *types.ContainerRequest)
+	PushContainerStoppedEvent(containerID string, workerID string, request *types.ContainerRequest, exitCode int)
 	PushContainerOOMEvent(containerID string, workerID string, request *types.ContainerRequest)
 	PushContainerResourceMetricsEvent(workerID string, request *types.ContainerRequest, metrics types.EventContainerMetricsData)
 	PushWorkerStartedEvent(workerID string)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -145,7 +145,7 @@ func (t *TCPEventClientRepo) PushContainerStartedEvent(containerID string, worke
 	)
 }
 
-func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, workerID string, request *types.ContainerRequest) {
+func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, workerID string, request *types.ContainerRequest, exitCode int) {
 	t.pushEvent(
 		types.EventContainerLifecycle,
 		types.EventContainerLifecycleSchemaVersion,
@@ -155,6 +155,7 @@ func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, worke
 			Request:     sanitizeContainerRequest(request),
 			StubID:      request.StubId,
 			Status:      types.EventContainerLifecycleStopped,
+			ExitCode:    exitCode,
 		},
 	)
 }

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -149,13 +149,15 @@ func (t *TCPEventClientRepo) PushContainerStoppedEvent(containerID string, worke
 	t.pushEvent(
 		types.EventContainerLifecycle,
 		types.EventContainerLifecycleSchemaVersion,
-		types.EventContainerLifecycleSchema{
-			ContainerID: containerID,
-			WorkerID:    workerID,
-			Request:     sanitizeContainerRequest(request),
-			StubID:      request.StubId,
-			Status:      types.EventContainerLifecycleStopped,
-			ExitCode:    exitCode,
+		types.EventContainerStoppedSchema{
+			EventContainerLifecycleSchema: types.EventContainerLifecycleSchema{
+				ContainerID: containerID,
+				WorkerID:    workerID,
+				Request:     sanitizeContainerRequest(request),
+				StubID:      request.StubId,
+				Status:      types.EventContainerLifecycleStopped,
+			},
+			ExitCode: exitCode,
 		},
 	)
 }

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -63,7 +63,7 @@ var (
 
 // Schema versions should be in ISO 8601 format
 
-var EventContainerLifecycleSchemaVersion = "1.2"
+var EventContainerLifecycleSchemaVersion = "1.1"
 
 type EventContainerLifecycleSchema struct {
 	ContainerID string           `json:"container_id"`
@@ -71,7 +71,13 @@ type EventContainerLifecycleSchema struct {
 	StubID      string           `json:"stub_id"`
 	Status      string           `json:"status"`
 	Request     ContainerRequest `json:"request"`
-	ExitCode    int              `json:"exit_code"`
+}
+
+var EventContainerStoppedSchemaVersion = "1.0"
+
+type EventContainerStoppedSchema struct {
+	EventContainerLifecycleSchema
+	ExitCode int `json:"exit_code"`
 }
 
 var EventContainerMetricsSchemaVersion = "1.0"

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -63,7 +63,7 @@ var (
 
 // Schema versions should be in ISO 8601 format
 
-var EventContainerLifecycleSchemaVersion = "1.1"
+var EventContainerLifecycleSchemaVersion = "1.2"
 
 type EventContainerLifecycleSchema struct {
 	ContainerID string           `json:"container_id"`
@@ -71,6 +71,7 @@ type EventContainerLifecycleSchema struct {
 	StubID      string           `json:"stub_id"`
 	Status      string           `json:"status"`
 	Request     ContainerRequest `json:"request"`
+	ExitCode    int              `json:"exit_code"`
 }
 
 var EventContainerMetricsSchemaVersion = "1.0"

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -669,11 +669,10 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 
 	outputWriter := containerInstance.OutputWriter
 
-	containerExitCode := -1
 	// Log metrics
 	go s.workerUsageMetrics.EmitContainerUsage(ctx, request)
 	go s.eventRepo.PushContainerStartedEvent(containerId, s.workerId, request)
-	defer func() { go s.eventRepo.PushContainerStoppedEvent(containerId, s.workerId, request, containerExitCode) }()
+	defer func() { go s.eventRepo.PushContainerStoppedEvent(containerId, s.workerId, request, exitCode) }()
 
 	startedChan := make(chan int, 1)
 	checkpointPIDChan := make(chan int, 1)
@@ -704,7 +703,7 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 		go s.watchOOMEvents(ctx, request, outputLogger, &isOOMKilled) // Watch for OOM events
 	}()
 
-	containerExitCode, containerId, _ = s.runContainer(ctx, request, configPath, outputWriter, startedChan, checkpointPIDChan)
+	exitCode, containerId, _ = s.runContainer(ctx, request, configPath, outputWriter, startedChan, checkpointPIDChan)
 
 	stopReason := types.StopContainerReasonUnknown
 	containerInstance, exists = s.containerInstances.Get(containerId)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added container exit code to the container stopped event, so exit codes are now included in event data.

- **Event Changes**
  - Updated event schema to include an exitCode field.
  - Increased schema version to 1.2.

<!-- End of auto-generated description by mrge. -->

