### PR TITLE
increase dump timeout

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -226,8 +226,9 @@ VOLUME "/usr/lib/aarch64-linux-gnu"
 RUN mkdir -p /etc/criu
 RUN touch /etc/criu/default.conf
 # add the following options to the default.conf file on new lines
-RUN echo "verbosity=4" >> /etc/criu/default.conf
+RUN echo "verbosity 4" >> /etc/criu/default.conf
 RUN echo "display-stats" >> /etc/criu/default.conf
+RUN echo "timeout 60" >> /etc/criu/default.conf
 
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics,ngx,video
 ENV _BUILDAH_STARTED_IN_USERNS="" \


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increased the CRIU dump timeout to 60 seconds in the worker Dockerfile to allow more time for process dumps.

<!-- End of auto-generated description by cubic. -->

