### PR TITLE
fix: correctly pass tcp-close

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -42,7 +42,7 @@ RUN <<EOT
 set -eux
 git clone -b dlm/force-compat-mode-on-restore https://github.com/beam-cloud/runc.git /workspace/runc \
   && cd /workspace/runc \
-  && git reset --hard d2945750f50a023ca3b1af45a9cf9bad655646d8
+  && git reset --hard d85a78033ba2905f5c57afdc81b73a12be72c03c
 
 cd /workspace/runc
 make

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
 	github.com/beam-cloud/blobcache-v2 v0.0.0-20250503151236-e2403183f563
 	github.com/beam-cloud/clip v0.0.0-20250815141247-71e2dd6c441d
-	github.com/beam-cloud/go-runc v0.0.0-20250910224200-d9097b87369c
+	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
 	github.com/cedana/cedana v0.9.240
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/beam-cloud/geesefs v0.0.0-20250606164905-2f3593d03f4f h1:0SRb1V1OO9Jg
 github.com/beam-cloud/geesefs v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:utihEuMyzBOeZ6oU2ozzZkJmyzbYBuYrxsLUo1DfZXs=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
-github.com/beam-cloud/go-runc v0.0.0-20250910224200-d9097b87369c h1:RMWaw+eCTEmn+35OMoUJf6YdZViAvQjMUToc0owquxw=
-github.com/beam-cloud/go-runc v0.0.0-20250910224200-d9097b87369c/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
+github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=
+github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324/go.mod h1:pBb6ZWEw7rhALuBZTGZxT3p+Sd5b8jsvP5EPEsM8T/Q=
 github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8 h1:lc3G6/sHW4e5/XPHO2w2Ni43fbu42nojS/uX45Ws6Ck=

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -93,7 +93,6 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 
 	exitCode, err := c.runcHandle.Restore(ctx, opts.request.ContainerId, bundlePath, &runc.RestoreOpts{
 		CheckpointOpts: runc.CheckpointOpts{
-			TCPClose:  true,
 			LinkRemap: true,
 			// Logs, irmap cache, sockets for lazy server and other go to working dir
 			WorkDir:      workDir,
@@ -101,7 +100,8 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, opts *Restore
 			OutputWriter: outputWriter,
 			Cgroups:      runc.Soft,
 		},
-		Started: opts.runcOpts.Started,
+		TCPClose: true,
+		Started:  opts.runcOpts.Started,
 	})
 
 	if err != nil {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes restore behavior by correctly passing --tcp-close to runc so CRIU closes TCP connections during restore. Prevents dangling sockets and improves reliability of NVIDIA container restores.

- **Bug Fixes**
  - Move TCPClose from CheckpointOpts to RestoreOpts to ensure runc receives --tcp-close on restore.

- **Dependencies**
  - Bump github.com/beam-cloud/go-runc to v0.0.0-20250911154456-bb45084abfe1.
  - Pin worker runc to commit d85a780 on dlm/force-compat-mode-on-restore.

<!-- End of auto-generated description by cubic. -->

