### PR TITLE
fix: bump blobcache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4
-	github.com/beam-cloud/blobcache-v2 v0.0.0-20250416151607-29d19f4cd10b
+	github.com/beam-cloud/blobcache-v2 v0.0.0-20250418203958-a940ff031281
 	github.com/beam-cloud/clip v0.0.0-20250415225442-70b041c523b5
 	github.com/beam-cloud/go-runc v0.0.0-20250226192420-34dad0fdc737
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.51.4
-	github.com/beam-cloud/blobcache-v2 v0.0.0-20250418203958-a940ff031281
+	github.com/beam-cloud/blobcache-v2 v0.0.0-20250419202813-8ec2c650a152
 	github.com/beam-cloud/clip v0.0.0-20250415225442-70b041c523b5
 	github.com/beam-cloud/go-runc v0.0.0-20250226192420-34dad0fdc737
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250418203958-a940ff031281 h1:xpYmOSrLK4ihV+gOGyI3mVQnsL+Z8j72TcLka/OqxEs=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250418203958-a940ff031281/go.mod h1:zvx1kpOx15N9NRutwfRDAzLrGRYrLBV0eGkwlg7GBfc=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20250419202813-8ec2c650a152 h1:pCfuRC4CbA5qqPdHqKwIncNaSq05UvtvL/12GTNih/k=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20250419202813-8ec2c650a152/go.mod h1:NXM7gjDOkHaqCcCtT5x6yrmIIB2wY9C5az85dMxqoCo=
 github.com/beam-cloud/clip v0.0.0-20250415225442-70b041c523b5 h1:9L7yeVs7BNuFOQrfH4aE/EoM4YSTrAV6t7xvfhK/i/4=
 github.com/beam-cloud/clip v0.0.0-20250415225442-70b041c523b5/go.mod h1:7NiHbwYqg/y21SdA28xmi5aQjDMhtzPQCIzQQHyi9UE=
 github.com/beam-cloud/go-runc v0.0.0-20250226192420-34dad0fdc737 h1:9dvNZag3gegzIl5i8W861lsnhnwz4joHr40K1HPcpmw=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250416151607-29d19f4cd10b h1:Pv9Tjfnwk/cJ/7IYy1KDPEe3cf4VaZPcfrxK6vKjsF0=
-github.com/beam-cloud/blobcache-v2 v0.0.0-20250416151607-29d19f4cd10b/go.mod h1:zvx1kpOx15N9NRutwfRDAzLrGRYrLBV0eGkwlg7GBfc=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20250418203958-a940ff031281 h1:xpYmOSrLK4ihV+gOGyI3mVQnsL+Z8j72TcLka/OqxEs=
+github.com/beam-cloud/blobcache-v2 v0.0.0-20250418203958-a940ff031281/go.mod h1:zvx1kpOx15N9NRutwfRDAzLrGRYrLBV0eGkwlg7GBfc=
 github.com/beam-cloud/clip v0.0.0-20250415225442-70b041c523b5 h1:9L7yeVs7BNuFOQrfH4aE/EoM4YSTrAV6t7xvfhK/i/4=
 github.com/beam-cloud/clip v0.0.0-20250415225442-70b041c523b5/go.mod h1:7NiHbwYqg/y21SdA28xmi5aQjDMhtzPQCIzQQHyi9UE=
 github.com/beam-cloud/go-runc v0.0.0-20250226192420-34dad0fdc737 h1:9dvNZag3gegzIl5i8W861lsnhnwz4joHr40K1HPcpmw=


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated the blobcache-v2 dependency to the latest version.

<!-- End of auto-generated description by mrge. -->

