### PR TITLE
handle ctrl-c correctly during mapped function

### DIFF
--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import inspect
+import os
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Union
 
@@ -234,22 +235,39 @@ class _CallableWrapper(DeployableMixin):
         return args
 
     def _threaded_map(self, inputs: Sequence[Any]) -> Iterator[Any]:
-        with terminal.progress(f"Running {len(inputs)} container(s)..."):
-            with concurrent.futures.ThreadPoolExecutor(len(inputs)) as pool:
-                futures = [
-                    pool.submit(self._call_remote, *self._format_args(args)) for args in inputs
-                ]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(inputs)) as pool:
+            futures = [pool.submit(self._call_remote, *self._format_args(args)) for args in inputs]
+            try:
                 for future in concurrent.futures.as_completed(futures):
-                    yield future.result()
+                    try:
+                        yield future.result()
+                    except Exception as e:
+                        terminal.error(f"Task failed during map: {e}", exit=False)
+                        yield None
+            except KeyboardInterrupt:
+                pool.shutdown(wait=False, cancel_futures=True)
+                terminal.error(
+                    f"Exiting shell. Mapped functions will {'be terminated.' if not self.parent.headless else 'continue running.'}",
+                    exit=False,
+                )
+                os._exit(1)
 
     def map(self, inputs: Sequence[Any]) -> Iterator[Any]:
         if not self.parent.prepare_runtime(
             func=self.func,
             stub_type=self.base_stub_type,
         ):
-            terminal.error("Function failed to prepare runtime ❌")
+            return iter([])
 
-        return self._threaded_map(inputs)
+        iterator = self._threaded_map(inputs)
+        try:
+            yield from iterator
+        except KeyboardInterrupt:
+            terminal.error(
+                f"Exiting shell. Mapped functions will {'be terminated.' if not self.parent.headless else 'continue running.'}",
+                exit=False,
+            )
+            os._exit(1)
 
 
 class ScheduleWrapper(_CallableWrapper):

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import inspect
-import os
+import sys
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Union
 
@@ -250,14 +250,14 @@ class _CallableWrapper(DeployableMixin):
                     f"Exiting shell. Mapped functions will {'be terminated.' if not self.parent.headless else 'continue running.'}",
                     exit=False,
                 )
-                os._exit(1)
+                sys.exit(1)
 
     def map(self, inputs: Sequence[Any]) -> Iterator[Any]:
         if not self.parent.prepare_runtime(
             func=self.func,
             stub_type=self.base_stub_type,
         ):
-            return iter([])
+            terminal.error("Function failed to prepare runtime ❌")
 
         iterator = self._threaded_map(inputs)
         try:
@@ -267,7 +267,7 @@ class _CallableWrapper(DeployableMixin):
                 f"Exiting shell. Mapped functions will {'be terminated.' if not self.parent.headless else 'continue running.'}",
                 exit=False,
             )
-            os._exit(1)
+            sys.exit(1)
 
 
 class ScheduleWrapper(_CallableWrapper):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Improved handling of Ctrl-C during mapped function execution to ensure clean shutdown and better user feedback.

- **Bug Fixes**
  - Cancels running tasks and exits cleanly when Ctrl-C is pressed.
  - Shows clear error messages if tasks fail or are interrupted.

<!-- End of auto-generated description by mrge. -->

