### PR TITLE
fix: make sandbox process cloud pickle-able

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.223"
+version = "0.1.224"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -49,6 +49,11 @@ def set_channel(
     _channel = _get_channel(context)
 
 
+def unset_channel():
+    global _channel
+    _channel = None
+
+
 def get_channel() -> Channel:
     global _channel
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Made SandboxProcess and related classes compatible with cloudpickle by adding custom serialization methods and handling non-picklable attributes.

- **Refactors**
  - Added __getstate__ and __setstate__ to SandboxProcess and SandboxProcessResponse.
  - Removed non-picklable attributes before pickling and restored them after unpickling.
  - Introduced unset_channel to clear global state during serialization.

<!-- End of auto-generated description by cubic. -->

