### PR TITLE
fix scheduler credential bug

### DIFF
--- a/pkg/registry/credentials.go
+++ b/pkg/registry/credentials.go
@@ -501,11 +501,50 @@ func GetECRToken(creds map[string]string) (string, error) {
 		return "", fmt.Errorf("failed to get ECR token: %w", err)
 	}
 
+	return decodeECRAuthorizationToken(output)
+}
+
+func GetAmbientECRTokenForImage(ctx context.Context, imageURI string) (string, error) {
+	registry := ParseRegistry(imageURI)
+	registryID, region, ok := parseECRRegistry(registry)
+	if !ok {
+		return "", fmt.Errorf("image is not an ECR registry: %s", registry)
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return "", fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	output, err := ecr.NewFromConfig(cfg).GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{
+		RegistryIds: []string{registryID},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get ambient ECR token: %w", err)
+	}
+
+	return decodeECRAuthorizationToken(output)
+}
+
+func parseECRRegistry(registry string) (registryID string, region string, ok bool) {
+	registry = strings.TrimPrefix(registry, "https://")
+	registry = strings.TrimPrefix(registry, "http://")
+	registry = strings.Split(registry, "/")[0]
+	registry = strings.Split(registry, ":")[0]
+
+	parts := strings.Split(registry, ".")
+	if len(parts) < 6 || parts[1] != "dkr" || parts[2] != "ecr" {
+		return "", "", false
+	}
+
+	return parts[0], parts[3], true
+}
+
+func decodeECRAuthorizationToken(output *ecr.GetAuthorizationTokenOutput) (string, error) {
 	if len(output.AuthorizationData) == 0 || output.AuthorizationData[0].AuthorizationToken == nil {
 		return "", fmt.Errorf("no authorization data returned from ECR")
 	}
 
-	// Decode base64 token (format: username:password)
 	base64Token := aws.ToString(output.AuthorizationData[0].AuthorizationToken)
 	decodedToken, err := base64.StdEncoding.DecodeString(base64Token)
 	if err != nil {
@@ -613,7 +652,7 @@ func GetDockerHubToken(creds map[string]string) (string, error) {
 	if hasAuth {
 		return buildBasicAuthToken(username, password), nil
 	}
-	
+
 	// Fall back to generic USERNAME/PASSWORD for non-Docker Hub registries
 	username, password, hasAuth, err = validateOptionalCredentials(creds, "USERNAME", "PASSWORD")
 	if err != nil {
@@ -622,7 +661,7 @@ func GetDockerHubToken(creds map[string]string) (string, error) {
 	if hasAuth {
 		return buildBasicAuthToken(username, password), nil
 	}
-	
+
 	// Also try REGISTRY_USERNAME/REGISTRY_PASSWORD
 	username, password, hasAuth, err = validateOptionalCredentials(creds, "REGISTRY_USERNAME", "REGISTRY_PASSWORD")
 	if err != nil {
@@ -631,7 +670,7 @@ func GetDockerHubToken(creds map[string]string) (string, error) {
 	if hasAuth {
 		return buildBasicAuthToken(username, password), nil
 	}
-	
+
 	return "", nil // Public access
 }
 

--- a/pkg/registry/credentials_test.go
+++ b/pkg/registry/credentials_test.go
@@ -66,6 +66,52 @@ func TestParseRegistry(t *testing.T) {
 	}
 }
 
+func TestParseECRRegistry(t *testing.T) {
+	tests := []struct {
+		name       string
+		registry   string
+		registryID string
+		region     string
+		ok         bool
+	}{
+		{
+			name:       "plain ecr registry",
+			registry:   "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			registryID: "123456789012",
+			region:     "us-east-1",
+			ok:         true,
+		},
+		{
+			name:       "ecr registry with port",
+			registry:   "123456789012.dkr.ecr.us-west-2.amazonaws.com:443",
+			registryID: "123456789012",
+			region:     "us-west-2",
+			ok:         true,
+		},
+		{
+			name:       "ecr registry with scheme and path",
+			registry:   "https://123456789012.dkr.ecr.eu-central-1.amazonaws.com/repo/image:tag",
+			registryID: "123456789012",
+			region:     "eu-central-1",
+			ok:         true,
+		},
+		{
+			name:     "non ecr registry",
+			registry: "registry.example.com:5000",
+			ok:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registryID, region, ok := parseECRRegistry(tt.registry)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.registryID, registryID)
+			assert.Equal(t, tt.region, region)
+		})
+	}
+}
+
 func TestParseCredentialsFromEnv(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -470,25 +470,39 @@ func (s *Scheduler) attachBuildRegistryCredentials(request *types.ContainerReque
 		return nil
 	}
 
-	// Check if we have credentials configured for the build registry
+	// Check if we have credentials configured for the build registry.
 	buildRegistryCredentials := s.config.ImageService.BuildRegistryCredentials
-	if buildRegistryCredentials.Type == "" || len(buildRegistryCredentials.Credentials) == 0 {
-		return nil
-	}
-
-	// Build a dummy image reference for the build registry
 	dummyImageRef := fmt.Sprintf("%s/%s:dummy", buildRegistry, s.config.ImageService.BuildRepositoryName)
 
-	// Generate fresh token using the credentials from config
-	token, err := reg.GetRegistryTokenForImage(dummyImageRef, buildRegistryCredentials.Credentials)
-	if err != nil {
-		log.Warn().
-			Err(err).
-			Str("container_id", request.ContainerId).
-			Str("build_registry", buildRegistry).
-			Str("cred_type", buildRegistryCredentials.Type).
-			Msg("failed to generate build registry token, will use ambient auth")
-		return nil // Don't fail the request, just log and continue
+	var token string
+	authSource := "ambient"
+	if buildRegistryCredentials.Type != "" && len(buildRegistryCredentials.Credentials) > 0 {
+		var err error
+		token, err = reg.GetRegistryTokenForImage(dummyImageRef, buildRegistryCredentials.Credentials)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("container_id", request.ContainerId).
+				Str("build_registry", buildRegistry).
+				Str("cred_type", buildRegistryCredentials.Type).
+				Msg("failed to generate build registry token from configured credentials")
+		}
+		if token != "" {
+			authSource = buildRegistryCredentials.Type
+		}
+	}
+
+	if token == "" {
+		var err error
+		token, err = reg.GetAmbientECRTokenForImage(context.TODO(), dummyImageRef)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("container_id", request.ContainerId).
+				Str("build_registry", buildRegistry).
+				Msg("failed to generate build registry token from ambient credentials")
+			return nil
+		}
 	}
 
 	if token == "" {
@@ -505,7 +519,7 @@ func (s *Scheduler) attachBuildRegistryCredentials(request *types.ContainerReque
 	log.Info().
 		Str("container_id", request.ContainerId).
 		Str("build_registry", buildRegistry).
-		Str("cred_type", buildRegistryCredentials.Type).
+		Str("auth_source", authSource).
 		Msg("attached build registry credentials to request")
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes build registry authentication in `pkg/scheduler` by falling back to ambient AWS ECR credentials when configured creds are missing or fail. Adds robust ECR parsing and token handling in `pkg/registry` to avoid auth errors.

- **Bug Fixes**
  - `pkg/scheduler`: Use configured token if available; otherwise fetch ambient ECR token. Log `auth_source` for visibility.
  - `pkg/registry`: Add `GetAmbientECRTokenForImage`, `parseECRRegistry`, and shared `decodeECRAuthorizationToken`. Handles schemes, ports, and paths.
  - Tests: Add coverage for `parseECRRegistry` with common ECR formats.

<sup>Written for commit f669313fd546b361e22afae95002585958581726. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1573?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

