### PR TITLE
small cache improvements

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -375,6 +375,11 @@ func (c *Client) addHost(host *Host) error {
 	c.grpcClients[host.HostId] = proto.NewCacheClient(conn)
 	c.grpcConns[host.HostId] = conn
 	c.hasher.Add(host)
+	for hash, entry := range c.localHostCache {
+		if entry.host != nil && entry.host.HostId == host.HostId {
+			delete(c.localHostCache, hash)
+		}
+	}
 
 	go c.monitorHost(host)
 	return nil
@@ -585,6 +590,43 @@ func (c *Client) CacheFSMetadata(ctx context.Context, path string) (*FSMetadata,
 		return nil, ErrClientNotFound
 	}
 	return c.metadataStore.GetFsNode(ctx, GenerateFsID(path))
+}
+
+func (c *Client) cachedLocalFileHash(ctx context.Context, cachePath string, info os.FileInfo, routingKey string) (string, bool) {
+	if c == nil || cachePath == "" || info == nil || info.IsDir() {
+		return "", false
+	}
+
+	metadata, err := c.CacheFSMetadata(ctx, cachePath)
+	if err != nil || !cacheFSMetadataMatchesFileInfo(metadata, info) {
+		return "", false
+	}
+
+	for _, store := range c.localStoresSnapshot() {
+		if store.Exists(metadata.Hash) {
+			return metadata.Hash, true
+		}
+	}
+
+	if routingKey == "" {
+		routingKey = cachePath
+	}
+	exists, err := c.IsCachedNearby(metadata.Hash, routingKey)
+	if err != nil || !exists {
+		return "", false
+	}
+	return metadata.Hash, true
+}
+
+func cacheFSMetadataMatchesFileInfo(metadata *FSMetadata, info os.FileInfo) bool {
+	if metadata == nil || metadata.Hash == "" || info == nil || info.IsDir() || info.Size() < 0 {
+		return false
+	}
+
+	modTime := info.ModTime()
+	return metadata.Size == uint64(info.Size()) &&
+		metadata.Mtime == uint64(modTime.Unix()) &&
+		metadata.Mtimensec == uint32(modTime.Nanosecond())
 }
 
 func (c *Client) IsCachedNearby(hash string, routingKey string) (bool, error) {
@@ -1374,12 +1416,7 @@ func (c *Client) StoreContentFromLocalFile(source LocalContentSource, opts Store
 		opts.RoutingKey = source.CachePath
 	}
 
-	file, err := os.Open(source.Path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	info, err := file.Stat()
+	info, err := os.Stat(source.Path)
 	if err != nil {
 		return "", err
 	}
@@ -1388,7 +1425,23 @@ func (c *Client) StoreContentFromLocalFile(source LocalContentSource, opts Store
 	ctx, cancel := context.WithTimeout(c.ctx, storeContentRequestTimeout)
 	defer cancel()
 
+	if hash, ok := c.cachedLocalFileHash(ctx, source.CachePath, info, opts.RoutingKey); ok {
+		return hash, nil
+	}
+
+	file, err := os.Open(source.Path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
 	hash, err := c.withStoreFromContentLock(ctx, source.CachePath, opts.Lock, func() (string, error) {
+		if hash, ok := c.cachedLocalFileHash(ctx, source.CachePath, info, opts.RoutingKey); ok {
+			return hash, nil
+		}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return "", err
+		}
 		return c.storeContentFromReaderWithContext(ctx, file, opts.RoutingKey, source.CachePath, metadata)
 	})
 	if err != nil {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	proto "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
@@ -97,6 +100,39 @@ func TestReadContentIntoPrefersAttachedLocalReplica(t *testing.T) {
 	require.Equal(t, content, dst)
 }
 
+func TestContentReadHotPathDoesNotUseCacheFSMetadata(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("local-cache-content")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	localHost := &Host{HostId: "local-host"}
+	store.currentHost = localHost
+	metadataStore := &failOnGetFsNodeMetadataStore{MockCacheMetadataStore: NewMockCacheMetadataStore(), t: t}
+	client := &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1, PreferLocalCacheHost: true},
+		metadataStore:         metadataStore,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{localHost}},
+		maxGetContentAttempts: 1,
+	}
+	client.AttachLocalStore(store)
+
+	dst := make([]byte, len(content))
+	n, err := client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{RoutingKey: "/images/test.clip"})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+
+	views, err := client.ClientLocalPageFileViews(hash, 0, int64(len(content)), ClientOptions{RoutingKey: "/images/test.clip"})
+	require.NoError(t, err)
+	require.NotEmpty(t, views)
+}
+
 func TestClientLocalPageFileViewsReturnsSelectedClientLocalPageFiles(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("abcdefghijkl")
@@ -171,6 +207,87 @@ func TestWithStoreFromContentLockReturnsUnlockErrorAndRetriesDeferredRelease(t *
 	require.False(t, registry.locks["store-lock:test:/source"])
 }
 
+func TestAddHostClearsCachedRoutingForReplacedHost(t *testing.T) {
+	client := &Client{
+		ctx:          context.Background(),
+		clientConfig: ClientConfig{NTopHosts: 1},
+		globalConfig: GlobalConfig{
+			GRPCMessageSizeBytes: 4 * 1024 * 1024,
+		},
+		grpcClients:    make(map[string]proto.CacheClient),
+		grpcConns:      make(map[string]*grpc.ClientConn),
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[string]*localClientCache),
+		hasher:         &orderedTestHasher{},
+	}
+	defer client.Cleanup()
+
+	oldHost := &Host{HostId: "host-a", Addr: "127.0.0.1:1"}
+	client.localHostCache["content-hash"] = &localClientCache{
+		host:      oldHost,
+		timestamp: time.Now(),
+	}
+
+	err := client.addHost(&Host{HostId: "host-a", Addr: "127.0.0.1:1"})
+	require.NoError(t, err)
+
+	_, exists := client.localHostCache["content-hash"]
+	require.False(t, exists)
+}
+
+func TestStoreContentFromLocalFileUsesMatchingCacheMetadata(t *testing.T) {
+	ctx := context.Background()
+	content := []byte("already cached local content")
+
+	sourcePath := filepath.Join(t.TempDir(), "source.txt")
+	require.NoError(t, os.WriteFile(sourcePath, content, 0644))
+	info, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+
+	store := newTestStore(t, 5)
+	hash, _, err := store.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	cachePath := "/workspace/source.txt"
+	metadataStore := NewMockCacheMetadataStore()
+	require.NoError(t, metadataStore.SetFsNode(ctx, GenerateFsID(cachePath), &FSMetadata{
+		Path:      cachePath,
+		Hash:      hash,
+		Size:      uint64(info.Size()),
+		Mtime:     uint64(info.ModTime().Unix()),
+		Mtimensec: uint32(info.ModTime().Nanosecond()),
+	}))
+
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          ClientConfig{NTopHosts: 1, PreferLocalCacheHost: true},
+		globalConfig:          GlobalConfig{GRPCMessageSizeBytes: 4 * 1024 * 1024},
+		metadataStore:         metadataStore,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		localPromotionSem:     make(chan struct{}, 1),
+		hasher:                &orderedTestHasher{},
+		maxGetContentAttempts: 1,
+	}
+	defer client.Cleanup()
+	client.AttachLocalStore(store)
+
+	got, err := client.StoreContentFromLocalFile(LocalContentSource{
+		Path:      sourcePath,
+		CachePath: cachePath,
+	}, StoreContentOptions{
+		RoutingKey: cachePath,
+		Lock:       true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, hash, got)
+	require.Empty(t, metadataStore.locks)
+}
+
 type failFirstUnlockRegistry struct {
 	*MockCacheMetadataStore
 	removeCalls int
@@ -182,4 +299,14 @@ func (r *failFirstUnlockRegistry) RemoveStoreFromContentLock(ctx context.Context
 		return errors.New("unlock failed")
 	}
 	return r.MockCacheMetadataStore.RemoveStoreFromContentLock(ctx, locality, sourcePath)
+}
+
+type failOnGetFsNodeMetadataStore struct {
+	*MockCacheMetadataStore
+	t *testing.T
+}
+
+func (m *failOnGetFsNodeMetadataStore) GetFsNode(ctx context.Context, id string) (*FSMetadata, error) {
+	m.t.Fatalf("content read hot path must not use cachefs metadata: %s", id)
+	return nil, errors.New("unexpected cachefs metadata lookup")
 }

