### PR TITLE
Increase GRPC Proxy Upload Limit

### DIFF
--- a/pkg/common/container_client.go
+++ b/pkg/common/container_client.go
@@ -58,12 +58,13 @@ func (c *ContainerClient) connect() error {
 	}
 
 	maxMessageSize := 1 << 30 // 1Gi
+	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(maxMessageSize),
+		grpc.MaxCallSendMsgSize(maxMessageSize),
+	))
+
 	if c.ServiceToken != "" {
-		dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(GRPCClientAuthInterceptor(c.ServiceToken)),
-			grpc.WithDefaultCallOptions(
-				grpc.MaxCallRecvMsgSize(maxMessageSize),
-				grpc.MaxCallSendMsgSize(maxMessageSize),
-			))
+		dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(GRPCClientAuthInterceptor(c.ServiceToken)))
 	}
 
 	conn, err := grpc.Dial(c.ServiceUrl, dialOpts...)

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -264,7 +264,13 @@ func (g *Gateway) initGrpcProxy(grpcAddr string) error {
 		cancel()
 	})
 	mux := runtime.NewServeMux()
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(g.Config.GatewayService.GRPC.MaxRecvMsgSize*1024*1024),
+			grpc.MaxCallSendMsgSize(g.Config.GatewayService.GRPC.MaxSendMsgSize*1024*1024),
+		),
+	}
 	if err := pb.RegisterPodServiceHandlerFromEndpoint(ctx, mux, grpcAddr, opts); err != nil {
 		return err
 	}

--- a/sdk/src/beta9/channel.py
+++ b/sdk/src/beta9/channel.py
@@ -142,7 +142,10 @@ def handle_grpc_error(error: grpc.RpcError):
     elif code == grpc.StatusCode.CANCELLED:
         return
     elif code == grpc.StatusCode.RESOURCE_EXHAUSTED:
-        terminal.error("Please ensure your payload or function arguments are less than 4 MiB.")
+        terminal.error(
+            f"Message size exceeds the gRPC limit. "
+            f"Please ensure your payload or function arguments are less than {GRPC_MAX_MESSAGE_SIZE // (1024 * 1024)} MiB."
+        )
     elif code == grpc.StatusCode.UNKNOWN:
         terminal.error(f"Error {details}")
     else:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raised gRPC message size limits to support larger uploads through the gateway proxy and container client. Improved SDK error messaging to show the actual configured limit.

- **New Features**
  - Gateway gRPC proxy sets MaxRecvMsgSize and MaxSendMsgSize from config (in MiB).
  - ContainerClient always applies 1 GiB max send/recv, regardless of auth token.
  - Python SDK shows the current gRPC max size in RESOURCE_EXHAUSTED errors.

<sup>Written for commit e0edc43b0b4dcbdf5be2dc5e114b97704c0f1518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

