### PR TITLE
Fix: Make sure to set default pageSize in listAllTasksWithRelatedPaginated

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -926,11 +926,15 @@ func (c *PostgresBackendRepository) listAllTasksWithRelatedPaginated(ctx context
 	filtersWorkspace.All = false
 	filtersWorkspace.WorkspaceID = filters.WorkspaceID
 	filtersWorkspace.ExternalWorkspaceID = 0
+	// We want to get one more result past the page size to check if there is more data
+	filtersWorkspace.Limit = filters.Limit + 1
 
 	filtersExternalWorkspace := filters
 	filtersExternalWorkspace.All = false
 	filtersExternalWorkspace.WorkspaceID = 0
 	filtersExternalWorkspace.ExternalWorkspaceID = filters.WorkspaceID
+	// We want to get one more result past the page size to check if there is more data
+	filtersExternalWorkspace.Limit = filters.Limit + 1
 
 	// Get results from both calls
 	resultWorkspace, err := c.ListTasksWithRelatedPaginated(ctx, filtersWorkspace)

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -923,7 +923,7 @@ func (c *PostgresBackendRepository) ListTasksWithRelatedPaginated(ctx context.Co
 
 func (c *PostgresBackendRepository) listAllTasksWithRelatedPaginated(ctx context.Context, filters types.TaskFilter) (common.CursorPaginationInfo[types.TaskWithRelated], error) {
 	// Apply limit// Apply limit
-	pageSize := uint32(filters.Limit)
+	pageSize := filters.Limit
 	if pageSize <= 0 {
 		pageSize = 10
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensure listAllTasksWithRelatedPaginated always uses a default page size (10) and fetches pageSize+1 items to correctly compute nextPage cursors, even when limit is not provided.

- **Bug Fixes**
  - Derive pageSize from filters.Limit with a default of 10; apply to both workspace queries as pageSize+1.
  - Slice the merged results by pageSize and compute nextCursor from the extra item.

<!-- End of auto-generated description by cubic. -->

