### PR TITLE
fix multi-gpu assignment

### DIFF
--- a/pkg/worker/gpu_info.go
+++ b/pkg/worker/gpu_info.go
@@ -61,15 +61,17 @@ var resolveVisibleDevices = func() string {
 		return os.Getenv("NVIDIA_VISIBLE_DEVICES")
 	}
 
+	var allUUIDs []string
 	for _, entry := range checkpoint.Data.PodDeviceEntries {
 		if entry.PodUID != podUID || entry.ResourceName != "nvidia.com/gpu" {
 			continue
 		}
 		for _, uuids := range entry.DeviceIDs {
-			if len(uuids) > 0 {
-				return strings.Join(uuids, ",")
-			}
+			allUUIDs = append(allUUIDs, uuids...)
 		}
+	}
+	if len(allUUIDs) > 0 {
+		return strings.Join(allUUIDs, ",")
 	}
 
 	return os.Getenv("NVIDIA_VISIBLE_DEVICES")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes multi‑GPU assignment by aggregating all assigned GPU UUIDs from the kubelet checkpoint so multi‑GPU pods see all devices via `NVIDIA_VISIBLE_DEVICES`.

- **Bug Fixes**
  - Collects all `DeviceIDs` for `nvidia.com/gpu` across matching entries and joins them into a single list.
  - Falls back to `NVIDIA_VISIBLE_DEVICES` env var when no UUIDs are found.

<sup>Written for commit 22571c31007e80d563de4f602f5de57a6949b6d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

