### PR TITLE
Fix chained image command rendering

### DIFF
--- a/pkg/abstractions/image/build.go
+++ b/pkg/abstractions/image/build.go
@@ -384,14 +384,10 @@ func generatePipInstallCommand(pythonPackages []string, pythonVersion string, vi
 }
 
 // generateStandardPipInstallCommand generates a pip install command for v2 dockerfile builds
-// using uv for faster installation. uv is copied from the official ghcr.io/astral-sh/uv image
-// for maximum efficiency and speed.
 func generateStandardPipInstallCommand(pythonPackages []string, pythonVersion string, virtualEnv bool) string {
 	flagLines, packages := parseFlagLinesAndPackages(pythonPackages)
 
-	// Use uv pip install for much faster installation
-	// The uv binary should be copied in the Dockerfile via: COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-	command := fmt.Sprintf("uv pip install --system --python %s", pythonVersion)
+	command := fmt.Sprintf("%s -m pip install", pythonVersion)
 
 	if len(flagLines) > 0 {
 		command += " " + strings.Join(flagLines, " ")

--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -171,9 +171,8 @@ func TestRenderV2Dockerfile_FromRegistryWithChainedCommands(t *testing.T) {
 			},
 			expected: []string{
 				"FROM docker.io/library/python:3.11-slim\n",
-				"COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv\n",
 				"RUN apt update\n",
-				"RUN uv pip install --system",
+				"RUN python3.10 -m pip install",
 				"numpy",
 				"RUN apt clean\n",
 			},
@@ -246,8 +245,7 @@ func TestRenderV2Dockerfile_ComprehensiveChaining(t *testing.T) {
 			},
 			expected: []string{
 				"FROM docker.io/library/python:3.11-slim\n",
-				"COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv\n",
-				"RUN uv pip install --system",
+				"RUN python3.10 -m pip install",
 				"numpy",
 				"pandas",
 				"RUN echo 'installed packages'\n",
@@ -271,10 +269,9 @@ func TestRenderV2Dockerfile_ComprehensiveChaining(t *testing.T) {
 			},
 			expected: []string{
 				"FROM docker.io/library/python:3.11-slim\n",
-				"COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv\n",
 				"ENV API_KEY=secret\n",
 				"RUN apt update\n",
-				"RUN uv pip install --system",
+				"RUN python3.10 -m pip install",
 				"requests",
 				"RUN apt clean\n",
 			},
@@ -1509,7 +1506,7 @@ func Test_parseBuildStepsForDockerfile(t *testing.T) {
 
 	expected := []string{
 		"apt update",
-		"uv pip install --system --python python3.9 \"requests\" \"numpy\"", // uv with --system flag
+		"python3.9 -m pip install \"requests\" \"numpy\"",
 		"echo done",
 	}
 

--- a/pkg/abstractions/image/builder.go
+++ b/pkg/abstractions/image/builder.go
@@ -296,12 +296,6 @@ func (b *Builder) appendToDockerfile(opts *BuildOpts) string {
 		sb.WriteString("\n")
 	}
 
-	// Copy uv binary from official image if we have any Python packages to install
-	// This is much faster than installing uv via pip
-	if len(opts.PythonPackages) > 0 || hasPipOrMambaSteps(opts.BuildSteps) {
-		sb.WriteString("COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv\n")
-	}
-
 	// Add environment variables and secrets
 	renderEnvVarsAndSecrets(&sb, opts)
 
@@ -377,12 +371,6 @@ func (b *Builder) RenderV2Dockerfile(opts *BuildOpts) (string, error) {
 	sb.WriteString("FROM ")
 	sb.WriteString(getSourceImage(opts))
 	sb.WriteString("\n")
-
-	// Copy uv binary from official image if we have any Python packages to install
-	// This is much faster than installing uv via pip
-	if len(opts.PythonPackages) > 0 || hasPipOrMambaSteps(opts.BuildSteps) {
-		sb.WriteString("COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv\n")
-	}
 
 	// Add environment variables and secrets
 	renderEnvVarsAndSecrets(&sb, opts)


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-c7a24874-43ed-4902-9da2-923663f4c44a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7a24874-43ed-4902-9da2-923663f4c44a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dockerfile generation to render chained shell commands for images created with from_registry when Python setup is skipped. Pip and shell steps now render as expected.

- **Bug Fixes**
  - Render RUN lines for shell BuildSteps even when IgnorePython=true.
  - Added tests for chained commands and mixed shell/pip steps with from_registry.

- **Dependencies**
  - Reverted to python -m pip installs and removed the uv COPY step.

<sup>Written for commit 64472f76ff505f420ebe1662aa47bc53db6373f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





