### PR TITLE
fix a warning in sandbox docstring

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.231"
+version = "0.1.232"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -1520,7 +1520,7 @@ class SandboxFileSystem:
             raise SandboxFileSystemError(resp.error_msg)
 
     def delete_file(self, sandbox_path: str):
-        """
+        r"""
         Delete a file in the sandbox.
 
         This method removes a file from the sandbox filesystem.
@@ -1551,7 +1551,7 @@ class SandboxFileSystem:
             raise SandboxFileSystemError(response.error_msg)
 
     def replace_in_files(self, sandbox_path: str, old_string: str, new_string: str):
-        """
+        r"""
         Replace a string in all files in a directory.
 
         This method performs a find-and-replace operation on all files
@@ -1588,7 +1588,7 @@ class SandboxFileSystem:
             raise SandboxFileSystemError(response.error_msg)
 
     def find_in_files(self, sandbox_path: str, pattern: str) -> List[SandboxFileSearchResult]:
-        """
+        r"""
         Search file contents in the sandbox using a regular expression pattern.
 
         This method scans files under the given directory and returns matches


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes docstring warnings in sandbox methods by switching to raw strings in delete_file, replace_in_files, and find_in_files. No runtime changes; bumps SDK version to 0.1.232.

<!-- End of auto-generated description by cubic. -->

