### PR TITLE
feat: add burst scheduling mode for cpu-only workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ build.sh
 okteto.yaml
 .vscode/launch.json
 pyrightconfig.json
-.go-version
+.go-version/gateway

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ build.sh
 okteto.yaml
 .vscode/launch.json
 pyrightconfig.json
-.go-version/gateway
+.go-version

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -14,6 +14,7 @@ type WorkerRepository interface {
 	GetId() string
 	GetWorkerById(workerId string) (*types.Worker, error)
 	GetAllWorkers() ([]*types.Worker, error)
+	GetAllWorkersLockFree() ([]*types.Worker, error)
 	GetAllWorkersInPool(poolName string) ([]*types.Worker, error)
 	CordonAllPendingWorkersInPool(poolName string) error
 	GetAllWorkersOnMachine(machineId string) ([]*types.Worker, error)

--- a/pkg/scheduler/backlog.go
+++ b/pkg/scheduler/backlog.go
@@ -59,7 +59,7 @@ func (rb *RequestBacklog) PopBatch(count int64) ([]*types.ContainerRequest, erro
 	for _, z := range result {
 		var req types.ContainerRequest
 		if err := json.Unmarshal([]byte(z.Member.(string)), &req); err != nil {
-			continue
+			return nil, err
 		}
 		requests = append(requests, &req)
 	}

--- a/pkg/scheduler/backlog.go
+++ b/pkg/scheduler/backlog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"sync"
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -13,55 +12,60 @@ import (
 
 type RequestBacklog struct {
 	rdb *common.RedisClient
-	mu  sync.Mutex
 }
 
 func NewRequestBacklog(rdb *common.RedisClient) *RequestBacklog {
 	return &RequestBacklog{rdb: rdb}
 }
 
-// Pushes a new container request into the sorted set
+// Redis sorted set, no mutex needed
 func (rb *RequestBacklog) Push(request *types.ContainerRequest) error {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
-
 	jsonData, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
-
-	// Use the timestamp as the score for sorting
 	timestamp := float64(request.Timestamp.UnixNano())
 	return rb.rdb.ZAdd(context.TODO(), common.RedisKeys.SchedulerContainerRequests(), redis.Z{Score: timestamp, Member: jsonData}).Err()
 }
 
-// Pops the oldest container request from the sorted set
 func (rb *RequestBacklog) Pop() (*types.ContainerRequest, error) {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
-
 	result, err := rb.rdb.ZPopMin(context.TODO(), common.RedisKeys.SchedulerContainerRequests(), 1).Result()
 	if err != nil {
 		return nil, err
 	}
-
 	if len(result) == 0 {
 		return nil, errors.New("backlog empty")
 	}
 
-	var poppedItem types.ContainerRequest
-	err = json.Unmarshal([]byte(result[0].Member.(string)), &poppedItem)
-	if err != nil {
+	var req types.ContainerRequest
+	if err := json.Unmarshal([]byte(result[0].Member.(string)), &req); err != nil {
 		return nil, err
 	}
 
-	return &poppedItem, nil
+	return &req, nil
 }
 
-// Gets the length of the sorted set
-func (rb *RequestBacklog) Len() int64 {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
+// PopBatch pops up to count requests from backlog atomically
+func (rb *RequestBacklog) PopBatch(count int64) ([]*types.ContainerRequest, error) {
+	result, err := rb.rdb.ZPopMin(context.TODO(), common.RedisKeys.SchedulerContainerRequests(), count).Result()
+	if err != nil {
+		return nil, err
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
 
+	requests := make([]*types.ContainerRequest, 0, len(result))
+	for _, z := range result {
+		var req types.ContainerRequest
+		if err := json.Unmarshal([]byte(z.Member.(string)), &req); err != nil {
+			continue
+		}
+		requests = append(requests, &req)
+	}
+	return requests, nil
+}
+
+func (rb *RequestBacklog) Len() int64 {
 	return rb.rdb.ZCard(context.TODO(), common.RedisKeys.SchedulerContainerRequests()).Val()
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -491,21 +491,6 @@ func (s *Scheduler) processRequest(request *types.ContainerRequest) {
 		}
 	}
 
-	// Standard provisioning
-	controllers, err := s.getControllers(request)
-	if err == nil {
-		for _, c := range controllers {
-			if c == nil {
-				continue
-			}
-			newWorker, err := c.AddWorker(request.Cpu, request.Memory, request.GpuCount)
-			if err == nil && s.scheduleOnWorker(newWorker, request) == nil {
-				metrics.RecordRequestSchedulingDuration(time.Since(request.Timestamp), request)
-				return
-			}
-		}
-	}
-
 	// CPU batching
 	if request.GpuCount == 0 && s.shouldUseCpuBatching() {
 		if s.addToCpuBatch(request) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -389,8 +389,11 @@ func shuffleWorkers(workers []*types.Worker) []*types.Worker {
 
 // Process single request with pre-fetched workers
 func (s *Scheduler) processRequestWithWorkers(request *types.ContainerRequest, workers []*types.Worker) {
+	filteredWorkers := filterWorkersByPoolSelector(workers, request)
+	filteredWorkers = filterWorkersByFlags(filteredWorkers, request)
+
 	// Try existing workers
-	for _, w := range workers {
+	for _, w := range filteredWorkers {
 		// Quick capacity check
 		if w.FreeCpu < request.Cpu || w.FreeMemory < request.Memory {
 			continue
@@ -461,8 +464,11 @@ func (s *Scheduler) processRequest(request *types.ContainerRequest) {
 			continue
 		}
 
+		filteredWorkers := filterWorkersByPoolSelector(workers, request)
+		filteredWorkers = filterWorkersByFlags(filteredWorkers, request)
+
 		// Try each suitable worker
-		for _, worker := range workers {
+		for _, worker := range filteredWorkers {
 			if worker.FreeCpu < request.Cpu || worker.FreeMemory < request.Memory {
 				continue
 			}


### PR DESCRIPTION














<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds burst scheduling for CPU-only workloads and batch provisioning to pack requests onto fewer, larger workers. This improves throughput, cuts provisioning overhead, and prevents double-scheduling via optimistic locking.

- **New Features**
  - Burst mode: when backlog is high, provision a larger CPU worker (with safety caps) and schedule immediately.
  - CPU batch provisioning: when CPU-only backlog is high, provision one worker sized for the batch and schedule all.
  - Batch request processing: PopBatch from Redis, run a worker pool with a semaphore, and reuse a shared worker list per batch.
  - Lock-free worker reads plus optimistic locking (resource version checks) to avoid capacity races and double-allocation.
  - Smarter retries and shorter locks to handle contention without requeue storms.

- **Bug Fixes**
  - Prometheus metrics registration made thread-safe (double-checked locking) to prevent duplicate collector panics.
  - More resilient image caching: file locking, atomic writes, and exponential backoff; correct CLIP v2 detection and logging.

<sup>Written for commit 150eee26fd3571dc3c037f5af6450a95d235be83. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













