### PR TITLE
sdk: improve config handle for beam client

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.233"
+version = "0.1.237"
 description = ""
 
 [project.scripts]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.237"
+version = "0.1.238"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -4,11 +4,8 @@ os.environ["GRPC_VERBOSITY"] = os.getenv("GRPC_VERBOSITY") or "NONE"
 
 import sys
 from abc import ABC
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional
 
-from ... import config
 from ...channel import Channel
 from ...channel import get_channel as _get_channel
 from ...config import ConfigContext, get_config_context, set_settings

--- a/sdk/src/beta9/abstractions/base/__init__.py
+++ b/sdk/src/beta9/abstractions/base/__init__.py
@@ -71,25 +71,10 @@ class BaseAbstraction(ABC):
     def __init_subclass__(cls, /, **kwargs):
         """
         Dynamically load settings depending on if this library is being used
-        by beta9 or beam. This is done by inspecting the first frame loaded
-        onto the stack.
+        by beta9 or beam.
         """
-
         if "beam" in sys.modules:
-
-            @dataclass
-            class SDKSettings(config.SDKSettings):
-                realtime_host: str = os.getenv("REALTIME_HOST", "wss://rt.beam.cloud")
-
-            settings = SDKSettings(
-                name="Beam",
-                api_host=os.getenv("API_HOST", "app.beam.cloud"),
-                api_port=int(os.getenv("API_PORT", 443)),
-                gateway_host=os.getenv("GATEWAY_HOST", "gateway.beam.cloud"),
-                gateway_port=int(os.getenv("GATEWAY_PORT", 443)),
-                config_path=Path("~/.beam/config.ini").expanduser(),
-                use_defaults_in_prompt=True,
-            )
-            set_settings(settings)
+            # Settings will be configured in SDKSettings.__post_init__
+            set_settings()
 
         super().__init_subclass__(**kwargs)

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -170,9 +170,6 @@ def get_channel(context: Optional[ConfigContext] = None) -> Channel:
 
 
 def prompt_first_auth(settings: SDKSettings) -> None:
-    terminal.header(f"Welcome to {settings.name.title()}! Let's get started 📡")
-    terminal.print(settings.ascii_logo, highlight=True)
-
     if settings.api_token:
         name = DEFAULT_CONTEXT_NAME
         context = ConfigContext(
@@ -181,6 +178,9 @@ def prompt_first_auth(settings: SDKSettings) -> None:
             gateway_port=settings.gateway_port,
         )
     else:
+        terminal.header(f"Welcome to {settings.name.title()}! Let's get started 📡")
+        terminal.print(settings.ascii_logo, highlight=True)
+
         name, context = prompt_for_config_context(
             name=DEFAULT_CONTEXT_NAME,
             gateway_host=settings.gateway_host,

--- a/sdk/src/beta9/client/task.py
+++ b/sdk/src/beta9/client/task.py
@@ -41,8 +41,11 @@ class Task:
         else:
             response.raise_for_status()
 
-        if self._result and self._result.get("base64"):
-            self._result = cloudpickle.loads(base64.b64decode(self._result["base64"]))
+        if self._result:
+            if hasattr(self._result, "get") and self._result.get("base64"):
+                self._result = cloudpickle.loads(base64.b64decode(self._result["base64"]))
+
+            # If it doesn't have a get method and no base64 field, it's probably just a string, return as-is
 
     def status(self) -> TaskStatus:
         """Returns the status of the task"""
@@ -109,7 +112,7 @@ class Task:
                                     self._result = task_data.get("result")
                                     self._outputs = task_data.get("outputs")
 
-                                    if self._result and self._result.get("base64"):
+                                    if hasattr(self._result, "get") and self._result.get("base64"):
                                         self._result = cloudpickle.loads(
                                             base64.b64decode(self._result["base64"])
                                         )


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Centralizes and simplifies Beam client configuration in the SDK. Automatically detects Beam, loads defaults and BEAM_TOKEN, and avoids showing the welcome banner when already authenticated.

- **Refactors**
  - Moved Beam-specific setup into SDKSettings.__post_init__ and call set_settings() without args.
  - Auto-apply Beam defaults (hosts, ports, ~/.beam/config.ini) and read BEAM_TOKEN.
  - get_config_context now falls back to SDK settings when BETA9_* env vars are missing.

- **Bug Fixes**
  - Show the welcome header/logo only when no API token is present.

<!-- End of auto-generated description by cubic. -->