--- a/pkg/cache/coordinator.go
+++ b/pkg/cache/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -69,21 +70,12 @@ func (c *Coordinator) RegisterHost(ctx context.Context, host CoordinatorHost, tt
 		return err
 	}
 
-	activeRegistrationID, found, err := c.repository.GetActiveCacheRegistration(ctx, host.LogicalHostID)
-	if err != nil {
-		return err
-	}
-	if !found || activeRegistrationID == host.RegistrationID {
-		return c.repository.SetActiveCacheRegistration(ctx, host.LogicalHostID, host.RegistrationID, ttl)
-	}
-
-	if _, activeFound, err := c.repository.GetCacheRegistration(ctx, host.LogicalHostID, activeRegistrationID); err != nil {
-		return err
-	} else if !activeFound {
-		return c.repository.SetActiveCacheRegistration(ctx, host.LogicalHostID, host.RegistrationID, ttl)
-	}
-
-	return nil
+	// A logical host represents one node-local cache path, not one worker
+	// process. Any live registration for that logical host can serve the same
+	// disk cache, so prefer the freshest registration. This avoids a worker
+	// cycle leaving clients routed to a dead pod until the previous active lease
+	// expires.
+	return c.repository.SetActiveCacheRegistration(ctx, host.LogicalHostID, host.RegistrationID, ttl)
 }
 
 func (c *Coordinator) UnregisterHost(ctx context.Context, poolName, locality, logicalHostID, registrationID string) error {
@@ -118,52 +110,78 @@ func (c *Coordinator) ListHosts(ctx context.Context, poolName, locality string) 
 
 	hosts := make([]CoordinatorHost, 0, len(logicalHostIDs))
 	for _, logicalHostID := range logicalHostIDs {
-		host, ok, err := c.activeHost(ctx, poolName, locality, logicalHostID)
+		logicalHosts, err := c.logicalHosts(ctx, poolName, locality, logicalHostID)
 		if err != nil {
 			return nil, err
 		}
-		if ok {
-			hosts = append(hosts, host)
-		}
+		hosts = append(hosts, logicalHosts...)
 	}
 	return hosts, nil
 }
 
