### PR TITLE
fix network race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CACHE_BENCH_PROFILE ?=
 CACHE_BENCH_CONFIG ?=
 TOKEN ?=
 
-.PHONY: startup-benchmark startup-benchmark-build sandbox-parallel-benchmark cache-benchmark bench-cache-smoke
+.PHONY: startup-benchmark startup-benchmark-build sandbox-parallel-benchmark sandbox-stage-cold-benchmark sandbox-stage-warm-benchmark cache-benchmark bench-cache-smoke
 
 setup:
 	bash bin/setup.sh
@@ -33,6 +33,12 @@ sandbox-parallel-benchmark:
 	PYTHONPATH="$(CURDIR)/sdk/src:$(PYTHONPATH)" \
 	BENCH_SDK_PYTHON="$(BENCH_SDK_PYTHON)" \
 	"$(CURDIR)/bin/bench" sandbox $(ARGS)
+
+sandbox-stage-cold-benchmark:
+	$(MAKE) sandbox-parallel-benchmark ARGS="--profile staging --suite sandbox-stage-cold $(ARGS)"
+
+sandbox-stage-warm-benchmark:
+	$(MAKE) sandbox-parallel-benchmark ARGS="--profile staging --suite sandbox-stage-warm $(ARGS)"
 
 cache-benchmark:
 	PYTHONPATH="$(CURDIR)/sdk/src:$(PYTHONPATH)" \

--- a/benchmarks/b9bench/README.md
+++ b/benchmarks/b9bench/README.md
@@ -23,6 +23,10 @@ flowchart TD
 bin/bench cache --suite cache-smoke --dry-run
 bin/bench cache --profile local --suite cache-default --out-dir /tmp/beta9-cache-run
 bin/bench full --profile local --suite local-full
