### PR TITLE
fix: add cgroups ignore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
 	github.com/beam-cloud/blobcache-v2 v0.0.0-20250503151236-e2403183f563
 	github.com/beam-cloud/clip v0.0.0-20250424185136-5f40b560b510
-	github.com/beam-cloud/go-runc v0.0.0-20250705192003-074a7a5f2124
+	github.com/beam-cloud/go-runc v0.0.0-20250804193923-7e2e1bff6915
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
 	github.com/cedana/cedana v0.9.240
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250705192003-074a7a5f2124 h1:mlJ80fXIvEEYVAWV8YY6QlzqXYJyPn/woT9HQahg7Rg=
 github.com/beam-cloud/go-runc v0.0.0-20250705192003-074a7a5f2124/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
+github.com/beam-cloud/go-runc v0.0.0-20250804193923-7e2e1bff6915 h1:d0p2YVmfxspueb7foipHH2CeZdpzBLGgzhC2qGuiO9o=
+github.com/beam-cloud/go-runc v0.0.0-20250804193923-7e2e1bff6915/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324/go.mod h1:pBb6ZWEw7rhALuBZTGZxT3p+Sd5b8jsvP5EPEsM8T/Q=
 github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8 h1:lc3G6/sHW4e5/XPHO2w2Ni43fbu42nojS/uX45Ws6Ck=

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -76,6 +76,7 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 			WorkDir:      workDir,
 			ImagePath:    imagePath,
 			OutputWriter: opts.runcOpts.OutputWriter,
+			Cgroups:      runc.Ignore,
 		},
 		Started: opts.runcOpts.Started,
 	})


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support to ignore cgroups during NVIDIA CRIU checkpoint restore by updating go-runc and setting the Cgroups flag.

- **Dependencies**
 - Updated go-runc to the latest version to enable cgroups ignore support.

<!-- End of auto-generated description by cubic. -->

