### PR TITLE
fix ready machines check

### DIFF
--- a/pkg/scheduler/pool_health.go
+++ b/pkg/scheduler/pool_health.go
@@ -111,7 +111,10 @@ func (p *PoolHealthMonitor) getPoolState() (*types.WorkerPoolState, error) {
 			switch machine.State.Status {
 			case types.MachineStatusPending:
 				pendingMachines++
-			case types.MachineStatusRegistered:
+			// HOTFIX: need to add better checks for whether or not a machine is ready here
+			// case types.MachineStatusRegistered:
+			// 	registeredMachines++
+			case types.MachineStatusReady:
 				registeredMachines++
 			}
 		}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed the pool health check to only count machines in the "ready" state as registered, preventing machines that are not fully ready from being included.

<!-- End of auto-generated description by mrge. -->

