### PR TITLE
Debug CLIP V2 env and secrets handling

### DIFF
--- a/pkg/abstractions/image/builder.go
+++ b/pkg/abstractions/image/builder.go
@@ -251,6 +251,8 @@ func (b *Builder) hasWorkToDo(opts *BuildOpts) bool {
 	return len(opts.Commands) > 0 ||
 		len(opts.BuildSteps) > 0 ||
 		len(opts.PythonPackages) > 0 ||
+		len(opts.EnvVars) > 0 ||
+		len(opts.BuildSecrets) > 0 ||
 		(opts.PythonVersion != "" && !opts.IgnorePython)
 }
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-94a27bbc-9b24-4a95-b3ea-818af9a0cb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94a27bbc-9b24-4a95-b3ea-818af9a0cb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure env vars and build secrets are correctly handled in CLIP V2 Dockerfile generation. Updates hasWorkToDo to trigger a build when env vars or secrets are present, with tests covering Dockerfile rendering, appending, and work detection.

<sup>Written for commit d388193c1e2254edef028410519e5914159b1843. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

