### PR TITLE
chore: include rest of stub information in list latest deployment

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1107,6 +1107,7 @@ func (c *PostgresBackendRepository) ListLatestDeploymentsWithRelatedPaginated(ct
 		Select(
 			"d.*",
 			"s.external_id AS \"stub.external_id\"", "s.name AS \"stub.name\"", "s.config AS \"stub.config\"",
+			"s.created_at AS \"stub.created_at\"", "s.type AS \"stub.type\"", "s.updated_at AS \"stub.updated_at\"",
 		).
 		From("deployment d").
 		Join(`(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added more stub fields (created_at, type, updated_at) to the latest deployments list for better data completeness.

<!-- End of auto-generated description by mrge. -->

