### PR TITLE
fix: only log events in debug mode

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -828,7 +828,10 @@ func (s *Worker) watchOOMEvents(ctx context.Context, request *types.ContainerReq
 				continue
 			}
 
-			log.Info().Str("container_id", containerId).Msgf("received container event: %+v", event)
+			if s.config.DebugMode {
+				log.Info().Str("container_id", containerId).Msgf("received container event: %+v", event)
+			}
+
 			if _, ok := seenEvents[event.Type]; ok {
 				continue
 			}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Container event logs now only appear when debug mode is enabled, reducing log noise during normal operation.

<!-- End of auto-generated description by cubic. -->

