### PR TITLE
fix restore network error

### DIFF
--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -206,7 +206,10 @@ func (s *Worker) createCheckpoint(ctx context.Context, request *types.ContainerR
 		}
 
 		// Create a file accessible to the container to indicate that the checkpoint has been captured
-		os.Create(filepath.Join(checkpointSignalDir(request.ContainerId), checkpointCompleteFileName))
+		_, err = os.Create(filepath.Join(checkpointSignalDir(request.ContainerId), checkpointCompleteFileName))
+		if err != nil {
+			log.Error().Str("container_id", request.ContainerId).Msgf("failed to create checkpoint complete file: %v", err)
+		}
 
 		outputLogger.Info("Checkpoint created successfully")
 

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -526,7 +526,6 @@ func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, option
 		fmt.Sprintf("BETA9_GATEWAY_PORT=%s", os.Getenv("BETA9_GATEWAY_PORT")),
 		fmt.Sprintf("BETA9_GATEWAY_HOST_HTTP=%s", os.Getenv("BETA9_GATEWAY_HOST_HTTP")),
 		fmt.Sprintf("BETA9_GATEWAY_PORT_HTTP=%s", os.Getenv("BETA9_GATEWAY_PORT_HTTP")),
-		fmt.Sprintf("CHECKPOINT_ENABLED=%t", request.CheckpointEnabled && s.IsCRIUAvailable(request.GpuCount)),
 		fmt.Sprintf("STORAGE_AVAILABLE=%t", request.StorageAvailable()),
 		"PYTHONUNBUFFERED=1",
 	}
@@ -675,6 +674,10 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 			log.Error().Str("container_id", containerId).Msgf("failed to expose container bind port: %v", err)
 			return
 		}
+	}
+
+	if request.CheckpointEnabled {
+		spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("CHECKPOINT_ENABLED=%t", request.CheckpointEnabled && s.IsCRIUAvailable(request.GpuCount)))
 	}
 
 	// Write runc config spec to disk


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes a restore networking error by only setting CHECKPOINT_ENABLED when checkpointing is requested. Moves the env injection from getContainerEnvironment to spawn(), so the variable is absent for non-checkpointed runs.

<!-- End of auto-generated description by cubic. -->

