### PR TITLE
fix geesefs panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -339,9 +339,9 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20250423015758-3404807b4804
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20250502185917-a45b09ee3201
 
-replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250423015758-3404807b4804
+replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250502185917-a45b09ee3201
 
 replace github.com/winfsp/cgofuse => github.com/vitalif/cgofuse v0.0.0-20230609211427-22e8fa44f6b8
 

--- a/go.sum
+++ b/go.sum
@@ -132,10 +132,10 @@ github.com/beam-cloud/blobcache-v2 v0.0.0-20250501023620-447539c5d94e h1:rX+jkn/
 github.com/beam-cloud/blobcache-v2 v0.0.0-20250501023620-447539c5d94e/go.mod h1:RrA2ruMma4/dN9Sa6wwhyAO1uI6di+tlLB5wuM7TuvQ=
 github.com/beam-cloud/clip v0.0.0-20250424185136-5f40b560b510 h1:CoYog6ZQ81/Kvs1n41RTCj2LhnJuIjWyPi2Jw+qkwKM=
 github.com/beam-cloud/clip v0.0.0-20250424185136-5f40b560b510/go.mod h1:GtCHH6ik2SkIFo+GdN/l0+kAzxhLTUjSboIB+7Br6dk=
-github.com/beam-cloud/geesefs v0.0.0-20250423015758-3404807b4804 h1:o9dbE3cgDGGx65jEdp6VV0TR3vMWnuLxZyrjTrDDh+w=
-github.com/beam-cloud/geesefs v0.0.0-20250423015758-3404807b4804/go.mod h1:utihEuMyzBOeZ6oU2ozzZkJmyzbYBuYrxsLUo1DfZXs=
-github.com/beam-cloud/geesefs/s3ext v0.0.0-20250423015758-3404807b4804 h1:36wEQvhNswD//3ugmDcMUwslSvUtdFD3d3tRgNFJXl0=
-github.com/beam-cloud/geesefs/s3ext v0.0.0-20250423015758-3404807b4804/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
+github.com/beam-cloud/geesefs v0.0.0-20250502185917-a45b09ee3201 h1:RL34iUhi+vq314xDRLxWdJlMzlAlsa/fcXQ7FUCBcOs=
+github.com/beam-cloud/geesefs v0.0.0-20250502185917-a45b09ee3201/go.mod h1:utihEuMyzBOeZ6oU2ozzZkJmyzbYBuYrxsLUo1DfZXs=
+github.com/beam-cloud/geesefs/s3ext v0.0.0-20250502185917-a45b09ee3201 h1:49mPZv6kVOE0dxpKXH0UMMUNzVXHmfab3J5/k+W7CW0=
+github.com/beam-cloud/geesefs/s3ext v0.0.0-20250502185917-a45b09ee3201/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250226192420-34dad0fdc737 h1:9dvNZag3gegzIl5i8W861lsnhnwz4joHr40K1HPcpmw=
 github.com/beam-cloud/go-runc v0.0.0-20250226192420-34dad0fdc737/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated geesefs and s3ext dependencies to fix a panic issue. This ensures more stable file system operations.

<!-- End of auto-generated description by mrge. -->

