### PR TITLE
Fix: Remove workspace_restricted auth check in StartTask EndTask

### DIFF
--- a/pkg/gateway/services/task.go
+++ b/pkg/gateway/services/task.go
@@ -19,12 +19,6 @@ import (
 func (gws *GatewayService) StartTask(ctx context.Context, in *pb.StartTaskRequest) (*pb.StartTaskResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	if !auth.HasPermission(authInfo) {
-		return &pb.StartTaskResponse{
-			Ok: false,
-		}, nil
-	}
-
 	task, err := gws.backendRepo.GetTaskWithRelated(ctx, in.TaskId)
 	if err != nil {
 		return &pb.StartTaskResponse{
@@ -66,12 +60,6 @@ func (gws *GatewayService) StartTask(ctx context.Context, in *pb.StartTaskReques
 
 func (gws *GatewayService) EndTask(ctx context.Context, in *pb.EndTaskRequest) (*pb.EndTaskResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
-
-	if !auth.HasPermission(authInfo) {
-		return &pb.EndTaskResponse{
-			Ok: false,
-		}, nil
-	}
 
 	task, err := gws.backendRepo.GetTaskWithRelated(ctx, in.TaskId)
 	if err != nil {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the workspace_restricted auth check from StartTask and EndTask so the backend handles authorization and valid requests aren’t blocked at the gateway.

- **Bug Fixes**
  - Removed the HasPermission(authInfo) short-circuit that returned Ok:false without an error; calls now proceed and return real task/backend errors if unauthorized.

<!-- End of auto-generated description by cubic. -->

