### PR TITLE
Dont start container on delayed worker when build is cancelled 

### DIFF
--- a/pkg/abstractions/image/builder.go
+++ b/pkg/abstractions/image/builder.go
@@ -306,6 +306,11 @@ func (b *Builder) handleBuildCancellation(ctx context.Context, build *Build) {
 		log.Error().Str("container_id", build.containerID).Err(err).Msg("failed to stop build")
 	}
 
+	err = b.containerRepo.UpdateContainerStatus(build.containerID, types.ContainerStatusStopping, time.Now().Unix())
+	if err != nil {
+		log.Error().Str("container_id", build.containerID).Err(err).Msg("failed to update container status")
+	}
+
 	if err := build.killContainer(); err != nil {
 		log.Error().Str("container_id", build.containerID).Err(err).Msg("failed to kill build container")
 	}


### PR DESCRIPTION
resolve BE-2680


There is an edge case where the build worker has not yet started when the build is cancelled. In these cases the event is lost and the worker starts the container. 

This change sets the status of the build container to "STOPPING" when its cancelled. We can then check that status and cancel the build context on the worker side. 