### PR TITLE
Fix docs: Default endpoint timeout is 180, not 3600

### DIFF
--- a/sdk/src/beta9/abstractions/endpoint.py
+++ b/sdk/src/beta9/abstractions/endpoint.py
@@ -58,7 +58,7 @@ class Endpoint(RunnerAbstraction):
             A list of volumes and/or cloud buckets to be mounted to the endpoint. Default is None.
         timeout (Optional[int]):
             The maximum number of seconds a task can run before it times out.
-            Default is 3600. Set it to -1 to disable the timeout.
+            Default is 180. Set it to -1 to disable the timeout.
         workers (Optional[int]):
             The number of processes handling tasks per container.
             Modifying this parameter can improve throughput for certain workloads.


### PR DESCRIPTION
Docs say 3600 seconds (1 hour) but it's actually 180 seconds (3 minutes)