### PR TITLE
Patch volume during clone

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -483,6 +483,20 @@ func (g *StubGroup) cloneStub(ctx context.Context, workspace *types.Workspace, s
 		})
 	}
 
+	for _, volumeConfig := range stubConfig.Volumes {
+		parentVolume, err := g.backendRepo.GetVolumeByExternalId(ctx, stub.WorkspaceId, volumeConfig.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		childVolume, err := g.backendRepo.GetOrCreateVolume(ctx, workspace.Id, parentVolume.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		volumeConfig.Id = childVolume.ExternalId
+	}
+
 	err = g.configureVolumes(ctx, stubConfig.Volumes, workspace)
 	if err != nil {
 		return nil, HTTPInternalServerError("Failed to configure volumes")

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1012,6 +1012,20 @@ func (c *PostgresBackendRepository) GetVolume(ctx context.Context, workspaceId u
 	return &volume, nil
 }
 
+func (c *PostgresBackendRepository) GetVolumeByExternalId(ctx context.Context, workspaceId uint, externalId string) (*types.Volume, error) {
+	var volume types.Volume
+	queryGet := `SELECT id, external_id, name, workspace_id, created_at, updated_at FROM volume WHERE external_id = $1 AND workspace_id = $2;`
+
+	if err := c.client.GetContext(ctx, &volume, queryGet, externalId, workspaceId); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &volume, nil
+}
+
 func (c *PostgresBackendRepository) GetOrCreateVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error) {
 	v, err := c.GetVolume(ctx, workspaceId, name)
 	if err == nil {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -129,6 +129,7 @@ type BackendRepository interface {
 	GetStubByExternalId(ctx context.Context, externalId string, queryFilters ...types.QueryFilter) (*types.StubWithRelated, error)
 	GetDeploymentBySubdomain(ctx context.Context, subdomain string, version uint) (*types.DeploymentWithRelated, error)
 	GetVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error)
+	GetVolumeByExternalId(ctx context.Context, workspaceId uint, externalId string) (*types.Volume, error)
 	GetOrCreateVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error)
 	DeleteVolume(ctx context.Context, workspaceId uint, name string) error
 	ListVolumesWithRelated(ctx context.Context, workspaceId uint) ([]types.VolumeWithRelated, error)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Volumes are now correctly patched when cloning a stub, ensuring cloned workspaces have the right volume references.

- **Bug Fixes**
  - Fixed volume ID assignment during stub cloning to prevent incorrect or missing volume links.

<!-- End of auto-generated description by cubic. -->

