### PR TITLE
Fix: Prevent gateway startup crash when failed to retrieve instance

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -452,7 +452,7 @@ func (c *InstanceController) Load(filter *types.DeploymentFilter) error {
 	for _, stub := range stubs {
 		instance, err := c.getOrCreateInstance(c.ctx, stub.Stub.ExternalId)
 		if err != nil {
-			return err
+			log.Error().Str("instance_name", stub.Stub.ExternalId).Err(err).Msg("unable to get or create instance")
 		}
 		instance.Sync()
 	}

--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -453,6 +453,7 @@ func (c *InstanceController) Load(filter *types.DeploymentFilter) error {
 		instance, err := c.getOrCreateInstance(c.ctx, stub.Stub.ExternalId)
 		if err != nil {
 			log.Error().Str("instance_name", stub.Stub.ExternalId).Err(err).Msg("unable to get or create instance")
+			continue
 		}
 		instance.Sync()
 	}

--- a/pkg/api/v1/workspace.go
+++ b/pkg/api/v1/workspace.go
@@ -59,6 +59,11 @@ func (g *WorkspaceGroup) CreateWorkspace(ctx echo.Context) error {
 		return HTTPInternalServerError("Unable to create workspace")
 	}
 
+	token, err := g.backendRepo.CreateToken(ctx.Request().Context(), workspace.Id, types.TokenTypeWorkspacePrimary, true)
+	if err != nil {
+		return HTTPInternalServerError("Unable to create workspace token")
+	}
+
 	bucketName := types.WorkspaceBucketName(g.config.Storage.WorkspaceStorage.DefaultBucketPrefix, workspace.ExternalId)
 	_, err = g.setupDefaultWorkspaceStorage(ctx, bucketName, workspace.Id)
 	if err != nil {
@@ -68,6 +73,7 @@ func (g *WorkspaceGroup) CreateWorkspace(ctx echo.Context) error {
 
 	return ctx.JSON(http.StatusOK, map[string]interface{}{
 		"workspace_id": workspace.ExternalId,
+		"token":        token.Key,
 	})
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevent gateway from crashing on startup when an instance retrieval fails during InstanceController.Load(). Now logs the error per instance and continues syncing the remaining instances.

<!-- End of auto-generated description by cubic. -->

