### PR TITLE
option to disable volume caching

### DIFF
--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -81,6 +81,10 @@ func (s *GeeseStorage) Mount(localPath string) error {
 	flags.FuseReadAheadKB = defaultGeeseFSFuseReadAheadKb
 	flags.MountOptions = s.config.MountOptions
 
+	if s.config.DisableVolumeCaching {
+		flags.HashAttr = ""
+	}
+
 	if s.config.ReadAheadLargeKB > 0 {
 		flags.ReadAheadLargeKB = uint64(s.config.ReadAheadLargeKB)
 	}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -227,23 +227,24 @@ type JuiceFSConfig struct {
 }
 
 type GeeseConfig struct {
-	Debug            bool     `key:"debug" json:"debug"`                          // --debug
-	FsyncOnClose     bool     `key:"fsyncOnClose" json:"fsync_on_close"`          // --fsync-on-close
-	MountOptions     []string `key:"mountOptions" json:"mount_options"`           // --mount-options
-	MemoryLimit      int64    `key:"memoryLimit" json:"memory_limit"`             // --memory-limit
-	MaxFlushers      int      `key:"maxFlushers" json:"max_flushers"`             // --max-flushers
-	MaxParallelParts int      `key:"maxParallelParts" json:"max_parallel_parts"`  // --max-parallel-parts
-	ReadAheadKB      int      `key:"readAheadKB" json:"read_ahead_kb"`            // --read-ahead-kb
-	ReadAheadLargeKB int      `key:"readAheadLargeKB" json:"read_ahead_large_kb"` // --read-ahead-large-kb
-	FuseReadAheadKB  int      `key:"fuseReadAheadKB" json:"fuse_read_ahead_kb"`   // --fuse-read-ahead-kb
-	DirMode          string   `key:"dirMode" json:"dir_mode"`                     // --dir-mode, e.g., "0777"
-	FileMode         string   `key:"fileMode" json:"file_mode"`                   // --file-mode, e.g., "0666"
-	ListType         int      `key:"listType" json:"list_type"`                   // --list-type
-	AccessKey        string   `key:"accessKey" json:"access_key"`
-	SecretKey        string   `key:"secretKey" json:"secret_key"`
-	EndpointUrl      string   `key:"endpointURL" json:"endpoint_url"` // --endpoint
-	BucketName       string   `key:"bucketName" json:"bucket_name"`
-	Region           string   `key:"region" json:"region"`
+	Debug                bool     `key:"debug" json:"debug"`                          // --debug
+	FsyncOnClose         bool     `key:"fsyncOnClose" json:"fsync_on_close"`          // --fsync-on-close
+	MountOptions         []string `key:"mountOptions" json:"mount_options"`           // --mount-options
+	MemoryLimit          int64    `key:"memoryLimit" json:"memory_limit"`             // --memory-limit
+	MaxFlushers          int      `key:"maxFlushers" json:"max_flushers"`             // --max-flushers
+	MaxParallelParts     int      `key:"maxParallelParts" json:"max_parallel_parts"`  // --max-parallel-parts
+	ReadAheadKB          int      `key:"readAheadKB" json:"read_ahead_kb"`            // --read-ahead-kb
+	ReadAheadLargeKB     int      `key:"readAheadLargeKB" json:"read_ahead_large_kb"` // --read-ahead-large-kb
+	FuseReadAheadKB      int      `key:"fuseReadAheadKB" json:"fuse_read_ahead_kb"`   // --fuse-read-ahead-kb
+	DirMode              string   `key:"dirMode" json:"dir_mode"`                     // --dir-mode, e.g., "0777"
+	FileMode             string   `key:"fileMode" json:"file_mode"`                   // --file-mode, e.g., "0666"
+	ListType             int      `key:"listType" json:"list_type"`                   // --list-type
+	AccessKey            string   `key:"accessKey" json:"access_key"`
+	SecretKey            string   `key:"secretKey" json:"secret_key"`
+	EndpointUrl          string   `key:"endpointURL" json:"endpoint_url"` // --endpoint
+	BucketName           string   `key:"bucketName" json:"bucket_name"`
+	Region               string   `key:"region" json:"region"`
+	DisableVolumeCaching bool     `key:"disableVolumeCaching" json:"disable_volume_caching"`
 }
 
 // @go2proto


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a config option to disable volume caching for Geese storage mounts.

- **New Features**
  - Added disable_volume_caching to GeeseConfig.
  - When set, disables volume caching during mount.

<!-- End of auto-generated description by mrge. -->

