### PR TITLE
Fix: Patch volume pathing

### DIFF
--- a/pkg/abstractions/volume/volume.go
+++ b/pkg/abstractions/volume/volume.go
@@ -494,7 +494,7 @@ func (vs *GlobalVolumeService) listPath(ctx context.Context, inputPath string, w
 			isDir := strings.HasSuffix(*obj.Key, "/")
 
 			files = append(files, FileInfo{
-				Path:    strings.TrimPrefix(*obj.Key, rootVolumePath+"/"),
+				Path:    strings.TrimSuffix(strings.TrimPrefix(*obj.Key, rootVolumePath+"/"), "/"),
 				Size:    uint64(*obj.Size),
 				ModTime: obj.LastModified.Unix(),
 				IsDir:   isDir,

--- a/pkg/abstractions/volume/volume.go
+++ b/pkg/abstractions/volume/volume.go
@@ -481,8 +481,9 @@ func (vs *GlobalVolumeService) listPath(ctx context.Context, inputPath string, w
 			return nil, err
 		}
 
-		volumePath = path.Join(types.DefaultVolumesPrefix, volume.ExternalId, volumePath)
-		objects, err := storageClient.ListDirectory(ctx, volumePath)
+		rootVolumePath := path.Join(types.DefaultVolumesPrefix, volume.ExternalId)
+		fullvolumePath := path.Join(rootVolumePath, volumePath)
+		objects, err := storageClient.ListDirectory(ctx, fullvolumePath)
 		if err != nil {
 			return nil, errors.New("unable to list files")
 		}
@@ -492,13 +493,8 @@ func (vs *GlobalVolumeService) listPath(ctx context.Context, inputPath string, w
 		for _, obj := range objects {
 			isDir := strings.HasSuffix(*obj.Key, "/")
 
-			path := strings.TrimPrefix(*obj.Key, volumePath+"/")
-			if isDir {
-				path = strings.TrimSuffix(path, "/")
-			}
-
 			files = append(files, FileInfo{
-				Path:    path,
+				Path:    strings.TrimPrefix(*obj.Key, rootVolumePath+"/"),
 				Size:    uint64(*obj.Size),
 				ModTime: obj.LastModified.Unix(),
 				IsDir:   isDir,

--- a/sdk/src/beta9/cli/volume.py
+++ b/sdk/src/beta9/cli/volume.py
@@ -85,7 +85,7 @@ def ls(service: ServiceClient, remote_path: str):
     for p in res.path_infos:
         total_size += p.size
         table.add_row(
-            p.path + ("/" if p.is_dir else ""),
+            Path(p.path).name + ("/" if p.is_dir else ""),
             "" if p.is_dir else terminal.humanize_memory(p.size),
             terminal.humanize_date(p.mod_time),
             "Yes" if p.is_dir else "No",


### PR DESCRIPTION
1. Made volume ls return value consistent for workspace and non-workspace storage
2. Show only final path in the volume ls command (so it doesnt render entire object path when inspecting a dir)