### PR TITLE
fix edge case when sandbox fails to build

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "websockets>=13,<14",
 ]
 name = "beta9"
-version = "0.1.241"
+version = "0.1.242"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -221,6 +221,7 @@ class Sandbox(Pod):
                 container_id="",
                 ok=False,
                 error_msg=create_response.error_msg,
+                stub_id="",
             )
 
         self.stub_id = create_response.stub_id
@@ -270,6 +271,7 @@ class Sandbox(Pod):
                 container_id="",
                 ok=False,
                 error_msg="Failed to prepare runtime",
+                stub_id="",
             )
 
         terminal.header("Creating sandbox")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix error handling when a sandbox fails to build or prepare by always returning a SandboxInstance with stub_id='' in error cases. Bump SDK version to 0.1.242.

<!-- End of auto-generated description by cubic. -->

