### PR TITLE
fix multiworker taskqueue checkpoint trigger

### DIFF
--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -194,7 +194,7 @@ class Sandbox(Pod):
 
         Example:
             ```python
-            # Create a sandbox instance from a me   mory snapshot
+            # Create a sandbox instance from a memory snapshot
             instance = sandbox.create_from_memory_snapshot("snapshot-123")
             print(f"Sandbox created with ID: {instance.sandbox_id()}")
             ```


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes auto-checkpointing in multi-worker taskqueue runs by coordinating worker readiness with a shared counter. Prevents premature checkpoints and startup hangs by signaling once after all workers are ready.

- **Bug Fixes**
  - Added a shared multiprocessing.Value workers_ready and pass it to each worker.
  - Updated wait_for_checkpoint to accept the shared counter (with safe fallback if missing).
  - Trigger checkpoint only when workers_ready equals configured worker count, then reload config.
  - Fixed a minor docstring typo in sandbox.py.

<!-- End of auto-generated description by cubic. -->

