### PR TITLE
pin buildah commit to go 1.23

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -52,6 +52,7 @@ cd ..
 
 git clone https://github.com/containers/buildah.git /workspace/buildah
 cd /workspace/buildah
+git reset --hard 9bd608b3c0eaa1476b62763d0bd225745e49d542
 make BUILDTAGS="cni"
 make install
 EOT


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pinned Buildah to commit 9bd608b in docker/Dockerfile.worker to match Go 1.23. This stabilizes worker builds and avoids breakage from upstream changes requiring newer Go versions.

<!-- End of auto-generated description by cubic. -->

