### PR TITLE
tweak k3d yaml

### DIFF
--- a/hack/k3d.yaml
+++ b/hack/k3d.yaml
@@ -27,7 +27,7 @@ volumes:
 - volume: $PWD/manifests/k3d:k3s-manifests-custom
   nodeFilters:
   - server:0
-- volume: $PWD/.k3d/storage:k3s-storage
+- volume: $HOME/.beta9-k3d/storage:k3s-storage
   nodeFilters:
   - servers:*
 
@@ -37,7 +37,7 @@ registries:
     host: "0.0.0.0"
     hostPort: "5001"
     volumes:
-    - $PWD/.k3d/registry:/var/lib/registry
+    - $HOME/.beta9-k3d/registry:/var/lib/registry
 
 options:
   k3d:


### PR DESCRIPTION
This small change just makes local development on a linux machine easier. There are permissions issues when building the worker once `.k3d` in the project directory. They re-appear everytime a PVC is created or modified, so easiest to just avoid having it in that directory.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated k3d.yaml to use a directory in the home folder instead of the project directory for storage and registry volumes. This avoids permission issues during local development on Linux.

<!-- End of auto-generated description by mrge. -->