-func (c *Coordinator) activeHost(ctx context.Context, poolName, locality, logicalHostID string) (CoordinatorHost, bool, error) {
+func (c *Coordinator) logicalHosts(ctx context.Context, poolName, locality, logicalHostID string) ([]CoordinatorHost, error) {
 	activeRegistrationID, found, err := c.repository.GetActiveCacheRegistration(ctx, logicalHostID)
 	if err != nil {
-		return CoordinatorHost{}, false, err
-	}
-	if found && activeRegistrationID != "" {
-		if host, ok, err := c.getRegistration(ctx, logicalHostID, activeRegistrationID); err != nil || ok {
-			return host, ok, err
-		}
+		return nil, err
 	}
 
 	registrationIDs, err := c.repository.ListCacheRegistrations(ctx, logicalHostID)
 	if err != nil {
-		return CoordinatorHost{}, false, err
+		return nil, err
 	}
 
+	registrationIDs = orderedCacheRegistrations(registrationIDs, activeRegistrationID)
+	hosts := make([]CoordinatorHost, 0, len(registrationIDs))
 	for _, registrationID := range registrationIDs {
 		host, ok, err := c.getRegistration(ctx, logicalHostID, registrationID)
 		if err != nil {
-			return CoordinatorHost{}, false, err
+			return nil, err
 		}
 		if !ok {
 			_ = c.repository.RemoveCacheRegistration(ctx, logicalHostID, registrationID)
 			continue
 		}
 
-		_ = c.repository.SetActiveCacheRegistration(ctx, logicalHostID, registrationID, defaultCoordinatorHostRegistrationTTL)
-		return host, true, nil
+		hosts = append(hosts, host)
 	}
 
-	return CoordinatorHost{}, false, c.pruneLogicalHost(ctx, poolName, locality, logicalHostID)
+	if len(hosts) == 0 {
+		return nil, c.pruneLogicalHost(ctx, poolName, locality, logicalHostID)
+	}
+
+	if !found || activeRegistrationID == "" || hosts[0].RegistrationID != activeRegistrationID {
+		_ = c.repository.SetActiveCacheRegistration(ctx, logicalHostID, hosts[0].RegistrationID, defaultCoordinatorHostRegistrationTTL)
+	}
+
+	return hosts, nil
 }
 
 func (c *Coordinator) getRegistration(ctx context.Context, logicalHostID, registrationID string) (CoordinatorHost, bool, error) {
 	return c.repository.GetCacheRegistration(ctx, logicalHostID, registrationID)
+}
+
+func orderedCacheRegistrations(registrationIDs []string, activeRegistrationID string) []string {
+	ordered := make([]string, 0, len(registrationIDs))
+	seen := make(map[string]struct{}, len(registrationIDs))
+
+	if activeRegistrationID != "" {
+		for _, registrationID := range registrationIDs {
+			if registrationID == activeRegistrationID {
+				ordered = append(ordered, registrationID)
+				seen[registrationID] = struct{}{}
+				break
+			}
+		}
+	}
+
+	sort.Strings(registrationIDs)
+	for _, registrationID := range registrationIDs {
+		if _, ok := seen[registrationID]; ok {
+			continue
+		}
+		ordered = append(ordered, registrationID)
+	}
+	return ordered
 }
 
 func (c *Coordinator) pruneLogicalHost(ctx context.Context, poolName, locality, logicalHostID string) error {

--- a/pkg/cache/coordinator_test.go
+++ b/pkg/cache/coordinator_test.go
@@ -88,7 +88,7 @@ func (r *memoryCoordinatorRepository) RemoveCacheLogicalHost(ctx context.Context
 	return nil
 }
 
-func TestCoordinatorDeduplicatesLogicalHostsAndPromotesRegistrations(t *testing.T) {
+func TestCoordinatorListsLiveRegistrationsWithActiveFirst(t *testing.T) {
 	repo := newMemoryCoordinatorRepository()
 	coordinator := NewCoordinator(repo)
 
@@ -117,9 +117,13 @@ func TestCoordinatorDeduplicatesLogicalHostsAndPromotesRegistrations(t *testing.
 
 	hosts, err := coordinator.ListHosts(ctx, "default", "default")
 	require.NoError(t, err)
-	require.Len(t, hosts, 1)
+	require.Len(t, hosts, 2)
 	require.Equal(t, logicalHostID, hosts[0].LogicalHostID)
-	require.Equal(t, "worker-a", hosts[0].RegistrationID)
+	require.Equal(t, "worker-b", hosts[0].RegistrationID)
+	require.Equal(t, "10.0.0.2:2049", hosts[0].PrivateAddr)
+	require.Equal(t, logicalHostID, hosts[1].LogicalHostID)
+	require.Equal(t, "worker-a", hosts[1].RegistrationID)
+	require.Equal(t, "10.0.0.1:2049", hosts[1].PrivateAddr)
 
 	err = coordinator.UnregisterHost(ctx, "default", "default", logicalHostID, "worker-a")
 	require.NoError(t, err)
@@ -130,6 +134,40 @@ func TestCoordinatorDeduplicatesLogicalHostsAndPromotesRegistrations(t *testing.
 	require.Equal(t, logicalHostID, hosts[0].LogicalHostID)
 	require.Equal(t, "worker-b", hosts[0].RegistrationID)
 	require.Equal(t, "10.0.0.2:2049", hosts[0].PrivateAddr)
+}
+
+func TestCoordinatorListsBackupRegistrationWhenActiveRegistrationStillExists(t *testing.T) {
+	repo := newMemoryCoordinatorRepository()
+	coordinator := NewCoordinator(repo)
+	ctx := context.Background()
+
+	logicalHostID := "cache-host-default-node-a-path-0"
+	for _, registration := range []struct {
+		id   string
+		addr string
+	}{
+		{id: "worker-a", addr: "10.0.0.1:2049"},
+		{id: "worker-b", addr: "10.0.0.2:2049"},
+	} {
+		require.NoError(t, coordinator.RegisterHost(ctx, CoordinatorHost{
+			LogicalHostID:  logicalHostID,
+			RegistrationID: registration.id,
+			PoolName:       "default",
+			Locality:       "default",
+			NodeID:         "node-a",
+			CachePathID:    "path",
+			Addr:           registration.addr,
+			PrivateAddr:    registration.addr,
+		}, 30*time.Second))
+	}
+
+	require.NoError(t, repo.SetActiveCacheRegistration(ctx, logicalHostID, "worker-a", 30*time.Second))
+
+	hosts, err := coordinator.ListHosts(ctx, "default", "default")
+	require.NoError(t, err)
+	require.Len(t, hosts, 2)
+	require.Equal(t, "worker-a", hosts[0].RegistrationID)
+	require.Equal(t, "worker-b", hosts[1].RegistrationID)
 }
 
 func TestCoordinatorPromotesRegisteringRegistrationWhenActiveRegistrationIsGone(t *testing.T) {

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -339,6 +339,10 @@ const (
 	ContainerLifecycleSchedulerProvisionWorker    ContainerLifecycleID = "scheduler.provision_worker"
 	ContainerLifecycleWorkerQueueReceive          ContainerLifecycleID = "worker.queue_receive"
 	ContainerLifecycleImageLoad                   ContainerLifecycleID = "image.load"
+	ContainerLifecycleImageEmbeddedCacheMetadata  ContainerLifecycleID = "image.embedded_cache_metadata_copy"
+	ContainerLifecycleImageEmbeddedCacheStore     ContainerLifecycleID = "image.embedded_cache_store"
+	ContainerLifecycleImageEmbeddedCacheWait      ContainerLifecycleID = "image.embedded_cache_wait"
+	ContainerLifecycleImageEmbeddedCacheRestore   ContainerLifecycleID = "image.embedded_cache_restore"
 	ContainerLifecycleSetWorkerAddress            ContainerLifecycleID = "worker.set_worker_address"
 	ContainerLifecyclePortAllocation              ContainerLifecycleID = "worker.port_allocation"
 	ContainerLifecycleReadBundleConfig            ContainerLifecycleID = "worker.read_bundle_config"
@@ -409,6 +413,10 @@ var ContainerLifecycleDefinitions = map[ContainerLifecycleID]ContainerLifecycleD
 	ContainerLifecycleSchedulerProvisionWorker:    {ID: ContainerLifecycleSchedulerProvisionWorker, Domain: EventDomainScheduler, ParentID: ContainerLifecycleStartup, Label: "Worker provisioning"},
 	ContainerLifecycleWorkerQueueReceive:          {ID: ContainerLifecycleWorkerQueueReceive, Domain: EventDomainWorker, ParentID: ContainerLifecycleStartup, Label: "Worker queue receive"},
 	ContainerLifecycleImageLoad:                   {ID: ContainerLifecycleImageLoad, Domain: EventDomainImage, ParentID: ContainerLifecycleStartup, Label: "Image load", Required: true},
+	ContainerLifecycleImageEmbeddedCacheMetadata:  {ID: ContainerLifecycleImageEmbeddedCacheMetadata, Domain: EventDomainImage, ParentID: ContainerLifecycleImageLoad, Label: "Embedded image cache metadata copy"},
+	ContainerLifecycleImageEmbeddedCacheStore:     {ID: ContainerLifecycleImageEmbeddedCacheStore, Domain: EventDomainImage, ParentID: ContainerLifecycleImageLoad, Label: "Embedded image cache store"},
+	ContainerLifecycleImageEmbeddedCacheWait:      {ID: ContainerLifecycleImageEmbeddedCacheWait, Domain: EventDomainImage, ParentID: ContainerLifecycleImageLoad, Label: "Wait for embedded image cache"},
+	ContainerLifecycleImageEmbeddedCacheRestore:   {ID: ContainerLifecycleImageEmbeddedCacheRestore, Domain: EventDomainImage, ParentID: ContainerLifecycleImageLoad, Label: "Embedded image cache restore"},
 	ContainerLifecycleSetWorkerAddress:            {ID: ContainerLifecycleSetWorkerAddress, Domain: EventDomainWorker, ParentID: ContainerLifecycleStartup, Label: "Set worker address"},
 	ContainerLifecyclePortAllocation:              {ID: ContainerLifecyclePortAllocation, Domain: EventDomainWorker, ParentID: ContainerLifecycleStartup, Label: "Port allocation"},
 	ContainerLifecycleReadBundleConfig:            {ID: ContainerLifecycleReadBundleConfig, Domain: EventDomainWorker, ParentID: ContainerLifecycleStartup, Label: "Read bundle config"},

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -38,10 +38,12 @@ import (
 )
 
 const (
-	imageBundlePath    string = "/dev/shm/images"
-	imageTmpDir        string = "/tmp"
-	metricsSourceLabel        = "image_client"
-	pullLazyBackoff           = 1000 * time.Millisecond
+	imageBundlePath                string = "/dev/shm/images"
+	imageTmpDir                    string = "/tmp"
+	metricsSourceLabel                    = "image_client"
+	pullLazyBackoff                       = 1000 * time.Millisecond
+	embeddedImageCacheWaitTimeout         = 2 * time.Minute
+	embeddedImageCacheWaitInterval        = 250 * time.Millisecond
 )
 
 var (
@@ -847,13 +849,13 @@ func (c *ImageClient) pullImageArchiveFromEmbeddedCache(ctx context.Context, arc
 
 	metadataStart := time.Now()
 	if ok, err := c.copyImageArchiveFromContentCacheMetadata(ctx, archivePath, imageId); ok {
-		c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_metadata_copy"), metadataStart, time.Since(metadataStart), true, nil)
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheMetadata, metadataStart, time.Since(metadataStart), true, nil)
 		return true, nil
 	} else if err != nil {
-		c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_metadata_copy"), metadataStart, time.Since(metadataStart), false, nil)
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheMetadata, metadataStart, time.Since(metadataStart), false, nil)
 		log.Warn().Err(err).Str("image_id", imageId).Msg("embedded image archive content cache metadata unavailable")
 	} else {
-		c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_metadata_copy"), metadataStart, time.Since(metadataStart), true, map[string]string{"hit": "false"})
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheMetadata, metadataStart, time.Since(metadataStart), true, map[string]string{"hit": "false"})
 	}
 
 	cachePath := c.imageArchiveCachePath(imageId)
@@ -896,26 +898,68 @@ func (c *ImageClient) pullImageArchiveFromEmbeddedCache(ctx context.Context, arc
 		}, cache.StoreContentOptions{RoutingKey: routingKey, Lock: true})
 	}
 	if err != nil {
-		c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_store"), storeStart, time.Since(storeStart), false, nil)
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheStore, storeStart, time.Since(storeStart), false, nil)
+		if errors.Is(err, cache.ErrUnableToAcquireLock) {
+			waitStart := time.Now()
+			if ok, waitErr := c.waitForImageArchiveContentCache(ctx, archivePath, imageId); ok {
+				c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheWait, waitStart, time.Since(waitStart), true, map[string]string{
+					"reason": "store_lock_contended",
+				})
+				return true, nil
+			} else if waitErr != nil {
+				c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheWait, waitStart, time.Since(waitStart), false, map[string]string{
+					"reason": "store_lock_contended",
+				})
+				return false, waitErr
+			}
+		}
 		return false, err
 	}
-	c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_store"), storeStart, time.Since(storeStart), true, map[string]string{
+	c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheStore, storeStart, time.Since(storeStart), true, map[string]string{
 		"registry_store": c.config.ImageService.RegistryStore,
 	})
 
 	restoreStart := time.Now()
 	size, err := c.registry.Size(ctx, imageId)
 	if err != nil {
-		c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_restore"), restoreStart, time.Since(restoreStart), false, nil)
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheRestore, restoreStart, time.Since(restoreStart), false, nil)
 		return false, err
 	}
 	if err := c.writeImageArchiveFromContentCache(ctx, archivePath, imageId, hash, size, routingKey); err != nil {
-		c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_restore"), restoreStart, time.Since(restoreStart), false, map[string]string{"size_bytes": fmt.Sprintf("%d", size)})
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheRestore, restoreStart, time.Since(restoreStart), false, map[string]string{"size_bytes": fmt.Sprintf("%d", size)})
 		return false, err
 	}
