### PR TITLE
Improve SandboxProcessError

### DIFF
--- a/manifests/kustomize/components/juicefs/helm-chart-generator.yaml
+++ b/manifests/kustomize/components/juicefs/helm-chart-generator.yaml
@@ -19,6 +19,10 @@ valuesInline:
   master:
     persistence:
       size: 1Gi
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+    tag: 7.2.4-debian-11-r2
 ---
 apiVersion: builtin
 kind: HelmChartInflationGenerator

--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -33,6 +33,13 @@ func (s *GenericPodService) SandboxExec(ctx context.Context, in *pb.PodSandboxEx
 		}, nil
 	}
 
+	if !resp.Ok {
+		return &pb.PodSandboxExecResponse{
+			Ok:       false,
+			ErrorMsg: resp.ErrorMsg,
+		}, nil
+	}
+
 	return &pb.PodSandboxExecResponse{
 		Ok:  true,
 		Pid: resp.Pid,

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -454,8 +454,9 @@ func (s *RunCServer) handleSandboxExec(ctx context.Context, in *pb.RunCSandboxEx
 		log.Error().Str("container_id", in.ContainerId).Msgf("failed to execute sandbox process: %v", err)
 
 		return &pb.RunCSandboxExecResponse{
-			Ok:  false,
-			Pid: -1,
+			Ok:       false,
+			Pid:      -1,
+			ErrorMsg: err.Error(),
 		}, nil
 	}
 

--- a/sdk/src/beta9/exceptions.py
+++ b/sdk/src/beta9/exceptions.py
@@ -130,7 +130,7 @@ class SandboxConnectionError(RuntimeError):
 class SandboxProcessError(RuntimeError):
     def __init__(self, message: str):
         self.message = message
-        super().__init__(f"Sandbox process error: {message}")
+        super().__init__(message)
 
 
 class SandboxFileSystemError(RuntimeError):


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improves sandbox exec error propagation so clients get the exact error message, and simplifies SandboxProcessError text.

- **Bug Fixes**
  - Return ErrorMsg from RunCServer on exec failures and forward it through PodSandboxExec.
  - Stop wrapping SandboxProcessError with a redundant prefix; use the raw message.

<!-- End of auto-generated description by cubic. -->

