### PR TITLE
fix: clean up cache args

### DIFF
--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -293,7 +293,7 @@ func (cs *Server) Serve(bindAddr string, advertiseHost string) (string, error) {
 	if tcpAddr, ok := localListener.Addr().(*net.TCPAddr); ok {
 		port := fmt.Sprintf("%d", tcpAddr.Port)
 		if advertiseHost != "" {
-			advertiseAddr = net.JoinHostPort(advertiseHost, port)
+			advertiseAddr = net.JoinHostPort(normalizeAdvertiseHost(advertiseHost), port)
 		} else if cs.privateIpAddr != "" {
 			advertiseAddr = net.JoinHostPort(cs.privateIpAddr, port)
 		} else {
@@ -324,6 +324,14 @@ func (cs *Server) Serve(bindAddr string, advertiseHost string) (string, error) {
 	}()
 
 	return advertiseAddr, nil
+}
+
+func normalizeAdvertiseHost(host string) string {
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+
+	return host
 }
 
 func (cs *Server) StartServer(port uint) error {

--- a/pkg/cache/server_test.go
+++ b/pkg/cache/server_test.go
@@ -1,0 +1,20 @@
+package cache
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAdvertiseHostForJoinHostPort(t *testing.T) {
+	host := normalizeAdvertiseHost("[2600:1f18:37a4:c02::c0dd]")
+	require.Equal(t, "2600:1f18:37a4:c02::c0dd", host)
+	require.Equal(t, "[2600:1f18:37a4:c02::c0dd]:2049", net.JoinHostPort(host, "2049"))
+}
+
+func TestNormalizeAdvertiseHostLeavesIPv4HostUnchanged(t *testing.T) {
+	host := normalizeAdvertiseHost("10.100.61.10")
+	require.Equal(t, "10.100.61.10", host)
+	require.Equal(t, "10.100.61.10:2049", net.JoinHostPort(host, "2049"))
+}

--- a/pkg/cache/server_test.go
+++ b/pkg/cache/server_test.go
@@ -18,3 +18,9 @@ func TestNormalizeAdvertiseHostLeavesIPv4HostUnchanged(t *testing.T) {
 	require.Equal(t, "10.100.61.10", host)
 	require.Equal(t, "10.100.61.10:2049", net.JoinHostPort(host, "2049"))
 }
+
+func TestNormalizeAdvertiseHostLeavesDNSHostUnchanged(t *testing.T) {
+	host := normalizeAdvertiseHost("machine-abc123.tailnet.example")
+	require.Equal(t, "machine-abc123.tailnet.example", host)
+	require.Equal(t, "machine-abc123.tailnet.example:2049", net.JoinHostPort(host, "2049"))
+}

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -165,6 +165,12 @@ worker:
       containerRuntimeConfig:
         gvisorPlatform: systrap
         gvisorRoot: /run/gvisor
+      # Optional per-pool cache disk override for nodes with different storage layouts.
+      # cache:
+      #   disk:
+      #     hostPath: /mnt/nvme/beta9/cache
+      #     mountPath: /var/lib/beta9/cache
+      #     maxUsagePct: 0.95
       jobSpec:
         nodeSelector: {}
       criuEnabled: true
@@ -184,6 +190,11 @@ worker:
       containerRuntimeConfig:
         gvisorPlatform: systrap
         gvisorRoot: /run/gvisor
+      # Optional per-pool cache disk override.
+      # cache:
+      #   disk:
+      #     hostPath: /mnt/build-cache/beta9/cache
+      #     mountPath: /var/lib/beta9/cache
       tmpSizeLimit: 50Gi
       jobSpec:
         nodeSelector: {}

--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -89,18 +89,33 @@ func GenerateWorkerId() string {
 	return uuid.New().String()[:8]
 }
 
-func workerCacheEnabled(config types.AppConfig) bool {
-	return config.Cache.Enabled && config.Worker.CacheEnabled && config.Cache.Disk.Enabled
+func workerCacheEnabled(config types.AppConfig, poolConfig types.WorkerPoolConfig) bool {
+	if !config.Cache.Enabled || !config.Worker.CacheEnabled {
+		return false
+	}
+	if poolConfig.Cache.Enabled != nil && !*poolConfig.Cache.Enabled {
+		return false
+	}
+	if poolConfig.Cache.Disk.Enabled != nil {
+		return *poolConfig.Cache.Disk.Enabled
+	}
+	return config.Cache.Disk.Enabled
 }
 
-func workerCacheHostPath(config types.AppConfig) string {
+func workerCacheHostPath(config types.AppConfig, poolConfig types.WorkerPoolConfig) string {
+	if poolConfig.Cache.Disk.HostPath != "" {
+		return poolConfig.Cache.Disk.HostPath
+	}
 	if config.Cache.Disk.HostPath != "" {
 		return config.Cache.Disk.HostPath
 	}
 	return defaultCachePath
 }
 
-func workerCacheMountPath(config types.AppConfig) string {
+func workerCacheMountPath(config types.AppConfig, poolConfig types.WorkerPoolConfig) string {
+	if poolConfig.Cache.Disk.MountPath != "" {
+		return poolConfig.Cache.Disk.MountPath
+	}
 	if config.Cache.Disk.MountPath != "" {
 		return config.Cache.Disk.MountPath
 	}

--- a/pkg/scheduler/pool_cache_test.go
+++ b/pkg/scheduler/pool_cache_test.go
@@ -1,0 +1,117 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestWorkerCachePoolDiskOverrides(t *testing.T) {
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   true,
+				HostPath:  "/var/lib/beta9/cache",
+				MountPath: "/var/lib/beta9/cache",
+			},
+		},
+	}
+	poolConfig := types.WorkerPoolConfig{
+		Cache: types.WorkerPoolCacheConfig{
+			Disk: types.WorkerPoolCacheDiskConfig{
+				HostPath:  "/mnt/nvme/beta9/cache",
+				MountPath: "/cache-disk",
+			},
+		},
+	}
+
+	require.True(t, workerCacheEnabled(config, poolConfig))
+	require.Equal(t, "/mnt/nvme/beta9/cache", workerCacheHostPath(config, poolConfig))
+	require.Equal(t, "/cache-disk", workerCacheMountPath(config, poolConfig))
+}
+
+func TestWorkerCachePoolCanDisableDiskCache(t *testing.T) {
+	disabled := false
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk:    cache.DiskConfig{Enabled: true},
+		},
+	}
+	poolConfig := types.WorkerPoolConfig{
+		Cache: types.WorkerPoolCacheConfig{
+			Disk: types.WorkerPoolCacheDiskConfig{Enabled: &disabled},
+		},
+	}
+
+	require.False(t, workerCacheEnabled(config, poolConfig))
+}
+
+func TestWorkerCacheHostPathIsCreatedForLocalPools(t *testing.T) {
+	config, poolConfig := cacheVolumeTestConfig()
+	controller := &LocalKubernetesWorkerPoolController{
+		config:           config,
+		workerPoolConfig: poolConfig,
+	}
+
+	volume := requireCacheVolume(t, controller.getWorkerVolumes(1024))
+	require.Equal(t, "/mnt/nvme/beta9/cache", volume.HostPath.Path)
+	require.NotNil(t, volume.HostPath.Type)
+	require.Equal(t, corev1.HostPathDirectoryOrCreate, *volume.HostPath.Type)
+}
+
+func TestWorkerCacheHostPathIsCreatedForExternalPools(t *testing.T) {
+	config, poolConfig := cacheVolumeTestConfig()
+	controller := &ExternalWorkerPoolController{
+		config:           config,
+		workerPoolConfig: poolConfig,
+	}
+
+	volume := requireCacheVolume(t, controller.getWorkerVolumes(1024))
+	require.Equal(t, "/mnt/nvme/beta9/cache", volume.HostPath.Path)
+	require.NotNil(t, volume.HostPath.Type)
+	require.Equal(t, corev1.HostPathDirectoryOrCreate, *volume.HostPath.Type)
+}
+
+func cacheVolumeTestConfig() (types.AppConfig, types.WorkerPoolConfig) {
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   true,
+				HostPath:  "/var/lib/beta9/cache",
+				MountPath: "/var/lib/beta9/cache",
+			},
+		},
+	}
+	poolConfig := types.WorkerPoolConfig{
+		Cache: types.WorkerPoolCacheConfig{
+			Disk: types.WorkerPoolCacheDiskConfig{
+				HostPath: "/mnt/nvme/beta9/cache",
+			},
+		},
+	}
+
+	return config, poolConfig
+}
+
+func requireCacheVolume(t *testing.T, volumes []corev1.Volume) corev1.Volume {
+	t.Helper()
+
+	for _, volume := range volumes {
+		if volume.Name == cacheVolumeName {
+			require.NotNil(t, volume.HostPath)
+			return volume
+		}
+	}
+
+	t.Fatalf("expected cache volume to be attached")
+	return corev1.Volume{}
+}

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -623,12 +623,12 @@ func (wpc *ExternalWorkerPoolController) getWorkerVolumes(workerMemory int64) []
 		})
 	}
 
