### PR TITLE
cgroups soft

### DIFF
--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -50,7 +50,7 @@ func (c *NvidiaCRIUManager) CreateCheckpoint(ctx context.Context, request *types
 		SkipInFlight: true,
 		LinkRemap:    true,
 		ImagePath:    checkpointPath,
-		Cgroups:      runc.Ignore,
+		Cgroups:      runc.Soft,
 	})
 	if err != nil {
 		return "", err
@@ -77,7 +77,7 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 			WorkDir:      workDir,
 			ImagePath:    imagePath,
 			OutputWriter: opts.runcOpts.OutputWriter,
-			Cgroups:      runc.Ignore,
+			Cgroups:      runc.Soft,
 		},
 		Started: opts.runcOpts.Started,
 	})


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Changed cgroup handling in checkpoint and restore to use runc.Soft instead of runc.Ignore for better compatibility with soft mode.

<!-- End of auto-generated description by cubic. -->

