### PR TITLE
Fix docker build network bridge error

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -93,6 +93,7 @@ type ContainerInstance struct {
 	StopReason                 types.StopContainerReason
 	SandboxProcessManager      *goproc.GoProcClient
 	SandboxProcessManagerReady bool
+	BuildxConfigured           bool
 	ContainerIp                string
 	Runtime                    runtime.Runtime
 	OOMWatcher                 runtime.OOMWatcher


### PR DESCRIPTION
Force BuildKit to use host networking for `dockerd` inside gVisor to resolve "network bridge not found" errors during Docker builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-e618fef8-98e6-4c65-b5dd-f97367e6d0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e618fef8-98e6-4c65-b5dd-f97367e6d0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker builds in gVisor by forcing BuildKit and buildx to use host networking. Prevents “network bridge not found” errors.

- **Bug Fixes**
  - Start dockerd via sh -ec and export BUILDKITD_FLAGS=--oci-worker-net=host; ensure docker-compose services use host networking via wrapper.
  - Configure docker buildx to use host networking by creating/using a gvisor-host-builder.

<sup>Written for commit d8245d0b4d5c49954f25300c383003bf195050c5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





