### PR TITLE
bump sdk

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.213"
+version = "0.1.215"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -78,7 +78,8 @@ class BaseAbstraction(ABC):
 
             settings = SDKSettings(
                 name="Beam",
-                api_host=os.getenv("API_HOST", "api.beam.cloud"),
+                api_host=os.getenv("API_HOST", "app.beam.cloud"),
+                api_port=int(os.getenv("API_PORT", 443)),
                 gateway_host=os.getenv("GATEWAY_HOST", "gateway.beam.cloud"),
                 gateway_port=int(os.getenv("GATEWAY_PORT", 443)),
                 config_path=Path("~/.beam/config.ini").expanduser(),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the SDK default API host to app.beam.cloud and added support for setting the API port from the environment. Bumped the SDK version to 0.1.215.

<!-- End of auto-generated description by cubic. -->

