### PR TITLE
feat: allow bucket prefix to be configurable

### DIFF
--- a/pkg/api/v1/workspace.go
+++ b/pkg/api/v1/workspace.go
@@ -59,7 +59,7 @@ func (g *WorkspaceGroup) CreateWorkspace(ctx echo.Context) error {
 		return HTTPInternalServerError("Unable to create workspace")
 	}
 
-	bucketName := types.WorkspaceBucketName(workspace.ExternalId)
+	bucketName := types.WorkspaceBucketName(g.config.Storage.WorkspaceStorage.DefaultBucketPrefix, workspace.ExternalId)
 	_, err = g.setupDefaultWorkspaceStorage(ctx, bucketName, workspace.Id)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to setup workspace storage for workspace %d", workspace.Id)
@@ -187,7 +187,7 @@ func (g *WorkspaceGroup) CreateWorkspaceStorage(ctx echo.Context) error {
 		return err
 	}
 
-	bucketName := types.WorkspaceBucketName(workspace.ExternalId)
+	bucketName := types.WorkspaceBucketName(g.config.Storage.WorkspaceStorage.DefaultBucketPrefix, workspace.ExternalId)
 
 	createdStorage, err := g.setupDefaultWorkspaceStorage(ctx, bucketName, workspace.Id)
 	if err != nil {

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -35,6 +35,11 @@ storage:
   workspaceStorage:
     mode: geese
     baseMountPath: /workspace/data
+    defaultBucketPrefix: workspace
+    defaultAccessKey: test
+    defaultSecretKey: test
+    defaultEndpointUrl: http://localstack:4566
+    defaultRegion: us-east-1
     geese:
       debug: false
       fsyncOnClose: true

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -205,13 +205,14 @@ type StorageConfig struct {
 }
 
 type WorkspaceStorageConfig struct {
-	Mode               string      `key:"mode" json:"mode"`
-	BaseMountPath      string      `key:"baseMountPath" json:"base_mount_path"`
-	Geese              GeeseConfig `key:"geese" json:"geese"`
-	DefaultAccessKey   string      `key:"defaultAccessKey" json:"default_access_key"`
-	DefaultSecretKey   string      `key:"defaultSecretKey" json:"default_secret_key"`
-	DefaultEndpointUrl string      `key:"defaultEndpointUrl" json:"default_endpoint_url"`
-	DefaultRegion      string      `key:"defaultRegion" json:"default_region"`
+	Mode                string      `key:"mode" json:"mode"`
+	BaseMountPath       string      `key:"baseMountPath" json:"base_mount_path"`
+	Geese               GeeseConfig `key:"geese" json:"geese"`
+	DefaultBucketPrefix string      `key:"defaultBucketPrefix" json:"default_bucket_prefix"`
+	DefaultAccessKey    string      `key:"defaultAccessKey" json:"default_access_key"`
+	DefaultSecretKey    string      `key:"defaultSecretKey" json:"default_secret_key"`
+	DefaultEndpointUrl  string      `key:"defaultEndpointUrl" json:"default_endpoint_url"`
+	DefaultRegion       string      `key:"defaultRegion" json:"default_region"`
 }
 
 type JuiceFSConfig struct {

--- a/pkg/types/storage.go
+++ b/pkg/types/storage.go
@@ -2,6 +2,6 @@ package types
 
 import "fmt"
 
-func WorkspaceBucketName(workspaceExternalId string) string {
-	return fmt.Sprintf("workspace-%s", workspaceExternalId)
+func WorkspaceBucketName(prefix, workspaceExternalId string) string {
+	return fmt.Sprintf("%s-%s", prefix, workspaceExternalId)
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Made the workspace storage bucket prefix configurable through the config file, allowing custom prefixes for new workspace buckets.

- **Config Updates**
  - Added defaultBucketPrefix to workspaceStorage config.
  - Updated code to use the new prefix when creating workspace buckets.

<!-- End of auto-generated description by mrge. -->

