### PR TITLE
add checkpoint model cache

### DIFF
--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -67,9 +67,6 @@ func (i *endpointInstance) startContainers(containersToRun int) error {
 	}
 
 	checkpointEnabled := i.StubConfig.CheckpointEnabled
-	if i.Stub.Type.IsServe() {
-		checkpointEnabled = false
-	}
 
 	if gpuCount > 1 {
 		checkpointEnabled = false

--- a/pkg/abstractions/taskqueue/instance.go
+++ b/pkg/abstractions/taskqueue/instance.go
@@ -65,10 +65,6 @@ func (i *taskQueueInstance) startContainers(containersToRun int) error {
 	}
 
 	checkpointEnabled := i.StubConfig.CheckpointEnabled
-	if i.Stub.Type.IsServe() {
-		checkpointEnabled = false
-	}
-
 	if gpuCount > 1 {
 		checkpointEnabled = false
 	}

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -290,9 +290,9 @@ func (gws *GatewayService) handleCheckpointEnabled(ctx context.Context, authInfo
 	}
 
 	// Force set cache vars
-	in.Env = append(in.Env, "TRITON_CACHE_DIR", modelCachePath)
-	in.Env = append(in.Env, "TRANSFORMERS_CACHE", modelCachePath)
-	in.Env = append(in.Env, "HF_HOME", modelCachePath)
+	in.Env = append(in.Env, fmt.Sprintf("TRITON_CACHE_DIR=%s", modelCachePath))
+	in.Env = append(in.Env, fmt.Sprintf("TRANSFORMERS_CACHE=%s", modelCachePath))
+	in.Env = append(in.Env, fmt.Sprintf("HF_HOME=%s", modelCachePath))
 
 	in.Volumes = append(in.Volumes, &pb.Volume{
 		Id:        volume.ExternalId,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a persistent model cache for checkpoint-enabled stubs to preserve model files across dump/restore and cut cold starts. When checkpoints are on, we auto-mount a workspace volume and point cache env vars to it.

- **New Features**
  - Auto-create and mount a workspace volume named checkpoint-model-cache at /checkpoint-model-cache.
  - Force TRITON_CACHE_DIR, TRANSFORMERS_CACHE, and HF_HOME to the mounted path.
  - Create the local volume directory when external storage isn’t available.
  - Return clear errors for unsupported cases: multi-GPU or multiple GPU types.

<!-- End of auto-generated description by cubic. -->

