### PR TITLE
fix another network issue

### DIFF
--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -93,9 +93,8 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 
 	exitCode, err := c.runcHandle.Restore(ctx, opts.request.ContainerId, bundlePath, &runc.RestoreOpts{
 		CheckpointOpts: runc.CheckpointOpts{
-			AllowOpenTCP: true,
-			TCPClose:     true,
-			LinkRemap:    true,
+			TCPClose:  true,
+			LinkRemap: true,
 			// Logs, irmap cache, sockets for lazy server and other go to working dir
 			WorkDir:      workDir,
 			ImagePath:    imagePath,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable restoring open TCP connections during CRIU restore by removing AllowOpenTCP from runc CheckpointOpts. This prevents resurrected TCP sessions and fixes network issues when resuming containers.

<!-- End of auto-generated description by cubic. -->

