### PR TITLE
fix locality setting

### DIFF
--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -445,7 +445,7 @@ func (wpc *ExternalWorkerPoolController) getWorkerEnvironment(workerId, machineI
 		},
 		{
 			Name:  "BLOBCACHE_LOCALITY",
-			Value: wpc.name,
+			Value: wpc.workerPoolConfig.ConfigGroup,
 		},
 		{
 			Name:  "WORKER_TOKEN",

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -404,7 +404,7 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerEnvironment(workerId st
 		},
 		{
 			Name:  "BLOBCACHE_LOCALITY",
-			Value: wpc.config.BlobCache.Global.DefaultLocality,
+			Value: wpc.workerPoolConfig.ConfigGroup,
 		},
 		{
 			Name:  "WORKER_TOKEN",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed the BLOBCACHE_LOCALITY environment variable to use the correct config group value in both external and local worker pools.

<!-- End of auto-generated description by mrge. -->

