### PR TITLE
allow open tcp

### DIFF
--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -60,7 +60,7 @@ func InitializeNvidiaCRIU(ctx context.Context, config types.CRIUConfig) (CRIUMan
 func (c *NvidiaCRIUManager) CreateCheckpoint(ctx context.Context, checkpointId string, request *types.ContainerRequest) (string, error) {
 	checkpointPath := fmt.Sprintf("%s/%s", c.cpStorageConfig.MountPath, checkpointId)
 	err := c.runcHandle.Checkpoint(ctx, request.ContainerId, &runc.CheckpointOpts{
-		AllowOpenTCP: false,
+		AllowOpenTCP: true,
 		LeaveRunning: true,
 		SkipInFlight: true,
 		LinkRemap:    true,
@@ -93,7 +93,7 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 
 	exitCode, err := c.runcHandle.Restore(ctx, opts.request.ContainerId, bundlePath, &runc.RestoreOpts{
 		CheckpointOpts: runc.CheckpointOpts{
-			AllowOpenTCP: false,
+			AllowOpenTCP: true,
 			TCPClose:     true,
 			LinkRemap:    true,
 			// Logs, irmap cache, sockets for lazy server and other go to working dir


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable CRIU to checkpoint and restore containers with open TCP connections by setting AllowOpenTCP=true in CreateCheckpoint and RestoreCheckpoint. This unblocks checkpoint/restore for networked workloads and prevents failures when sockets are open.

<!-- End of auto-generated description by cubic. -->

