### PR TITLE
Feat: Add ability to get container as admin

### DIFF
--- a/pkg/api/v1/container.go
+++ b/pkg/api/v1/container.go
@@ -35,6 +35,7 @@ func NewContainerGroup(
 	}
 
 	g.GET("/:workspaceId", auth.WithWorkspaceAuth(group.ListContainersByWorkspaceId))
+	g.GET("/admin/:containerId", auth.WithClusterAdminAuth(group.GetContainerAsAdmin))
 	g.GET("/:workspaceId/:containerId", auth.WithWorkspaceAuth(group.GetContainer))
 	g.POST("/:workspaceId/:containerId/stop", auth.WithWorkspaceAuth(group.StopContainer))
 	g.POST("/:workspaceId/stop-all", auth.WithWorkspaceAuth(group.StopAllWorkspaceContainers))
@@ -74,6 +75,17 @@ func (c *ContainerGroup) ListContainersByWorkspaceId(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, containerStatesWithAppId)
+}
+
+func (c *ContainerGroup) GetContainerAsAdmin(ctx echo.Context) error {
+	containerId := ctx.Param("containerId")
+
+	containerState, err := c.containerRepo.GetContainerState(containerId)
+	if err != nil {
+		return HTTPBadRequest("Invalid container id")
+	}
+
+	return ctx.JSON(http.StatusOK, containerState)
 }
 
 func (c *ContainerGroup) GetContainer(ctx echo.Context) error {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add an admin-only endpoint to fetch a container’s state by ID without needing a workspace context. This helps cluster admins debug or manage containers across workspaces.

- **New Features**
  - Added GET /containers/admin/:containerId (auth.WithClusterAdminAuth).
  - Returns 200 with container state; 400 "Invalid container id" for bad IDs.
  - Bypasses workspaceId requirement of the existing container lookup.

<!-- End of auto-generated description by cubic. -->

