### PR TITLE
fix: move buildah storage to /dev/shm

### DIFF
--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -718,8 +718,7 @@ func (c *ImageClient) createOCIImageWithProgress(ctx context.Context, outputLogg
 func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *slog.Logger, request *types.ContainerRequest) error {
 	startTime := time.Now()
 
-	// Use /dev/shm (tmpfs/RAM) for buildah storage to eliminate disk I/O bottleneck
-	// This dramatically improves commit and push performance
+	// Use /dev/shm (tmpfs/RAM) for buildah storage to eliminate disk I/O bottlenecks
 	buildPath, err := os.MkdirTemp("/dev/shm", "buildah-")
 	if err != nil {
 		// Fallback to /tmp if /dev/shm is not available
@@ -846,8 +845,7 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 			pushArgs = append(pushArgs, "--tls-verify=false")
 		}
 
-		// Disable compression for fast networks to eliminate I/O overhead
-		// This significantly reduces commit time by avoiding compression work
+		// TODO: Disable compression for fast networks to eliminate I/O overhead (make configurable)
 		pushArgs = append(pushArgs, "--compression-format", "gzip")
 		pushArgs = append(pushArgs, "--compression-level", "1")
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move Buildah storage to /dev/shm and force the vfs storage driver to cut disk I/O and speed up image builds and pushes. Adds parallel jobs and a safe fallback to /tmp if /dev/shm isn’t available.

- **Refactors**
  - Use /dev/shm as the Buildah root; fallback to /tmp when unavailable.
  - Force --storage-driver=vfs for pull, bud, and push to keep I/O in RAM.
  - Enable --jobs 8 and keep --layers for faster builds.

<sup>Written for commit 026d1a79dfdf28f9910a400ed10938ae359b060e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

