### PR TITLE
Fix docker compose gvisor network issue

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -648,18 +648,6 @@ func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, option
 		"PYTHONUNBUFFERED=1",
 	}
 
-	// Add Docker-specific environment variables for gVisor compatibility
-	// These prevent buildx/bake from interfering with docker-compose commands
-	if request.DockerEnabled {
-		env = append(env, []string{
-			"DOCKER_BUILDKIT=0",                    // Use legacy builder instead of BuildKit
-			"COMPOSE_DOCKER_CLI_BUILD=0",           // Don't delegate to docker CLI
-			"DOCKER_DEFAULT_PLATFORM=linux/amd64",  // Set explicit platform to avoid parsing errors
-			"BUILDX_NO_DEFAULT_ATTESTATIONS=1",     // Disable buildx attestations
-			"DOCKER_CLI_HINTS=false",               // Disable CLI hints to avoid buildx suggestions
-		}...)
-	}
-
 	// Add env vars from request
 	env = append(request.Env, env...)
 


### PR DESCRIPTION
Add environment variables to disable buildx interference in docker-compose builds to fix platform parsing errors in gVisor sandboxes.

The "failed to parse platform" error occurred because Docker Compose v2 was attempting to use buildx functionality, reading from a builder configuration with empty or invalid platform specifications, even though BuildKit was explicitly disabled. The added `BUILDX_NO_DEFAULT_ATTESTATIONS=1` and `DOCKER_CLI_HINTS=false` environment variables prevent buildx from interfering, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-920b097a-362e-487e-9e36-33f66ab77772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-920b097a-362e-487e-9e36-33f66ab77772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set BUILDX_NO_DEFAULT_ATTESTATIONS=1 and DOCKER_CLI_HINTS=false in compose_up/build, and remove buildx builders in the worker sandbox to prevent Docker Compose from using Bake, fixing "failed to parse platform" in gVisor sandboxes. Keep legacy builder (DOCKER_BUILDKIT=0, COMPOSE_DOCKER_CLI_BUILD=0) and explicit platform (DOCKER_DEFAULT_PLATFORM=linux/amd64) for reliable builds.

<sup>Written for commit f1fa4d86114e0752611ad99d41ad1ca822bba56d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





