### PR TITLE
fix: exit task queue if theres an unexpected error popping from the queue

### DIFF
--- a/sdk/src/beta9/runner/taskqueue.py
+++ b/sdk/src/beta9/runner/taskqueue.py
@@ -186,7 +186,7 @@ class TaskQueueWorker:
             )
         except (grpc.RpcError, OSError):
             print("Failed to retrieve task due to unexpected error", traceback.format_exc())
-            return None
+            os._exit(TaskExitCode.Error)
 
     def _monitor_task(
         self,


### PR DESCRIPTION
This should resolve exceptions like this where DNS resolution etc fails unexpectedly:

```
Failed to retrieve task due to unexpected error Traceback (most recent call last):   File "/usr/local/lib/python3.9/dist-packages/beta9/runner/taskqueue.py", line 174, in _get_next_task     r: TaskQueuePopResponse = taskqueue_stub.task_queue_pop(   File "/usr/local/lib/python3.9/dist-packages/beta9/clients/taskqueue/__init__.py", line 121, in task_queue_pop     return self._unary_unary(   File "/usr/local/lib/python3.9/dist-packages/grpc/_interceptor.py", line 277, in __call__     response, ignored_call = self._with_call(   File "/usr/local/lib/python3.9/dist-packages/grpc/_interceptor.py", line 332, in _with_call     return call.result(), call   File "/usr/local/lib/python3.9/dist-packages/grpc/_channel.py", line 437, in result     raise self   File "/usr/local/lib/python3.9/dist-packages/grpc/_interceptor.py", line 315, in continuation     response, call = self._thunk(new_method).with_call(   File "/usr/local/lib/python3.9/dist-packages/grpc/_channel.py", line 1177, in with_call     return _end_unary_response_blocking(state, call, True, None)   File "/usr/local/lib/python3.9/dist-packages/grpc/_channel.py", line 1003, in _end_unary_response_blocking     raise _InactiveRpcError(state)  # pytype: disable=not-instantiable grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with: 	status = StatusCode.UNAVAILABLE 	details = "DNS resolution failed for gateway.beam.cloud:443: C-ares status is not ARES_SUCCESS qtype=A name=gateway.beam.cloud is_balancer=0: Could not contact DNS servers" 	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"DNS resolution failed for gateway.beam.cloud:443: C-ares status is not ARES_SUCCESS qtype=A name=gateway.beam.cloud is_balancer=0: Could not contact DNS servers", grpc_status:14, created_time:"2025-08-21T20:16:44.854715034+00:00"}" >
--



```