### PR TITLE
fix: minor task queue hotfix for taskqueue stubs

### DIFF
--- a/pkg/abstractions/taskqueue/instance.go
+++ b/pkg/abstractions/taskqueue/instance.go
@@ -167,9 +167,8 @@ func (i *taskQueueInstance) stoppableContainers() ([]string, error) {
 			continue
 		}
 
-		if i.Stub.Type.IsDeployment() {
-
-			// Skip containers with keep warm locks
+		// Skip containers with keep warm locks (for taskqueue & taskqueue/deployment stubs) if it is not a serve
+		if !i.Stub.Type.IsServe() {
 			keepWarmVal, err := i.Rdb.Get(context.TODO(), Keys.taskQueueKeepWarmLock(i.Workspace.Name, i.Stub.ExternalId, container.ContainerId)).Int()
 			if err != nil && err != redis.Nil {
 				log.Error().Str("instance_name", i.Name).Err(err).Msg("error getting keep warm lock for container")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes task queue shutdown logic by honoring keep-warm locks for all non-serve stubs, not just deployments. Prevents warm taskqueue containers from being stopped.

- **Bug Fixes**
  - Check keep-warm locks when the stub type is not Serve (covers taskqueue and taskqueue/deployment stubs).

<!-- End of auto-generated description by cubic. -->

