### PR TITLE
fix: always complete inflight task

### DIFF
--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -69,6 +69,8 @@ func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellation
 		return err
 	}
 
+	defer t.es.taskDispatcher.Complete(ctx, t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId)
+
 	// Don't update tasks that are already in a terminal state
 	if task.Status.IsCompleted() {
 		return nil
@@ -91,7 +93,7 @@ func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellation
 		return err
 	}
 
-	return t.es.taskDispatcher.Complete(ctx, t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId)
+	return nil
 }
 
 func (t *EndpointTask) HeartBeat(ctx context.Context) (bool, error) {

--- a/pkg/abstractions/endpoint/task.go
+++ b/pkg/abstractions/endpoint/task.go
@@ -64,12 +64,12 @@ func (t *EndpointTask) Retry(ctx context.Context) error {
 }
 
 func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellationReason) error {
-	task, err := t.es.backendRepo.GetTask(ctx, t.msg.TaskId)
+	task, err := t.es.backendRepo.GetTask(context.Background(), t.msg.TaskId)
 	if err != nil {
 		return err
 	}
 
-	defer t.es.taskDispatcher.Complete(ctx, t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId)
+	defer t.es.taskDispatcher.Complete(context.Background(), t.msg.WorkspaceName, t.msg.StubId, t.msg.TaskId)
 
 	// Don't update tasks that are already in a terminal state
 	if task.Status.IsCompleted() {
@@ -88,7 +88,7 @@ func (t *EndpointTask) Cancel(ctx context.Context, reason types.TaskCancellation
 		task.Status = types.TaskStatusError
 	}
 
-	_, err = t.es.backendRepo.UpdateTask(ctx, t.msg.TaskId, *task)
+	_, err = t.es.backendRepo.UpdateTask(context.Background(), t.msg.TaskId, *task)
 	if err != nil {
 		return err
 	}

--- a/pkg/abstractions/taskqueue/task.go
+++ b/pkg/abstractions/taskqueue/task.go
@@ -76,7 +76,7 @@ func (t *TaskQueueTask) HeartBeat(ctx context.Context) (bool, error) {
 }
 
 func (t *TaskQueueTask) Cancel(ctx context.Context, reason types.TaskCancellationReason) error {
-	task, err := t.tq.backendRepo.GetTask(ctx, t.msg.TaskId)
+	task, err := t.tq.backendRepo.GetTask(context.Background(), t.msg.TaskId)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (t *TaskQueueTask) Cancel(ctx context.Context, reason types.TaskCancellatio
 		task.Status = types.TaskStatusError
 	}
 
-	_, err = t.tq.backendRepo.UpdateTask(ctx, t.msg.TaskId, *task)
+	_, err = t.tq.backendRepo.UpdateTask(context.Background(), t.msg.TaskId, *task)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensured that inflight tasks are always marked as complete when canceled, even if they are already in a terminal state.

- **Bug Fixes**
 - Moved task completion to a deferred call to guarantee it runs on every cancel attempt.

<!-- End of auto-generated description by cubic. -->

