### PR TITLE
Revert serializer on retrieve task

### DIFF
--- a/pkg/api/v1/task.go
+++ b/pkg/api/v1/task.go
@@ -130,12 +130,7 @@ func (g *TaskGroup) RetrieveTask(ctx echo.Context) error {
 		g.addOutputsToTask(ctx.Request().Context(), cc.AuthInfo, task)
 		g.addStatsToTask(ctx.Request().Context(), cc.AuthInfo.Workspace.Name, task)
 
-		serializedTask, err := serializer.Serialize(task)
-		if err != nil {
-			return HTTPInternalServerError("Failed to serialize response")
-		}
-
-		return ctx.JSON(http.StatusOK, serializedTask)
+		return ctx.JSON(http.StatusOK, task)
 	}
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Reverted the use of the serializer in the retrieve task endpoint to return the raw task object directly.

<!-- End of auto-generated description by mrge. -->

