### PR TITLE
fix: dockerfile must be Image w/ correct config

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.211"
+version = "0.1.212"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/pod.py
+++ b/sdk/src/beta9/abstractions/pod.py
@@ -286,7 +286,7 @@ app = Pod(
             if key != "dockerfile" and (key not in argkwargs or value is None):
                 continue
 
-            if key == "dockerfile":
+            if key == "dockerfile" and isinstance(value, Image):
                 imports.append("Image")
                 key = "image"
                 value = f"Image.from_dockerfile('{value.dockerfile_path}')"

--- a/sdk/src/beta9/cli/extraclick.py
+++ b/sdk/src/beta9/cli/extraclick.py
@@ -261,6 +261,7 @@ class DockerfileParser(click.ParamType):
 
         image = Image.from_dockerfile(value)
         image.dockerfile_path = value
+        image.ignore_python = True
         return image
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed Dockerfile handling to ensure only valid Image objects are processed and set ignore_python to True when creating images from Dockerfiles.

<!-- End of auto-generated description by cubic. -->

