### PR TITLE
fix: handle  runc err event

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -836,7 +836,7 @@ func (s *Worker) watchOOMEvents(ctx context.Context, request *types.ContainerReq
 			}
 
 			if event.Type == "error" && event.Err != nil && strings.Contains(event.Err.Error(), "file already closed") {
-				log.Warn().Str("container_id", containerId).Msgf("received error event from runc: %s, stopping OOM event monitoring goroutine", event.Err.Error())
+				log.Warn().Str("container_id", containerId).Msgf("received error event: %s, stopping OOM event monitoring", event.Err.Error())
 				cancelEvents()
 				return
 			}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved OOM event monitoring by handling runc error events and stopping the goroutine when a "file already closed" error is received.

- **Bug Fixes**
  - Cancels event monitoring if runc returns a "file already closed" error to prevent unnecessary retries.

<!-- End of auto-generated description by cubic. -->

