### PR TITLE
Improve SandboxFileSystemError

### DIFF
--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -168,7 +168,7 @@ func (s *GenericPodService) SandboxUploadFile(ctx context.Context, in *pb.PodSan
 	if err != nil {
 		return &pb.PodSandboxUploadFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to upload file to sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to upload file '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -199,7 +199,7 @@ func (s *GenericPodService) SandboxDownloadFile(ctx context.Context, in *pb.PodS
 	if err != nil {
 		return &pb.PodSandboxDownloadFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to download file from sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to download file '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -231,7 +231,7 @@ func (s *GenericPodService) SandboxDeleteFile(ctx context.Context, in *pb.PodSan
 	if err != nil {
 		return &pb.PodSandboxDeleteFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to delete file in sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to delete file '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -262,7 +262,7 @@ func (s *GenericPodService) SandboxCreateDirectory(ctx context.Context, in *pb.P
 	if err != nil {
 		return &pb.PodSandboxCreateDirectoryResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to create dir in sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to create directory '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -293,7 +293,7 @@ func (s *GenericPodService) SandboxDeleteDirectory(ctx context.Context, in *pb.P
 	if err != nil {
 		return &pb.PodSandboxDeleteDirectoryResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to delete dir in sandbox",
+			ErrorMsg: fmt.Sprintf("Failed to delete directory '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -361,7 +361,7 @@ func (s *GenericPodService) SandboxStatFile(ctx context.Context, in *pb.PodSandb
 	if err != nil {
 		return &pb.PodSandboxStatFileResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to get file info",
+			ErrorMsg: fmt.Sprintf("Failed to get file info for '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -404,7 +404,7 @@ func (s *GenericPodService) SandboxListFiles(ctx context.Context, in *pb.PodSand
 	if err != nil {
 		return &pb.PodSandboxListFilesResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to list files",
+			ErrorMsg: fmt.Sprintf("Failed to list files in '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -444,7 +444,7 @@ func (s *GenericPodService) SandboxReplaceInFiles(ctx context.Context, in *pb.Po
 	if err != nil {
 		return &pb.PodSandboxReplaceInFilesResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to replace in file",
+			ErrorMsg: fmt.Sprintf("Failed to replace in files at '%s': %s", in.ContainerPath, err.Error()),
 		}, nil
 	}
 
@@ -475,7 +475,7 @@ func (s *GenericPodService) SandboxFindInFiles(ctx context.Context, in *pb.PodSa
 	if err != nil {
 		return &pb.PodSandboxFindInFilesResponse{
 			Ok:       false,
-			ErrorMsg: "Failed to find files",
+			ErrorMsg: fmt.Sprintf("Failed to find '%s' in '%s': %s", in.Pattern, in.ContainerPath, err.Error()),
 		}, nil
 	}
 

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -1444,7 +1444,12 @@ class SandboxFileSystem:
             )
 
             if not response.ok:
-                raise SandboxFileSystemError(response.error_msg)
+                raise SandboxFileSystemError(
+                    message=response.error_msg,
+                    operation="upload_file",
+                    path=sandbox_path,
+                    container_id=self.sandbox_instance.container_id,
+                )
 
     def download_file(self, sandbox_path: str, local_path: str):
         """
@@ -1477,7 +1482,12 @@ class SandboxFileSystem:
         )
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="download_file",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         with open(local_path, "wb") as f:
             f.write(response.data)
@@ -1515,7 +1525,12 @@ class SandboxFileSystem:
             )
         )
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="stat_file",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         return SandboxFileInfo(
             **{
@@ -1567,7 +1582,12 @@ class SandboxFileSystem:
             )
         )
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="list_files",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         file_infos = []
         for file in response.files:
@@ -1602,7 +1622,12 @@ class SandboxFileSystem:
             )
         )
         if not resp.ok:
-            raise SandboxFileSystemError(resp.error_msg)
+            raise SandboxFileSystemError(
+                message=resp.error_msg,
+                operation="create_directory",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def delete_directory(self, sandbox_path: str):
         """
@@ -1621,7 +1646,12 @@ class SandboxFileSystem:
             )
         )
         if not resp.ok:
-            raise SandboxFileSystemError(resp.error_msg)
+            raise SandboxFileSystemError(
+                message=resp.error_msg,
+                operation="delete_directory",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def delete_file(self, sandbox_path: str):
         r"""
@@ -1652,7 +1682,12 @@ class SandboxFileSystem:
         )
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="delete_file",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def replace_in_files(self, sandbox_path: str, old_string: str, new_string: str):
         r"""
@@ -1689,7 +1724,12 @@ class SandboxFileSystem:
         )
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="replace_in_files",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
     def find_in_files(self, sandbox_path: str, pattern: str) -> List[SandboxFileSearchResult]:
         r"""
@@ -1748,7 +1788,12 @@ class SandboxFileSystem:
             results.append(SandboxFileSearchResult(path=result.path, matches=matches))
 
         if not response.ok:
-            raise SandboxFileSystemError(response.error_msg)
+            raise SandboxFileSystemError(
+                message=response.error_msg,
+                operation="find_in_files",
+                path=sandbox_path,
+                container_id=self.sandbox_instance.container_id,
+            )
 
         return results
 

--- a/sdk/src/beta9/exceptions.py
+++ b/sdk/src/beta9/exceptions.py
@@ -134,9 +134,14 @@ class SandboxProcessError(RuntimeError):
 
 
 class SandboxFileSystemError(RuntimeError):
-    def __init__(self, message: str):
+    def __init__(self, message: str, operation: str, path: str, container_id: str):
         self.message = message
-        super().__init__(f"Unable to perform sandbox filesystem operation: {message}")
+        self.operation = operation
+        self.path = path
+        self.container_id = container_id
+        super().__init__(
+            f"Sandbox filesystem error [{operation}] on '{path}' (container: {container_id}): {message}"
+        )
 
 
 class DockerException(RuntimeError):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved sandbox filesystem error reporting with clear, contextual messages and a structured exception in the SDK. This makes it easier to see which operation failed, on which path, and in which container.

- **Refactors**
  - Go services now return detailed error messages including the container path and underlying error across upload/download/stat/list/create/delete/replace/find.
  - SDK SandboxFileSystemError now includes operation, path, and container_id; all sandbox methods raise this with full context.

<sup>Written for commit 94cb11e9d6ad329d622ff4197fd653d30f1cf7dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

