### PR TITLE
Fix clip v2 build auth and improve buildah concurrency

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -254,3 +254,9 @@ RUN echo "timeout 60" >> /etc/criu/default.conf
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics,ngx,video
 ENV _BUILDAH_STARTED_IN_USERNS="" \
     BUILDAH_ISOLATION=chroot
+
+# Configure buildah/containers for better concurrency
+# image_parallel_copies controls how many layers can be pushed/pulled simultaneously
+RUN mkdir -p /etc/containers && \
+    echo '[engine]' > /etc/containers/containers.conf && \
+    echo 'image_parallel_copies = 8' >> /etc/containers/containers.conf


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-9f20aee5-9a65-46d1-85f4-cefdfb9d0d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f20aee5-9a65-46d1-85f4-cefdfb9d0d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLIP v2 image auth by prioritizing build registry credentials over source image creds, and speeds up builds/pushes with caching, concurrency, and retries.

- **Bug Fixes**
  - Updated credential priority to: runtime > build registry > source image > ambient, with registry + repo checks to avoid false positives when final images live in the build registry.

- **Performance**
  - Enabled buildah layer caching (--layers) for faster rebuilds.
  - Configured parallel layer operations (image_parallel_copies=8) and added retries (--retry 3, --retry-delay 2s) for more reliable pushes/pulls.

<sup>Written for commit f9842a107530b26ec47a8cf40a2a309cdfe893f3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



