### PR TITLE
remove hacky secondary registry

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -108,18 +108,11 @@ imageService:
       username:
       password:
     s3:
-      primary:
-        bucketName: beta9-images
-        region: us-east-1
-        accessKey: test
-        secretKey: test
-        endpoint:
-      secondary:
-        bucketName: beta9-images-old
-        region: us-east-1
-        accessKey: test
-        secretKey: test
-        endpoint:
+      bucketName: beta9-images
+      region: us-east-1
+      accessKey: test
+      secretKey: test
+      endpoint:
   runner:
     baseImageName: beta9-runner
     baseImageRegistry: registry.localhost:5000

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -199,6 +199,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 	elapsed, err := s.imageClient.PullLazy(ctx, request, outputLogger)
 	if err != nil {
 		if !request.IsBuildRequest() {
+			log.Error().Str("container_id", containerId).Msgf("failed to pull image: %v", err)
 			return err
 		}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the secondary image registry and the fallback/copy hack. The worker now uses a single S3 registry for all image pulls and pushes, with clearer error logging on pull failures.

- **Refactors**
  - ImageClient now holds one registry; removed secondary fallback and async copy.
  - Simplified archive naming and push/pull calls to use the single registry.
  - Flattened S3 config to a single bucket (removed primary/secondary keys).
  - Added explicit error log when image pull fails for non-build requests.

- **Migration**
  - Update config to use a single S3 block and delete the secondary block.
  - Ensure the chosen bucket contains required images; no automatic backfill from the old bucket.

<!-- End of auto-generated description by cubic. -->

