### PR TITLE
Add Monitoring to GRPC Gateway

### DIFF
--- a/pkg/gateway/middleware/events.go
+++ b/pkg/gateway/middleware/events.go
@@ -8,7 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// GatewayEvents returns a middleware that tracks grpc-gateway endpoint calls by sending events to the event repository
+// GatewayEvents returns middleware that tracks grpc-gateway endpoint calls by sending events to the event repository
 func GatewayEvents(eventRepo repository.EventRepository) func(http.Handler) echo.HandlerFunc {
 	return func(handler http.Handler) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -23,9 +23,6 @@ func GatewayEvents(eventRepo repository.EventRepository) func(http.Handler) echo
 			accept := c.Request().Header.Get(echo.HeaderAccept)
 
 			statusCode := c.Response().Status
-			if statusCode == 0 {
-				statusCode = http.StatusOK
-			}
 
 			workspaceID := ""
 			if workspace := c.Get("workspace"); workspace != nil {

--- a/pkg/gateway/middleware/events.go
+++ b/pkg/gateway/middleware/events.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/labstack/echo/v4"
+)
+
+// GatewayEvents returns a middleware that tracks grpc-gateway endpoint calls by sending events to the event repository
+func GatewayEvents(eventRepo repository.EventRepository) func(http.Handler) echo.HandlerFunc {
+	return func(handler http.Handler) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			handler.ServeHTTP(c.Response(), c.Request())
+
+			method := c.Request().Method
+			path := c.Request().URL.Path
+			userAgent := c.Request().UserAgent()
+			remoteIP := c.RealIP()
+			requestID := c.Response().Header().Get(echo.HeaderXRequestID)
+			contentType := c.Request().Header.Get(echo.HeaderContentType)
+			accept := c.Request().Header.Get(echo.HeaderAccept)
+
+			statusCode := c.Response().Status
+			if statusCode == 0 {
+				statusCode = http.StatusOK
+			}
+
+			workspaceID := ""
+			if workspace := c.Get("workspace"); workspace != nil {
+				if ws, ok := workspace.(*types.Workspace); ok {
+					workspaceID = ws.ExternalId
+				}
+			}
+
+			errorMessage := ""
+			if statusCode >= 400 {
+				errorMessage = http.StatusText(statusCode)
+			}
+
+			go eventRepo.PushGatewayEndpointCalledEvent(
+				method,
+				path,
+				workspaceID,
+				statusCode,
+				userAgent,
+				remoteIP,
+				requestID,
+				contentType,
+				accept,
+				errorMessage,
+			)
+
+			return nil
+		}
+	}
+}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -236,6 +236,7 @@ type EventRepository interface {
 	PushStubStateUnhealthy(workspaceId string, stubId string, currentState, previousState string, reason string, failedContainers []string)
 	PushWorkerPoolDegradedEvent(poolName string, reasons []string, poolState *types.WorkerPoolState)
 	PushWorkerPoolHealthyEvent(poolName string, poolState *types.WorkerPoolState)
+	PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, errorMessage string, headers map[string]string)
 }
 
 type UsageMetricsRepository interface {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -236,7 +236,7 @@ type EventRepository interface {
 	PushStubStateUnhealthy(workspaceId string, stubId string, currentState, previousState string, reason string, failedContainers []string)
 	PushWorkerPoolDegradedEvent(poolName string, reasons []string, poolState *types.WorkerPoolState)
 	PushWorkerPoolHealthyEvent(poolName string, poolState *types.WorkerPoolState)
-	PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, errorMessage string, headers map[string]string)
+	PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, contentType, accept, errorMessage string)
 }
 
 type UsageMetricsRepository interface {

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -379,7 +379,7 @@ func (t *TCPEventClientRepo) PushWorkerPoolHealthyEvent(poolName string, poolSta
 	)
 }
 
