### PR TITLE
checkpoint deletion

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -2559,7 +2559,7 @@ func (r *PostgresBackendRepository) GetCheckpointById(ctx context.Context, check
 		SELECT checkpoint_id, external_id, source_container_id, container_ip, status, remote_key,
 		       workspace_id, stub_id, stub_type, app_id, exposed_ports, created_at, last_restored_at
 		FROM checkpoint 
-		WHERE checkpoint_id = $1 
+		WHERE checkpoint_id = $1 AND deleted_at IS NULL
 		LIMIT 1;`
 
 	var checkpoint types.Checkpoint
@@ -2598,7 +2598,7 @@ func (r *PostgresBackendRepository) GetLatestCheckpointByStubId(ctx context.Cont
 		       c.workspace_id, c.stub_id, c.stub_type, c.app_id, c.exposed_ports, c.created_at, c.last_restored_at
 		FROM checkpoint c
 		INNER JOIN stub s ON c.stub_id = s.id
-		WHERE s.external_id = $1 
+		WHERE s.external_id = $1 AND c.deleted_at IS NULL
 		ORDER BY c.created_at DESC
 		LIMIT 1;`
 

--- a/pkg/repository/backend_postgres_migrations/034_add_checkpoint_deleted_at.go
+++ b/pkg/repository/backend_postgres_migrations/034_add_checkpoint_deleted_at.go
@@ -1,0 +1,24 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddCheckpointDeletedAt, downAddCheckpointDeletedAt)
+}
+
+func upAddCheckpointDeletedAt(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+		ALTER TABLE checkpoint ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
+	`)
+	return err
+}
+
+func downAddCheckpointDeletedAt(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`ALTER TABLE checkpoint DROP COLUMN deleted_at;`)
+	return err
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -123,7 +123,7 @@ func (s *Scheduler) Run(request *types.ContainerRequest) error {
 
 	// Add checkpoint state to request if auto checkpoint is enabled and checkpoint is not set
 	if request.CheckpointEnabled && request.Checkpoint == nil {
-		checkpoint, err := s.backendRepo.GetCheckpointById(context.Background(), request.StubId)
+		checkpoint, err := s.backendRepo.GetLatestCheckpointByStubId(context.Background(), request.StubId)
 		if err == nil && checkpoint != nil {
 			log.Info().Str("container_id", request.ContainerId).Str("stub_id", request.StubId).Str("checkpoint_id", checkpoint.CheckpointId).Msg("adding checkpoint to request")
 			request.Checkpoint = checkpoint

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -389,6 +389,7 @@ type Checkpoint struct {
 	ExposedPorts      []uint32 `db:"exposed_ports" json:"exposed_ports" serializer:"exposed_ports"`
 	CreatedAt         Time     `db:"created_at" json:"created_at" serializer:"created_at"`
 	LastRestoredAt    Time     `db:"last_restored_at" json:"last_restored_at" serializer:"last_restored_at"`
+	DeletedAt         NullTime `db:"deleted_at" json:"deleted_at" serializer:"deleted_at"`
 }
 
 func (c *Checkpoint) ToProto() *pb.Checkpoint {

--- a/pkg/types/types.proto
+++ b/pkg/types/types.proto
@@ -37,6 +37,7 @@ message Checkpoint {
   repeated uint32 exposed_ports = 12;
   google.protobuf.Timestamp created_at = 13;
   google.protobuf.Timestamp last_restored_at = 14;
+  NullTime deleted_at = 15;
 }
 
 message ConcurrencyLimit {

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -17,6 +17,7 @@ import (
 	types "github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/beam-cloud/go-runc"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -87,7 +88,7 @@ func InitializeCRIUManager(ctx context.Context, config types.CRIUConfig) (CRIUMa
 }
 
 func (s *Worker) attemptAutoCheckpoint(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger, outputWriter io.Writer, startedChan chan int, checkpointPIDChan chan int) {
-	checkpointId := request.StubId
+	checkpointId := uuid.New().String()
 
 	// If checkpointing is enabled and there is no existing checkpoint, attempt to create a checkpoint
 	if s.shouldCreateCheckpoint(request) {

--- a/proto/types.pb.go
+++ b/proto/types.pb.go
@@ -220,6 +220,7 @@ type Checkpoint struct {
 	ExposedPorts      []uint32               `protobuf:"varint,12,rep,packed,name=exposed_ports,json=exposedPorts,proto3" json:"exposed_ports,omitempty"`
 	CreatedAt         *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	LastRestoredAt    *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=last_restored_at,json=lastRestoredAt,proto3" json:"last_restored_at,omitempty"`
+	DeletedAt         *NullTime              `protobuf:"bytes,15,opt,name=deleted_at,json=deletedAt,proto3" json:"deleted_at,omitempty"`
 }
 
 func (x *Checkpoint) Reset() {
@@ -320,6 +321,13 @@ func (x *Checkpoint) GetCreatedAt() *timestamppb.Timestamp {
 func (x *Checkpoint) GetLastRestoredAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.LastRestoredAt
+	}
+	return nil
+}
+
+func (x *Checkpoint) GetDeletedAt() *NullTime {
+	if x != nil {
+		return x.DeletedAt
 	}
 	return nil
 }
