### PR TITLE
Bumped SDK Version

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.242"
+version = "0.1.243"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped SDK version to 0.1.243 to publish the next patch release. Updates pyproject.toml only.

<sup>Written for commit 24c62fe9890dd3e18645f886ab71002c64a132fd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

