### PR TITLE
fix: process leakage / reaping bug

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -157,10 +157,10 @@ WORKDIR /workspace
 RUN apt-get update && \
     apt-get install -y curl gpg && \
     curl -fsSL https://nvidia.github.io/nvidia-container-runtime/gpgkey | apt-key add - && \
-    curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu22.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list \
+    curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu22.04/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list && \
     curl -fsSL https://nvidia.github.io/nvidia-container-runtime/ubuntu22.04/nvidia-container-runtime.list | tee /etc/apt/sources.list.d/nvidia-container-runtime.list && \
     apt-get update && \
-    apt-get install psmisc
+    apt-get install -y psmisc tini
 
 RUN curl -L https://beam-runner-python-deps.s3.amazonaws.com/juicefs -o /usr/local/bin/juicefs && chmod +x /usr/local/bin/juicefs
 RUN curl -fsSL https://tailscale.com/install.sh | sh

--- a/pkg/cache/source_juicefs.go
+++ b/pkg/cache/source_juicefs.go
@@ -1,17 +1,22 @@
 package cache
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"time"
+
+	managedprocess "github.com/beam-cloud/beta9/pkg/common/process"
 )
 
-const juiceFsMountTimeout time.Duration = 30 * time.Second
+const (
+	juiceFsSourceMountTimeout   time.Duration = 30 * time.Second
+	juiceFsSourceUnmountTimeout time.Duration = 10 * time.Second
+)
 
 type JuiceFsSource struct {
-	mountCmd *exec.Cmd
+	mountCmd *managedprocess.ManagedCommand
 	config   JuiceFSConfig
 }
 
@@ -36,57 +41,45 @@ func (s *JuiceFsSource) Mount(localPath string) error {
 		bufferSize = "300"
 	}
 
-	mountCtx, cancelMount := context.WithCancel(context.Background())
-
-	s.mountCmd = exec.CommandContext(
-		mountCtx,
-		"juicefs",
+	args := []string{
 		"mount",
 		s.config.RedisURI,
 		localPath,
-		"-d",
 		"--bucket", s.config.Bucket,
 		"--cache-size", cacheSize,
 		"--prefetch", prefetch,
 		"--buffer-size", bufferSize,
 		"--no-bgjob",
 		"--no-usage-report",
-	)
-
-	type mountResult struct {
-		output []byte
-		err    error
 	}
-	resultCh := make(chan mountResult, 1)
-	go func() {
-		output, err := s.mountCmd.CombinedOutput()
-		resultCh <- mountResult{output: output, err: err}
-	}()
+
+	mountCmd, err := managedprocess.StartManagedCommand("juicefs", args, nil)
+	if err != nil {
+		return err
+	}
+	s.mountCmd = mountCmd
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
-	timeout := time.NewTimer(juiceFsMountTimeout)
+	timeout := time.NewTimer(juiceFsSourceMountTimeout)
 	defer timeout.Stop()
 
 	for {
+		if isMounted(localPath) {
+			Logger.Infof("JuiceFS filesystem mounted to: '%s'", localPath)
+			return nil
+		}
+		if err, done := s.mountCmd.DoneErr(); done {
+			return fmt.Errorf("juicefs mount exited before filesystem was mounted to: '%s': %w, output: %s", localPath, err, s.mountCmd.OutputString())
+		}
+
 		select {
-		case result := <-resultCh:
-			if result.err != nil {
-				return fmt.Errorf("error executing juicefs mount: %w, output: %s", result.err, string(result.output))
-			}
-			if isMounted(localPath) {
-				Logger.Infof("JuiceFS filesystem mounted to: '%s'", localPath)
-				return nil
-			}
-			resultCh = nil
 		case <-ticker.C:
-			if isMounted(localPath) {
-				Logger.Infof("JuiceFS filesystem mounted to: '%s'", localPath)
-				return nil
-			}
 		case <-timeout.C:
-			cancelMount()
-			return fmt.Errorf("failed to mount JuiceFS filesystem to: '%s': timed out after %s", localPath, juiceFsMountTimeout)
+			output := s.mountCmd.OutputString()
+			_ = s.mountCmd.Terminate(juiceFsSourceUnmountTimeout)
+			s.mountCmd = nil
+			return fmt.Errorf("failed to mount JuiceFS filesystem to: '%s': timed out after %s, output: %s", localPath, juiceFsSourceMountTimeout, output)
 		}
 	}
 }
@@ -125,13 +118,21 @@ func (s *JuiceFsSource) Format(fsName string) error {
 }
 
 func (s *JuiceFsSource) Unmount(localPath string) error {
-	cmd := exec.Command("juicefs", "umount", "--force", localPath)
-
-	output, err := cmd.CombinedOutput()
+	var errs error
+	output, err := managedprocess.RunCommandWithTimeout(juiceFsSourceUnmountTimeout, "juicefs", "umount", "--force", localPath)
 	if err != nil {
-		return fmt.Errorf("error executing juicefs umount: %v, output: %s", err, string(output))
+		errs = errors.Join(errs, fmt.Errorf("error executing juicefs umount: %v, output: %s", err, string(output)))
+	}
+
+	if s.mountCmd != nil {
+		if err := s.mountCmd.Wait(juiceFsSourceUnmountTimeout); errors.Is(err, managedprocess.ErrStillRunning) {
+			if terminateErr := s.mountCmd.Terminate(juiceFsSourceUnmountTimeout); terminateErr != nil {
+				errs = errors.Join(errs, fmt.Errorf("error terminating juicefs source process: %w, output: %s", terminateErr, s.mountCmd.OutputString()))
+			}
+		}
+		s.mountCmd = nil
 	}
 
 	Logger.Infof("JuiceFS filesystem unmounted from: '%s'", localPath)
-	return nil
+	return errs
 }

--- a/pkg/cache/source_mountpoint.go
+++ b/pkg/cache/source_mountpoint.go
@@ -1,17 +1,21 @@
 package cache
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"time"
+
+	managedprocess "github.com/beam-cloud/beta9/pkg/common/process"
 )
 
-const mountPointMountTimeout time.Duration = 30 * time.Second
+const (
+	mountPointMountTimeout   time.Duration = 30 * time.Second
+	mountPointUnmountTimeout time.Duration = 10 * time.Second
+)
 
 type MountPointSource struct {
-	mountCmd *exec.Cmd
+	mountCmd *managedprocess.ManagedCommand
 	config   MountPointConfig
 }
 