@@ -2414,7 +2422,7 @@ var file_types_proto_rawDesc = []byte{
 	0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x49,
 	0x6d, 0x61, 0x67, 0x65, 0x43, 0x72, 0x65, 0x64, 0x73, 0x12, 0x23, 0x0a, 0x0d, 0x62, 0x75, 0x69,
 	0x6c, 0x64, 0x5f, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x73, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09,
-	0x52, 0x0c, 0x62, 0x75, 0x69, 0x6c, 0x64, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x73, 0x22, 0x9f,
+	0x52, 0x0c, 0x62, 0x75, 0x69, 0x6c, 0x64, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x73, 0x22, 0xcf,
 	0x03, 0x0a, 0x0a, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x12, 0x23, 0x0a,
 	0x0d, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x5f, 0x69, 0x64, 0x18, 0x02,
 	0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x70, 0x6f, 0x69, 0x6e, 0x74,
@@ -2441,6 +2449,9 @@ var file_types_proto_rawDesc = []byte{
 	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70,
 	0x52, 0x0e, 0x6c, 0x61, 0x73, 0x74, 0x52, 0x65, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x41, 0x74,
+	0x12, 0x2e, 0x0a, 0x0a, 0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x0f,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2e, 0x4e, 0x75, 0x6c,
+	0x6c, 0x54, 0x69, 0x6d, 0x65, 0x52, 0x09, 0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64, 0x41, 0x74,
 	0x22, 0xa9, 0x02, 0x0a, 0x10, 0x43, 0x6f, 0x6e, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x79,
 	0x4c, 0x69, 0x6d, 0x69, 0x74, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
 	0x0d, 0x52, 0x02, 0x69, 0x64, 0x12, 0x1f, 0x0a, 0x0b, 0x65, 0x78, 0x74, 0x65, 0x72, 0x6e, 0x61,
@@ -2857,41 +2868,42 @@ var file_types_proto_depIdxs = []int32{
 	14, // 2: types.App.deleted_at:type_name -> types.NullTime
 	23, // 3: types.Checkpoint.created_at:type_name -> google.protobuf.Timestamp
 	23, // 4: types.Checkpoint.last_restored_at:type_name -> google.protobuf.Timestamp
-	23, // 5: types.ConcurrencyLimit.created_at:type_name -> google.protobuf.Timestamp
-	23, // 6: types.ConcurrencyLimit.updated_at:type_name -> google.protobuf.Timestamp
-	23, // 7: types.Container.scheduled_at:type_name -> google.protobuf.Timestamp
-	23, // 8: types.Container.started_at:type_name -> google.protobuf.Timestamp
-	21, // 9: types.ContainerRequest.workspace:type_name -> types.Workspace
-	18, // 10: types.ContainerRequest.stub:type_name -> types.StubWithRelated
-	23, // 11: types.ContainerRequest.timestamp:type_name -> google.protobuf.Timestamp
-	12, // 12: types.ContainerRequest.mounts:type_name -> types.Mount
-	1,  // 13: types.ContainerRequest.build_options:type_name -> types.BuildOptions
-	2,  // 14: types.ContainerRequest.checkpoint:type_name -> types.Checkpoint
-	10, // 15: types.FileSearchMatch.range:type_name -> types.FileSearchRange
-	9,  // 16: types.FileSearchRange.start:type_name -> types.FileSearchPosition
-	9,  // 17: types.FileSearchRange.end:type_name -> types.FileSearchPosition
-	8,  // 18: types.FileSearchResult.matches:type_name -> types.FileSearchMatch
-	13, // 19: types.Mount.mount_point_config:type_name -> types.MountPointConfig
-	23, // 20: types.NullTime.time:type_name -> google.protobuf.Timestamp
-	23, // 21: types.Object.created_at:type_name -> google.protobuf.Timestamp
-	23, // 22: types.Stub.created_at:type_name -> google.protobuf.Timestamp
-	23, // 23: types.Stub.updated_at:type_name -> google.protobuf.Timestamp
-	17, // 24: types.StubWithRelated.stub:type_name -> types.Stub
-	21, // 25: types.StubWithRelated.workspace:type_name -> types.Workspace
-	15, // 26: types.StubWithRelated.object:type_name -> types.Object
-	0,  // 27: types.StubWithRelated.app:type_name -> types.App
-	4,  // 28: types.Worker.active_containers:type_name -> types.Container
-	23, // 29: types.Workspace.created_at:type_name -> google.protobuf.Timestamp
-	23, // 30: types.Workspace.updated_at:type_name -> google.protobuf.Timestamp
-	3,  // 31: types.Workspace.concurrency_limit:type_name -> types.ConcurrencyLimit
-	22, // 32: types.Workspace.storage:type_name -> types.WorkspaceStorage
-	23, // 33: types.WorkspaceStorage.created_at:type_name -> google.protobuf.Timestamp
-	23, // 34: types.WorkspaceStorage.updated_at:type_name -> google.protobuf.Timestamp
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	14, // 5: types.Checkpoint.deleted_at:type_name -> types.NullTime
+	23, // 6: types.ConcurrencyLimit.created_at:type_name -> google.protobuf.Timestamp
+	23, // 7: types.ConcurrencyLimit.updated_at:type_name -> google.protobuf.Timestamp
+	23, // 8: types.Container.scheduled_at:type_name -> google.protobuf.Timestamp
+	23, // 9: types.Container.started_at:type_name -> google.protobuf.Timestamp
+	21, // 10: types.ContainerRequest.workspace:type_name -> types.Workspace
+	18, // 11: types.ContainerRequest.stub:type_name -> types.StubWithRelated
+	23, // 12: types.ContainerRequest.timestamp:type_name -> google.protobuf.Timestamp
+	12, // 13: types.ContainerRequest.mounts:type_name -> types.Mount
+	1,  // 14: types.ContainerRequest.build_options:type_name -> types.BuildOptions
+	2,  // 15: types.ContainerRequest.checkpoint:type_name -> types.Checkpoint
+	10, // 16: types.FileSearchMatch.range:type_name -> types.FileSearchRange
+	9,  // 17: types.FileSearchRange.start:type_name -> types.FileSearchPosition
+	9,  // 18: types.FileSearchRange.end:type_name -> types.FileSearchPosition
+	8,  // 19: types.FileSearchResult.matches:type_name -> types.FileSearchMatch
+	13, // 20: types.Mount.mount_point_config:type_name -> types.MountPointConfig
+	23, // 21: types.NullTime.time:type_name -> google.protobuf.Timestamp
+	23, // 22: types.Object.created_at:type_name -> google.protobuf.Timestamp
+	23, // 23: types.Stub.created_at:type_name -> google.protobuf.Timestamp
+	23, // 24: types.Stub.updated_at:type_name -> google.protobuf.Timestamp
+	17, // 25: types.StubWithRelated.stub:type_name -> types.Stub
+	21, // 26: types.StubWithRelated.workspace:type_name -> types.Workspace
+	15, // 27: types.StubWithRelated.object:type_name -> types.Object
+	0,  // 28: types.StubWithRelated.app:type_name -> types.App
+	4,  // 29: types.Worker.active_containers:type_name -> types.Container
+	23, // 30: types.Workspace.created_at:type_name -> google.protobuf.Timestamp
+	23, // 31: types.Workspace.updated_at:type_name -> google.protobuf.Timestamp
+	3,  // 32: types.Workspace.concurrency_limit:type_name -> types.ConcurrencyLimit
+	22, // 33: types.Workspace.storage:type_name -> types.WorkspaceStorage
+	23, // 34: types.WorkspaceStorage.created_at:type_name -> google.protobuf.Timestamp
+	23, // 35: types.WorkspaceStorage.updated_at:type_name -> google.protobuf.Timestamp
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_types_proto_init() }

--- a/sdk/src/beta9/clients/types/__init__.py
+++ b/sdk/src/beta9/clients/types/__init__.py
@@ -43,6 +43,7 @@ class Checkpoint(betterproto.Message):
     exposed_ports: List[int] = betterproto.uint32_field(12)
     created_at: datetime = betterproto.message_field(13)
     last_restored_at: datetime = betterproto.message_field(14)
+    deleted_at: "NullTime" = betterproto.message_field(15)
 
 
 @dataclass(eq=False, repr=False)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add soft-deletion for checkpoints and fix auto-checkpoint behavior. Deleted checkpoints are ignored in queries; the scheduler now selects the latest checkpoint for a stub, and new checkpoints get UUIDs.

- **New Features**
  - Added deleted_at to checkpoints with a migration; repository excludes soft-deleted rows.
  - Exposed deleted_at in proto/types and SDK clients.

- **Bug Fixes**
  - Scheduler uses GetLatestCheckpointByStubId when auto checkpointing.
  - Worker generates a UUID for new checkpoint IDs instead of using the stub ID.

<!-- End of auto-generated description by cubic. -->

