### PR TITLE
do not manage cgroups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
 	github.com/beam-cloud/blobcache-v2 v0.0.0-20250503151236-e2403183f563
 	github.com/beam-cloud/clip v0.0.0-20250424185136-5f40b560b510
-	github.com/beam-cloud/go-runc v0.0.0-20250804193923-7e2e1bff6915
+	github.com/beam-cloud/go-runc v0.0.0-20250804222058-26754319f4e0
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
 	github.com/cedana/cedana v0.9.240
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/beam-cloud/go-runc v0.0.0-20250705192003-074a7a5f2124 h1:mlJ80fXIvEEY
 github.com/beam-cloud/go-runc v0.0.0-20250705192003-074a7a5f2124/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/go-runc v0.0.0-20250804193923-7e2e1bff6915 h1:d0p2YVmfxspueb7foipHH2CeZdpzBLGgzhC2qGuiO9o=
 github.com/beam-cloud/go-runc v0.0.0-20250804193923-7e2e1bff6915/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
+github.com/beam-cloud/go-runc v0.0.0-20250804222058-26754319f4e0 h1:tqw5R8MTFRmRVX4DjGX32LfPjla+X6udahWtpRdpJyc=
+github.com/beam-cloud/go-runc v0.0.0-20250804222058-26754319f4e0/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324/go.mod h1:pBb6ZWEw7rhALuBZTGZxT3p+Sd5b8jsvP5EPEsM8T/Q=
 github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8 h1:lc3G6/sHW4e5/XPHO2w2Ni43fbu42nojS/uX45Ws6Ck=

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -50,7 +50,7 @@ func (c *NvidiaCRIUManager) CreateCheckpoint(ctx context.Context, request *types
 		SkipInFlight: true,
 		LinkRemap:    true,
 		ImagePath:    checkpointPath,
-		Cgroups:      runc.Ignore,
+		Cgroups:      runc.None,
 	})
 	if err != nil {
 		return "", err
@@ -77,7 +77,7 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 			WorkDir:      workDir,
 			ImagePath:    imagePath,
 			OutputWriter: opts.runcOpts.OutputWriter,
-			Cgroups:      runc.Ignore,
+			Cgroups:      runc.None,
 		},
 		Started: opts.runcOpts.Started,
 	})


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated checkpoint and restore logic to stop managing cgroups by setting the cgroups option to runc.None.

- **Dependencies**
 - Bumped go-runc to use the latest version that supports runc.None.

<!-- End of auto-generated description by cubic. -->

