### PR TITLE
Fix: revert code that was incorrectly reverted

### DIFF
--- a/pkg/api/v1/task.go
+++ b/pkg/api/v1/task.go
@@ -130,7 +130,12 @@ func (g *TaskGroup) RetrieveTask(ctx echo.Context) error {
 		g.addOutputsToTask(ctx.Request().Context(), cc.AuthInfo, task)
 		g.addStatsToTask(ctx.Request().Context(), cc.AuthInfo.Workspace.Name, task)
 
-		return ctx.JSON(http.StatusOK, task)
+		serializedTask, err := serializer.Serialize(task)
+		if err != nil {
+			return err
+		}
+
+		return ctx.JSON(http.StatusOK, serializedTask)
 	}
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Restored the correct task serialization in the RetrieveTask API endpoint to fix response formatting.

<!-- End of auto-generated description by mrge. -->

