### PR TITLE
disable throttling for gpu workloads

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -356,7 +356,8 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 	spec.Process.Args = request.EntryPoint
 	spec.Process.Terminal = false
 
-	if !request.IsBuildRequest() && (s.config.Worker.ContainerResourceLimits.CPUEnforced || s.config.Worker.ContainerResourceLimits.MemoryEnforced) {
+	throttlingEnabled := !request.IsBuildRequest() && !request.RequiresGPU()
+	if throttlingEnabled && (s.config.Worker.ContainerResourceLimits.CPUEnforced || s.config.Worker.ContainerResourceLimits.MemoryEnforced) {
 		spec.Linux.Resources.Unified = cgroupV2Parameters
 
 		if s.config.Worker.ContainerResourceLimits.CPUEnforced {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disabled CPU and memory throttling for GPU workloads to ensure they run without resource limits.

<!-- End of auto-generated description by cubic. -->

