### PR TITLE
add geesefs mount options

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -52,6 +52,7 @@ storage:
       readAheadKB: 32768
       readAheadLargeKB: 131072
       fuseReadAheadKB: 32768
+      mountOptions: []
 gateway:
   host: beta9-gateway
   invokeURLType: path

--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -79,6 +79,7 @@ func (s *GeeseStorage) Mount(localPath string) error {
 	flags.HTTPTimeout = defaultGeeseFSRequestTimeout
 	flags.NoPreloadDir = true
 	flags.FuseReadAheadKB = defaultGeeseFSFuseReadAheadKb
+	flags.MountOptions = s.config.MountOptions
 
 	if s.config.ReadAheadLargeKB > 0 {
 		flags.ReadAheadLargeKB = uint64(s.config.ReadAheadLargeKB)

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -227,22 +227,23 @@ type JuiceFSConfig struct {
 }
 
 type GeeseConfig struct {
-	Debug            bool   `key:"debug" json:"debug"`                          // --debug
-	FsyncOnClose     bool   `key:"fsyncOnClose" json:"fsync_on_close"`          // --fsync-on-close
-	MemoryLimit      int64  `key:"memoryLimit" json:"memory_limit"`             // --memory-limit
-	MaxFlushers      int    `key:"maxFlushers" json:"max_flushers"`             // --max-flushers
-	MaxParallelParts int    `key:"maxParallelParts" json:"max_parallel_parts"`  // --max-parallel-parts
-	ReadAheadKB      int    `key:"readAheadKB" json:"read_ahead_kb"`            // --read-ahead-kb
-	ReadAheadLargeKB int    `key:"readAheadLargeKB" json:"read_ahead_large_kb"` // --read-ahead-large-kb
-	FuseReadAheadKB  int    `key:"fuseReadAheadKB" json:"fuse_read_ahead_kb"`   // --fuse-read-ahead-kb
-	DirMode          string `key:"dirMode" json:"dir_mode"`                     // --dir-mode, e.g., "0777"
-	FileMode         string `key:"fileMode" json:"file_mode"`                   // --file-mode, e.g., "0666"
-	ListType         int    `key:"listType" json:"list_type"`                   // --list-type
-	AccessKey        string `key:"accessKey" json:"access_key"`
-	SecretKey        string `key:"secretKey" json:"secret_key"`
-	EndpointUrl      string `key:"endpointURL" json:"endpoint_url"` // --endpoint
-	BucketName       string `key:"bucketName" json:"bucket_name"`
-	Region           string `key:"region" json:"region"`
+	Debug            bool     `key:"debug" json:"debug"`                          // --debug
+	FsyncOnClose     bool     `key:"fsyncOnClose" json:"fsync_on_close"`          // --fsync-on-close
+	MountOptions     []string `key:"mountOptions" json:"mount_options"`           // --mount-options
+	MemoryLimit      int64    `key:"memoryLimit" json:"memory_limit"`             // --memory-limit
+	MaxFlushers      int      `key:"maxFlushers" json:"max_flushers"`             // --max-flushers
+	MaxParallelParts int      `key:"maxParallelParts" json:"max_parallel_parts"`  // --max-parallel-parts
+	ReadAheadKB      int      `key:"readAheadKB" json:"read_ahead_kb"`            // --read-ahead-kb
+	ReadAheadLargeKB int      `key:"readAheadLargeKB" json:"read_ahead_large_kb"` // --read-ahead-large-kb
+	FuseReadAheadKB  int      `key:"fuseReadAheadKB" json:"fuse_read_ahead_kb"`   // --fuse-read-ahead-kb
+	DirMode          string   `key:"dirMode" json:"dir_mode"`                     // --dir-mode, e.g., "0777"
+	FileMode         string   `key:"fileMode" json:"file_mode"`                   // --file-mode, e.g., "0666"
+	ListType         int      `key:"listType" json:"list_type"`                   // --list-type
+	AccessKey        string   `key:"accessKey" json:"access_key"`
+	SecretKey        string   `key:"secretKey" json:"secret_key"`
+	EndpointUrl      string   `key:"endpointURL" json:"endpoint_url"` // --endpoint
+	BucketName       string   `key:"bucketName" json:"bucket_name"`
+	Region           string   `key:"region" json:"region"`
 }
 
 // @go2proto

--- a/pkg/worker/storage_manager.go
+++ b/pkg/worker/storage_manager.go
@@ -71,7 +71,6 @@ func (s *WorkspaceStorageManager) Mount(workspaceName string, workspaceStorage *
 		FilesystemName: workspaceName,
 		FilesystemPath: mountPath,
 		Geese: types.GeeseConfig{
-
 			// Workspace specific config
 			EndpointUrl: *workspaceStorage.EndpointUrl,
 			BucketName:  *workspaceStorage.BucketName,
@@ -88,6 +87,10 @@ func (s *WorkspaceStorageManager) Mount(workspaceName string, workspaceStorage *
 			DirMode:          s.config.WorkspaceStorage.Geese.DirMode,
 			FileMode:         s.config.WorkspaceStorage.Geese.FileMode,
 			ListType:         s.config.WorkspaceStorage.Geese.ListType,
+			MountOptions:     s.config.WorkspaceStorage.Geese.MountOptions,
+			ReadAheadKB:      s.config.WorkspaceStorage.Geese.ReadAheadKB,
+			ReadAheadLargeKB: s.config.WorkspaceStorage.Geese.ReadAheadLargeKB,
+			FuseReadAheadKB:  s.config.WorkspaceStorage.Geese.FuseReadAheadKB,
 		},
 	}, s.cacheClient)
 	if err != nil {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added support for custom mount options in the GeeseFS storage config.

- **New Features**
  - Added a mountOptions field to GeeseFS config to allow passing extra mount options.

<!-- End of auto-generated description by mrge. -->

