### PR TITLE
Small Docstring Updates

### DIFF
--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -27,7 +27,7 @@ def set_channel(
     Use this before importing any abstraction to control which
     gateway to connect to. When you provide a channel, it should already be
     authenticated. When you provide a context, this will authenticate for you.
-    If neither are provided, this uses the default context and will create a
+    If neither is provided, this uses the default context and will create a
     channel. If there is no default context (or config file), then we will
     prompt the user for it.
 

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -27,7 +27,7 @@ def set_channel(
     Use this before importing any abstraction to control which
     gateway to connect to. When you provide a channel, it should already be
     authenticated. When you provide a context, this will authenticate for you.
-    If neithe are provided, this uses the default context and will create a
+    If neither are provided, this uses the default context and will create a
     channel. If there is no default context (or config file), then we will
     prompt the user for it.
 

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -1489,7 +1489,7 @@ class SandboxFileSystem:
             sandbox_path (str): The path where the directory should be created.
 
         Raises:
-            NotImplementedError: This method is not yet implemented.
+            SandboxFileSystemError: If the directory creation fails.
         """
         resp = self.sandbox_instance.stub.sandbox_create_directory(
             PodSandboxCreateDirectoryRequest(
@@ -1508,7 +1508,7 @@ class SandboxFileSystem:
             sandbox_path (str): The path of the directory to delete.
 
         Raises:
-            NotImplementedError: This method is not yet implemented.
+            SandboxFileSystemError: If the directory deletion fails.
         """
         resp = self.sandbox_instance.stub.sandbox_delete_directory(
             PodSandboxDeleteDirectoryRequest(


### PR DESCRIPTION
Updates a few docstrings
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes docstrings to match actual behavior. Corrects a typo in set_channel() and updates create_directory/delete_directory to document SandboxFileSystemError instead of NotImplementedError.

<!-- End of auto-generated description by cubic. -->

