### PR TITLE
fix: dont allow min containers for one-off taskqueues

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -163,7 +163,7 @@ func (i *AutoscaledInstance) ConsumeScaleResult(result *AutoscalerResult) {
 		minContainers = 0
 	}
 
-	if string(i.Stub.Type) == string(types.StubTypeTaskQueue) {
+	if string(i.Stub.Type) == types.StubTypeTaskQueue {
 		minContainers = 0
 	}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix autoscaling to not enforce a minimum for one-off task queues. When the instance type is TaskQueue, minContainers is forced to 0 so these queues can scale to zero and avoid idle containers.

<!-- End of auto-generated description by cubic. -->

