### PR TITLE
Fix: force expiry

### DIFF
--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -203,7 +203,12 @@ func (d *Dispatcher) monitor(ctx context.Context) {
 				}
 
 				if !claimed {
-					if time.Now().After(taskMessage.Policy.Expires) {
+					expires := taskMessage.Policy.Expires
+					if expires.IsZero() {
+						expires = time.Now().Add(time.Duration(taskMessage.Policy.TTL) * time.Second)
+					}
+
+					if time.Now().After(expires) {
 						err = task.Cancel(ctx, types.TaskExpired)
 						if err != nil {
 							log.Error().Str("task_id", task.Metadata().TaskId).Err(err).Msg("dispatcher unable to cancel task")

--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -203,12 +203,7 @@ func (d *Dispatcher) monitor(ctx context.Context) {
 				}
 
 				if !claimed {
-					expires := taskMessage.Policy.Expires
-					if expires.IsZero() {
-						expires = time.Now().Add(time.Duration(taskMessage.Policy.TTL) * time.Second)
-					}
-
-					if time.Now().After(expires) {
+					if time.Now().After(taskMessage.Policy.Expires) {
 						err = task.Cancel(ctx, types.TaskExpired)
 						if err != nil {
 							log.Error().Str("task_id", task.Metadata().TaskId).Err(err).Msg("dispatcher unable to cancel task")


### PR DESCRIPTION
Fix a strange edge with cancelled tasks.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where cancelled tasks without an expiry time were not expiring as expected. Now, tasks with no set expiry use their TTL to determine when to expire.

<!-- End of auto-generated description by cubic. -->

