### PR TITLE
bump sdk, remove unnecessary mkdir

### DIFF
--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -215,7 +215,6 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 	parentDir := filepath.Dir(instance.Overlay.TopLayerPath())
 	upperDir := path.Join(parentDir, "upper")
 
-	os.MkdirAll(checkpointFsDir, 0755)
 	err = copyDirectory(upperDir, path.Join(checkpointPath, checkpointFsDir), []string{"config.json", "outputs", "snapshot"})
 	if err != nil {
 		log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to copy upper directory: %v", err)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.230"
+version = "0.1.231"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped the Python SDK to 0.1.231 and removed an unnecessary mkdir in CRIU checkpointing. This simplifies the worker code and relies on copyDirectory to handle destination paths.

<!-- End of auto-generated description by cubic. -->

