### PR TITLE
Fix: Make Endpoint TTL Configurable

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -520,7 +520,9 @@ func (gws *GatewayService) configureTaskPolicy(policy *pb.TaskPolicy, stubType t
 			p.Timeout = endpoint.DefaultEndpointRequestTimeoutS
 		}
 		p.MaxRetries = 0
-		p.TTL = endpoint.DefaultEndpointRequestTTL // Endpoints should still transition to expire from pending if it never runs
+		if p.TTL == 0 {
+			p.TTL = endpoint.DefaultEndpointRequestTTL // Endpoints should still transition to expire from pending if it never runs
+		}
 	case types.StubTypeScheduledJob:
 		fallthrough
 	case types.StubTypeFunction:


### PR DESCRIPTION
For endpoints the TTL was hardcoded to the default. This fix only sets the ttl to the default if no TTL is passed in

Bug Report:
> Hi there, I'm just wondering if the TTL container setting is configurable for endpoints.. it doesn't seem to be applied when we pass in a TaskPolicy with the value set. We'd like to set it to ~2 mins but it seems to always go to the default of 10. The timeout value seems to work, but not TTL
"task_policy": {
"max_retries": 0,
"timeout": 120,
"expires": "0001-01-01T00:00:00Z",
"ttl": 600
},

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make endpoint TTL configurable by honoring TaskPolicy TTL for endpoints. The default TTL is now applied only when TTL is 0, fixing the bug where endpoints always used the 10-minute default.

<!-- End of auto-generated description by cubic. -->

