### PR TITLE
minimal build pool

### DIFF
--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -123,11 +123,12 @@ func workerCacheMountPath(config types.AppConfig, poolConfig types.WorkerPoolCon
 }
 
 func MonitorPoolSize(wpc WorkerPoolController,
+	config types.AppConfig,
 	workerPoolConfig *types.WorkerPoolConfig,
 	workerRepo repository.WorkerRepository,
 	workerPoolRepo repository.WorkerPoolRepository,
 	providerRepo repository.ProviderRepository) error {
-	poolSizer, err := NewWorkerPoolSizer(wpc, workerPoolConfig, workerRepo, workerPoolRepo, providerRepo)
+	poolSizer, err := NewWorkerPoolSizer(wpc, config, workerPoolConfig, workerRepo, workerPoolRepo, providerRepo)
 	if err != nil {
 		return err
 	}

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -93,7 +93,7 @@ func NewExternalWorkerPoolController(opts WorkerPoolControllerOptions) (WorkerPo
 	}
 
 	// Start monitoring worker pool size
-	err = MonitorPoolSize(wpc, &workerPoolConfig, wpc.workerRepo, wpc.workerPoolRepo, opts.ProviderRepo)
+	err = MonitorPoolSize(wpc, opts.Config, &workerPoolConfig, wpc.workerRepo, wpc.workerPoolRepo, opts.ProviderRepo)
 	if err != nil {
 		log.Error().Str("pool_name", wpc.name).Err(err).Msg("unable to monitor pool size")
 	}

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -64,7 +64,7 @@ func NewLocalKubernetesWorkerPoolController(opts WorkerPoolControllerOptions) (W
 	}
 
 	// Start monitoring worker pool size
-	err = MonitorPoolSize(wpc, &workerPoolConfig, wpc.workerRepo, wpc.workerPoolRepo, opts.ProviderRepo)
+	err = MonitorPoolSize(wpc, opts.Config, &workerPoolConfig, wpc.workerRepo, wpc.workerPoolRepo, opts.ProviderRepo)
 	if err != nil {
 		log.Error().Str("pool_name", wpc.name).Err(err).Msg("unable to monitor pool size")
 	}

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -21,6 +21,7 @@ type WorkerPoolSizer struct {
 }
 
 func NewWorkerPoolSizer(controller WorkerPoolController,
+	config types.AppConfig,
 	workerPoolConfig *types.WorkerPoolConfig,
 	workerRepo repository.WorkerRepository,
 	workerPoolRepo repository.WorkerPoolRepository,
@@ -29,6 +30,7 @@ func NewWorkerPoolSizer(controller WorkerPoolController,
 	if err != nil {
 		return nil, err
 	}
+	applyBuildPoolSizingMinimums(controller.Name(), config, poolSizingConfig)
 
 	return &WorkerPoolSizer{
 		controller:             controller,
@@ -210,4 +212,19 @@ func parsePoolSizingConfig(config types.WorkerPoolJobSpecPoolSizingConfig) (*typ
 	}
 
 	return c, nil
+}
+
+func applyBuildPoolSizingMinimums(poolName string, config types.AppConfig, sizing *types.WorkerPoolSizingConfig) {
+	if sizing == nil || poolName == "" || poolName != config.ImageService.BuildContainerPoolSelector {
+		return
+	}
+
+	if config.ImageService.BuildContainerCpu > sizing.DefaultWorkerCpu {
+		sizing.DefaultWorkerCpu = config.ImageService.BuildContainerCpu
+	}
+
+	buildMemory := capacityMemoryForScheduling(&types.ContainerRequest{Memory: config.ImageService.BuildContainerMemory})
+	if buildMemory > sizing.DefaultWorkerMemory {
+		sizing.DefaultWorkerMemory = buildMemory
+	}
 }

--- a/pkg/scheduler/pool_sizing_test.go
+++ b/pkg/scheduler/pool_sizing_test.go
@@ -229,6 +229,44 @@ func TestParsePoolSizingConfig(t *testing.T) {
 	}
 }
 
+func TestApplyBuildPoolSizingMinimums(t *testing.T) {
+	config := types.AppConfig{}
+	config.ImageService.BuildContainerPoolSelector = "build"
+	config.ImageService.BuildContainerCpu = 14000
+	config.ImageService.BuildContainerMemory = 54000
+
+	sizing := &types.WorkerPoolSizingConfig{
+		MinFreeCpu:          14000,
+		MinFreeMemory:       55296,
+		DefaultWorkerCpu:    1000,
+		DefaultWorkerMemory: 55296,
+	}
+
+	applyBuildPoolSizingMinimums("build", config, sizing)
+
+	assert.Equal(t, int64(14000), sizing.DefaultWorkerCpu)
+	assert.Equal(t, int64(67500), sizing.DefaultWorkerMemory)
+	assert.Equal(t, int64(14000), sizing.MinFreeCpu)
+	assert.Equal(t, int64(55296), sizing.MinFreeMemory)
+}
+
+func TestApplyBuildPoolSizingMinimumsOnlyAppliesToBuildPool(t *testing.T) {
+	config := types.AppConfig{}
+	config.ImageService.BuildContainerPoolSelector = "build"
+	config.ImageService.BuildContainerCpu = 14000
+	config.ImageService.BuildContainerMemory = 54000
+
+	sizing := &types.WorkerPoolSizingConfig{
+		DefaultWorkerCpu:    1000,
+		DefaultWorkerMemory: 1024,
+	}
+
+	applyBuildPoolSizingMinimums("default", config, sizing)
+
+	assert.Equal(t, int64(1000), sizing.DefaultWorkerCpu)
+	assert.Equal(t, int64(1024), sizing.DefaultWorkerMemory)
+}
+
 func TestOccupyAvailableMachines(t *testing.T) {
 	s, err := miniredis.Run()
 	assert.NotNil(t, s)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the build worker pool is never under-provisioned by enforcing minimum CPU and memory from `types.AppConfig.ImageService` when sizing the pool (only when the pool matches `BuildContainerPoolSelector`). Pass `types.AppConfig` into pool sizing and add tests confirming defaults are raised to fit build containers.

<sup>Written for commit 165441d0890314e86dc2bfaaa67713aaef2a3081. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

