### PR TITLE
change return type of task.put

### DIFF
--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -10,6 +10,7 @@ from ... import terminal
 from ...abstractions.base import BaseAbstraction
 from ...abstractions.image import Image, ImageBuildResult
 from ...abstractions.volume import Volume
+from ...client.client import Client
 from ...clients.gateway import Autoscaler as AutoscalerProto
 from ...clients.gateway import (
     GatewayServiceStub,
@@ -178,6 +179,7 @@ class RunnerAbstraction(BaseAbstraction):
         self.pricing: Optional[PricingPolicy] = pricing
         self.inputs: Optional[Schema] = inputs
         self.outputs: Optional[Schema] = outputs
+        self.client = Client(token=self.config_context.token) if self.config_context.token else None
 
     def print_invocation_snippet(self, url_type: str = "") -> GetUrlResponse:
         """Print curl request to call deployed container URL"""

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -179,7 +179,13 @@ class RunnerAbstraction(BaseAbstraction):
         self.pricing: Optional[PricingPolicy] = pricing
         self.inputs: Optional[Schema] = inputs
         self.outputs: Optional[Schema] = outputs
+        self.client: Optional[Client] = None
+
+    def get_client(self):
+        if self.client:
+            return self.client
         self.client = Client(token=self.config_context.token) if self.config_context.token else None
+        return self.client
 
     def print_invocation_snippet(self, url_type: str = "") -> GetUrlResponse:
         """Print curl request to call deployed container URL"""

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -181,7 +181,7 @@ class RunnerAbstraction(BaseAbstraction):
         self.outputs: Optional[Schema] = outputs
         self.client: Optional[Client] = None
 
-    def get_client(self):
+    def get_client(self) -> Client | None:
         if self.client:
             return self.client
         self.client = Client(token=self.config_context.token) if self.config_context.token else None

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -269,6 +269,4 @@ class _CallableWrapper(DeployableMixin):
             terminal.error("Failed to enqueue task")
             return False
 
-        terminal.detail(f"Enqueued task: {r.task_id}")
-
         return self.parent.get_client().get_task_by_id(r.task_id)

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -14,6 +14,7 @@ from ..abstractions.base.runner import (
 from ..abstractions.image import Image
 from ..abstractions.volume import CloudBucket, Volume
 from ..channel import with_grpc_error_handling
+from ..client.task import Task
 from ..clients.taskqueue import (
     StartTaskQueueServeRequest,
     StartTaskQueueServeResponse,
@@ -250,11 +251,15 @@ class _CallableWrapper(DeployableMixin):
         container = Container(container_id=r.container_id)
         container.attach(container_id=r.container_id, sync_dir=dir)
 
-    def put(self, *args, **kwargs) -> bool:
+    def put(self, *args, **kwargs) -> Union[bool, Task]:
         if not self.parent.prepare_runtime(
             func=self.func,
             stub_type=TASKQUEUE_STUB_TYPE,
         ):
+            return False
+
+        if not self.parent.client:
+            terminal.error("No API client was instantiated.")
             return False
 
         payload = {"args": args, "kwargs": kwargs}
@@ -269,4 +274,6 @@ class _CallableWrapper(DeployableMixin):
             return False
 
         terminal.detail(f"Enqueued task: {r.task_id}")
-        return True
+        task = self.parent.client.get_task_by_id(r.task_id)
+
+        return task

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -258,10 +258,6 @@ class _CallableWrapper(DeployableMixin):
         ):
             return False
 
-        if not self.parent.client:
-            terminal.error("No API client was instantiated.")
-            return False
-
         payload = {"args": args, "kwargs": kwargs}
         json_payload = json.dumps(payload)
 
@@ -274,6 +270,5 @@ class _CallableWrapper(DeployableMixin):
             return False
 
         terminal.detail(f"Enqueued task: {r.task_id}")
-        task = self.parent.client.get_task_by_id(r.task_id)
 
-        return task
+        return self.parent.client.get_task_by_id(r.task_id)

--- a/sdk/src/beta9/abstractions/taskqueue.py
+++ b/sdk/src/beta9/abstractions/taskqueue.py
@@ -271,4 +271,4 @@ class _CallableWrapper(DeployableMixin):
 
         terminal.detail(f"Enqueued task: {r.task_id}")
 
-        return self.parent.client.get_task_by_id(r.task_id)
+        return self.parent.get_client().get_task_by_id(r.task_id)

--- a/sdk/tests/test_task_queue.py
+++ b/sdk/tests/test_task_queue.py
@@ -42,6 +42,10 @@ class TestTaskQueue(TestCase):
                 return_value=(TaskQueuePutResponse(ok=True, task_id="1234"))
             )
             test_func.parent.prepare_runtime = MagicMock(return_value=True)
+            test_func.parent.client = MagicMock().assign_attr(
+                "get_task_by_id",
+                MagicMock(return_value=MagicMock()),
+            )
 
             test_func.put()
 
@@ -67,6 +71,10 @@ class TestTaskQueue(TestCase):
             )
 
             test_func.parent.prepare_runtime = MagicMock(return_value=True)
+            test_func.parent.client = MagicMock().assign_attr(
+                "get_task_by_id",
+                MagicMock(return_value=MagicMock()),
+            )
 
             self.assertRaises(
                 NotImplementedError,

--- a/sdk/tests/test_task_queue.py
+++ b/sdk/tests/test_task_queue.py
@@ -42,9 +42,11 @@ class TestTaskQueue(TestCase):
                 return_value=(TaskQueuePutResponse(ok=True, task_id="1234"))
             )
             test_func.parent.prepare_runtime = MagicMock(return_value=True)
-            test_func.parent.client = MagicMock().assign_attr(
-                "get_task_by_id",
-                MagicMock(return_value=MagicMock()),
+            test_func.parent.get_client = MagicMock(
+                return_value=MagicMock().assign_attr(
+                    "get_task_by_id",
+                    MagicMock(return_value=MagicMock()),
+                )
             )
 
             test_func.put()
@@ -71,9 +73,11 @@ class TestTaskQueue(TestCase):
             )
 
             test_func.parent.prepare_runtime = MagicMock(return_value=True)
-            test_func.parent.client = MagicMock().assign_attr(
-                "get_task_by_id",
-                MagicMock(return_value=MagicMock()),
+            test_func.parent.get_client = MagicMock(
+                return_value=MagicMock().assign_attr(
+                    "get_task_by_id",
+                    MagicMock(return_value=MagicMock()),
+                )
             )
 
             self.assertRaises(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Changed the return type of task.put to return a Task object instead of a boolean, allowing callers to access the enqueued task directly.

- **Refactors**
 - Instantiated the API client in the runner abstraction to support fetching the Task by ID.
 - Updated error handling for missing API client.

<!-- End of auto-generated description by cubic. -->

