### PR TITLE
Fix: Sentinel Bug

### DIFF
--- a/sdk/src/beta9/cli/extraclick.py
+++ b/sdk/src/beta9/cli/extraclick.py
@@ -35,6 +35,7 @@ config_context_param = click.Option(
 config_context_option = click.option(
     "-c",
     "--context",
+    default=config_context_param.default,
     required=config_context_param.required,
     help=config_context_param.help,
     hidden=config_context_param.hidden,


### PR DESCRIPTION
## Bug report
> When I run beam deploy I get this strange "=> Context 'Sentinel.UNSET' does not exist. Let's try setting it up.". When I give it a token it then says "Sentinel.UNSET" section already exists and errors out. The default context already exists and I can list volumes, ect, but deploy wants to use this strange context."

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the CLI --context option by applying its default value from config_context_param. Omitting --context now uses the intended default and avoids errors.

<!-- End of auto-generated description by cubic. -->