-func (t *TCPEventClientRepo) PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, errorMessage string, headers map[string]string) {
+func (t *TCPEventClientRepo) PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, contentType, accept, errorMessage string) {
 	t.pushEvent(
 		types.EventGatewayEndpointCalled,
 		types.EventGatewayEndpointSchemaVersion,
@@ -391,8 +391,9 @@ func (t *TCPEventClientRepo) PushGatewayEndpointCalledEvent(method, path, worksp
 			UserAgent:    userAgent,
 			RemoteIP:     remoteIP,
 			RequestID:    requestID,
+			ContentType:  contentType,
+			Accept:       accept,
 			ErrorMessage: errorMessage,
-			Headers:      headers,
 		},
 	)
 }

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -379,6 +379,24 @@ func (t *TCPEventClientRepo) PushWorkerPoolHealthyEvent(poolName string, poolSta
 	)
 }
 
+func (t *TCPEventClientRepo) PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, errorMessage string, headers map[string]string) {
+	t.pushEvent(
+		types.EventGatewayEndpointCalled,
+		types.EventGatewayEndpointSchemaVersion,
+		types.EventGatewayEndpointSchema{
+			Method:       method,
+			Path:         path,
+			WorkspaceID:  workspaceID,
+			StatusCode:   statusCode,
+			UserAgent:    userAgent,
+			RemoteIP:     remoteIP,
+			RequestID:    requestID,
+			ErrorMessage: errorMessage,
+			Headers:      headers,
+		},
+	)
+}
+
 func sanitizeContainerRequest(request *types.ContainerRequest) types.ContainerRequest {
 	requestCopy := *request
 	requestCopy.Env = nil

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -44,6 +44,8 @@ var (
 
 	EventWorkerPoolDegraded = "workerpool.degraded"
 	EventWorkerPoolHealthy  = "workerpool.healthy"
+
+	EventGatewayEndpointCalled = "gateway.endpoint.called"
 )
 
 var (
@@ -182,4 +184,18 @@ type EventWorkerPoolStateSchema struct {
 	Reasons   []string         `json:"reasons"`
 	Status    string           `json:"status"`
 	PoolState *WorkerPoolState `json:"pool_state"`
+}
+
+var EventGatewayEndpointSchemaVersion = "1.0"
+
+type EventGatewayEndpointSchema struct {
+	Method       string            `json:"method"`
+	Path         string            `json:"path"`
+	WorkspaceID  string            `json:"workspace_id,omitempty"`
+	StatusCode   int               `json:"status_code"`
+	UserAgent    string            `json:"user_agent,omitempty"`
+	RemoteIP     string            `json:"remote_ip,omitempty"`
+	RequestID    string            `json:"request_id,omitempty"`
+	ErrorMessage string            `json:"error_message,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
 }

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -189,13 +189,14 @@ type EventWorkerPoolStateSchema struct {
 var EventGatewayEndpointSchemaVersion = "1.0"
 
 type EventGatewayEndpointSchema struct {
-	Method       string            `json:"method"`
-	Path         string            `json:"path"`
-	WorkspaceID  string            `json:"workspace_id,omitempty"`
-	StatusCode   int               `json:"status_code"`
-	UserAgent    string            `json:"user_agent,omitempty"`
-	RemoteIP     string            `json:"remote_ip,omitempty"`
-	RequestID    string            `json:"request_id,omitempty"`
-	ErrorMessage string            `json:"error_message,omitempty"`
-	Headers      map[string]string `json:"headers,omitempty"`
+	Method       string `json:"method"`
+	Path         string `json:"path"`
+	WorkspaceID  string `json:"workspace_id,omitempty"`
+	StatusCode   int    `json:"status_code"`
+	UserAgent    string `json:"user_agent,omitempty"`
+	RemoteIP     string `json:"remote_ip,omitempty"`
+	RequestID    string `json:"request_id,omitempty"`
+	ContentType  string `json:"content_type,omitempty"`
+	Accept       string `json:"accept,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add request monitoring to the gRPC Gateway by wrapping the /gateway route to emit gateway.endpoint.called events with request/response data. Improves observability of gateway traffic and error rates without changing existing behavior.

- **New Features**
  - Track method, path, workspace ID, status code, user agent, remote IP, request ID, and selected headers (Content-Type, Accept, X-Request-Id).
  - Capture response status via a lightweight response recorder; include error message for 4xx/5xx.
  - Push events asynchronously via EventRepo (new PushGatewayEndpointCalledEvent).
  - Define new event type and schema: EventGatewayEndpointCalled (version 1.0).

<!-- End of auto-generated description by cubic. -->

