### PR TITLE
Feat: Make app name a requirement

### DIFF
--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -402,7 +402,7 @@ class RunnerAbstraction(BaseAbstraction):
             return False
 
         if not self.app:
-            self.app = self.name or os.path.basename(os.getcwd())
+            terminal.error("Missing app name")
 
         if not self.stub_created:
             stub_request = GetOrCreateStubRequest(

--- a/sdk/src/beta9/abstractions/integrations/vllm.py
+++ b/sdk/src/beta9/abstractions/integrations/vllm.py
@@ -373,6 +373,9 @@ class VLLM(ASGI):
 
         if context is not None:
             self.config_context = context
+        
+        if self.app == "":
+            self.app = name
 
         if not self.prepare_runtime(
             stub_type=ASGI_DEPLOYMENT_STUB_TYPE,

--- a/sdk/src/beta9/abstractions/mixins.py
+++ b/sdk/src/beta9/abstractions/mixins.py
@@ -60,6 +60,9 @@ class DeployableMixin:
         ):
             terminal.header("Running on_deploy hook")
             self.parent.on_deploy()
+        
+        if self.parent.app == "":
+            self.parent.app = name
 
         if not self.parent.prepare_runtime(
             func=self.func, stub_type=self.deployment_stub_type, force_create_stub=True

--- a/sdk/src/beta9/abstractions/pod.py
+++ b/sdk/src/beta9/abstractions/pod.py
@@ -242,6 +242,9 @@ class Pod(RunnerAbstraction, DeployableMixin):
 
         if context is not None:
             self.config_context = context
+        
+        if self.app == "":
+            self.app = name
 
         if not self.prepare_runtime(stub_type=POD_DEPLOYMENT_STUB_TYPE, force_create_stub=True):
             return False


### PR DESCRIPTION
Make app name required but also automatically set the `deployment` name to the app name if app name is not set.