### PR TITLE
Improve SandboxFileSystemError Handling

### DIFF
--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -168,7 +168,7 @@ func (s *GenericPodService) SandboxUploadFile(ctx context.Context, in *pb.PodSan
 	if err != nil {
 		return &pb.PodSandboxUploadFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to upload file to sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to upload file '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -199,7 +199,7 @@ func (s *GenericPodService) SandboxDownloadFile(ctx context.Context, in *pb.PodS
 	if err != nil {
 		return &pb.PodSandboxDownloadFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to download file from sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to download file '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -231,7 +231,7 @@ func (s *GenericPodService) SandboxDeleteFile(ctx context.Context, in *pb.PodSan
 	if err != nil {
 		return &pb.PodSandboxDeleteFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to delete file in sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to delete file '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -262,7 +262,7 @@ func (s *GenericPodService) SandboxCreateDirectory(ctx context.Context, in *pb.P
 	if err != nil {
 		return &pb.PodSandboxCreateDirectoryResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to create dir in sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to create directory '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -293,7 +293,7 @@ func (s *GenericPodService) SandboxDeleteDirectory(ctx context.Context, in *pb.P
 	if err != nil {
 		return &pb.PodSandboxDeleteDirectoryResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to delete dir in sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to delete directory '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -361,7 +361,7 @@ func (s *GenericPodService) SandboxStatFile(ctx context.Context, in *pb.PodSandb
 	if err != nil {
 		return &pb.PodSandboxStatFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to get file info",
+			ErrorMsg: fmt.Sprintf("Failed to get file info for '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -404,7 +404,7 @@ func (s *GenericPodService) SandboxListFiles(ctx context.Context, in *pb.PodSand
 	if err != nil {
 		return &pb.PodSandboxListFilesResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to list files",
+			ErrorMsg: fmt.Sprintf("Failed to list files in '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -444,7 +444,7 @@ func (s *GenericPodService) SandboxReplaceInFiles(ctx context.Context, in *pb.Po
 	if err != nil {
 		return &pb.PodSandboxReplaceInFilesResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to replace in file",
+			ErrorMsg: fmt.Sprintf("Failed to replace in files at '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -475,7 +475,7 @@ func (s *GenericPodService) SandboxFindInFiles(ctx context.Context, in *pb.PodSa
 	if err != nil {
 		return &pb.PodSandboxFindInFilesResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to find files",
+			ErrorMsg: fmt.Sprintf("Failed to find files in '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 

--- a/pkg/worker/runc_server.go
+++ b/pkg/worker/runc_server.go
@@ -685,7 +685,7 @@ func (s *RunCServer) RunCSandboxUploadFile(ctx context.Context, in *pb.RunCSandb
 	hostPath := s.getHostPathFromContainerPath(containerPath, instance)
 	err = os.WriteFile(hostPath, in.Data, os.FileMode(in.Mode))
 	if err != nil {
-		return &pb.RunCSandboxUploadFileResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxUploadFileResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to write file to %s: %s", containerPath, err.Error())}, nil
 	}
 
 	return &pb.RunCSandboxUploadFileResponse{Ok: true}, nil
@@ -708,7 +708,7 @@ func (s *RunCServer) RunCSandboxCreateDirectory(ctx context.Context, in *pb.RunC
 
 	hostPath := s.getHostPathFromContainerPath(filepath.Clean(containerPath), instance)
 	if err := os.MkdirAll(hostPath, os.FileMode(in.Mode)); err != nil {
-		return &pb.RunCSandboxCreateDirectoryResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxCreateDirectoryResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to create directory %s: %s", containerPath, err.Error())}, nil
 	}
 
 	return &pb.RunCSandboxCreateDirectoryResponse{Ok: true}, nil
@@ -731,7 +731,7 @@ func (s *RunCServer) RunCSandboxDeleteDirectory(ctx context.Context, in *pb.RunC
 
 	hostPath := s.getHostPathFromContainerPath(filepath.Clean(containerPath), instance)
 	if err := os.RemoveAll(hostPath); err != nil {
-		return &pb.RunCSandboxDeleteDirectoryResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxDeleteDirectoryResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to delete directory %s: %s", containerPath, err.Error())}, nil
 	}
 
 	return &pb.RunCSandboxDeleteDirectoryResponse{Ok: true}, nil
@@ -756,7 +756,7 @@ func (s *RunCServer) RunCSandboxDownloadFile(ctx context.Context, in *pb.RunCSan
 	hostPath := s.getHostPathFromContainerPath(containerPath, instance)
 	data, err := os.ReadFile(hostPath)
 	if err != nil {
-		return &pb.RunCSandboxDownloadFileResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxDownloadFileResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to read file %s: %s", containerPath, err.Error())}, nil
 	}
 
 	return &pb.RunCSandboxDownloadFileResponse{Ok: true, Data: data}, nil
@@ -781,7 +781,7 @@ func (s *RunCServer) RunCSandboxDeleteFile(ctx context.Context, in *pb.RunCSandb
 	hostPath := s.getHostPathFromContainerPath(containerPath, instance)
 	err = os.RemoveAll(hostPath)
 	if err != nil {
-		return &pb.RunCSandboxDeleteFileResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxDeleteFileResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to delete file %s: %s", containerPath, err.Error())}, nil
 	}
 
 	return &pb.RunCSandboxDeleteFileResponse{Ok: true}, nil
@@ -806,7 +806,7 @@ func (s *RunCServer) RunCSandboxStatFile(ctx context.Context, in *pb.RunCSandbox
 	hostPath := s.getHostPathFromContainerPath(containerPath, instance)
 	stat, err := os.Stat(hostPath)
 	if err != nil {
-		return &pb.RunCSandboxStatFileResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxStatFileResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to stat file %s: %s", containerPath, err.Error())}, nil
 	}
 
 	return &pb.RunCSandboxStatFileResponse{Ok: true, FileInfo: &pb.FileInfo{
@@ -840,14 +840,14 @@ func (s *RunCServer) RunCSandboxListFiles(ctx context.Context, in *pb.RunCSandbo
 	hostPath := s.getHostPathFromContainerPath(containerPath, instance)
 	files, err := os.ReadDir(hostPath)
 	if err != nil {
-		return &pb.RunCSandboxListFilesResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxListFilesResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to list directory %s: %s", containerPath, err.Error())}, nil
 	}
 
 	responseFiles := make([]*pb.FileInfo, 0)
 	for _, file := range files {
 		stat, err := file.Info()
 		if err != nil {
-			return &pb.RunCSandboxListFilesResponse{Ok: false, ErrorMsg: err.Error()}, nil
+			return &pb.RunCSandboxListFilesResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to get file info for %s in %s: %s", file.Name(), containerPath, err.Error())}, nil
 		}
 
 		responseFiles = append(responseFiles, &pb.FileInfo{
@@ -997,13 +997,13 @@ func (s *RunCServer) RunCSandboxReplaceInFiles(ctx context.Context, in *pb.RunCS
 	hostPath := s.getHostPathFromContainerPath(containerPath, instance)
 	stagedFiles, err := stageFilesForReplacement(hostPath, in.Pattern, in.NewString)
 	if err != nil {
-		return &pb.RunCSandboxReplaceInFilesResponse{Ok: false, ErrorMsg: err.Error()}, nil
+		return &pb.RunCSandboxReplaceInFilesResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to replace in files at %s: %s", containerPath, err.Error())}, nil
 	}
 
 	for _, stagedFile := range stagedFiles {
 		err = os.WriteFile(stagedFile.Path, []byte(stagedFile.Content), 0644)
 		if err != nil {
-			return &pb.RunCSandboxReplaceInFilesResponse{Ok: false, ErrorMsg: err.Error()}, nil
+			return &pb.RunCSandboxReplaceInFilesResponse{Ok: false, ErrorMsg: fmt.Sprintf("failed to write replaced file %s: %s", stagedFile.Path, err.Error())}, nil
 		}
 	}
 

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -1413,7 +1413,12 @@ class SandboxFileSystem:
             )
 
             if not response.ok:
-                raise SandboxFileSystemError(response.error_msg)
+                raise SandboxFileSystemError(
+                    message=response.error_msg,
+                    operation="upload_file",
+                    path=sandbox_path,
+                    container_id=self.sandbox_instance.container_id,
+                )
 
     def download_file(self, sandbox_path: str, local_path: str):
         """
@@ -1446,7 +1451,12 @@ class SandboxFileSystem:
         )
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="download_file",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         with open(local_path, "wb") as f:
             f.write(response.data)
@@ -1484,7 +1494,12 @@ class SandboxFileSystem:
             )
         )
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="stat_file",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         return SandboxFileInfo(
             **{
@@ -1536,7 +1551,12 @@ class SandboxFileSystem:
             )
         )
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="list_files",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         file_infos = []
         for file in response.files:
@@ -1571,7 +1591,12 @@ class SandboxFileSystem:
             )
         )
         if not resp.ok:
-            raise SandboxFileSystemError(resp.error_msg)
+            raise SandboxFileSystemError(
+                message=resp.error_msg,
+                operation="create_directory",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def delete_directory(self, sandbox_path: str):
         """
@@ -1590,7 +1615,12 @@ class SandboxFileSystem:
             )
         )
         if not resp.ok:
-            raise SandboxFileSystemError(resp.error_msg)
+            raise SandboxFileSystemError(
+                message=resp.error_msg,
+                operation="delete_directory",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def delete_file(self, sandbox_path: str):
         r"""
@@ -1621,7 +1651,12 @@ class SandboxFileSystem:
         )
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="delete_file",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def replace_in_files(self, sandbox_path: str, old_string: str, new_string: str):
         r"""
@@ -1658,7 +1693,12 @@ class SandboxFileSystem:
         )
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="replace_in_files",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def find_in_files(self, sandbox_path: str, pattern: str) -> List[SandboxFileSearchResult]:
         r"""
@@ -1717,6 +1757,11 @@ class SandboxFileSystem:
             results.append(SandboxFileSearchResult(path=result.path, matches=matches))
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="find_in_files",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         return results

--- a/sdk/src/beta9/exceptions.py
+++ b/sdk/src/beta9/exceptions.py
@@ -134,6 +134,17 @@ class SandboxProcessError(RuntimeError):
 
 
 class SandboxFileSystemError(RuntimeError):
-    def __init__(self, message: str):
+    def __init__(
+        self,
+        message: str,
+        operation: str,
+        path: str,
+        container_id: str,
+    ):
         self.message = message
-        super().__init__(f"Unable to perform sandbox filesystem operation: {message}")
+        self.operation = operation
+        self.path = path
+        self.container_id = container_id
+        super().__init__(
+            f"Sandbox filesystem error [{operation}] on '{path}' (container: {container_id}): {message}"
+        )


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved sandbox filesystem error reporting across server and SDK to include operation, path, and container ID for clearer, actionable debugging.

- **Refactors**
  - Go services now return descriptive error messages with the affected container path.
  - Python SDK raises SandboxFileSystemError with operation, path, and container_id for all sandbox file ops (upload, download, stat, list, create/delete dir, delete file, replace/find in files).
  - Errors use a consistent format for easier logging and troubleshooting.

- **Migration**
  - No changes needed unless you instantiate SandboxFileSystemError directly; update calls to include operation, path, and container_id.

<sup>Written for commit e54b6796c2a3a461ba315fccfb38011c93d43b11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Examples
### Before Changes
`Unable to perform sandbox filesystem operation: ripgrep failed: exit status 2, stderr:`

### After Changes
`Sandbox filesystem error [find_in_files] on '/nonexistent/directory' (container: sandbox-23e8e527-0d2c-4805-880b-2204788aa2cc-6fc665f9): ripgrep failed: exit status 2, stderr:`

