### PR TITLE
Optimize skopeo image push performance

### DIFF
--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -942,12 +942,11 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 		skopeoArgs = append(skopeoArgs, srcRef, destRef)
 
 		cmd = exec.CommandContext(ctx, "skopeo", skopeoArgs...)
-		
-		// Add aggressive parallelism settings for maximum upload throughput
+
 		env := c.buildahEnv(runroot, tmpdir, storageConf)
-		env = common.AddSkopeoPerformanceEnv(env)
+		env = common.AddSkopeoEnvVars(env)
 		cmd.Env = env
-		
+
 		cmd.Stdout = &common.ExecWriter{Logger: outputLogger}
 		cmd.Stderr = &common.ExecWriter{Logger: outputLogger}
 		if err = cmd.Run(); err != nil {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-2d5623ce-a2aa-4993-95f9-d3cbf4447191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d5623ce-a2aa-4993-95f9-d3cbf4447191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>













<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up skopeo image pushes by adding optimized copy flags in both the skopeo client and worker, and enabling parallel blob transfers in both. Uses v2s2 format, pushes only the current system architecture, preserves digests, disables destination compression, and sets default parallel downloads/uploads to 16 (overridable via env).

<sup>Written for commit d5296b44e9b39e03d9213c31e6942460b4f3ae23. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











