### PR TITLE
Feat: Populate default config if API token is in envvars

### DIFF
--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -173,11 +173,19 @@ def prompt_first_auth(settings: SDKSettings) -> None:
     terminal.header(f"Welcome to {settings.name.title()}! Let's get started 📡")
     terminal.print(settings.ascii_logo, highlight=True)
 
-    name, context = prompt_for_config_context(
-        name=DEFAULT_CONTEXT_NAME,
-        gateway_host=settings.gateway_host,
-        gateway_port=settings.gateway_port,
-    )
+    if settings.api_token:
+        name = DEFAULT_CONTEXT_NAME
+        context = ConfigContext(
+            token=settings.api_token,
+            gateway_host=settings.gateway_host,
+            gateway_port=settings.gateway_port,
+        )
+    else:
+        name, context = prompt_for_config_context(
+            name=DEFAULT_CONTEXT_NAME,
+            gateway_host=settings.gateway_host,
+            gateway_port=settings.gateway_port,
+        )
 
     channel = Channel(
         addr=f"{context.gateway_host}:{context.gateway_port}",

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -46,7 +46,7 @@ class SDKSettings:
     config_path: Path = Path("~/.beta9/config.ini").expanduser()
     ascii_logo: str = DEFAULT_ASCII_LOGO
     use_defaults_in_prompt: bool = False
-    api_token: Optional[str] = None
+    api_token: Optional[str] = os.getenv("BETA9_TOKEN")
 
     def __post_init__(self, **kwargs):
         if p := os.getenv("CONFIG_PATH"):

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -46,6 +46,7 @@ class SDKSettings:
     config_path: Path = Path("~/.beta9/config.ini").expanduser()
     ascii_logo: str = DEFAULT_ASCII_LOGO
     use_defaults_in_prompt: bool = False
+    api_token: Optional[str] = None
 
     def __post_init__(self, **kwargs):
         if p := os.getenv("CONFIG_PATH"):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for importing an API token from the BETA9_TOKEN environment variable to allow automatic config setup.

- **New Features**
  - If BETA9_TOKEN is set, the SDK uses it to create a default config without prompting the user.

<!-- End of auto-generated description by cubic. -->

