### PR TITLE
fix: bump max message sizes

### DIFF
--- a/pkg/worker/container_server.go
+++ b/pkg/worker/container_server.go
@@ -32,6 +32,11 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const (
+	gRPCMaxRecvMsgSize = 1024 * 1024 * 16
+	gRPCMaxSendMsgSize = 1024 * 1024 * 16
+)
+
 // ContainerRuntimeServer is a runtime-agnostic container server that works with any OCI runtime
 type ContainerRuntimeServer struct {
 	baseConfigSpec specs.Spec
@@ -99,7 +104,11 @@ func (s *ContainerRuntimeServer) Start() error {
 	s.port = listener.Addr().(*net.TCPAddr).Port
 	log.Info().Int("port", s.port).Msg("container runtime server started")
 
-	s.grpcServer = grpc.NewServer()
+	s.grpcServer = grpc.NewServer(
+		grpc.MaxRecvMsgSize(gRPCMaxRecvMsgSize),
+		grpc.MaxSendMsgSize(gRPCMaxSendMsgSize),
+	)
+
 	pb.RegisterContainerServiceServer(s.grpcServer, s)
 
 	go func() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase gRPC send and receive message size limits to 16 MB in the container runtime server to support larger payloads. Prevents errors and timeouts when handling big specs or log streams.

<sup>Written for commit 917cd42a46272c046d71e05cf7b5d15781391163. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

