### PR TITLE
Fix docker networking in gvisor sandbox

### DIFF
--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -103,7 +103,7 @@ func (s *Worker) enableIPv4Forwarding(ctx context.Context, containerId string, i
 
 	pid, err := instance.SandboxProcessManager.Exec([]string{"sh", "-c", script}, "/", []string{}, false)
 	if err != nil {
-		return fmt.Errorf("failed to enable IPv4 forwarding: %w", err)
+		return err
 	}
 
 	time.Sleep(cgroupSetupCompletionWait)

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -2394,7 +2394,7 @@ class SandboxDockerManager:
         if not self._authenticated:
             self._auto_login()
 
-        # Create override file to force host networking for gVisor compatibility
+        # Create override file to force gVisor network compatibility
         override_path = "/tmp/.docker-compose-gvisor-override.yml"
         override_content = """# Auto-generated for gVisor compatibility
 # Bridge networking is not supported in Docker-in-gVisor


### PR DESCRIPTION
Fix Docker networking in gVisor sandbox by enabling IPv4 forwarding and configuring the daemon for gVisor compatibility.

The previous Docker daemon configuration attempted to disable bridge networking via command-line flags, but it didn't fully prevent Docker from trying to create veth interfaces or address the disabled IPv4 forwarding, leading to networking errors within the gVisor environment. This PR configures the daemon via `daemon.json` and explicitly enables IPv4 forwarding to resolve these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-294af9ce-f938-4916-8ab2-62268ea1bf6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-294af9ce-f938-4916-8ab2-62268ea1bf6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>











































<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker networking in the gVisor sandbox by enabling IPv4 forwarding, starting dockerd with gVisor-safe flags, and forcing host networking for Docker run/compose. Restores container egress and prevents startup/build failures.

- **Bug Fixes**
  - Enable IPv4 forwarding via sysctl in the sandbox.
  - Start dockerd with --iptables=false, --ip6tables=false, and --bridge=none per gVisor guidance.
  - Force --network=host for docker run and add a docker-compose override to use the host network.

- **Refactors**
  - Remove ports argument from docker.run; containers use host networking, so ports are accessible directly.

<sup>Written for commit 386a0814943246f1c624a2cae6ab3158f2695eb8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









































