### PR TITLE
Fix: Create workspace primary token for admin

### DIFF
--- a/pkg/gateway/services/auth.go
+++ b/pkg/gateway/services/auth.go
@@ -45,6 +45,15 @@ func (gws *GatewayService) Authorize(ctx context.Context, in *pb.AuthorizeReques
 		}, nil
 	}
 
+	// Also create a workspace primary token
+	_, err = gws.backendRepo.CreateToken(ctx, workspace.Id, types.TokenTypeWorkspacePrimary, true)
+	if err != nil {
+		return &pb.AuthorizeResponse{
+			Ok:       false,
+			ErrorMsg: "Failed to create new workspace primary token",
+		}, nil
+	}
+
 	return &pb.AuthorizeResponse{
 		Ok:          true,
 		NewToken:    token.Key,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Automatically create a workspace primary token during admin authorization to prevent missing-token errors and ensure admins have a valid primary token. Returns a clear error if token creation fails.

<!-- End of auto-generated description by cubic. -->

