### PR TITLE
dont constrain build requests

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -356,7 +356,7 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 	spec.Process.Args = request.EntryPoint
 	spec.Process.Terminal = false
 
-	if s.config.Worker.ContainerResourceLimits.CPUEnforced || s.config.Worker.ContainerResourceLimits.MemoryEnforced {
+	if !request.IsBuildRequest() && (s.config.Worker.ContainerResourceLimits.CPUEnforced || s.config.Worker.ContainerResourceLimits.MemoryEnforced) {
 		spec.Linux.Resources.Unified = cgroupV2Parameters
 
 		if s.config.Worker.ContainerResourceLimits.CPUEnforced {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Build requests are no longer limited by CPU or memory resource constraints. This allows build jobs to use all available resources.

<!-- End of auto-generated description by cubic. -->