-	if workerCacheEnabled(wpc.config) {
+	if workerCacheEnabled(wpc.config, wpc.workerPoolConfig) {
 		volumes = append(volumes, corev1.Volume{
 			Name: cacheVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: workerCacheHostPath(wpc.config),
+					Path: workerCacheHostPath(wpc.config, wpc.workerPoolConfig),
 					Type: &hostPathType,
 				},
 			},
@@ -694,10 +694,10 @@ func (wpc *ExternalWorkerPoolController) getWorkerVolumeMounts() []corev1.Volume
 		})
 	}
 
-	if workerCacheEnabled(wpc.config) {
+	if workerCacheEnabled(wpc.config, wpc.workerPoolConfig) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      cacheVolumeName,
-			MountPath: workerCacheMountPath(wpc.config),
+			MountPath: workerCacheMountPath(wpc.config, wpc.workerPoolConfig),
 			ReadOnly:  false,
 		})
 	}

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -376,12 +376,12 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerVolumes(workerMemory in
 		})
 	}
 
-	if workerCacheEnabled(wpc.config) {
+	if workerCacheEnabled(wpc.config, wpc.workerPoolConfig) {
 		volumes = append(volumes, corev1.Volume{
 			Name: cacheVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: workerCacheHostPath(wpc.config),
+					Path: workerCacheHostPath(wpc.config, wpc.workerPoolConfig),
 					Type: &hostPathType,
 				},
 			},
@@ -448,10 +448,10 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerVolumeMounts() []corev1
 		})
 	}
 
