### PR TITLE
feat: add config group to worker pool config

### DIFF
--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -338,6 +338,7 @@ type WorkerPoolConfig struct {
 	UserData             string                            `key:"userData" json:"user_data"`
 	CRIUEnabled          bool                              `key:"criuEnabled" json:"criu_enabled"`
 	TmpSizeLimit         string                            `key:"tmpSizeLimit" json:"tmp_size_limit"`
+	ConfigGroup          string                            `key:"configGroup" json:"config_group"`
 }
 
 type WorkerPoolJobSpecConfig struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a config_group field to WorkerPoolConfig to support grouping worker pool configurations.

<!-- End of auto-generated description by mrge. -->

