### PR TITLE
Optimize buildah commit and push performance

### DIFF
--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -463,9 +463,9 @@ func (c *ImageClient) getCredentialProviderForImage(ctx context.Context, imageId
 	// We check both the registry domain AND the build repository name to avoid false positives
 	buildRegistry := c.getBuildRegistry()
 	buildRepoName := c.config.ImageService.BuildRepositoryName
-	if buildRegistry != "" && buildRepoName != "" && 
-		strings.Contains(sourceRef, buildRegistry) && 
-		strings.Contains(sourceRef, buildRepoName) && 
+	if buildRegistry != "" && buildRepoName != "" &&
+		strings.Contains(sourceRef, buildRegistry) &&
+		strings.Contains(sourceRef, buildRepoName) &&
 		request.BuildRegistryCredentials != "" {
 		return c.parseAndCreateProvider(ctx, request.BuildRegistryCredentials, registry, imageId, "build registry")
 	}
@@ -791,7 +791,7 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 	budArgs = append(budArgs, "--layers")
 
 	// Use parallel jobs for faster layer processing
-	budArgs = append(budArgs, "--jobs", "4")
+	budArgs = append(budArgs, "--jobs", "8")
 
 	// Add credentials for multi-stage builds and private base images
 	if authArgs := c.getBuildahAuthArgs(ctx, sourceImage, request.BuildOptions.SourceImageCreds); len(authArgs) > 0 {
@@ -854,9 +854,6 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 		// Add retry logic for network resilience
 		pushArgs = append(pushArgs, "--retry", "3")
 		pushArgs = append(pushArgs, "--retry-delay", "2s")
-
-		// Force disable content de-duplication to speed up push
-		pushArgs = append(pushArgs, "--disable-content-trust")
 
 		// Add authentication for build registry (uses credentials from request)
 		if authArgs := c.getBuildRegistryAuthArgs(buildRegistry, request.BuildRegistryCredentials); len(authArgs) > 0 {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-4b8b213b-b930-42d1-b67a-225c86a2059a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b8b213b-b930-42d1-b67a-225c86a2059a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up buildah image build and push by using RAM-backed storage and tuned flags. This reduces disk I/O and shortens commit/push times.

- **Refactors**
  - Use /dev/shm for build storage with fallback to /tmp.
  - Force --storage-driver=vfs for pull, bud, and push (including local OCI push).
  - Add --jobs 8 to bud for parallel layer processing.
  - Use gzip compression level 1 on push to speed up uploads.

<sup>Written for commit 9071b3ea83be56555f98a75d1d38e8685b2bd1e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



