### PR TITLE
fix task race

### DIFF
--- a/pkg/abstractions/common/stream.go
+++ b/pkg/abstractions/common/stream.go
@@ -131,8 +131,9 @@ _stream:
 			}
 
 			if err := l.exitCallback(int32(exitCode)); err != nil {
-				break _stream
+				return err
 			}
+			return nil
 
 		case <-ctx.Done():
 			// This ensures when the sdk exits, the message printed is

--- a/pkg/common/key_events.go
+++ b/pkg/common/key_events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -58,11 +57,20 @@ func (kem *KeyEventManager) ListenForPattern(ctx context.Context, patternPrefix 
 	pattern := fmt.Sprintf("%s%s*", keyspacePrefix, patternPrefix)
 	messages, errs, close := kem.rdb.PSubscribe(ctx, pattern)
 
-	timer := time.NewTicker(10 * time.Second)
+	existingKeys, err := kem.fetchExistingKeys(patternPrefix)
+	if err != nil {
+		return err
+	}
+
+	for _, key := range existingKeys {
+		keyEventChan <- KeyEvent{
+			Key:       key,
+			Operation: KeyOperationSet,
+		}
+	}
 
 	go func() {
 		defer close()
-		defer timer.Stop()
 
 	retry:
 		for {
@@ -74,21 +82,6 @@ func (kem *KeyEventManager) ListenForPattern(ctx context.Context, patternPrefix 
 				keyEventChan <- KeyEvent{
 					Key:       key,
 					Operation: operation,
-				}
-
-			case <-timer.C:
-				// There is a chance that the key was set before the subscription
-				existingKeys, err := kem.fetchExistingKeys(patternPrefix)
-				if err != nil {
-					log.Error().Err(err).Msg("error fetching existing keys")
-					continue
-				}
-
-				for _, key := range existingKeys {
-					keyEventChan <- KeyEvent{
-						Key:       key,
-						Operation: KeyOperationSet,
-					}
 				}
 
 			case <-ctx.Done():


### PR DESCRIPTION
Race occured when task completed between preliminary check and subscription start. Therefore we should do the backwards check after the subscriptions is established so that there is no gap. 

<img width="691" alt="Screenshot 2025-05-02 at 14 27 57" src="https://github.com/user-attachments/assets/1cf14bbe-f051-4bf6-8a5a-d3a3cc6eba08" />

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a race condition where tasks could complete before event subscriptions started, causing missed events. Now, existing keys are checked and emitted on a timer after the subscription is active to prevent gaps.

- **Bug Fixes**
  - Moved the check for existing keys to run periodically after subscription setup.
  - Ensured no events are missed if they occur between the initial check and subscription start.

<!-- End of auto-generated description by mrge. -->