+bin/bench sandbox --profile staging --suite sandbox-stage-cold
+bin/bench sandbox --profile staging --suite sandbox-stage-warm
+make sandbox-stage-cold-benchmark
+make sandbox-stage-warm-benchmark
 ```
 
 Use `--param key=value` for suite/script overrides, for example:

--- a/benchmarks/b9bench/config.py
+++ b/benchmarks/b9bench/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import configparser
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from .model import RunConfig, slug
@@ -21,6 +22,9 @@ def normalize_local_host(host: str) -> str:
 def http_url_from_gateway(host: str, port: str) -> str:
     if host.startswith(("http://", "https://")):
         return host
+    if port == "443" and host.startswith("gateway.") and host.endswith(".beam.cloud"):
+        http_host = "app." + host[len("gateway."):]
+        return f"https://{http_host}"
     if port == "1993":
         return f"http://{host}:1994"
     if port == "80":
@@ -30,16 +34,31 @@ def http_url_from_gateway(host: str, port: str) -> str:
     return f"http://{host}:{port}"
 
 
-def read_profile(config_path: Path, profile: str) -> tuple[str, str, str]:
+@dataclass(frozen=True)
+class ProfileConfig:
+    token: str = ""
+    gateway_host: str = ""
+    gateway_port: str = ""
+    http_url: str = ""
+
+
+def read_profile(config_path: Path, profile: str) -> ProfileConfig:
     parser = configparser.ConfigParser()
     parser.read(config_path.expanduser())
     if not parser.has_section(profile):
-        return "", "", ""
+        return ProfileConfig()
     section = parser[profile]
-    return (
-        section.get("token", ""),
-        section.get("gateway_host", ""),
-        section.get("gateway_port", ""),
+    http_url = section.get("gateway_http_url", "") or section.get("http_url", "")
+    http_host = section.get("gateway_http_host", "") or section.get("http_host", "")
+    http_port = section.get("gateway_http_port", "") or section.get("http_port", "")
+    if not http_url and http_host:
+        http_url = http_url_from_gateway(normalize_local_host(http_host), http_port or "443")
+
+    return ProfileConfig(
+        token=section.get("token", ""),
+        gateway_host=section.get("gateway_host", ""),
+        gateway_port=section.get("gateway_port", ""),
+        http_url=http_url.strip(),
     )
 
 
@@ -107,23 +126,23 @@ def resolve_run_config(args) -> RunConfig:
         or "~/.beta9/config.ini"
     ).expanduser()
 
-    config_token = config_host = config_port = ""
+    profile_config = ProfileConfig()
     if config_path.exists():
-        config_token, config_host, config_port = read_profile(config_path, profile)
+        profile_config = read_profile(config_path, profile)
 
     token = (
         args.token
         or os.getenv("BENCH_TOKEN")
         or os.getenv("TOKEN")
         or os.getenv("BETA9_TOKEN")
-        or config_token
+        or profile_config.token
     )
     grpc_addr = args.grpc_addr or os.getenv("BENCH_GRPC_ADDR")
     gateway_url = args.gateway_url or os.getenv("BENCH_GATEWAY_URL")
-    if config_host and config_port:
-        host = normalize_local_host(config_host)
-        grpc_addr = grpc_addr or f"{host}:{config_port}"
-        gateway_url = gateway_url or http_url_from_gateway(host, config_port)
+    if profile_config.gateway_host and profile_config.gateway_port:
+        host = normalize_local_host(profile_config.gateway_host)
+        grpc_addr = grpc_addr or f"{host}:{profile_config.gateway_port}"
+        gateway_url = gateway_url or profile_config.http_url or http_url_from_gateway(host, profile_config.gateway_port)
 
     raw_out_dir = args.out_dir or os.getenv("BENCH_OUT_DIR")
     out_dir = (

--- a/benchmarks/b9bench/suite_defs/sandbox-stage-cold.yaml
+++ b/benchmarks/b9bench/suite_defs/sandbox-stage-cold.yaml
@@ -1,0 +1,21 @@
+name: sandbox-stage-cold
+kind: sandbox
+runner: sandbox
+description: Staging 100-way cold sandbox startup benchmark.
+defaults:
+  count: 100
+  parallelism: 100
+  warmup: 0
+  wait_running: true
+  wait_exec_complete: true
+  reset_workers: true
+  install: false
+  port_forward: false
+  bootstrap_local_image: false
+  sandbox_image_uri: public.ecr.aws/docker/library/alpine:latest
+  sandbox_cpu: "0.1"
+  sandbox_memory: "192"
+  sandbox_ready_timeout_seconds: 240
+  timeout_seconds: 420
+  event_wait_seconds: 60
+  event_top_lifecycle: 200

--- a/benchmarks/b9bench/suite_defs/sandbox-stage-warm.yaml
+++ b/benchmarks/b9bench/suite_defs/sandbox-stage-warm.yaml
@@ -1,0 +1,25 @@
+name: sandbox-stage-warm
+kind: sandbox
+runner: sandbox
+description: Staging 100-way warm sandbox startup benchmark after prewarming workers and image.
+defaults:
+  count: 100
+  parallelism: 100
+  prewarm_count: 100
+  prewarm_parallelism: 100
+  prewarm_cooldown_seconds: 20
+  prewarm_wait_idle: false
+  warmup: 0
+  wait_running: true
+  wait_exec_complete: true
+  reset_workers: false
+  install: false
+  port_forward: false
+  bootstrap_local_image: false
+  sandbox_image_uri: public.ecr.aws/docker/library/alpine:latest
+  sandbox_cpu: "0.1"
+  sandbox_memory: "192"
+  sandbox_ready_timeout_seconds: 240
+  timeout_seconds: 420
+  event_wait_seconds: 60
+  event_top_lifecycle: 200

--- a/benchmarks/b9bench/test_b9bench.py
+++ b/benchmarks/b9bench/test_b9bench.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from pathlib import Path
 
 from benchmarks.b9bench.config import resolve_run_config
+from benchmarks.b9bench.config import http_url_from_gateway
 from benchmarks.b9bench.model import Measurement, ScenarioSpec
 from benchmarks.b9bench.payload import deterministic_payload_range, deterministic_sha256
 from benchmarks.b9bench.reports import MetricSink
@@ -91,6 +92,48 @@ class B9BenchTests(unittest.TestCase):
         self.assertEqual(config.out_dir.parent.name, "runs")
         self.assertIn("sandbox", config.out_dir.name)
         self.assertIn("sandbox-default", config.out_dir.name)
+
+    def test_stage_gateway_profile_maps_to_stage_http_host(self):
+        self.assertEqual(
+            http_url_from_gateway("gateway.stage.beam.cloud", "443"),
+            "https://app.stage.beam.cloud",
+        )
+
+    def test_profile_can_define_explicit_http_url(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "config.ini"
+            config_path.write_text(
+                "\n".join(
+                    (
+                        "[staging]",
+                        "token = token-1",
+                        "gateway_host = gateway.stage.beam.cloud",
+                        "gateway_port = 443",
+                        "gateway_http_url = https://custom.stage.example.com",
+                        "",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            args = SimpleNamespace(
+                command="sandbox",
+                suite="sandbox-default",
+                profile="staging",
+                config=str(config_path),
+                token=None,
+                gateway_url=None,
+                grpc_addr=None,
+                namespace=None,
+                out_dir=None,
+                dry_run=True,
+                param=[],
+                script_arg=[],
+            )
+
+            config = resolve_run_config(args)
+
+            self.assertEqual(config.gateway_url, "https://custom.stage.example.com")
+            self.assertEqual(config.grpc_addr, "gateway.stage.beam.cloud:443")
 
     def test_scenario_tags_include_core_dimensions(self):
         scenario = ScenarioSpec(

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -258,25 +258,90 @@ func containerIPv6Address(ip net.IP, ipv6Net *net.IPNet) (net.IP, error) {
 	return ipv6, nil
 }
 
-func containerIdFromIptablesRule(rule string) (string, bool) {
+type containerNetworkRuleInfo struct {
+	ContainerID string
+	Namespace   string
+	VethHost    string
+	IPv4        string
+	IPv6        string
+}
+
+func containerNetworkComment(vethHost, containerId, namespace string) string {
+	if namespace == "" {
+		namespace = containerId
+	}
+	return fmt.Sprintf("%s:%s:%s", vethHost, containerId, namespace)
+}
+
+func containerNetworkRuleInfoFromIptablesRule(rule string) (containerNetworkRuleInfo, bool) {
 	idx := strings.LastIndex(rule, containerVethHostPrefix)
 	if idx == -1 {
 		idx = strings.LastIndex(rule, legacyContainerVethHostPrefix)
 	}
 	if idx == -1 {
-		return "", false
+		return containerNetworkRuleInfo{}, false
 	}
 
 	comment := rule[idx:]
-	parts := strings.SplitN(comment, ":", 2)
-	if len(parts) != 2 {
-		return "", false
+	comment = strings.Fields(comment)[0]
+	comment = strings.Trim(comment, `"`)
+	comment = strings.TrimRight(comment, `\`)
+	comment = strings.TrimSuffix(comment, "*/")
+
+	parts := strings.Split(comment, ":")
+	if len(parts) < 2 {
+		return containerNetworkRuleInfo{}, false
 	}
 
-	containerId := strings.Fields(parts[1])[0]
-	containerId = strings.Trim(containerId, `"`)
-	containerId = strings.TrimRight(containerId, `\`)
-	return strings.TrimSuffix(containerId, "*/"), true
+	info := containerNetworkRuleInfo{
+		VethHost:    parts[0],
+		ContainerID: parts[1],
+		Namespace:   parts[1],
+	}
+	if len(parts) >= 3 && parts[2] != "" {
+		info.Namespace = parts[2]
+	}
+
+	if ip, ok := iptablesRuleDestinationIP(rule); ok {
+		if strings.Contains(ip, ":") {
+			info.IPv6 = ip
+		} else {
+			info.IPv4 = ip
+		}
+	}
+
+	return info, info.ContainerID != ""
+}
+
+func containerIdFromIptablesRule(rule string) (string, bool) {
+	info, ok := containerNetworkRuleInfoFromIptablesRule(rule)
+	return info.ContainerID, ok
+}
+
+func iptablesRuleDestinationIP(rule string) (string, bool) {
+	fields := strings.Fields(rule)
+	for i, field := range fields {
+		if field != "--to-destination" || i+1 >= len(fields) {
+			continue
+		}
+		destination := strings.Trim(fields[i+1], `"`)
+		if strings.HasPrefix(destination, "[") {
+			end := strings.Index(destination, "]")
+			if end > 1 {
+				return destination[1:end], true
+			}
+			return "", false
+		}
+		host, _, err := net.SplitHostPort(destination)
+		if err == nil {
+			return host, true
+		}
+		if idx := strings.LastIndex(destination, ":"); idx > 0 {
+			return destination[:idx], true
+		}
+		return destination, destination != ""
+	}
+	return "", false
 }
 
 func NewContainerNetworkManager(ctx context.Context, workerId, poolName string, workerRepoClient pb.WorkerRepositoryServiceClient, containerRepoClient pb.ContainerRepositoryServiceClient, eventRepo repo.EventRepository, config types.AppConfig, containerInstances *common.SafeMap[*ContainerInstance], poolConfig types.WorkerPoolConfig, containerStartLimit int) (*ContainerNetworkManager, error) {
@@ -397,6 +462,15 @@ func (m *ContainerNetworkManager) lockContainerNetwork(containerId string) func(
 
 func isRedisLockNotObtained(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "redislock: not obtained")
+}
+
+func isMissingNetworkReservation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "redis: nil") ||
+		strings.Contains(msg, "source container does not own requested ip")
 }
 
 func (m *ContainerNetworkManager) maintainNetworkSlotPool() {
@@ -986,10 +1060,21 @@ func (m *ContainerNetworkManager) recordNetworkLifecycle(request *types.Containe
 }
 
 func (m *ContainerNetworkManager) getContainerNetworkInfo(containerId string) (*containerNetworkInfo, error) {
+	if slot := m.containerNetworkSlot(containerId); slot != nil {
+		return containerNetworkInfoFromSlot(containerId, slot, m.ipt6 != nil)
+	}
 	if instance, exists := m.containerInstances.Get(containerId); exists && instance.ContainerIp != "" {
 		return containerNetworkInfoFromIP(containerId, instance.ContainerIp, m.ipt6 != nil)
 	}
-	return getContainerNetworkInfo(m.ctx, m.workerRepoClient, m.networkPrefix, containerId, m.ipt6 != nil)
+	info, err := getContainerNetworkInfo(m.ctx, m.workerRepoClient, m.networkPrefix, containerId, m.ipt6 != nil)
+	if err == nil {
+		return info, nil
+	}
+	if fallback, fallbackErr := m.getContainerNetworkInfoFromIptables(containerId); fallbackErr == nil {
+		log.Debug().Str("container_id", containerId).Err(err).Msg("recovered container network info from iptables")
+		return fallback, nil
+	}
+	return nil, err
 }
 
 func taskIDFromContainerRequestEnv(env []string) string {
@@ -1818,8 +1903,6 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 		return err
 	}
 
-	namespace := containerId
-
 	hostVeth, err := netlink.LinkByName(info.VethHost)
 	if err == nil {
 		// Remove the veth from the bridge
@@ -1850,7 +1933,9 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 
 	// Delete container namespace don't bother handling
 	// the error because the namespace is likely to be gone at this point
-	netns.DeleteNamed(namespace)
+	if info.Namespace != "" {
+		netns.DeleteNamed(info.Namespace)
+	}
 
 	_, err = handleGRPCResponse(m.workerRepoClient.RemoveContainerIp(m.ctx, &pb.RemoveContainerIpRequest{
 		NetworkPrefix: m.networkPrefix,
@@ -1878,6 +1963,10 @@ func (m *ContainerNetworkManager) tearDownPreallocatedNetworkSlot(containerId st
 
 	if err := m.releasePreallocatedNetworkSlot(containerId, slot); err != nil {
 		m.discardNetworkSlot(containerId, slot)
+		if isMissingNetworkReservation(err) {
+			log.Debug().Str("container_id", containerId).Str("network_slot", slot.id).Err(err).Msg("discarded preallocated network slot with missing reservation")
+			return nil
+		}
 		return err
 	}
 
@@ -2203,6 +2292,100 @@ func (m *ContainerNetworkManager) listContainerIdsFromIptables() ([]string, erro
 	}
 
 	return containerIds, nil
+}
+
+func (m *ContainerNetworkManager) getContainerNetworkInfoFromIptables(containerId string) (*containerNetworkInfo, error) {
+	ruleInfo, err := m.findContainerNetworkRuleInfo(containerId)
+	if err != nil {
+		return nil, err
+	}
+	if ruleInfo.IPv4 == "" {
+		return nil, fmt.Errorf("container %s has no IPv4 iptables destination", containerId)
+	}
+
+	info := &containerNetworkInfo{
+		ContainerIp:   ruleInfo.IPv4,
+		ContainerIpv6: ruleInfo.IPv6,
+		Namespace:     ruleInfo.Namespace,
+		VethHost:      ruleInfo.VethHost,
+		Comment:       containerNetworkComment(ruleInfo.VethHost, ruleInfo.ContainerID, ruleInfo.Namespace),
+	}
+	if info.Namespace == "" {
+		info.Namespace = containerId
+	}
+	if info.VethHost == "" {
+		info.VethHost, _ = containerVethNames(info.Namespace)
+	}
+	if m.ipt6 != nil && info.ContainerIpv6 == "" {
+		ip := net.ParseIP(info.ContainerIp)
+		if ip == nil || ip.To4() == nil {
+			return nil, fmt.Errorf("invalid IPv4 address from iptables: %s", info.ContainerIp)
+		}
+		_, ipv6Net, err := net.ParseCIDR(containerSubnetIPv6)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse IPv6 subnet: %w", err)
+		}
+		ipv6Address, err := containerIPv6Address(ip, ipv6Net)
+		if err != nil {
+			return nil, err
+		}
+		info.ContainerIpv6 = ipv6Address.String()
+	}
+
+	return info, nil
+}
+
+func (m *ContainerNetworkManager) findContainerNetworkRuleInfo(containerId string) (containerNetworkRuleInfo, error) {
+	var found containerNetworkRuleInfo
+
+	rules, err := m.ipt.List("nat", "PREROUTING")
+	if err != nil {
+		return containerNetworkRuleInfo{}, err
+	}
+	for _, rule := range rules {
+		info, ok := containerNetworkRuleInfoFromIptablesRule(rule)
+		if !ok || info.ContainerID != containerId {
+			continue
+		}
+		if found.ContainerID == "" {
+			found = info
+		}
+		if info.IPv4 != "" {
+			found.IPv4 = info.IPv4
+			found.VethHost = info.VethHost
+			found.Namespace = info.Namespace
+		}
+	}
+
+	if m.ipt6 != nil {
+		rules6, err := m.ipt6.List("nat", "PREROUTING")
+		if err != nil {
+			return containerNetworkRuleInfo{}, err
+		}
+		for _, rule := range rules6 {
+			info, ok := containerNetworkRuleInfoFromIptablesRule(rule)
+			if !ok || info.ContainerID != containerId {
+				continue
+			}
+			if found.ContainerID == "" {
+				found = info
+			}
+			if info.IPv6 != "" {
+				found.IPv6 = info.IPv6
+			}
+			if found.VethHost == "" {
+				found.VethHost = info.VethHost
+			}
+			if found.Namespace == "" {
+				found.Namespace = info.Namespace
+			}
+		}
+	}
+
+	if found.ContainerID == "" {
+		return containerNetworkRuleInfo{}, fmt.Errorf("container %s not found in iptables", containerId)
+	}
+	return found, nil
 }
 
 // generateUniqueMAC generates a random MAC address with a specific OUI (Organizationally Unique Identifier).

--- a/pkg/worker/network_test.go
+++ b/pkg/worker/network_test.go
@@ -551,6 +551,50 @@ func TestContainerIdFromIptablesRuleHandlesIPv6Colons(t *testing.T) {
 	}
 }
 
+func TestContainerNetworkRuleInfoFromIptablesRule(t *testing.T) {
+	rule := `-A PREROUTING -p tcp -m tcp --dport 12345 -j DNAT --to-destination 192.168.0.44:8080 -m comment --comment "b9habcdef123456:sandbox-123:network-slot-abc"`
+
+	info, ok := containerNetworkRuleInfoFromIptablesRule(rule)
+	if !ok {
+		t.Fatal("expected container network info in iptables rule")
+	}
+	if info.ContainerID != "sandbox-123" {
+		t.Fatalf("expected sandbox-123, got %s", info.ContainerID)
+	}
+	if info.Namespace != "network-slot-abc" {
+		t.Fatalf("expected network-slot-abc namespace, got %s", info.Namespace)
+	}
+	if info.VethHost != "b9habcdef123456" {
+		t.Fatalf("expected b9habcdef123456 veth, got %s", info.VethHost)
+	}
+	if info.IPv4 != "192.168.0.44" {
+		t.Fatalf("expected IPv4 destination, got %s", info.IPv4)
+	}
+}
+
+func TestContainerNetworkInfoFromSlotUsesSlotResources(t *testing.T) {
+	slot := &containerNetworkSlot{
+		id:        "network-slot-abc",
+		namespace: "network-slot-abc",
+		vethHost:  "b9hslotabc",
+		ip:        "192.168.0.44",
+	}
+
+	info, err := containerNetworkInfoFromSlot("sandbox-123", slot, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Namespace != slot.namespace {
+		t.Fatalf("expected namespace %s, got %s", slot.namespace, info.Namespace)
+	}
+	if info.VethHost != slot.vethHost {
+		t.Fatalf("expected veth %s, got %s", slot.vethHost, info.VethHost)
+	}
+	if info.Comment != "b9hslotabc:sandbox-123:network-slot-abc" {
+		t.Fatalf("unexpected comment: %s", info.Comment)
+	}
+}
+
 func containerNetworkAddress() string {
 	_, ipNet, _ := net.ParseCIDR(containerSubnet)
 	return ipNet.IP.String()

--- a/pkg/worker/network_util.go
+++ b/pkg/worker/network_util.go
@@ -16,6 +16,7 @@ func validateCIDR(entry string) (string, bool, error) {
 type containerNetworkInfo struct {
 	ContainerIp   string
 	ContainerIpv6 string // empty if IPv6 is not enabled
+	Namespace     string
 	VethHost      string
 	Comment       string
 }
@@ -36,12 +37,12 @@ func getContainerNetworkInfo(ctx context.Context, workerRepoClient pb.WorkerRepo
 
 func containerNetworkInfoFromIP(containerId string, containerIp string, ipv6Enabled bool) (*containerNetworkInfo, error) {
 	vethHost, _ := containerVethNames(containerId)
-	comment := fmt.Sprintf("%s:%s", vethHost, containerId)
 
 	info := &containerNetworkInfo{
 		ContainerIp: containerIp,
+		Namespace:   containerId,
 		VethHost:    vethHost,
-		Comment:     comment,
+		Comment:     containerNetworkComment(vethHost, containerId, containerId),
 	}
 
 	if ipv6Enabled {
@@ -58,6 +59,50 @@ func containerNetworkInfoFromIP(containerId string, containerIp string, ipv6Enab
 			return nil, err
 		}
 		info.ContainerIpv6 = ipv6Address.String()
+	}
+
+	return info, nil
+}
+
+func containerNetworkInfoFromSlot(containerId string, slot *containerNetworkSlot, ipv6Enabled bool) (*containerNetworkInfo, error) {
+	if slot == nil {
+		return nil, fmt.Errorf("missing network slot for container %s", containerId)
+	}
+
+	namespace := slot.namespace
+	if namespace == "" {
+		namespace = slot.id
+	}
+	vethHost := slot.vethHost
+	if vethHost == "" {
+		vethHost, _ = containerVethNames(namespace)
+	}
+
+	info := &containerNetworkInfo{
+		ContainerIp: slot.ip,
+		Namespace:   namespace,
+		VethHost:    vethHost,
+		Comment:     containerNetworkComment(vethHost, containerId, namespace),
+	}
+
+	if ipv6Enabled {
+		if slot.ipv6 != "" {
+			info.ContainerIpv6 = slot.ipv6
+		} else {
+			ip := net.ParseIP(slot.ip)
+			if ip == nil || ip.To4() == nil {
+				return nil, fmt.Errorf("invalid IPv4 address: %s", slot.ip)
+			}
+			_, ipv6Net, err := net.ParseCIDR(containerSubnetIPv6)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse IPv6 subnet: %w", err)
+			}
+			ipv6Address, err := containerIPv6Address(ip, ipv6Net)
+			if err != nil {
+				return nil, err
+			}
+			info.ContainerIpv6 = ipv6Address.String()
+		}
 	}
 
 	return info, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a container networking race that caused teardown flakiness by reliably recovering network info and cleaning up the correct namespace. Also adds staging sandbox benchmark suites and improves gateway URL resolution for staging.

- **Bug Fixes**
  - `pkg/worker/network.go` resolves container network info from a preallocated slot first, then falls back to iptables (parsing IPv4/IPv6, veth, and namespace from rule comments `veth:container:namespace`).
  - `containerNetworkInfo` now carries `Namespace`; teardown deletes the correct netns and avoids leaks.
  - Gracefully discards a preallocated slot when the reservation is missing instead of failing the teardown.
  - Robust iptables parsing of `--to-destination` for IPv4/IPv6; added focused tests.

- **New Features**
  - `benchmarks/b9bench`: added `sandbox-stage-cold` and `sandbox-stage-warm` suites with Makefile targets, plus README examples.
  - Profile config supports explicit `gateway_http_url`/`http_url` and maps `gateway.stage.beam.cloud:443` to `https://app.stage.beam.cloud`.

<sup>Written for commit 5d45a5eb3e57d9c9446e3a921c330040804134f1. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1575?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

