### PR TITLE
Fix: Increase initial wait time of shell

### DIFF
--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -245,7 +245,7 @@ func (ss *SSHShellService) CreateShell(ctx context.Context, in *pb.CreateShellRe
 		startupCommand,
 	}
 
-	err = ss.rdb.Set(ctx, Keys.shellContainerTTL(containerId), "1", time.Duration(shellContainerTtlS)*time.Second).Err()
+	err = ss.rdb.Set(ctx, Keys.shellContainerTTL(containerId), "1", containerWaitTimeoutDurationS).Err()
 	if err != nil {
 		return &pb.CreateShellResponse{
 			Ok:     false,


### PR DESCRIPTION
```
if !strings.Contains(event.Key, Keys.shellContainerTTL("")) {
					containerId := shellContainerPrefix + event.Key

					if ss.rdb.Exists(ss.ctx, Keys.shellContainerTTL(containerId)).Val() == 0 {
						ss.scheduler.Stop(&types.StopContainerArgs{
							ContainerId: containerId,
							Force:       true,
							Reason:      types.StopContainerReasonTtl,
						})
					}
				}
```

If this key doesn't exist the container is sent a stop event.

Initially this was set too low. The expectation was that the keepalive would refresh it. However, the keepalive requires the ssh server to be active which wont always happen for images that take too long to spin up.

This extends the initial keepalive of this key to the same duration as the waitForContainer check