-	c.recordImageLifecycle(request, types.ContainerLifecycleID("image.embedded_cache_restore"), restoreStart, time.Since(restoreStart), true, map[string]string{"size_bytes": fmt.Sprintf("%d", size)})
+	c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheRestore, restoreStart, time.Since(restoreStart), true, map[string]string{"size_bytes": fmt.Sprintf("%d", size)})
 
 	return true, nil
+}
+
+func (c *ImageClient) waitForImageArchiveContentCache(ctx context.Context, archivePath, imageId string) (bool, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, embeddedImageCacheWaitTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(embeddedImageCacheWaitInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		ok, err := c.copyImageArchiveFromContentCacheMetadata(waitCtx, archivePath, imageId)
+		if ok {
+			return true, nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+
+		select {
+		case <-waitCtx.Done():
+			if lastErr != nil {
+				return false, lastErr
+			}
+			return false, waitCtx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (c *ImageClient) copyImageArchiveFromContentCacheMetadata(ctx context.Context, archivePath, imageId string) (bool, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves cache routing and hot paths for faster, more reliable reads and stores. Adds an embedded image cache wait/restore flow and new lifecycle events for better observability.

- **New Features**
  - Coordinator: list all live registrations for a logical host (active first) and prefer the freshest registration on `RegisterHost`.
  - Worker image: wait for embedded image cache when the store lock is contended; add lifecycle events for metadata/store/wait/restore.

- **Bug Fixes**
  - Client: clear cached routing when a host is re-added to avoid stale routes after restarts.
  - Client: reuse cached local files via verified `CacheFSMetadata` and locality checks to skip reading/hashing when content already exists; avoid cachefs lookups on the hot read path.

<sup>Written for commit 53749ee42a7d527ad88dc4b0c825f333f010b7e9. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1576?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

