### PR TITLE
Clean up some skopeo settings and tune throughput

### DIFF
--- a/pkg/common/skopeo.go
+++ b/pkg/common/skopeo.go
@@ -123,7 +123,11 @@ func (p *skopeoClient) Copy(ctx context.Context, sourceImage string, dest string
 
 	args = append(args, p.copyArgs(creds)...)
 	cmd := exec.CommandContext(ctx, p.pullCommand, args...)
-	cmd.Env = os.Environ()
+
+	env := os.Environ()
+	env = p.addSkopeoEnvVars(env)
+	cmd.Env = env
+
 	cmd.Dir = imageTmpDir
 	cmd.Stdout = &ZerologIOWriter{LogFn: func() *zerolog.Event { return log.Info().Str("operation", fmt.Sprintf("%s copy", p.pullCommand)) }}
 	cmd.Stderr = &ZerologIOWriter{LogFn: func() *zerolog.Event { return log.Error().Str("operation", fmt.Sprintf("%s copy", p.pullCommand)) }}
@@ -190,7 +194,45 @@ func (p *skopeoClient) copyArgs(creds string) (out []string) {
 		out = append(out, "--debug")
 	}
 
+	out = append(out, "--format=v2s2")
+	out = append(out, "--multi-arch=system")
+	out = append(out, "--preserve-digests")
+	out = append(out, "--dest-compress=false")
+
 	return out
+}
+
+// AddSkopeoEnvVars adds performance-tuning environment variables for skopeo
+// These control parallel blob transfers and other performance characteristics
+// Exported so it can be used by other packages (e.g., image.go)
+func AddSkopeoEnvVars(env []string) []string {
+	// Check if already set in environment to allow override
+	hasMaxParallelDownloads := false
+	hasMaxParallelUploads := false
+
+	for _, e := range env {
+		if strings.HasPrefix(e, "SKOPEO_MAX_PARALLEL_DOWNLOADS=") {
+			hasMaxParallelDownloads = true
+		}
+		if strings.HasPrefix(e, "SKOPEO_MAX_PARALLEL_UPLOADS=") {
+			hasMaxParallelUploads = true
+		}
+	}
+
+	// Set aggressive defaults if not already configured
+	// These values work well for fast networks and multi-core systems
+	if !hasMaxParallelDownloads {
+		env = append(env, "SKOPEO_MAX_PARALLEL_DOWNLOADS=16")
+	}
+	if !hasMaxParallelUploads {
+		env = append(env, "SKOPEO_MAX_PARALLEL_UPLOADS=16")
+	}
+
+	return env
+}
+
+func (p *skopeoClient) addSkopeoEnvVars(env []string) []string {
+	return AddSkopeoEnvVars(env)
 }
 
 func (p *skopeoClient) startCommand(cmd *exec.Cmd) (chan runc.Exit, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speed up image pushes by tuning skopeo throughput and standardizing copy flags, and use skopeo for pushes in the worker. Defaults to v2s2 format, system-only multi-arch, preserved digests, no destination compression, and parallel downloads/uploads set to 16 (overridable via env).

- **Refactors**
  - Expose AddSkopeoEnvVars and apply it in worker push commands.
  - Simplify build tag to registry/repo:imageId (remove workspace component).

<sup>Written for commit c0b82fffdfc89b66e51cdf89667486771207ef3c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

