### PR TITLE
fix: devices pointer should always be nil

### DIFF
--- a/pkg/runtime/runsc.go
+++ b/pkg/runtime/runsc.go
@@ -75,9 +75,13 @@ func (r *Runsc) Prepare(ctx context.Context, spec *specs.Spec) error {
 
 	if r.nvproxyEnabled {
 		r.mountCudaCheckpoint(spec)
-	} else {
-		spec.Linux.Devices = nil
 	}
+
+	// gVisor does not use spec.Linux.Devices for device passthrough.
+	// For GPU workloads, nvproxy handles GPU access via its own virtualization layer
+	// using CDI annotations and mounts, not device entries.
+	// Clear devices to prevent conflicts with nvproxy
+	spec.Linux.Devices = nil
 
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure spec.Linux.Devices is always cleared in Runsc.Prepare. This avoids conflicts with nvproxy GPU handling and aligns with gVisor, which doesn’t use device entries for passthrough.

<sup>Written for commit 98ed20a28c0fad61ae78ad5c276e4ee3bbafb4ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

