### PR TITLE
Refine image credential system for OCI images

### DIFF
--- a/pkg/abstractions/image/build_options.go
+++ b/pkg/abstractions/image/build_options.go
@@ -61,18 +61,19 @@ func (o *BuildOpts) setCustomImageBuildOptions() error {
 		return err
 	}
 
-	if len(o.ExistingImageCreds) > 0 && o.ExistingImageUri != "" {
-		token, err := GetRegistryToken(o)
-		if err != nil {
-			return err
-		}
-		o.BaseImageCreds = token
-	}
-
+	// Set base image details
 	o.BaseImageRegistry = baseImage.Registry
 	o.BaseImageName = baseImage.Repo
 	o.BaseImageTag = baseImage.Tag
 	o.BaseImageDigest = baseImage.Digest
+
+	// Convert credentials if provided
+	if len(o.ExistingImageCreds) > 0 {
+		o.BaseImageCreds, err = GetRegistryToken(o)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -353,107 +353,55 @@ func convertBuildSteps(buildSteps []*pb.BuildStep) []BuildStep {
 // createCredentialSecretIfNeeded creates a workspace secret for OCI registry credentials
 // if base image credentials were provided during the build
 func (is *RuncImageService) createCredentialSecretIfNeeded(ctx context.Context, imageId string, opts *BuildOpts) error {
-	// Only create secrets for OCI images (v2) and if credentials were provided
+	// Only create secrets for OCI images (v2) with credentials
 	if is.config.ImageService.ClipVersion != 2 || opts == nil || opts.BaseImageCreds == "" {
 		return nil
 	}
 
-	// Only create secrets if a base image was used
 	baseImage := getSourceImage(opts)
 	if baseImage == "" {
 		return nil
 	}
 
-	// Parse the registry from the base image
+	// Parse registry and credentials
 	registry := reg.ParseRegistry(baseImage)
 	if registry == "" {
 		return fmt.Errorf("failed to parse registry from base image: %s", baseImage)
 	}
 
-	// Parse credentials from the BaseImageCreds string
-	// The format can be:
-	// 1. "username:password" (legacy format)
-	// 2. JSON map of credential keys to values
-	var credMap map[string]string
-
-	// Try to parse as JSON first
-	if err := json.Unmarshal([]byte(opts.BaseImageCreds), &credMap); err != nil {
-		// Not JSON, try legacy username:password format
-		parts := strings.SplitN(opts.BaseImageCreds, ":", 2)
-		if len(parts) == 2 {
-			credMap = map[string]string{
-				"USERNAME": parts[0],
-				"PASSWORD": parts[1],
-			}
-		} else {
-			// Unknown format
-			return fmt.Errorf("unable to parse base image credentials")
-		}
+	creds, err := is.parseCredentials(opts.BaseImageCreds)
+	if err != nil {
+		return err
 	}
 
-	// Filter to only known credential keys
-	creds := reg.ParseCredentialsFromEnv(credMap)
-	if len(creds) == 0 {
-		log.Info().Str("image_id", imageId).Msg("no recognizable credentials found, skipping secret creation")
-		return nil
-	}
-
-	// Detect credential type
+	// Skip if no valid credentials or public registry
 	credType := reg.DetectCredentialType(registry, creds)
 	if credType == reg.CredTypePublic {
-		log.Info().Str("image_id", imageId).Msg("public registry detected, skipping secret creation")
+		log.Info().Str("image_id", imageId).Msg("public registry, skipping secret creation")
 		return nil
 	}
 
-	// Marshal credentials to JSON
-	secretValue, err := reg.MarshalCredentials(registry, credType, creds)
-	if err != nil {
-		return fmt.Errorf("failed to marshal credentials: %w", err)
-	}
-
-	// Create secret name
-	secretName := reg.CreateSecretName(registry)
-
-	// Get auth info to access workspace
+	// Get workspace context
 	authInfo, ok := auth.AuthInfoFromContext(ctx)
 	if !ok || authInfo.Workspace == nil {
 		return fmt.Errorf("no workspace found in context")
 	}
 
-	// Create or update the secret
-	secret, err := is.backendRepo.GetSecretByName(ctx, authInfo.Workspace, secretName)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("failed to check for existing secret: %w", err)
+	// Prepare secret
+	secretValue, err := reg.MarshalCredentials(registry, credType, creds)
+	if err != nil {
+		return fmt.Errorf("failed to marshal credentials: %w", err)
 	}
 
-	if secret != nil {
-		// Secret already exists, update it
-		log.Info().
-			Str("image_id", imageId).
-			Str("secret_name", secretName).
-			Str("registry", registry).
-			Msg("updating existing credential secret")
+	secretName := reg.CreateSecretName(registry)
 
-		secret, err = is.backendRepo.UpdateSecret(ctx, authInfo.Workspace, authInfo.Token.Id, secret.ExternalId, secretValue)
-		if err != nil {
-			return fmt.Errorf("failed to update credential secret: %w", err)
-		}
-	} else {
-		// Create new secret
-		log.Info().
-			Str("image_id", imageId).
-			Str("secret_name", secretName).
-			Str("registry", registry).
-			Str("cred_type", string(credType)).
-			Msg("creating credential secret")
-
-		secret, err = is.backendRepo.CreateSecret(ctx, authInfo.Workspace, authInfo.Token.Id, secretName, secretValue)
-		if err != nil {
-			return fmt.Errorf("failed to create credential secret: %w", err)
-		}
+	// Create or update secret
+	secret, err := is.upsertSecret(ctx, authInfo, secretName, secretValue, registry)
+	if err != nil {
+		return err
 	}
 
-	// Associate the secret with the image
+	// Link secret to image
 	if err := is.backendRepo.SetImageCredentialSecret(ctx, imageId, secretName, secret.ExternalId); err != nil {
 		return fmt.Errorf("failed to associate secret with image: %w", err)
 	}
@@ -461,8 +409,58 @@ func (is *RuncImageService) createCredentialSecretIfNeeded(ctx context.Context, 
 	log.Info().
 		Str("image_id", imageId).
 		Str("secret_name", secretName).
-		Str("secret_id", secret.ExternalId).
-		Msg("credential secret created and associated with image")
+		Msg("credential secret saved")
 
 	return nil
+}
+
+// parseCredentials parses credential string (JSON or username:password format)
+func (is *RuncImageService) parseCredentials(credStr string) (map[string]string, error) {
+	var credMap map[string]string
+	
+	// Try JSON format first
+	if err := json.Unmarshal([]byte(credStr), &credMap); err == nil {
+		creds := reg.ParseCredentialsFromEnv(credMap)
+		if len(creds) > 0 {
+			return creds, nil
+		}
+		return nil, fmt.Errorf("no recognizable credentials found")
+	}
+	
+	// Try legacy username:password format
+	parts := strings.SplitN(credStr, ":", 2)
+	if len(parts) == 2 {
+		return map[string]string{
+			"USERNAME": parts[0],
+			"PASSWORD": parts[1],
+		}, nil
+	}
+	
+	return nil, fmt.Errorf("unable to parse credentials")
+}
+
+// upsertSecret creates or updates a secret in the workspace
+func (is *RuncImageService) upsertSecret(ctx context.Context, authInfo *auth.AuthInfo, secretName, secretValue, registry string) (*types.Secret, error) {
+	secret, err := is.backendRepo.GetSecretByName(ctx, authInfo.Workspace, secretName)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("failed to check for existing secret: %w", err)
+	}
+
+	if secret != nil {
+		// Update existing secret
+		secret, err = is.backendRepo.UpdateSecret(ctx, authInfo.Workspace, authInfo.Token.Id, secret.ExternalId, secretValue)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update secret: %w", err)
+		}
+		log.Info().Str("secret_name", secretName).Str("registry", registry).Msg("updated credential secret")
+	} else {
+		// Create new secret
+		secret, err = is.backendRepo.CreateSecret(ctx, authInfo.Workspace, authInfo.Token.Id, secretName, secretValue)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create secret: %w", err)
+		}
+		log.Info().Str("secret_name", secretName).Str("registry", registry).Msg("created credential secret")
+	}
+
+	return secret, nil
 }

--- a/pkg/registry/credentials.go
+++ b/pkg/registry/credentials.go
@@ -1,0 +1,149 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/beam-cloud/clip/pkg/provider"
+	"github.com/beam-cloud/clip/pkg/provider/aws"
+	"github.com/beam-cloud/clip/pkg/provider/gcp"
+	"github.com/beam-cloud/clip/pkg/provider/generic"
+)
+
+// CredentialType represents the type of credentials detected
+type CredentialType string
+
+const (
+	CredTypePublic   CredentialType = "public"
+	CredTypeAWS      CredentialType = "aws"
+	CredTypeGCP      CredentialType = "gcp"
+	CredTypeBasic    CredentialType = "basic"
+	CredTypeToken    CredentialType = "token"
+)
+
+// Known credential environment variable keys
+var (
+	awsCredKeys   = []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_REGION"}
+	gcpCredKeys   = []string{"GCP_ACCESS_TOKEN"}
+	basicCredKeys = []string{"USERNAME", "PASSWORD"}
+	tokenCredKeys = []string{"NGC_API_KEY", "GITHUB_TOKEN", "DOCKERHUB_TOKEN"}
+)
+
+// ParseRegistry extracts the registry hostname from an image reference
+func ParseRegistry(imageRef string) string {
+	parts := strings.SplitN(imageRef, "/", 2)
+	if len(parts) < 2 {
+		return "docker.io"
+	}
+	
+	// Check if first part looks like a registry (contains a dot or colon)
+	if strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":") {
+		return parts[0]
+	}
+	
+	return "docker.io"
+}
+
+// ParseCredentialsFromEnv extracts known credential keys from a credential map
+func ParseCredentialsFromEnv(envMap map[string]string) map[string]string {
+	creds := make(map[string]string)
+	allKnownKeys := append(append(append(awsCredKeys, gcpCredKeys...), basicCredKeys...), tokenCredKeys...)
+	
+	for _, key := range allKnownKeys {
+		if val, ok := envMap[key]; ok && val != "" {
+			creds[key] = val
+		}
+	}
+	
+	return creds
+}
+
+// DetectCredentialType determines the type of credentials based on what keys are present
+func DetectCredentialType(registry string, creds map[string]string) CredentialType {
+	if len(creds) == 0 {
+		return CredTypePublic
+	}
+	
+	// Check for AWS credentials
+	if _, hasAccessKey := creds["AWS_ACCESS_KEY_ID"]; hasAccessKey {
+		if _, hasSecretKey := creds["AWS_SECRET_ACCESS_KEY"]; hasSecretKey {
+			return CredTypeAWS
+		}
+	}
+	
+	// Check for GCP credentials
+	if _, hasToken := creds["GCP_ACCESS_TOKEN"]; hasToken {
+		return CredTypeGCP
+	}
+	
+	// Check for token-based auth
+	for _, key := range tokenCredKeys {
+		if _, hasToken := creds[key]; hasToken {
+			return CredTypeToken
+		}
+	}
+	
+	// Check for basic auth
+	if _, hasUser := creds["USERNAME"]; hasUser {
+		if _, hasPass := creds["PASSWORD"]; hasPass {
+			return CredTypeBasic
+		}
+	}
+	
+	return CredTypePublic
+}
+
+// MarshalCredentials converts credentials to JSON for storage
+func MarshalCredentials(registry string, credType CredentialType, creds map[string]string) (string, error) {
+	payload := map[string]interface{}{
+		"registry":    registry,
+		"credentials": creds,
+	}
+	
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	
+	return string(data), nil
+}
+
+// CreateSecretName generates a consistent secret name for a registry
+func CreateSecretName(registry string) string {
+	// Normalize the registry name to create a valid secret name
+	normalized := strings.ReplaceAll(registry, ".", "-")
+	normalized = strings.ReplaceAll(normalized, ":", "-")
+	normalized = strings.ToLower(normalized)
+	return fmt.Sprintf("oci-registry-%s", normalized)
+}
+
+// CreateProviderFromEnv creates a CLIP credential provider from environment variables
+func CreateProviderFromEnv(ctx context.Context, registry string, credKeys []string) (provider.Provider, error) {
+	// Collect credentials from environment
+	creds := make(map[string]string)
+	for _, key := range credKeys {
+		// Keys are already set in environment by caller
+		creds[key] = ""  // Will be read by provider from env
+	}
+	
+	// Detect credential type and create appropriate provider
+	credType := DetectCredentialType(registry, creds)
+	
+	switch credType {
+	case CredTypeAWS:
+		if region, ok := creds["AWS_REGION"]; ok && region != "" {
+			return aws.NewProvider(ctx, registry, region)
+		}
+		return nil, fmt.Errorf("AWS_REGION required for ECR authentication")
+		
+	case CredTypeGCP:
+		return gcp.NewProvider(ctx, registry)
+		
+	default:
+		// For basic auth and tokens, use generic provider
+		// The generic provider reads from environment variables
+		return generic.NewProvider(ctx, registry)
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -326,31 +326,44 @@ func (s *Scheduler) scheduleRequest(worker *types.Worker, request *types.Contain
 
 	request.Gpu = worker.Gpu
 
-	// Fetch OCI image credentials if available (for lazy layer loading)
-	if request.ImageId != "" {
-		secretName, _, err := s.backendRepo.GetImageCredentialSecret(context.TODO(), request.ImageId)
-		if err == nil && secretName != "" {
-			secret, err := s.backendRepo.GetSecretByNameDecrypted(context.TODO(), &request.Workspace, secretName)
-			if err == nil {
-				request.ImageCredentials = secret.Value
-				log.Info().
-					Str("container_id", request.ContainerId).
-					Str("image_id", request.ImageId).
-					Str("secret_name", secretName).
-					Msg("added OCI credentials to container request")
-			} else {
-				log.Warn().
-					Err(err).
-					Str("container_id", request.ContainerId).
-					Str("image_id", request.ImageId).
-					Msg("failed to retrieve OCI credentials, container will use default provider")
-			}
-		}
+	// Attach OCI credentials for runtime lazy layer loading
+	if err := s.attachImageCredentials(request); err != nil {
+		log.Warn().
+			Err(err).
+			Str("container_id", request.ContainerId).
+			Str("image_id", request.ImageId).
+			Msg("failed to attach OCI credentials, will use default provider")
 	}
 
 	go s.schedulerUsageMetrics.CounterIncContainerScheduled(request)
 	go s.eventRepo.PushContainerScheduledEvent(request.ContainerId, worker.Id, request)
 	return s.workerRepo.ScheduleContainerRequest(worker, request)
+}
+
+// attachImageCredentials fetches and attaches OCI credentials to a container request
+func (s *Scheduler) attachImageCredentials(request *types.ContainerRequest) error {
+	if request.ImageId == "" {
+		return nil
+	}
+
+	secretName, _, err := s.backendRepo.GetImageCredentialSecret(context.TODO(), request.ImageId)
+	if err != nil || secretName == "" {
+		return err
+	}
+
+	secret, err := s.backendRepo.GetSecretByNameDecrypted(context.TODO(), &request.Workspace, secretName)
+	if err != nil {
+		return err
+	}
+
+	request.ImageCredentials = secret.Value
+	log.Info().
+		Str("container_id", request.ContainerId).
+		Str("image_id", request.ImageId).
+		Str("secret_name", secretName).
+		Msg("attached OCI credentials")
+	
+	return nil
 }
 
 func filterControllersByFlags(controllers []WorkerPoolController, request *types.ContainerRequest) []WorkerPoolController {
@@ -423,7 +436,7 @@ func filterWorkersByResources(workers []*types.Worker, request *types.ContainerR
 			}
 
 			// This will account for the preset priorities for the pool type as well as the order of the GPU requests
-			// NOTE: will only work properly if all GPU types and their pools start from 0 and pool priority are incremental by changes of ±1
+			// NOTE: will only work properly if all GPU types and their pools start from 0 and pool priority are incremental by changes of ?1
 			worker.Priority -= int32(priorityModifier)
 		}
 

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -322,49 +322,11 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 
 	if strings.ToLower(storageType) == string(clipCommon.StorageModeOCI) {
 		// v2 (OCI index-only): ClipFS will read embedded OCI storage info; no S3 info needed
-		// Ensure we don't pass a stale S3 StorageInfo
 		mountOptions.StorageInfo = nil
-
-		// Use credentials from request (passed by scheduler)
-		if request.ImageCredentials != "" {
-			var credData map[string]interface{}
-			if err := json.Unmarshal([]byte(request.ImageCredentials), &credData); err == nil {
-				registry, _ := credData["registry"].(string)
-				credsMap, _ := credData["credentials"].(map[string]interface{})
-
-				if registry != "" && credsMap != nil {
-					// Convert to string map and build credential keys list
-					credMap := make(map[string]string)
-					credKeys := []string{}
-					for k, v := range credsMap {
-						if strVal, ok := v.(string); ok {
-							credMap[k] = strVal
-							credKeys = append(credKeys, k)
-							// Set in environment for CreateProviderFromEnv to read
-							os.Setenv(k, strVal)
-						}
-					}
-
-					// Create CLIP provider from credentials
-					if provider, err := reg.CreateProviderFromEnv(ctx, registry, credKeys); err == nil && provider != nil {
-						mountOptions.RegistryCredProvider = provider
-						log.Info().
-							Str("image_id", imageId).
-							Str("registry", registry).
-							Msg("using credential provider from request for OCI image mount")
-					} else if err != nil {
-						log.Warn().
-							Err(err).
-							Str("image_id", imageId).
-							Msg("failed to create credential provider, using default")
-					}
-				}
-			} else {
-				log.Warn().
-					Err(err).
-					Str("image_id", imageId).
-					Msg("failed to parse ImageCredentials JSON, using default provider")
-			}
+		
+		// Attach credential provider for runtime layer loading
+		if provider := c.createCredentialProvider(ctx, request.ImageCredentials, imageId); provider != nil {
+			mountOptions.RegistryCredProvider = provider
 		}
 	} else {
 		// v1 (legacy S3 data-carrying)
@@ -420,6 +382,56 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 // GetSourceImageRef retrieves the cached source image reference for a v2 image
 func (c *ImageClient) GetSourceImageRef(imageId string) (string, bool) {
 	return c.v2ImageRefs.Get(imageId)
+}
+
+// createCredentialProvider creates a CLIP credential provider from JSON credentials
+func (c *ImageClient) createCredentialProvider(ctx context.Context, credentialsJSON, imageId string) clip.RegistryCredProvider {
+	if credentialsJSON == "" {
+		return nil
+	}
+	
+	var credData map[string]interface{}
+	if err := json.Unmarshal([]byte(credentialsJSON), &credData); err != nil {
+		log.Warn().
+			Err(err).
+			Str("image_id", imageId).
+			Msg("failed to parse image credentials JSON")
+		return nil
+	}
+	
+	registry, _ := credData["registry"].(string)
+	credsMap, _ := credData["credentials"].(map[string]interface{})
+	
+	if registry == "" || credsMap == nil {
+		return nil
+	}
+	
+	// Convert credentials to environment variables and collect keys
+	credKeys := []string{}
+	for k, v := range credsMap {
+		if strVal, ok := v.(string); ok && strVal != "" {
+			os.Setenv(k, strVal)
+			credKeys = append(credKeys, k)
+		}
+	}
+	
+	// Create provider from environment
+	provider, err := reg.CreateProviderFromEnv(ctx, registry, credKeys)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("image_id", imageId).
+			Str("registry", registry).
+			Msg("failed to create credential provider")
+		return nil
+	}
+	
+	log.Info().
+		Str("image_id", imageId).
+		Str("registry", registry).
+		Msg("created credential provider for OCI image")
+	
+	return provider
 }
 
 // cacheV2SourceImageRef caches the source image reference for a v2 image build

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -384,51 +384,66 @@ func (s *Worker) readBundleConfig(request *types.ContainerRequest) (*specs.Spec,
 // deriveSpecFromSourceImage creates an OCI spec from the source image metadata.
 // This is used for v2 images where we don't have an unpacked bundle with config.json.
 func (s *Worker) deriveSpecFromSourceImage(request *types.ContainerRequest) (*specs.Spec, error) {
-	// Get source image reference from the request or from cache
-	var sourceImageRef string
-	var sourceImageCreds string
-
-	if request.BuildOptions.SourceImage != nil {
-		sourceImageRef = *request.BuildOptions.SourceImage
-		sourceImageCreds = request.BuildOptions.SourceImageCreds
-	} else {
-		// For non-build containers, try to get the source image from the cache
-		if ref, ok := s.imageClient.GetSourceImageRef(request.ImageId); ok {
-			sourceImageRef = ref
-			log.Info().Str("image_id", request.ImageId).Str("source_image", sourceImageRef).Msg("retrieved source image from cache")
-		}
-	}
-
-	// If we don't have a source image reference, return nil (will use base spec)
+	// Determine source image reference and credentials
+	sourceImageRef, sourceImageCreds := s.getSourceImageInfo(request)
 	if sourceImageRef == "" {
-		log.Warn().Str("image_id", request.ImageId).Msg("no source image reference available, using base spec")
+		log.Warn().Str("image_id", request.ImageId).Msg("no source image reference, using base spec")
 		return nil, nil
 	}
 
-	// Inspect the source image to get its configuration
+	// Inspect source image with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	imgMeta, err := s.imageClient.skopeoClient.Inspect(ctx, sourceImageRef, sourceImageCreds, nil)
 	if err != nil {
-		log.Warn().Str("image_id", request.ImageId).Str("source_image", sourceImageRef).Err(err).Msg("failed to inspect source image, using base spec")
+		log.Warn().
+			Str("image_id", request.ImageId).
+			Str("source_image", sourceImageRef).
+			Err(err).
+			Msg("failed to inspect source image, using base spec")
 		return nil, nil
 	}
 
-	log.Info().Str("image_id", request.ImageId).Str("source_image", sourceImageRef).Msg("derived spec from source image")
+	log.Info().
+		Str("image_id", request.ImageId).
+		Str("source_image", sourceImageRef).
+		Msg("derived spec from source image")
 
-	// Create a clean spec with only the base config env (TERM=xterm)
-	// We'll let the caller merge this with the request-specific env
+	// Build spec from image metadata
+	return s.buildSpecFromImageMetadata(imgMeta), nil
+}
+
+// getSourceImageInfo retrieves the source image reference and credentials
+func (s *Worker) getSourceImageInfo(request *types.ContainerRequest) (string, string) {
+	// Build containers have source image in BuildOptions
+	if request.BuildOptions.SourceImage != nil {
+		return *request.BuildOptions.SourceImage, request.BuildOptions.SourceImageCreds
+	}
+
+	// Non-build containers: try cache
+	if ref, ok := s.imageClient.GetSourceImageRef(request.ImageId); ok {
+		log.Info().
+			Str("image_id", request.ImageId).
+			Str("source_image", ref).
+			Msg("retrieved source image from cache")
+		return ref, ""
+	}
+
+	return "", ""
+}
+
+// buildSpecFromImageMetadata constructs an OCI spec from image metadata
+func (s *Worker) buildSpecFromImageMetadata(imgMeta *common.SkopeoInspectOutput) *specs.Spec {
 	spec := specs.Spec{
 		Process: &specs.Process{
-			Env: []string{}, // Start with empty env - will be populated from image
+			Env: []string{},
 		},
 	}
 
-	// Apply image configuration
+	// Use Config if available, otherwise fallback to legacy Env field
 	if imgMeta.Config != nil {
 		if len(imgMeta.Config.Env) > 0 {
-			// Only use image env, don't append to base spec to avoid duplicates
 			spec.Process.Env = imgMeta.Config.Env
 		}
 		if imgMeta.Config.WorkingDir != "" {
@@ -437,18 +452,17 @@ func (s *Worker) deriveSpecFromSourceImage(request *types.ContainerRequest) (*sp
 		if imgMeta.Config.User != "" {
 			spec.Process.User.Username = imgMeta.Config.User
 		}
-		// Set default args from Cmd if Entrypoint is not set, or combine them
+		// Combine Entrypoint and Cmd, or use Cmd alone
 		if len(imgMeta.Config.Entrypoint) > 0 {
 			spec.Process.Args = append(imgMeta.Config.Entrypoint, imgMeta.Config.Cmd...)
 		} else if len(imgMeta.Config.Cmd) > 0 {
 			spec.Process.Args = imgMeta.Config.Cmd
 		}
 	} else if len(imgMeta.Env) > 0 {
-		// Fallback to legacy Env field if Config is not available
 		spec.Process.Env = imgMeta.Env
 	}
 
-	return &spec, nil
+	return &spec
 }
 
 // Generate a runc spec from a given request


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-51053cfa-a15c-424d-946d-f1bf4db4b0fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51053cfa-a15c-424d-946d-f1bf4db4b0fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined OCI image credential flow for OCI v2 images, with unified credential parsing, secure secret management, and runtime provider creation for lazy layer loading. Improves reliability across ECR, GAR, GHCR, Docker Hub, and NGC, and skips secret creation for public registries.

- **New Features**
  - Added pkg/registry/credentials for registry parsing, credential type detection, JSON marshaling, and secret naming.
  - Automatically create/update workspace secrets for OCI v2 images and link them to images; skip public registries.
  - Scheduler attaches decrypted OCI credentials to container requests for runtime layer loading.
  - Worker builds a credential provider from JSON credentials to mount OCI layers with auth.
  - Added helper to derive OCI spec from source image metadata for v2 images.

- **Refactors**
  - Simplified credential validation and token generation (ECR, GAR, NGC, GHCR, Docker Hub).
  - Build options set base image details and convert provided credentials to tokens consistently.
  - Extracted helpers for credential parsing and secret upsert; clearer logs and errors.
  - Streamlined scheduler and worker code paths; reduced duplication.

<sup>Written for commit 2ba6be9e03f646583e2a210d5f8440fa65911eab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

