### PR TITLE
bump geesefs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -339,7 +339,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20250606164905-2f3593d03f4f
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20250913210834-d2aaa4c9dd6c
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -138,14 +138,12 @@ github.com/beam-cloud/blobcache-v2 v0.0.0-20250503151236-e2403183f563 h1:kn8/lBy
 github.com/beam-cloud/blobcache-v2 v0.0.0-20250503151236-e2403183f563/go.mod h1:RrA2ruMma4/dN9Sa6wwhyAO1uI6di+tlLB5wuM7TuvQ=
 github.com/beam-cloud/clip v0.0.0-20250815141247-71e2dd6c441d h1:M6RtY4ANRr+NbbCCkL9l8Vksl5mW0F5hWCctaLAD4I8=
 github.com/beam-cloud/clip v0.0.0-20250815141247-71e2dd6c441d/go.mod h1:JqYuoB5waiXZrLmBO0rKM+Kl4iRWqfWb+pI+lk3BX+Q=
-github.com/beam-cloud/geesefs v0.0.0-20250606164905-2f3593d03f4f h1:0SRb1V1OO9Jgy9LffOkNAVbFEs/3SQ4MCIxGFZiOM9U=
-github.com/beam-cloud/geesefs v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:utihEuMyzBOeZ6oU2ozzZkJmyzbYBuYrxsLUo1DfZXs=
+github.com/beam-cloud/geesefs v0.0.0-20250913210834-d2aaa4c9dd6c h1:FtaiTGhakEg8sJmUonKTQXbQfxXAD7GfFxDy2xD+8OA=
+github.com/beam-cloud/geesefs v0.0.0-20250913210834-d2aaa4c9dd6c/go.mod h1:utihEuMyzBOeZ6oU2ozzZkJmyzbYBuYrxsLUo1DfZXs=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
-github.com/beam-cloud/goproc v0.1.4 h1:xS6ZzsUrSP252gWtIX+Immo6HjBAbncJDYuLuBybiNQ=
-github.com/beam-cloud/goproc v0.1.4/go.mod h1:eis19sZHSHNCmj8PjiRCdHwp3kkc31wdW3hrynKZq8k=
 github.com/beam-cloud/goproc v0.1.5 h1:FDldQgLn5AbfEJ4Ais70xxmbQhfl2Cmx1IqupJYF11M=
 github.com/beam-cloud/goproc v0.1.5/go.mod h1:eis19sZHSHNCmj8PjiRCdHwp3kkc31wdW3hrynKZq8k=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped our geesefs fork to the latest commit to pull in recent changes. Updated go.mod replace and go.sum; no app code changes.

- **Dependencies**
  - replace github.com/yandex-cloud/geesefs -> github.com/beam-cloud/geesefs v0.0.0-20250913210834-d2aaa4c9dd6c (from v0.0.0-20250606164905-2f3593d03f4f)

<!-- End of auto-generated description by cubic. -->

