### PR TITLE
Fix: Update RetrieveActiveToken to get workspace_primary token

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -302,8 +302,7 @@ func (r *PostgresBackendRepository) RetrieveActiveToken(ctx context.Context, wor
 	query := `
 	SELECT id, external_id, key, created_at, updated_at, active, token_type, reusable, workspace_id
 	FROM token
-	WHERE workspace_id = $1 AND active = TRUE
-	ORDER BY updated_at DESC
+	WHERE workspace_id = $1 AND active = TRUE AND token_type = 'workspace_primary' AND disabled_by_cluster_admin = FALSE
 	LIMIT 1;
 	`
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
RetrieveActiveToken now returns the active workspace_primary token that isn’t disabled by a cluster admin. This prevents selecting non-primary or disabled tokens.

- **Bug Fixes**
  - Filter by token_type = 'workspace_primary' and disabled_by_cluster_admin = FALSE.
  - Removed updated_at ordering to avoid returning the wrong active token.

<!-- End of auto-generated description by cubic. -->

