### PR TITLE
add gpu blacklist config

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -86,6 +86,15 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		}, nil
 	}
 
+	if len(gws.appConfig.GatewayService.StubLimits.GPUBlackList.GPUTypes) > 0 {
+		if slices.Contains(gws.appConfig.GatewayService.StubLimits.GPUBlackList.GPUTypes, in.Gpu) {
+			return &pb.GetOrCreateStubResponse{
+				Ok:     false,
+				ErrMsg: gws.appConfig.GatewayService.StubLimits.GPUBlackList.Message,
+			}, nil
+		}
+	}
+
 	var pricing *types.PricingPolicy = nil
 	if in.Pricing != nil {
 		pricing = &types.PricingPolicy{

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -112,10 +112,16 @@ type CORSConfig struct {
 }
 
 type StubLimits struct {
-	Cpu         uint64 `key:"cpu" json:"cpu"`
-	Memory      uint64 `key:"memory" json:"memory"`
-	MaxReplicas uint64 `key:"maxReplicas" json:"max_replicas"`
-	MaxGpuCount uint32 `key:"maxGpuCount" json:"max_gpu_count"`
+	Cpu          uint64             `key:"cpu" json:"cpu"`
+	Memory       uint64             `key:"memory" json:"memory"`
+	MaxReplicas  uint64             `key:"maxReplicas" json:"max_replicas"`
+	MaxGpuCount  uint32             `key:"maxGpuCount" json:"max_gpu_count"`
+	GPUBlackList GPUBlackListConfig `key:"gpuBlackList" json:"gpu_black_list"`
+}
+
+type GPUBlackListConfig struct {
+	GPUTypes []string `key:"gpuTypes" json:"gpu_types"`
+	Message  string   `key:"message" json:"message"`
 }
 
 // ValidateCpuAndMemory enforces limits on CPU and memory (min and max)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a GPU blacklist to stub limits and enforce it in GetOrCreateStub. Requests for blacklisted GPU types are blocked with a configurable message.

- **New Features**
  - New config: gpu_black_list with gpu_types (string[]) and message (string) under StubLimits.
  - Gateway check: if in.Gpu is in gpu_types, returns Ok=false with ErrMsg set to the configured message.

<!-- End of auto-generated description by cubic. -->

