### PR TITLE
remove detach temporarily

### DIFF
--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -460,7 +460,6 @@ func (s *RunCServer) handleSandboxExec(ctx context.Context, in *pb.RunCSandboxEx
 	opts := &runc.ExecOpts{
 		IO:      processIO,
 		Started: started,
-		Detach:  true,
 	}
 
 	stdoutBuf := &common.SafeBuffer{}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Temporarily switch RunC sandbox exec to attached mode by removing ExecOpts.Detach, so we wait for the process and stream stdout/stderr reliably.

<!-- End of auto-generated description by cubic. -->

