### PR TITLE
fix: remove skip in flight on restore

### DIFF
--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -71,7 +71,6 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 		CheckpointOpts: runc.CheckpointOpts{
 			AllowOpenTCP: true,
 			LinkRemap:    true,
-			SkipInFlight: true,
 			// Logs, irmap cache, sockets for lazy server and other go to working dir
 			// must be overriden bc blobcache is read-only
 			WorkDir:      workDir,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the SkipInFlight option from the NVIDIA CRIU restore process to ensure all in-flight file descriptors are restored.

<!-- End of auto-generated description by cubic. -->

