### PR TITLE
Fix nil pointer dereference in specFromRequest

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -468,7 +468,7 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 	spec.Process.Args = request.EntryPoint
 	spec.Process.Terminal = false
 
-	if request.Stub.Type.Kind() == types.StubTypePod {
+	if request.Stub.Type.Kind() == types.StubTypePod && options.InitialSpec != nil {
 		if len(request.EntryPoint) == 0 {
 			log.Info().
 				Str("container_id", request.ContainerId).


### PR DESCRIPTION
Fixes a nil pointer dereference in `TestV2ImageEnvironmentFlow` by initializing the worker's runtime and adding a nil check for `InitialSpec`.

The test failed because the `Worker`'s `runtime` field was uninitialized, causing `s.runtime.Name()` to panic. Additionally, `specFromRequest` accessed `options.InitialSpec` without a nil check when the stub type was `Pod`, which is valid for v2 images. The `Stub` field in the test request was also updated to the correct type.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9e99c77-fed3-4470-aaea-ba539e5c45d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9e99c77-fed3-4470-aaea-ba539e5c45d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent nil pointer dereference in specFromRequest and stabilize v2 image tests. Adds a nil check for InitialSpec when handling Pod stubs and initializes the worker runtime in tests to avoid runtime.Name() panics.

- **Bug Fixes**
  - specFromRequest: only use InitialSpec when Stub.Type is Pod and options.InitialSpec != nil.
  - Tests: add a mock runtime and set worker.runtime to prevent nil runtime.Name() panics.
  - Tests: correct Stub type in requests and validate v2 env flow, non-build containers, and cached metadata.

<sup>Written for commit 842ac60f954d8ea5acf5fc29256556a6d3ef8edb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

