### PR TITLE
Fix: Pin Elastic Search image to Bitnami Legacy

### DIFF
--- a/manifests/kustomize/components/monitoring/elasticsearch.yaml
+++ b/manifests/kustomize/components/monitoring/elasticsearch.yaml
@@ -18,10 +18,6 @@ valuesInline:
     kibanaEnabled: true
   sysctlImage:
     enabled: false
-    image:
-      registry: docker.io
-      repository: bitnami/os-shell
-      tag: 12-debian-12-r51
   kibana:
     image:
       registry: docker.io

--- a/manifests/kustomize/components/monitoring/elasticsearch.yaml
+++ b/manifests/kustomize/components/monitoring/elasticsearch.yaml
@@ -16,6 +16,17 @@ valuesInline:
     tag: 9.1.2-debian-12-r0
   global:
     kibanaEnabled: true
+  sysctlImage:
+    enabled: false
+    image:
+      registry: docker.io
+      repository: bitnami/os-shell
+      tag: 12-debian-12-r51
+  kibana:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/kibana
+      tag: 9.1.2-debian-12-r0
   master:
     masterOnly: false
     replicaCount: 1

--- a/manifests/kustomize/components/monitoring/elasticsearch.yaml
+++ b/manifests/kustomize/components/monitoring/elasticsearch.yaml
@@ -10,6 +10,10 @@ version: 21.3.1
 namespace: monitoring
 includeCRDs: true
 valuesInline:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/elasticsearch
+    tag: 9.1.2-debian-12-r0
   global:
     kibanaEnabled: true
   master:

--- a/manifests/kustomize/overlays/cluster-dev/kustomization.yaml
+++ b/manifests/kustomize/overlays/cluster-dev/kustomization.yaml
@@ -25,10 +25,6 @@ patches:
     name: elasticsearch-master
   patch: |-
     - op: remove
-      path: /spec/template/spec/initContainers/0/resources
-    - op: remove
-      path: /spec/template/spec/initContainers/1/resources
-    - op: remove
       path: /spec/template/spec/containers/0/resources
 - target:
     kind: Deployment


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pins the Elasticsearch image to the Bitnami Legacy repository for the monitoring stack. Sets docker.io/bitnamilegacy/elasticsearch:9.1.2-debian-12-r0 to ensure stable, reproducible deployments.

<!-- End of auto-generated description by cubic. -->

