### PR TITLE
Hotfix: Modify nsswitch to remove systemd as a valid check for creds

### DIFF
--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -39,8 +39,9 @@ const (
 	containerWaitPollIntervalS    time.Duration = 1 * time.Second
 	containerKeepAliveIntervalS   time.Duration = 5 * time.Second
 	sshBannerTimeoutDurationS     time.Duration = 2 * time.Second
-	startupScript                 string        = `SHELL=$(ls /bin/bash || ls /bin/sh); /usr/local/bin/dropbear -e -c "cd /mnt/code && $SHELL" -p %d -R -E -F 2>> /etc/dropbear/logs.txt`
-	createUserScript              string        = `SHELL=$(ls /bin/bash || ls /bin/sh); \
+	// Remove systemd from nsswitch.conf to prevent systemd from being used for user referencing with dropbear
+	startupScript    string = `SHELL=$(ls /bin/bash || ls /bin/sh); sed 's/systemd//g' /etc/nsswitch.conf > /etc/nsswitch.conf; /usr/local/bin/dropbear -e -c "cd /mnt/code && $SHELL" -p %d -R -E -F 2>> /etc/dropbear/logs.txt`
+	createUserScript string = `SHELL=$(ls /bin/bash || ls /bin/sh); \
 (command -v useradd >/dev/null && useradd -m -s $SHELL -u 0 -g 0 "$USERNAME" 2>> /etc/dropbear/logs.txt) || \
 (command -v adduser >/dev/null && adduser --disabled-password --gecos "" --shell $SHELL --uid 0 --gid 0 "$USERNAME" 2>> /etc/dropbear/logs.txt) || \
 (echo "$USERNAME:x:0:0:$USERNAME:/root:$SHELL" >> /etc/passwd && mkdir -p "/root" && chown 0:0 "/root") && \

--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -39,7 +39,7 @@ const (
 	containerWaitPollIntervalS    time.Duration = 1 * time.Second
 	containerKeepAliveIntervalS   time.Duration = 5 * time.Second
 	sshBannerTimeoutDurationS     time.Duration = 2 * time.Second
-	// Remove systemd from nsswitch.conf to prevent systemd from being used for user referencing with dropbear
+	// Remove systemd from nsswitch.conf to prevent systemd from being used as credential provider by dropbear
 	startupScript    string = `SHELL=$(ls /bin/bash || ls /bin/sh); sed 's/systemd//g' /etc/nsswitch.conf > /etc/nsswitch.conf; /usr/local/bin/dropbear -e -c "cd /mnt/code && $SHELL" -p %d -R -E -F 2>> /etc/dropbear/logs.txt`
 	createUserScript string = `SHELL=$(ls /bin/bash || ls /bin/sh); \
 (command -v useradd >/dev/null && useradd -m -s $SHELL -u 0 -g 0 "$USERNAME" 2>> /etc/dropbear/logs.txt) || \

--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -40,7 +40,7 @@ const (
 	containerKeepAliveIntervalS   time.Duration = 5 * time.Second
 	sshBannerTimeoutDurationS     time.Duration = 2 * time.Second
 	// Remove systemd from nsswitch.conf to prevent systemd from being used as credential provider by dropbear
-	startupScript    string = `SHELL=$(ls /bin/bash || ls /bin/sh); sed 's/systemd//g' /etc/nsswitch.conf > /etc/nsswitch.conf; /usr/local/bin/dropbear -e -c "cd /mnt/code && $SHELL" -p %d -R -E -F 2>> /etc/dropbear/logs.txt`
+	startupScript    string = `SHELL=$(ls /bin/bash || ls /bin/sh); sed -i 's/systemd//g' /etc/nsswitch.conf; /usr/local/bin/dropbear -e -c "cd /mnt/code && $SHELL" -p %d -R -E -F 2>> /etc/dropbear/logs.txt`
 	createUserScript string = `SHELL=$(ls /bin/bash || ls /bin/sh); \
 (command -v useradd >/dev/null && useradd -m -s $SHELL -u 0 -g 0 "$USERNAME" 2>> /etc/dropbear/logs.txt) || \
 (command -v adduser >/dev/null && adduser --disabled-password --gecos "" --shell $SHELL --uid 0 --gid 0 "$USERNAME" 2>> /etc/dropbear/logs.txt) || \


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable systemd in nsswitch.conf during startup so Dropbear doesn’t use systemd for user lookups. This fixes credential resolution issues in containers without systemd.

<!-- End of auto-generated description by cubic. -->