@@ -22,16 +26,13 @@ func NewMountPointSource(config MountPointConfig) (Source, error) {
 }
 
 func (s *MountPointSource) Mount(localPath string) error {
-	// NOTE: this is called to force unmount previous mounts
-	// It seems like mountpoint doesn't clean up gracefully by itself
+	// Clear any stale mount before remounting.
 	s.Unmount(localPath)
 	if err := os.MkdirAll(localPath, 0755); err != nil {
 		return fmt.Errorf("failed to create mount path %s: %w", localPath, err)
 	}
 
-	mountCtx, cancelMount := context.WithCancel(context.Background())
-	s.mountCmd = exec.CommandContext(
-		mountCtx,
+	args := []string{
 		"mount-s3",
 		s.config.BucketName,
 		localPath,
@@ -39,29 +40,27 @@ func (s *MountPointSource) Mount(localPath string) error {
 		s.config.Region,
 		"--endpoint-url",
 		s.config.EndpointURL,
+		"--foreground",
 		"--read-only",
-	)
-
-	if s.config.ForcePathStyle {
-		s.mountCmd.Args = append(s.mountCmd.Args, "--force-path-style")
 	}
 
+	if s.config.ForcePathStyle {
+		args = append(args, "--force-path-style")
+	}
+
+	env := []string{}
 	if s.config.AccessKey != "" || s.config.SecretKey != "" {
-		s.mountCmd.Env = append(os.Environ(),
+		env = append(env,
 			fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", s.config.AccessKey),
 			fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", s.config.SecretKey),
 		)
 	}
 
-	type mountResult struct {
-		output []byte
-		err    error
+	mountCmd, err := managedprocess.StartManagedCommand(args[0], args[1:], env)
+	if err != nil {
+		return err
 	}
-	resultCh := make(chan mountResult, 1)
-	go func() {
-		output, err := s.mountCmd.CombinedOutput()
-		resultCh <- mountResult{output: output, err: err}
-	}()
+	s.mountCmd = mountCmd
 
 	Logger.Infof("Mountpoint filesystem is being mounted to: '%s'", localPath)
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -70,26 +69,21 @@ func (s *MountPointSource) Mount(localPath string) error {
 	defer timeout.Stop()
 
 	for {
+		if isMounted(localPath) {
+			Logger.Infof("Mountpoint filesystem mounted to: '%s'", localPath)
+			return nil
+		}
+		if err, done := s.mountCmd.DoneErr(); done {
+			return fmt.Errorf("mount-s3 exited before filesystem was mounted to: '%s': %w, output: %s", localPath, err, s.mountCmd.OutputString())
+		}
+
 		select {
-		case result := <-resultCh:
-			if result.err != nil {
-				cancelMount()
-				return fmt.Errorf("error executing mount-s3 mount: %w, output: %s", result.err, string(result.output))
-			}
-			if isMounted(localPath) {
-				Logger.Infof("Mountpoint filesystem mounted to: '%s'", localPath)
-				return nil
-			}
-			cancelMount()
-			return fmt.Errorf("mount-s3 exited before filesystem was mounted to: '%s', output: %s", localPath, string(result.output))
 		case <-ticker.C:
-			if isMounted(localPath) {
-				Logger.Infof("Mountpoint filesystem mounted to: '%s'", localPath)
-				return nil
-			}
 		case <-timeout.C:
-			cancelMount()
-			return fmt.Errorf("failed to mount Mountpoint filesystem to: '%s': timed out after %s", localPath, mountPointMountTimeout)
+			output := s.mountCmd.OutputString()
+			_ = s.mountCmd.Terminate(mountPointUnmountTimeout)
+			s.mountCmd = nil
+			return fmt.Errorf("failed to mount Mountpoint filesystem to: '%s': timed out after %s, output: %s", localPath, mountPointMountTimeout, output)
 		}
 	}
 }
@@ -99,12 +93,22 @@ func (s *MountPointSource) Format(fsName string) error {
 }
 
 func (s *MountPointSource) Unmount(localPath string) error {
-	cmd := exec.Command("umount", localPath)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("error executing mount-s3 umount: %v, output: %s", err, string(output))
+	var errs error
+	if isMounted(localPath) {
+		output, err := managedprocess.RunCommandWithTimeout(mountPointUnmountTimeout, "umount", localPath)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error executing mount-s3 umount: %v, output: %s", err, string(output)))
+		}
 	}
 
-	return nil
+	if s.mountCmd != nil {
+		if err := s.mountCmd.Wait(mountPointUnmountTimeout); errors.Is(err, managedprocess.ErrStillRunning) {
+			if terminateErr := s.mountCmd.Terminate(mountPointUnmountTimeout); terminateErr != nil {
+				errs = errors.Join(errs, fmt.Errorf("error terminating mountpoint source process: %w, output: %s", terminateErr, s.mountCmd.OutputString()))
+			}
+		}
+		s.mountCmd = nil
+	}
+
+	return errs
 }

--- a/pkg/common/process/managed_command.go
+++ b/pkg/common/process/managed_command.go
@@ -1,0 +1,176 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var ErrStillRunning = errors.New("managed command still running")
+
+type lockedBuffer struct {
+	mu  *sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (b lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+type ManagedCommand struct {
+	cmd      *exec.Cmd
+	done     chan struct{}
+	errMu    sync.Mutex
+	err      error
+	outputMu sync.Mutex
+	output   bytes.Buffer
+}
+
+func StartManagedCommand(name string, args []string, env []string) (*ManagedCommand, error) {
+	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if env != nil {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	c := &ManagedCommand{
+		cmd:  cmd,
+		done: make(chan struct{}),
+	}
+	w := lockedBuffer{mu: &c.outputMu, buf: &c.output}
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		err := cmd.Wait()
+		c.errMu.Lock()
+		c.err = err
+		c.errMu.Unlock()
+		close(c.done)
+	}()
+
+	return c, nil
+}
+
+func (c *ManagedCommand) Wait(timeout time.Duration) error {
+	if c == nil {
+		return nil
+	}
+
+	if timeout <= 0 {
+		<-c.done
+		return c.result()
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-c.done:
+		return c.result()
+	case <-timer.C:
+		return ErrStillRunning
+	}
+}
+
+func (c *ManagedCommand) DoneErr() (error, bool) {
+	if c == nil {
+		return nil, true
+	}
+
+	select {
+	case <-c.done:
+		return c.result(), true
+	default:
+		return nil, false
+	}
+}
+
+func (c *ManagedCommand) result() error {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+	return c.err
+}
+
+func (c *ManagedCommand) Terminate(timeout time.Duration) error {
+	if c == nil || c.cmd == nil || c.cmd.Process == nil {
+		return nil
+	}
+	if err, done := c.DoneErr(); done {
+		return err
+	}
+
+	if err := c.signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal managed command: %w", err)
+	}
+	if err := c.Wait(timeout); !errors.Is(err, ErrStillRunning) {
+		return nil
+	}
+
+	if err := c.signal(syscall.SIGKILL); err != nil {
+		return fmt.Errorf("kill managed command: %w", err)
+	}
+	if err := c.Wait(timeout); errors.Is(err, ErrStillRunning) {
+		return err
+	}
+	return nil
+}
+
+func (c *ManagedCommand) signal(sig syscall.Signal) error {
+	if c == nil || c.cmd == nil || c.cmd.Process == nil {
+		return nil
+	}
+
+	pid := c.cmd.Process.Pid
+	if pgid, err := syscall.Getpgid(pid); err == nil {
+		if err := syscall.Kill(-pgid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return nil
+	}
+
+	if err := c.cmd.Process.Signal(sig); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}
+
+func (c *ManagedCommand) OutputString() string {
+	if c == nil {
+		return ""
+	}
+	c.outputMu.Lock()
+	defer c.outputMu.Unlock()
+	return c.output.String()
+}
+
+func (c *ManagedCommand) PID() int {
+	if c == nil || c.cmd == nil || c.cmd.Process == nil {
+		return 0
+	}
+	return c.cmd.Process.Pid
+}
+
+func RunCommandWithTimeout(timeout time.Duration, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	return output, err
+}

--- a/pkg/common/process/managed_command_test.go
+++ b/pkg/common/process/managed_command_test.go
@@ -1,0 +1,27 @@
+package process
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestManagedCommandTerminateKillsAndWaits(t *testing.T) {
+	cmd, err := StartManagedCommand("sh", []string{"-c", "trap '' TERM; sleep 60"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.PID()
+
+	if err := cmd.Terminate(100 * time.Millisecond); err != nil {
+		t.Fatalf("terminate failed: %v, output=%s", err, cmd.OutputString())
+	}
+
+	if err := syscall.Kill(pid, 0); err == nil || !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("expected process %d to be gone after terminate, kill(0) err=%v", pid, err)
+	}
+	if _, done := cmd.DoneErr(); !done {
+		t.Fatal("managed command was not reaped")
+	}
+}

--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -33,6 +33,7 @@ const (
 	devicePluginVolumeName      string  = "kubelet-device-plugins"
 	defaultDevicePluginPath     string  = "/var/lib/kubelet/device-plugins"
 	defaultContainerName        string  = "worker"
+	defaultWorkerInit           string  = "/usr/bin/tini"
 	defaultWorkerEntrypoint     string  = "/usr/local/bin/worker"
 	defaultWorkerLogPath        string  = "/var/log/worker"
 	defaultImagesPath           string  = "/images"
@@ -40,9 +41,15 @@ const (
 	defaultStoragePath          string  = "/storage"
 	defaultCachePath            string  = "/var/lib/beta9/cache"
 	defaultSharedMemoryPct      float32 = 0.5
+	defaultWorkerStopGraceS     int64   = 30
+	minWorkerPodGraceS          int64   = 120
 	poolMonitoringInterval              = 1 * time.Second
 	poolHealthCheckInterval             = 10 * time.Second
 )
+
+func workerPodCommand() []string {
+	return []string{defaultWorkerInit, "-g", "--", defaultWorkerEntrypoint}
+}
 
 type WorkerPoolController interface {
 	AddWorker(cpu int64, memory int64, gpuCount uint32) (*types.Worker, error)
@@ -120,6 +127,19 @@ func workerCacheMountPath(config types.AppConfig, poolConfig types.WorkerPoolCon
 		return config.Cache.Disk.MountPath
 	}
 	return defaultCachePath
+}
+
+func workerPodTerminationGracePeriod(workerStopGraceS int64) int64 {
+	if workerStopGraceS <= 0 {
+		workerStopGraceS = defaultWorkerStopGraceS
+	}
+
+	// Covers task drain, forced nested-container stop, and FUSE unmounts.
+	grace := workerStopGraceS*2 + 60
+	if grace < minWorkerPodGraceS {
+		return minWorkerPodGraceS
+	}
+	return grace
 }
 
 func MonitorPoolSize(wpc WorkerPoolController,

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -363,11 +363,9 @@ func (wpc *ExternalWorkerPoolController) createWorkerJob(workerId, machineId str
 
 	containers := []corev1.Container{
 		{
-			Name:  defaultContainerName,
-			Image: workerImage,
-			Command: []string{
-				defaultWorkerEntrypoint,
-			},
+			Name:    defaultContainerName,
+			Image:   workerImage,
+			Command: workerPodCommand(),
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: ptr.To(true),
 			},
@@ -388,14 +386,15 @@ func (wpc *ExternalWorkerPoolController) createWorkerJob(workerId, machineId str
 			Labels: labels,
 		},
 		Spec: corev1.PodSpec{
-			HostNetwork:        true,
-			ImagePullSecrets:   imagePullSecrets,
-			RestartPolicy:      corev1.RestartPolicyOnFailure,
-			NodeSelector:       wpc.workerPoolConfig.JobSpec.NodeSelector,
-			Containers:         containers,
-			Volumes:            wpc.getWorkerVolumes(workerMemory),
-			EnableServiceLinks: ptr.To(false),
-			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+			HostNetwork:                   true,
+			ImagePullSecrets:              imagePullSecrets,
+			RestartPolicy:                 corev1.RestartPolicyOnFailure,
+			NodeSelector:                  wpc.workerPoolConfig.JobSpec.NodeSelector,
+			Containers:                    containers,
+			Volumes:                       wpc.getWorkerVolumes(workerMemory),
+			EnableServiceLinks:            ptr.To(false),
+			DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
+			TerminationGracePeriodSeconds: ptr.To(workerPodTerminationGracePeriod(wpc.config.Worker.TerminationGracePeriod)),
 		},
 	}
 

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -218,11 +218,9 @@ func (wpc *LocalKubernetesWorkerPoolController) createWorkerJob(workerId string,
 
 	containers := []corev1.Container{
 		{
-			Name:  defaultContainerName,
-			Image: workerImage,
-			Command: []string{
-				defaultWorkerEntrypoint,
-			},
+			Name:      defaultContainerName,
+			Image:     workerImage,
+			Command:   workerPodCommand(),
 			Resources: resources,
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: ptr.To(true),
@@ -249,15 +247,16 @@ func (wpc *LocalKubernetesWorkerPoolController) createWorkerJob(workerId string,
 			Labels: labels,
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName:           wpc.config.Worker.ServiceAccountName,
-			AutomountServiceAccountToken: ptr.To(true),
-			HostNetwork:                  wpc.config.Worker.HostNetwork,
-			ImagePullSecrets:             imagePullSecrets,
-			RestartPolicy:                corev1.RestartPolicyOnFailure,
-			NodeSelector:                 wpc.workerPoolConfig.JobSpec.NodeSelector,
-			Containers:                   containers,
-			Volumes:                      wpc.getWorkerVolumes(workerMemory),
-			EnableServiceLinks:           ptr.To(false),
+			ServiceAccountName:            wpc.config.Worker.ServiceAccountName,
+			AutomountServiceAccountToken:  ptr.To(true),
+			HostNetwork:                   wpc.config.Worker.HostNetwork,
+			ImagePullSecrets:              imagePullSecrets,
+			RestartPolicy:                 corev1.RestartPolicyOnFailure,
+			NodeSelector:                  wpc.workerPoolConfig.JobSpec.NodeSelector,
+			Containers:                    containers,
+			Volumes:                       wpc.getWorkerVolumes(workerMemory),
+			EnableServiceLinks:            ptr.To(false),
+			TerminationGracePeriodSeconds: ptr.To(workerPodTerminationGracePeriod(wpc.config.Worker.TerminationGracePeriod)),
 		},
 	}
 

--- a/pkg/scheduler/pool_test.go
+++ b/pkg/scheduler/pool_test.go
@@ -55,3 +55,27 @@ func TestGetPercentageWithDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkerPodTerminationGracePeriodAllowsNestedCleanup(t *testing.T) {
+	tests := []struct {
+		name            string
+		workerStopGrace int64
+		want            int64
+	}{
+		{name: "default", workerStopGrace: 0, want: 120},
+		{name: "short", workerStopGrace: 10, want: 120},
+		{name: "long", workerStopGrace: 90, want: 240},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workerPodTerminationGracePeriod(tt.workerStopGrace); got != tt.want {
+				t.Fatalf("workerPodTerminationGracePeriod(%d) = %d, want %d", tt.workerStopGrace, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkerPodCommandUsesInitReaper(t *testing.T) {
+	assert.Equal(t, []string{"/usr/bin/tini", "-g", "--", "/usr/local/bin/worker"}, workerPodCommand())
+}

--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -21,6 +22,7 @@ const (
 	defaultGeeseFSFileMode         = 0644
 	defaultGeeseFSMountTimeout     = 30 * time.Second
 	defaultGeeseFSRequestTimeout   = 60 * time.Second
+	defaultGeeseFSUnmountTimeout   = 2 * defaultGeeseFSRequestTimeout
 	defaultGeeseFSFuseReadAheadKb  = 32768
 	defaultGeeseFSReadAheadKb      = 32768
 	defaultGeeseFSReadAheadLargeKb = 131072
@@ -296,14 +298,29 @@ func (s *GeeseStorage) Unmount(localPath string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var errs error
+
 	if s.fs != nil {
 		log.Info().Str("local_path", localPath).Msg("geesefs: waiting for files to flush")
-		s.fs.WaitForFlush()
-		log.Info().Str("local_path", localPath).Msg("geesefs: files flushed")
+		flushed := make(chan struct{})
+		go func(fs *core.Goofys) {
+			fs.WaitForFlush()
+			close(flushed)
+		}(s.fs)
+
+		select {
+		case <-flushed:
+			log.Info().Str("local_path", localPath).Msg("geesefs: files flushed")
+		case <-time.After(defaultGeeseFSUnmountTimeout):
+			errs = errors.Join(errs, fmt.Errorf("timed out waiting for geesefs files to flush after %s", defaultGeeseFSUnmountTimeout))
+			log.Warn().Str("local_path", localPath).Dur("timeout", defaultGeeseFSUnmountTimeout).Msg("geesefs: flush wait timed out during unmount")
+		}
 	}
 
 	if s.mfs != nil {
-		s.mfs.Unmount()
+		if err := s.mfs.Unmount(); err != nil {
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	log.Info().Str("local_path", localPath).Msg("geesefs: filesystem unmounted")
@@ -311,7 +328,7 @@ func (s *GeeseStorage) Unmount(localPath string) error {
 	s.mfs = nil
 	s.fs = nil
 
-	return nil
+	return errs
 }
 
 func (s *GeeseStorage) Format(fsName string) error {

--- a/pkg/storage/juicefs.go
+++ b/pkg/storage/juicefs.go
@@ -1,20 +1,25 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"time"
 
+	managedprocess "github.com/beam-cloud/beta9/pkg/common/process"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/cenkalti/backoff"
 	"github.com/rs/zerolog/log"
 )
 
-const juiceFsMountTimeout time.Duration = 30 * time.Second
+const (
+	juiceFsMountTimeout   time.Duration = 30 * time.Second
+	juiceFsUnmountTimeout time.Duration = 10 * time.Second
+)
 
 type JuiceFsStorage struct {
-	mountCmd *exec.Cmd
+	mountCmd *managedprocess.ManagedCommand
 	config   types.JuiceFSConfig
 }
 
@@ -39,8 +44,7 @@ func (s *JuiceFsStorage) Mount(localPath string) error {
 		bufferSize = "300"
 	}
 
-	s.mountCmd = exec.Command(
-		"juicefs",
+	args := []string{
 		"mount",
 		s.config.RedisURI,
 		localPath,
@@ -49,41 +53,36 @@ func (s *JuiceFsStorage) Mount(localPath string) error {
 		"--prefetch", prefetch,
 		"--buffer-size", bufferSize,
 		"--no-usage-report",
-	)
-
-	// Start command in the background
-	go func() {
-		if out, err := s.mountCmd.CombinedOutput(); err != nil {
-			log.Error().Err(err).Str("output", string(out)).Msg("error with juicefs mount command")
-		}
-	}()
+	}
+	mountCmd, err := managedprocess.StartManagedCommand("juicefs", args, nil)
+	if err != nil {
+		return err
+	}
+	s.mountCmd = mountCmd
 
 	ticker := time.NewTicker(100 * time.Millisecond)
-	timeout := time.After(juiceFsMountTimeout)
+	defer ticker.Stop()
+	timeout := time.NewTimer(juiceFsMountTimeout)
+	defer timeout.Stop()
 
-	done := make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-timeout:
-				done <- false
-				return
-			case <-ticker.C:
-				if isMounted(localPath) {
-					done <- true
-					return
-				}
-			}
+	for {
+		if isMounted(localPath) {
+			log.Info().Str("local_path", localPath).Msg("juicefs filesystem mounted")
+			return nil
 		}
-	}()
+		if err, done := s.mountCmd.DoneErr(); done {
+			return fmt.Errorf("juicefs mount exited before mount completed: %w, output: %s", err, s.mountCmd.OutputString())
+		}
 
-	// Wait for confirmation or timeout
-	if !<-done {
-		return fmt.Errorf("failed to mount JuiceFS filesystem to: '%s'", localPath)
+		select {
+		case <-ticker.C:
+		case <-timeout.C:
+			output := s.mountCmd.OutputString()
+			_ = s.mountCmd.Terminate(juiceFsUnmountTimeout)
+			s.mountCmd = nil
+			return fmt.Errorf("failed to mount JuiceFS filesystem to %q, output: %s", localPath, output)
+		}
 	}
-
-	log.Info().Str("local_path", localPath).Msg("juicefs filesystem mounted")
-	return nil
 }
 
 func (s *JuiceFsStorage) Mode() string {
@@ -124,10 +123,9 @@ func (s *JuiceFsStorage) Format(fsName string) error {
 }
 
 func (s *JuiceFsStorage) Unmount(localPath string) error {
+	var errs error
 	juiceFsUmount := func() error {
-		cmd := exec.Command("juicefs", "umount", localPath)
-
-		output, err := cmd.CombinedOutput()
+		output, err := managedprocess.RunCommandWithTimeout(juiceFsUnmountTimeout, "juicefs", "umount", localPath)
 		if err != nil {
 			log.Error().Err(err).Str("output", string(output)).Msg("error executing juicefs umount")
 			return err
@@ -138,15 +136,20 @@ func (s *JuiceFsStorage) Unmount(localPath string) error {
 	}
 
 	err := backoff.Retry(juiceFsUmount, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 10))
-	if err == nil {
-		return nil
-	}
-
-	// Forcefully kill the fuse mount devices
-	err = exec.Command("fuser", "-k", "/dev/fuse").Run()
 	if err != nil {
-		return fmt.Errorf("error executing fuser -k /dev/fuse: %v", err)
+		errs = errors.Join(errs, err)
 	}
 
-	return nil
+	if s.mountCmd != nil {
+		if err := s.mountCmd.Wait(juiceFsUnmountTimeout); errors.Is(err, managedprocess.ErrStillRunning) {
+			if terminateErr := s.mountCmd.Terminate(juiceFsUnmountTimeout); terminateErr != nil {
+				errs = errors.Join(errs, fmt.Errorf("error terminating juicefs process: %w, output: %s", terminateErr, s.mountCmd.OutputString()))
+			}
+		} else if err != nil {
+			log.Debug().Err(err).Str("output", s.mountCmd.OutputString()).Msg("juicefs process exited during unmount")
+		}
+		s.mountCmd = nil
+	}
+
+	return errs
 }

--- a/pkg/storage/mountpoint.go
+++ b/pkg/storage/mountpoint.go
@@ -1,19 +1,24 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+	"time"
 
+	managedprocess "github.com/beam-cloud/beta9/pkg/common/process"
 	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/rs/zerolog/log"
 )
 
 const (
-	mountpointBinary = "ms3"
+	mountpointBinary         = "ms3"
+	mountpointMountTimeout   = 30 * time.Second
+	mountpointUnmountTimeout = 10 * time.Second
 )
 
 type MountPointStorage struct {
-	mountCmd *exec.Cmd
+	mountCmd *managedprocess.ManagedCommand
 	config   types.MountPointConfig
 }
 
@@ -24,8 +29,7 @@ func NewMountPointStorage(config types.MountPointConfig) (Storage, error) {
 }
 
 func (s *MountPointStorage) Mount(localPath string) error {
-	// NOTE: this is called to force unmount previous mounts
-	// It seems like mountpoint doesn't clean up gracefully by itself
+	// Clear any stale mount before remounting.
 	s.Unmount(localPath)
 
 	if _, err := os.Stat(localPath); os.IsNotExist(err) {
@@ -36,23 +40,45 @@ func (s *MountPointStorage) Mount(localPath string) error {
 	}
 
 	cmdArgs := newMountpointCmdArgs(s, localPath)
-	s.mountCmd = exec.Command(mountpointBinary, cmdArgs...)
-
+	env := []string{}
 	if s.config.AccessKey != "" || s.config.SecretKey != "" {
-		s.mountCmd.Env = append(s.mountCmd.Env,
+		env = append(env,
 			fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", s.config.AccessKey),
 			fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", s.config.SecretKey),
 		)
 	}
 
-	output, err := s.mountCmd.CombinedOutput()
+	mountCmd, err := managedprocess.StartManagedCommand(mountpointBinary, cmdArgs, env)
 	if err != nil {
-		// Cleanup the temporary mountpoint directory if the mount fails
 		os.RemoveAll(localPath)
-		return fmt.Errorf("%+v, %s", err, string(output))
+		return err
 	}
+	s.mountCmd = mountCmd
 
-	return nil
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(mountpointMountTimeout)
+	defer timeout.Stop()
+
+	for {
+		if isMounted(localPath) {
+			return nil
+		}
+		if err, done := s.mountCmd.DoneErr(); done {
+			os.RemoveAll(localPath)
+			return fmt.Errorf("mountpoint exited before mount completed: %w, output: %s", err, s.mountCmd.OutputString())
+		}
+
+		select {
+		case <-ticker.C:
+		case <-timeout.C:
+			output := s.mountCmd.OutputString()
+			_ = s.mountCmd.Terminate(mountpointUnmountTimeout)
+			s.mountCmd = nil
+			os.RemoveAll(localPath)
+			return fmt.Errorf("timed out mounting mountpoint filesystem to %q, output: %s", localPath, output)
+		}
+	}
 }
 
 func (s *MountPointStorage) Format(fsName string) error {
@@ -64,20 +90,33 @@ func (s *MountPointStorage) Mode() string {
 }
 
 func (s *MountPointStorage) Unmount(localPath string) error {
-	cmd := exec.Command("umount", localPath)
+	var errs error
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("error executing mount-s3 umount: %v, output: %s", err, string(output))
+	if isMounted(localPath) {
+		output, err := managedprocess.RunCommandWithTimeout(mountpointUnmountTimeout, "umount", localPath)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error executing mount-s3 umount: %v, output: %s", err, string(output)))
+		}
+	}
+
+	if s.mountCmd != nil {
+		if err := s.mountCmd.Wait(mountpointUnmountTimeout); errors.Is(err, managedprocess.ErrStillRunning) {
+			if terminateErr := s.mountCmd.Terminate(mountpointUnmountTimeout); terminateErr != nil {
+				errs = errors.Join(errs, fmt.Errorf("error terminating mountpoint process: %w, output: %s", terminateErr, s.mountCmd.OutputString()))
+			}
+		} else if err != nil {
+			log.Debug().Err(err).Str("output", s.mountCmd.OutputString()).Msg("mountpoint process exited during unmount")
+		}
+		s.mountCmd = nil
 	}
 
 	os.RemoveAll(localPath)
 
-	return nil
+	return errs
 }
 
 func newMountpointCmdArgs(s *MountPointStorage, localPath string) []string {
-	cmdArgs := []string{s.config.BucketName, localPath, "--allow-other", "--log-directory=/var/log/", "--upload-checksums=off"}
+	cmdArgs := []string{s.config.BucketName, localPath, "--foreground", "--allow-other", "--log-directory=/var/log/", "--upload-checksums=off"}
 	if s.config.ReadOnly {
 		cmdArgs = append(cmdArgs, "--read-only")
 	} else {

--- a/pkg/storage/mountpoint_test.go
+++ b/pkg/storage/mountpoint_test.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestNewMountpointCmdArgsRunsForeground(t *testing.T) {
+	s := &MountPointStorage{config: types.MountPointConfig{BucketName: "bucket"}}
+
+	args := newMountpointCmdArgs(s, "/mnt/test")
+	for _, arg := range args {
+		if arg == "--foreground" {
+			return
+		}
+	}
+
+	t.Fatalf("expected mountpoint args to include --foreground, got %v", args)
+}

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -22,17 +22,22 @@ import (
 )
 
 type ContainerMountManager struct {
-	mountPointPaths *common.SafeMap[[]string]
-	storageConfig   types.StorageConfig
-	codeCacheRoot   string
-	codeCacheGroup  singleflight.Group
+	mountPointMounts *common.SafeMap[[]containerMountPoint]
+	storageConfig    types.StorageConfig
+	codeCacheRoot    string
+	codeCacheGroup   singleflight.Group
+}
+
+type containerMountPoint struct {
+	localPath string
+	storage   storage.Storage
 }
 
 func NewContainerMountManager(config types.AppConfig) *ContainerMountManager {
 	return &ContainerMountManager{
-		mountPointPaths: common.NewSafeMap[[]string](),
-		storageConfig:   config.Storage,
-		codeCacheRoot:   filepath.Join(os.TempDir(), "beta9-stub-code-cache"),
+		mountPointMounts: common.NewSafeMap[[]containerMountPoint](),
+		storageConfig:    config.Storage,
+		codeCacheRoot:    filepath.Join(os.TempDir(), "beta9-stub-code-cache"),
 	}
 }
 
@@ -269,19 +274,21 @@ func copyRegularFile(src, dest string, mode os.FileMode) error {
 
 // RemoveContainerMounts removes all mounts for a container
 func (c *ContainerMountManager) RemoveContainerMounts(containerId string) {
-	mountPointPaths, ok := c.mountPointPaths.Get(containerId)
+	mountPoints, ok := c.mountPointMounts.Get(containerId)
 	if !ok {
 		return
 	}
 
-	mountPointS3, _ := storage.NewMountPointStorage(types.MountPointConfig{})
-	for _, localPath := range mountPointPaths {
-		if err := mountPointS3.Unmount(localPath); err != nil {
-			log.Error().Str("container_id", containerId).Err(err).Msg("failed to unmount external s3 bucket")
+	for _, mountPoint := range mountPoints {
+		if mountPoint.storage == nil {
+			continue
+		}
+		if err := mountPoint.storage.Unmount(mountPoint.localPath); err != nil {
+			log.Error().Str("container_id", containerId).Str("local_path", mountPoint.localPath).Err(err).Msg("failed to unmount external s3 bucket")
 		}
 	}
 
-	c.mountPointPaths.Delete(containerId)
+	c.mountPointMounts.Delete(containerId)
 }
 
 func (c *ContainerMountManager) setupMountPointS3(containerId string, m types.Mount) error {
@@ -292,14 +299,14 @@ func (c *ContainerMountManager) setupMountPointS3(containerId string, m types.Mo
 		return err
 	}
 
-	mountPointPaths, ok := c.mountPointPaths.Get(containerId)
+	mountPoints, ok := c.mountPointMounts.Get(containerId)
 	if !ok {
-		mountPointPaths = []string{m.LocalPath}
+		mountPoints = []containerMountPoint{{localPath: m.LocalPath, storage: mountPointS3}}
 	} else {
-		mountPointPaths = append(mountPointPaths, m.LocalPath)
+		mountPoints = append(mountPoints, containerMountPoint{localPath: m.LocalPath, storage: mountPointS3})
 	}
 
-	c.mountPointPaths.Set(containerId, mountPointPaths)
+	c.mountPointMounts.Set(containerId, mountPoints)
 
 	return nil
 }

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -50,6 +50,7 @@ const (
 	defaultContainerNetworkSlotPoolSize               = 16
 	containerNetworkSlotPoolEnv         string        = "CONTAINER_NETWORK_SLOT_POOL_SIZE"
 	containerNetworkSlotFillInterval    time.Duration = 2 * time.Second
+	containerNetworkCleanupRPCTimeout   time.Duration = 30 * time.Second
 )
 
 type ContainerNetworkManager struct {
@@ -1882,7 +1883,10 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 		return m.tearDownPreallocatedNetworkSlot(containerId, slot)
 	}
 
-	lockResponse, err := handleGRPCResponse(m.workerRepoClient.SetNetworkLock(m.ctx, &pb.SetNetworkLockRequest{
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), containerNetworkCleanupRPCTimeout)
+	defer cleanupCancel()
+
+	lockResponse, err := handleGRPCResponse(m.workerRepoClient.SetNetworkLock(cleanupCtx, &pb.SetNetworkLockRequest{
 		NetworkPrefix: m.networkPrefix,
 		Ttl:           10,
 		Retries:       10,
@@ -1890,10 +1894,14 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 	if err != nil {
 		return err
 	}
-	defer m.workerRepoClient.RemoveNetworkLock(m.ctx, &pb.RemoveNetworkLockRequest{
-		NetworkPrefix: m.networkPrefix,
-		Token:         lockResponse.Token,
-	})
+	defer func() {
+		unlockCtx, unlockCancel := context.WithTimeout(context.Background(), containerNetworkCleanupRPCTimeout)
+		defer unlockCancel()
+		m.workerRepoClient.RemoveNetworkLock(unlockCtx, &pb.RemoveNetworkLockRequest{
+			NetworkPrefix: m.networkPrefix,
+			Token:         lockResponse.Token,
+		})
+	}()
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -1937,7 +1945,7 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 		netns.DeleteNamed(info.Namespace)
 	}
 
-	_, err = handleGRPCResponse(m.workerRepoClient.RemoveContainerIp(m.ctx, &pb.RemoveContainerIpRequest{
+	_, err = handleGRPCResponse(m.workerRepoClient.RemoveContainerIp(cleanupCtx, &pb.RemoveContainerIpRequest{
 		NetworkPrefix: m.networkPrefix,
 		ContainerId:   containerId,
 	}))
@@ -1999,7 +2007,10 @@ func (m *ContainerNetworkManager) removePreallocatedNetworkSlotRules(slot *conta
 
 func (m *ContainerNetworkManager) releasePreallocatedNetworkSlot(containerId string, slot *containerNetworkSlot) error {
 	reservationID := m.containerNetworkSlotReservation(slot)
-	_, err := handleGRPCResponse(m.workerRepoClient.MoveContainerIp(m.ctx, &pb.MoveContainerIpRequest{
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), containerNetworkCleanupRPCTimeout)
+	defer cleanupCancel()
+
+	_, err := handleGRPCResponse(m.workerRepoClient.MoveContainerIp(cleanupCtx, &pb.MoveContainerIpRequest{
 		NetworkPrefix:   m.networkPrefix,
 		FromContainerId: containerId,
 		ToContainerId:   reservationID,

--- a/pkg/worker/network_test.go
+++ b/pkg/worker/network_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os"
@@ -11,7 +12,19 @@ import (
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
+	"google.golang.org/grpc"
 )
+
+type cleanupContextWorkerRepoClient struct {
+	pb.WorkerRepositoryServiceClient
+	moveCtxErr error
+}
+
+func (c *cleanupContextWorkerRepoClient) MoveContainerIp(ctx context.Context, in *pb.MoveContainerIpRequest, opts ...grpc.CallOption) (*pb.MoveContainerIpResponse, error) {
+	c.moveCtxErr = ctx.Err()
+	return &pb.MoveContainerIpResponse{Ok: true}, nil
+}
 
 func TestGetIPFromEnv(t *testing.T) {
 	tests := []struct {
@@ -162,6 +175,33 @@ func TestContainerNetworkSlotReservationParsing(t *testing.T) {
 	manager := &ContainerNetworkManager{workerId: "worker-a"}
 	if got := manager.containerNetworkSlotReservationID("slot-b"); got != scoped {
 		t.Fatalf("unexpected worker-scoped reservation id: got %q want %q", got, scoped)
+	}
+}
+
+func TestReleasePreallocatedNetworkSlotUsesFreshCleanupContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	repoClient := &cleanupContextWorkerRepoClient{}
+	manager := &ContainerNetworkManager{
+		ctx:              ctx,
+		workerId:         "worker-a",
+		workerRepoClient: repoClient,
+		networkPrefix:    "network-a",
+		allocatedIPs:     map[string]struct{}{"192.168.0.2": {}},
+		containerIPs:     map[string]string{"container-a": "192.168.0.2"},
+	}
+
+	err := manager.releasePreallocatedNetworkSlot("container-a", &containerNetworkSlot{
+		id: "slot-a",
+		ip: "192.168.0.2",
+	})
+
+	if err != nil {
+		t.Fatalf("releasePreallocatedNetworkSlot failed: %v", err)
+	}
+	if repoClient.moveCtxErr != nil {
+		t.Fatalf("cleanup RPC used canceled worker context: %v", repoClient.moveCtxErr)
 	}
 }
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -37,6 +37,9 @@ const (
 	workerEventStreamReconnectMax  time.Duration = 5 * time.Second
 	defaultRuncStartConcurrency    int           = types.DefaultRuncStartConcurrency
 	defaultGvisorStartConcurrency  int           = types.DefaultGvisorStartConcurrency
+	defaultWorkerStopGracePeriodS  int64         = 30
+	shutdownDrainPollInterval      time.Duration = 100 * time.Millisecond
+	shutdownForceWait              time.Duration = 30 * time.Second
 )
 
 type Worker struct {
@@ -897,6 +900,7 @@ func (s *Worker) shutdown() error {
 
 	var errs error
 	s.waitForActiveContainersBeforeShutdown()
+	s.stopActiveContainersForShutdown()
 
 	if s.containerNetworkManager != nil {
 		if err := s.containerNetworkManager.Close(); err != nil {
@@ -959,12 +963,109 @@ func (s *Worker) waitForActiveContainersBeforeShutdown() {
 		return
 	}
 
-	log.Info().Int("containers", s.containerInstances.Len()).Msg("waiting for active containers before worker shutdown")
-	for s.containerInstances.Len() > 0 {
-		s.containerWg.Wait()
-		if s.containerInstances.Len() == 0 {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
+	timeout := workerShutdownDrainTimeout(s.config.Worker.TerminationGracePeriod)
+	log.Info().
+		Int("containers", s.containerInstances.Len()).
+		Dur("timeout", timeout).
+		Msg("waiting for active containers before worker shutdown")
+	if s.waitForActiveContainers(timeout) {
+		return
 	}
+
+	log.Warn().
+		Int("containers", s.containerInstances.Len()).
+		Dur("timeout", timeout).
+		Msg("active containers still present after worker shutdown drain")
+}
+
+func (s *Worker) stopActiveContainersForShutdown() {
+	if s.containerInstances == nil || s.containerInstances.Len() == 0 {
+		return
+	}
+
+	ids := s.activeContainerIDs()
+	log.Info().Int("containers", len(ids)).Msg("stopping active containers before worker shutdown")
+
+	for _, id := range ids {
+		if instance, exists := s.containerInstances.Get(id); exists {
+			instance.StopReason = types.StopContainerReasonAdmin
+			s.containerInstances.Set(id, instance)
+		}
+		if err := s.stopContainer(id, false); err != nil {
+			log.Warn().Str("container_id", id).Err(err).Msg("failed to stop container during worker shutdown")
+		}
+	}
+
+	grace := workerContainerStopGrace(s.config.Worker.TerminationGracePeriod)
+	if s.waitForActiveContainers(grace) {
+		return
+	}
+
+	remaining := s.activeContainerIDs()
+	log.Warn().
+		Int("containers", len(remaining)).
+		Dur("grace", grace).
+		Msg("force stopping active containers during worker shutdown")
+	for _, id := range remaining {
+		if err := s.stopContainer(id, true); err != nil {
+			log.Warn().Str("container_id", id).Err(err).Msg("failed to force stop container during worker shutdown")
+		}
+	}
+
+	s.waitForActiveContainers(shutdownForceWait)
+}
+
+func (s *Worker) activeContainerIDs() []string {
+	ids := []string{}
+	if s.containerInstances == nil {
+		return ids
+	}
+	s.containerInstances.Range(func(key string, _ *ContainerInstance) bool {
+		ids = append(ids, key)
+		return true
+	})
+	return ids
+}
+
+func (s *Worker) waitForActiveContainers(timeout time.Duration) bool {
+	if s.containerInstances == nil || s.containerInstances.Len() == 0 {
+		return true
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for s.containerInstances.Len() > 0 {
+			s.containerWg.Wait()
+			if s.containerInstances.Len() == 0 {
+				return
+			}
+			time.Sleep(shutdownDrainPollInterval)
+		}
+	}()
+
+	if timeout <= 0 {
+		<-done
+		return true
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return s.containerInstances.Len() == 0
+	}
+}
+
+func workerContainerStopGrace(configuredSeconds int64) time.Duration {
+	if configuredSeconds <= 0 {
+		configuredSeconds = defaultWorkerStopGracePeriodS
+	}
+	return time.Duration(configuredSeconds) * time.Second
+}
+
+func workerShutdownDrainTimeout(configuredSeconds int64) time.Duration {
+	return workerContainerStopGrace(configuredSeconds) + shutdownForceWait
 }

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -3,15 +3,40 @@ package worker
 import (
 	"context"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/runtime"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
+
+type shutdownSignalRuntime struct {
+	mockRuntime
+	mu      sync.Mutex
+	signals []syscall.Signal
+	onKill  func(syscall.Signal)
+}
+
+func (m *shutdownSignalRuntime) Kill(ctx context.Context, containerID string, sig syscall.Signal, opts *runtime.KillOpts) error {
+	m.mu.Lock()
+	m.signals = append(m.signals, sig)
+	m.mu.Unlock()
+	if m.onKill != nil {
+		m.onKill(sig)
+	}
+	return nil
+}
+
+func (m *shutdownSignalRuntime) recordedSignals() []syscall.Signal {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]syscall.Signal(nil), m.signals...)
+}
 
 func TestCalculateCPUShares(t *testing.T) {
 	tests := []struct {
@@ -183,12 +208,16 @@ func TestUpdateContainerStatusOnceReconcilesStartedPendingContainer(t *testing.T
 	require.Equal(t, int64(types.ContainerStateTtlS), repoClient.lastUpdateStatus.ExpirySeconds)
 }
 
-func TestWaitForActiveContainersBeforeShutdownWaitsForInstanceDrain(t *testing.T) {
+func TestShutdownWaitDrainsWithoutStoppingActiveContainer(t *testing.T) {
 	worker := &Worker{
 		containerInstances: common.NewSafeMap[*ContainerInstance](),
 		containerWg:        sync.WaitGroup{},
 	}
-	worker.containerInstances.Set("container-1", &ContainerInstance{Id: "container-1"})
+	rt := &shutdownSignalRuntime{}
+	worker.containerInstances.Set("container-1", &ContainerInstance{
+		Id:      "container-1",
+		Runtime: rt,
+	})
 
 	done := make(chan struct{})
 	go func() {
@@ -201,6 +230,7 @@ func TestWaitForActiveContainersBeforeShutdownWaitsForInstanceDrain(t *testing.T
 		t.Fatal("shutdown wait returned before active instance drained")
 	case <-time.After(25 * time.Millisecond):
 	}
+	require.Empty(t, rt.recordedSignals())
 
 	worker.containerInstances.Delete("container-1")
 
@@ -209,6 +239,57 @@ func TestWaitForActiveContainersBeforeShutdownWaitsForInstanceDrain(t *testing.T
 	case <-time.After(time.Second):
 		t.Fatal("shutdown wait did not return after active instance drained")
 	}
+	require.Empty(t, rt.recordedSignals())
+}
+
+func TestStopActiveContainersForShutdownStopsNestedRuntimeBeforeWorkerExit(t *testing.T) {
+	worker := &Worker{
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		containerWg:        sync.WaitGroup{},
+		config: types.AppConfig{
+			Worker: types.WorkerConfig{TerminationGracePeriod: 30},
+		},
+	}
+	rt := &shutdownSignalRuntime{}
+	rt.onKill = func(sig syscall.Signal) {
+		worker.containerInstances.Delete("container-1")
+	}
+	worker.containerInstances.Set("container-1", &ContainerInstance{
+		Id:      "container-1",
+		Runtime: rt,
+	})
+
+	worker.stopActiveContainersForShutdown()
+
+	require.Empty(t, worker.activeContainerIDs())
+	require.Equal(t, []syscall.Signal{syscall.SIGTERM}, rt.recordedSignals())
+}
+
+func TestStopActiveContainersForShutdownForceKillsStuckRuntime(t *testing.T) {
+	worker := &Worker{
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		containerWg:        sync.WaitGroup{},
+		config: types.AppConfig{
+			Worker: types.WorkerConfig{TerminationGracePeriod: 1},
+		},
+	}
+	rt := &shutdownSignalRuntime{}
+	rt.onKill = func(sig syscall.Signal) {
+		if sig == syscall.SIGKILL {
+			worker.containerInstances.Delete("container-1")
+		}
+	}
+	worker.containerInstances.Set("container-1", &ContainerInstance{
+		Id:      "container-1",
+		Runtime: rt,
+	})
+
+	start := time.Now()
+	worker.stopActiveContainersForShutdown()
+
+	require.GreaterOrEqual(t, time.Since(start), time.Second)
+	require.Empty(t, worker.activeContainerIDs())
+	require.Equal(t, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, rt.recordedSignals())
 }
 
 func TestMarkContainerStoppingUsesStoppingTTL(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes leaked/zombie processes by introducing a managed process runner and running the worker under `tini`. Improves shutdown, mount, and network cleanup to prevent stuck pods and lingering FUSE processes.

- **Bug Fixes**
  - Added `pkg/common/process` with `ManagedCommand` to run children in a process group, capture output, wait with timeouts, and terminate with SIGTERM→SIGKILL.
  - Reworked `juicefs`, `mount-s3`, and `geesefs` mounts to run in foreground, poll for readiness, enforce mount/unmount timeouts, and reap/kill lingering processes.
  - Made unmount paths resilient: wait for flush (with timeout), join errors, and always reap tracked mount processes.
  - Worker shutdown now drains containers, sends SIGTERM, then SIGKILL after grace; prevents leaked runtimes during pod termination.
  - Network teardown uses fresh 30s contexts for cleanup RPCs (locks, Move/Remove IP), so cleanup finishes even if the worker context is canceled.
  - Tracks per-container mountpoints to unmount reliably on container cleanup.
  - Added tests for process reaping, mount `--foreground`, worker pod command, grace period calc, and cleanup contexts.

- **Dependencies**
  - Worker image installs `tini` and `psmisc`; pods run `/usr/bin/tini -g -- /usr/local/bin/worker`.
  - Pod `terminationGracePeriodSeconds` is computed to cover drain + nested cleanup.

<sup>Written for commit 6f9dc59f056b672389fa28fd80f70393bcc515c2. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

