### PR TITLE
fix: clean up locking logic

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -763,13 +763,19 @@ func (c *Client) withStoreFromContentLock(ctx context.Context, sourcePath string
 		return "", ErrUnableToAcquireLock
 	}
 	lockReleased := false
+	releaseLock := func() error {
+		if err := c.coordinator.RemoveStoreFromContentLock(ctx, c.locality, sourcePath); err != nil {
+			Logger.Errorf("StoreContent[ERR] - error removing lock: %v", err)
+			return err
+		}
+		lockReleased = true
+		return nil
+	}
 	defer func() {
 		if lockReleased {
 			return
 		}
-		if err := c.coordinator.RemoveStoreFromContentLock(ctx, c.locality, sourcePath); err != nil {
-			Logger.Errorf("StoreContent[ERR] - error removing lock: %v", err)
-		}
+		_ = releaseLock()
 	}()
 
 	storeContext, cancel := context.WithCancel(ctx)
@@ -795,10 +801,9 @@ func (c *Client) withStoreFromContentLock(ctx context.Context, sourcePath string
 		return hash, err
 	}
 
-	if err := c.coordinator.RemoveStoreFromContentLock(ctx, c.locality, sourcePath); err != nil {
-		Logger.Errorf("StoreContent[ERR] - error removing lock: %v", err)
+	if err := releaseLock(); err != nil {
+		return hash, err
 	}
-	lockReleased = true
 	return hash, nil
 }
 

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithStoreFromContentLockReturnsUnlockErrorAndRetriesDeferredRelease(t *testing.T) {
+	registry := &failFirstUnlockRegistry{MockRegistry: NewMockRegistry()}
+	client := &Client{
+		ctx:         context.Background(),
+		locality:    "test",
+		coordinator: registry,
+	}
+
+	hash, err := client.withStoreFromContentLock(context.Background(), "/source", true, func() (string, error) {
+		return "hash", nil
+	})
+
+	require.Equal(t, "hash", hash)
+	require.ErrorContains(t, err, "unlock failed")
+	require.Equal(t, 2, registry.removeCalls)
+	require.False(t, registry.locks["store-lock:test:/source"])
+}
+
+type failFirstUnlockRegistry struct {
+	*MockRegistry
+	removeCalls int
+}
+
+func (r *failFirstUnlockRegistry) RemoveStoreFromContentLock(ctx context.Context, locality string, sourcePath string) error {
+	r.removeCalls++
+	if r.removeCalls == 1 {
+		return errors.New("unlock failed")
+	}
+	return r.MockRegistry.RemoveStoreFromContentLock(ctx, locality, sourcePath)
+}

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -39,6 +40,7 @@ type Store struct {
 	metrics                 CacheMetrics
 	bufferPool              *BufferPool
 	prefetcher              *Prefetcher
+	closing                 atomic.Bool
 }
 
 func NewStore(ctx context.Context, currentHost *Host, locality string, coordinator Registry, config Config) (*Store, error) {
@@ -191,6 +193,13 @@ func (cas *Store) AddReader(ctx context.Context, reader io.Reader) (string, int6
 	if cas.serverConfig.PageSizeBytes <= 0 {
 		return "", 0, errors.New("invalid page size")
 	}
+	if cas.diskCachedUsageExceeded {
+		if !cas.memoryCacheEnabled {
+			return "", 0, errors.New("disk cache capacity exceeded")
+		}
+		return cas.addReaderToMemory(ctx, reader)
+	}
+
 	if err := os.MkdirAll(cas.diskCacheDir, 0755); err != nil {
 		return "", 0, fmt.Errorf("failed to create cache directory: %w", err)
 	}
@@ -239,13 +248,8 @@ func (cas *Store) AddReader(ctx context.Context, reader io.Reader) (string, int6
 
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	dirPath := filepath.Join(cas.diskCacheDir, hash)
-	if cas.diskCachedUsageExceeded && !cas.memoryCacheEnabled {
-		return "", size, errors.New("disk cache capacity exceeded")
-	}
-	if !cas.diskCachedUsageExceeded {
-		if err := os.MkdirAll(dirPath, 0755); err != nil {
-			return "", size, fmt.Errorf("failed to create cache directory: %w", err)
-		}
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return "", size, fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
 	chunkKeys := make([]string, 0, chunkCount)
@@ -253,21 +257,16 @@ func (cas *Store) AddReader(ctx context.Context, reader io.Reader) (string, int6
 		chunkKey := fmt.Sprintf("%s-%d", hash, chunkIdx)
 		chunkKeys = append(chunkKeys, chunkKey)
 
-		if !cas.diskCachedUsageExceeded {
-			tempChunkPath := filepath.Join(tempDir, fmt.Sprintf("chunk-%d", chunkIdx))
-			filePath := filepath.Join(dirPath, chunkKey)
-			if err := linkCacheChunkAtomic(tempChunkPath, filePath); err != nil {
-				return "", size, fmt.Errorf("failed to install cache chunk: %w", err)
-			}
+		tempChunkPath := filepath.Join(tempDir, fmt.Sprintf("chunk-%d", chunkIdx))
+		filePath := filepath.Join(dirPath, chunkKey)
+		if err := linkCacheChunkAtomic(tempChunkPath, filePath); err != nil {
+			return "", size, fmt.Errorf("failed to install cache chunk: %w", err)
 		}
 	}
 
 	if cas.memoryCacheEnabled {
-		for chunkIdx, chunkKey := range chunkKeys {
+		for _, chunkKey := range chunkKeys {
 			filePath := filepath.Join(dirPath, chunkKey)
-			if cas.diskCachedUsageExceeded {
-				filePath = filepath.Join(tempDir, fmt.Sprintf("chunk-%d", chunkIdx))
-			}
 			chunk, err := os.ReadFile(filePath)
 			if err != nil {
 				return "", size, fmt.Errorf("failed to read cache chunk for memory cache: %w", err)
@@ -287,6 +286,60 @@ func (cas *Store) AddReader(ctx context.Context, reader io.Reader) (string, int6
 	}
 
 	Logger.Debugf("Added object: %s, size: %d bytes", hash, size)
+	return hash, size, nil
+}
+
+func (cas *Store) addReaderToMemory(ctx context.Context, reader io.Reader) (string, int64, error) {
+	hasher := sha256.New()
+	pageSize := int(cas.serverConfig.PageSizeBytes)
+	buf := make([]byte, pageSize)
+	chunks := make([][]byte, 0)
+	var size int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", size, err
+		}
+
+		n, readErr := reader.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			if _, err := hasher.Write(chunk); err != nil {
+				return "", size, err
+			}
+
+			chunks = append(chunks, chunk)
+			size += int64(n)
+		}
+
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return "", size, readErr
+		}
+	}
+
+	hash := hex.EncodeToString(hasher.Sum(nil))
+	chunkKeys := make([]string, 0, len(chunks))
+	for chunkIdx, chunk := range chunks {
+		chunkKey := fmt.Sprintf("%s-%d", hash, chunkIdx)
+		chunkKeys = append(chunkKeys, chunkKey)
+
+		added := cas.cache.Set(chunkKey, cacheValue{Hash: hash, Content: chunk}, int64(len(chunk)))
+		if !added {
+			return "", size, errors.New("unable to cache: set dropped")
+		}
+	}
+
+	chunksValue := strings.Join(chunkKeys, ",")
+	added := cas.cache.SetWithTTL(hash, chunksValue, int64(len(chunksValue)), time.Duration(cas.serverConfig.ObjectTtlS)*time.Second)
+	if !added {
+		return "", size, errors.New("unable to cache: set dropped")
+	}
+
+	Logger.Debugf("Added object to memory cache: %s, size: %d bytes", hash, size)
 	return hash, size, nil
 }
 
@@ -509,6 +562,10 @@ func (cas *Store) getFromDiskCache(hash, chunkKey string) (value cacheValue, fou
 }
 
 func (cas *Store) onEvict(item *ristretto.Item[interface{}]) {
+	if cas.closing.Load() {
+		return
+	}
+
 	hash := ""
 	var chunkKeys []string = []string{}
 
@@ -539,6 +596,7 @@ func (cas *Store) onEvict(item *ristretto.Item[interface{}]) {
 
 func (cas *Store) Cleanup() {
 	if cas.cache != nil {
+		cas.closing.Store(true)
 		cas.cache.Close()
 	}
 }

--- a/pkg/cache/storage_test.go
+++ b/pkg/cache/storage_test.go
@@ -6,7 +6,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/stretchr/testify/require"
@@ -64,6 +66,57 @@ func TestStoreAddReaderStoresEmptyContent(t *testing.T) {
 	n, err := store.Get(hash, 0, 0, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), n)
+}
+
+func TestStoreAddReaderFallsBackToMemoryWhenDiskExceeded(t *testing.T) {
+	InitLogger(false, false)
+
+	cacheDir := filepath.Join(t.TempDir(), "cache-dir")
+	store, err := NewStore(context.Background(), &Host{HostId: "test-host"}, "test", NewMockRegistry(), Config{
+		Server: ServerConfig{
+			DiskCacheDir:         cacheDir,
+			DiskCacheMaxUsagePct: 90,
+			MaxCachePct:          1,
+			PageSizeBytes:        5,
+			ObjectTtlS:           300,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(store.Cleanup)
+
+	store.diskCachedUsageExceeded = true
+	content := []byte("memory fallback content")
+	sum := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(sum[:])
+
+	hash, size, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	require.Equal(t, expectedHash, hash)
+	require.Equal(t, int64(len(content)), size)
+	require.Eventually(t, func() bool {
+		return store.Exists(hash)
+	}, time.Second, 10*time.Millisecond)
+	_, statErr := os.Stat(cacheDir)
+	require.True(t, os.IsNotExist(statErr))
+
+	dst := make([]byte, len(content))
+	n, err := store.Get(hash, 0, int64(len(dst)), dst)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+}
+
+func TestStoreAddReaderRejectsWhenDiskExceededWithoutMemory(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache-dir")
+	store := newTestStore(t, 5)
+	store.diskCacheDir = cacheDir
+	store.diskCachedUsageExceeded = true
+
+	_, _, err := store.AddReader(context.Background(), bytes.NewReader([]byte("content")))
+	require.ErrorContains(t, err, "disk cache capacity exceeded")
+	_, statErr := os.Stat(cacheDir)
+	require.True(t, os.IsNotExist(statErr))
 }
 
 func TestCacheFSMetadataFromFileInfoPreservesFileMode(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes lock cleanup in the cache client and adds a safe memory-only fallback when the disk cache is full. Also guards eviction during shutdown and adds tests to cover these cases.

- **Bug Fixes**
  - `withStoreFromContentLock`: centralizes unlock via a `releaseLock` helper, surfaces unlock errors, and retries lock removal in the deferred cleanup.
  - Storage: falls back to in-memory caching when `diskCachedUsageExceeded` is true (if memory cache is enabled); returns a clear error and avoids creating disk dirs when memory cache is disabled.
  - Cleanup: prevents eviction side effects during shutdown by gating `onEvict` with an atomic `closing` flag.
  - Tests: added coverage for unlock retry behavior and memory fallback/rejection paths.

<sup>Written for commit b66baa6ad450e95825a4d6324df0533bc211ed06. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1567?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

