### PR TITLE
Optimize buildah image operations for speed

### DIFF
--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -883,7 +883,6 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 	// Clip v2: Build and push directly to registry, skip OCI layout
 	if c.config.ImageService.ClipVersion == uint32(types.ClipVersion2) {
 		archiveName := fmt.Sprintf("%s.%s.tmp", request.ImageId, c.registry.ImageFileExtension)
-		// Use fast tmpdir instead of /tmp for better performance
 		archivePath := filepath.Join(tmpdir, archiveName)
 
 		// Get build registry and construct tag


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-052ac9a4-0082-41ea-a4b3-5ae98ed702fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-052ac9a4-0082-41ea-a4b3-5ae98ed702fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize Buildah build and push performance by moving all storage to tmpfs (/dev/shm) and tuning build/push flags. Builds and pushes run faster on most machines.

- **New Features**
  - Use /dev/shm for graphroot, runroot, and tmpdir; generate overlay storage config with fallback to vfs; set CONTAINERS_STORAGE_CONF, XDG_RUNTIME_DIR, TMPDIR, BUILDAH_LAYERS.
  - Build flags: --layers, --jobs=8, --format=docker; pull/build/push use the selected storage driver.
  - Push flags: gzip compression level 1 and --retry=3.
  - Temporary archives moved from /tmp to /dev/shm.

<sup>Written for commit afd5c125f37842ca7d402ba7a77884aa76ded26a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







