### PR TITLE
cancel concurrency limited tasks

### DIFF
--- a/pkg/abstractions/function/task.go
+++ b/pkg/abstractions/function/task.go
@@ -184,10 +184,7 @@ func (t *FunctionTask) run(ctx context.Context, stub *types.StubWithRelated, tas
 		Stub:        *stub,
 	})
 	if err != nil {
-		// Check if it's a concurrency limit error
 		if _, ok := err.(*types.ThrottledByConcurrencyLimitError); ok {
-			// For concurrency limit errors, we still want to cancel the task
-			// but we can log it specifically for debugging
 			log.Info().Str("task_id", task.ExternalId).Str("reason", err.Error()).Msg("task cancelled due to concurrency limit")
 		}
 

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -242,7 +242,7 @@ func (m *ContainerNetworkManager) setupBridge(bridgeName string) (netlink.Link, 
 	lockResponse, err := handleGRPCResponse(m.workerRepoClient.SetNetworkLock(m.ctx, &pb.SetNetworkLockRequest{
 		NetworkPrefix: m.networkPrefix,
 		Ttl:           10,
-		Retries:       5,
+		Retries:       10,
 	}))
 	if err != nil {
 		return nil, err
@@ -333,7 +333,7 @@ func (m *ContainerNetworkManager) configureContainerNetwork(containerId string, 
 	lockResponse, err := handleGRPCResponse(m.workerRepoClient.SetNetworkLock(m.ctx, &pb.SetNetworkLockRequest{
 		NetworkPrefix: m.networkPrefix,
 		Ttl:           10,
-		Retries:       5,
+		Retries:       10,
 	}))
 	if err != nil {
 		return err
@@ -525,7 +525,7 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 	lockResponse, err := handleGRPCResponse(m.workerRepoClient.SetNetworkLock(m.ctx, &pb.SetNetworkLockRequest{
 		NetworkPrefix: m.networkPrefix,
 		Ttl:           10,
-		Retries:       5,
+		Retries:       10,
 	}))
 	if err != nil {
 		return err

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.205"
+version = "0.1.206"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/function.py
+++ b/sdk/src/beta9/abstractions/function.py
@@ -40,7 +40,7 @@ class Function(RunnerAbstraction):
             Assign the function to an app. If the app does not exist, it will be created with the given name.
             An app is a group of resources (endpoints, task queues, functions, etc).
         cpu (Union[int, float, str]):
-            The number of CPU cores allocated to the container. Default is 1.0.
+            The number of CPU cores allocated to the container. Default is 0.125.
         memory (Union[int, str]):
             The amount of memory allocated to the container. It should be specified in
             MiB, or as a string with units (e.g. "1Gi"). Default is 128 MiB.
@@ -101,7 +101,7 @@ class Function(RunnerAbstraction):
     def __init__(
         self,
         app: str = "",
-        cpu: Union[int, float, str] = 1.0,
+        cpu: Union[int, float, str] = 0.125,
         memory: Union[int, str] = 128,
         gpu: Union[GpuTypeAlias, List[GpuTypeAlias]] = GpuType.NoGPU,
         gpu_count: int = 0,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Tasks that hit concurrency limits are now cancelled and marked as such, improving task state accuracy and debugging.

- **Other Changes**
  - Increased network lock retry attempts from 5 to 10.
  - Updated default CPU allocation for functions from 1.0 to 0.125.

<!-- End of auto-generated description by cubic. -->