-	if workerCacheEnabled(wpc.config) {
+	if workerCacheEnabled(wpc.config, wpc.workerPoolConfig) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      cacheVolumeName,
-			MountPath: workerCacheMountPath(wpc.config),
+			MountPath: workerCacheMountPath(wpc.config, wpc.workerPoolConfig),
 			ReadOnly:  false,
 		})
 	}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -426,6 +426,19 @@ type WorkerPoolConfig struct {
 	StoragePath               string                            `key:"storagePath" json:"storage_path"`
 	StorageMode               string                            `key:"storageMode" json:"storage_mode"`
 	CheckpointPath            string                            `key:"checkpointPath" json:"checkpoint_path"`
+	Cache                     WorkerPoolCacheConfig             `key:"cache" json:"cache"`
+}
+
+type WorkerPoolCacheConfig struct {
+	Enabled *bool                     `key:"enabled" json:"enabled"`
+	Disk    WorkerPoolCacheDiskConfig `key:"disk" json:"disk"`
+}
+
+type WorkerPoolCacheDiskConfig struct {
+	Enabled     *bool   `key:"enabled" json:"enabled"`
+	HostPath    string  `key:"hostPath" json:"host_path"`
+	MountPath   string  `key:"mountPath" json:"mount_path"`
+	MaxUsagePct float64 `key:"maxUsagePct" json:"max_usage_pct"`
 }
 
 type RuntimeConfig struct {

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -61,6 +61,7 @@ type WorkerCacheManager struct {
 	ctx            context.Context
 	cancel         context.CancelFunc
 	config         types.AppConfig
+	poolConfig     types.WorkerPoolConfig
 	redis          *common.RedisClient
 	workerID       string
 	instanceID     string
@@ -86,6 +87,7 @@ func NewWorkerCacheManager(ctx context.Context, config types.AppConfig, poolConf
 		ctx:        cacheCtx,
 		cancel:     cancel,
 		config:     config,
+		poolConfig: poolConfig,
 		redis:      redisClient,
 		workerID:   workerID,
 		instanceID: cacheWorkerInstanceID(workerID),
@@ -102,7 +104,7 @@ func (m *WorkerCacheManager) Start() (*cache.Client, error) {
 		return nil, nil
 	}
 
-	cacheConfig := normalizeCacheConfig(m.config, m.nodeID, m.locality)
+	cacheConfig := normalizeCacheConfig(m.config, m.poolConfig, m.nodeID, m.locality)
 	registry := cache.NewRedisRegistryWithClient(cacheConfig.Global, cacheConfig.Server, m.redis.UniversalClient)
 	m.registry = registry
 
@@ -156,7 +158,16 @@ func (m *WorkerCacheManager) Close() error {
 }
 
 func (m *WorkerCacheManager) enabled() bool {
-	return m.config.Cache.Enabled && m.config.Worker.CacheEnabled
+	if !m.config.Cache.Enabled || !m.config.Worker.CacheEnabled {
+		return false
+	}
+	if m.poolConfig.Cache.Enabled != nil && !*m.poolConfig.Cache.Enabled {
+		return false
+	}
+	if m.poolConfig.Cache.Disk.Enabled != nil {
+		return *m.poolConfig.Cache.Disk.Enabled
+	}
+	return m.config.Cache.Disk.Enabled
 }
 
 func (m *WorkerCacheManager) runReplicaElection(cacheConfig cache.Config) {
@@ -424,7 +435,7 @@ func (m *WorkerCacheManager) releaseActiveLease(ctx context.Context) error {
 	return m.releaseLeaseKey(ctx, leaseKey)
 }
 
-func normalizeCacheConfig(config types.AppConfig, nodeID, locality string) cache.Config {
+func normalizeCacheConfig(config types.AppConfig, poolConfig types.WorkerPoolConfig, nodeID, locality string) cache.Config {
 	cacheConfig := config.Cache
 
 	if cacheConfig.Global.DefaultLocality == "" {
@@ -482,6 +493,7 @@ func normalizeCacheConfig(config types.AppConfig, nodeID, locality string) cache
 	if cacheConfig.Disk.MaxUsagePct == 0 {
 		cacheConfig.Disk.MaxUsagePct = cacheDefaultDiskMaxUsage
 	}
+	applyWorkerPoolCacheOverrides(&cacheConfig, poolConfig)
 
 	if cacheConfig.Server.Mode == "" {
 		cacheConfig.Server.Mode = cache.ServerModeNode
@@ -520,6 +532,24 @@ func normalizeCacheConfig(config types.AppConfig, nodeID, locality string) cache
 
 	applyCacheRedisConfig(&cacheConfig, config.Database.Redis)
 	return cacheConfig
+}
+
+func applyWorkerPoolCacheOverrides(cacheConfig *cache.Config, poolConfig types.WorkerPoolConfig) {
+	if poolConfig.Cache.Disk.Enabled != nil {
+		cacheConfig.Disk.Enabled = *poolConfig.Cache.Disk.Enabled
+	}
+	if poolConfig.Cache.Disk.HostPath != "" {
+		cacheConfig.Disk.HostPath = poolConfig.Cache.Disk.HostPath
+	}
+	if poolConfig.Cache.Disk.MountPath != "" {
+		cacheConfig.Disk.MountPath = poolConfig.Cache.Disk.MountPath
+	}
+	if poolConfig.Cache.Disk.MaxUsagePct > 0 {
+		cacheConfig.Disk.MaxUsagePct = poolConfig.Cache.Disk.MaxUsagePct
+	}
+	if poolConfig.Cache.Enabled != nil && !*poolConfig.Cache.Enabled {
+		cacheConfig.Disk.Enabled = false
+	}
 }
 
 func applyCacheRedisConfig(cacheConfig *cache.Config, redisConfig types.RedisConfig) {

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -1,0 +1,61 @@
+package worker
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeCacheConfigAppliesPoolDiskOverrides(t *testing.T) {
+	config := types.AppConfig{
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:     true,
+				HostPath:    "/var/lib/beta9/cache",
+				MountPath:   "/var/lib/beta9/cache",
+				MaxUsagePct: 0.95,
+			},
+		},
+	}
+	poolConfig := types.WorkerPoolConfig{
+		Cache: types.WorkerPoolCacheConfig{
+			Disk: types.WorkerPoolCacheDiskConfig{
+				HostPath:    "/mnt/a100-cache",
+				MountPath:   "/cache-disk",
+				MaxUsagePct: 0.85,
+			},
+		},
+	}
+
+	got := normalizeCacheConfig(config, poolConfig, "node-a", "gpu")
+
+	require.Equal(t, "/mnt/a100-cache", got.Disk.HostPath)
+	require.Equal(t, "/cache-disk", got.Disk.MountPath)
+	require.Equal(t, 0.85, got.Disk.MaxUsagePct)
+	require.Equal(t, filepath.Join("/cache-disk", "gpu", "node-a"), got.Server.DiskCacheDir)
+	require.Equal(t, 0.85, got.Server.DiskCacheMaxUsagePct)
+}
+
+func TestWorkerCacheManagerDisabledWhenPoolDiskCacheDisabled(t *testing.T) {
+	disabled := false
+	manager := &WorkerCacheManager{
+		config: types.AppConfig{
+			Worker: types.WorkerConfig{CacheEnabled: true},
+			Cache: cache.Config{
+				Enabled: true,
+				Disk:    cache.DiskConfig{Enabled: true},
+			},
+		},
+		poolConfig: types.WorkerPoolConfig{
+			Cache: types.WorkerPoolCacheConfig{
+				Disk: types.WorkerPoolCacheDiskConfig{Enabled: &disabled},
+			},
+		},
+	}
+
+	require.False(t, manager.enabled())
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds pool-level cache config (enable/disable, disk paths, max usage) and fixes cache server advertise host formatting. Schedulers and workers honor per-pool overrides and create cache host paths when needed.

- **New Features**
  - Pool-level cache overrides: `enabled`, disk `hostPath`, `mountPath`, `maxUsagePct` via `WorkerPoolCacheConfig` and `WorkerPoolCacheDiskConfig`.
  - Scheduler mounts cache volumes for local/external pools; `hostPath` uses DirectoryOrCreate.
  - Worker cache manager applies pool overrides; disk cache can be disabled per pool.
  - `config.default.yaml` documents per-pool cache examples.

- **Bug Fixes**
  - `pkg/cache/server`: normalize IPv6 `advertiseHost` (strip brackets) before `net.JoinHostPort`; IPv4 and DNS hosts unchanged.
  - Correct worker cache enablement to respect pool-level disables.

Tests added: `pkg/cache/server_test.go`, `pkg/scheduler/pool_cache_test.go`, `pkg/worker/cache_manager_test.go`.

<sup>Written for commit 4b107909e2557174ca0209d2f598950e35a889eb. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1565?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

