### PR TITLE
fix log buffer concurrency

### DIFF
--- a/pkg/common/io.go
+++ b/pkg/common/io.go
@@ -110,15 +110,15 @@ type SafeBuffer struct {
 
 func (b *SafeBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	n, err := b.buf.Write(p)
-	b.mu.Unlock()
 	return n, err
 }
 
 func (b *SafeBuffer) StringAndReset() string {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	s := b.buf.String()
 	b.buf.Reset()
-	b.mu.Unlock()
 	return s
 }

--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -1,11 +1,12 @@
 package worker
 
 import (
-	"bytes"
 	"io"
 	"os/exec"
 	"sync"
 	"time"
+
+	common "github.com/beam-cloud/beta9/pkg/common"
 )
 
 type SandboxProcessStatus string
@@ -27,8 +28,8 @@ type SandboxProcessState struct {
 	EndTime   time.Time
 	Status    SandboxProcessStatus
 	Error     error
-	StdoutBuf *bytes.Buffer // buffer for stdout
-	StderrBuf *bytes.Buffer // buffer for stderr
+	StdoutBuf *common.SafeBuffer
+	StderrBuf *common.SafeBuffer
 	mu        sync.Mutex
 }
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.215"
+version = "0.1.221"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed concurrency issues in log buffers by replacing bytes.Buffer with a thread-safe SafeBuffer in sandbox process handling.

- **Bug Fixes**
  - Prevented race conditions when reading and writing to stdout and stderr buffers during sandbox execution.

<!-- End of auto-generated description by cubic. -->

