### PR TITLE
Use multi-arch postgres image

### DIFF
--- a/manifests/kustomize/components/postgresql/helm-chart-generator.yaml
+++ b/manifests/kustomize/components/postgresql/helm-chart-generator.yaml
@@ -23,7 +23,7 @@ valuesInline:
         database: main
   image:
     registry: public.ecr.aws
-    repository: n4e0e1y0/postgres
+    repository: docker/library/postgres
     tag: 16.1
     pullPolicy: IfNotPresent
   primary:


### PR DESCRIPTION
Fixes #1285.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the Postgres image to a multi-architecture version to support more deployment environments.

<!-- End of auto-generated description by cubic. -->

