### PR TITLE
clean up cache logs

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -479,13 +479,6 @@ func (c *Client) removeLocalHostCache(hash string) {
 	delete(c.localHostCache, hash)
 }
 
-func sameHostEndpoint(a *Host, b *Host) bool {
-	if a == nil || b == nil {
-		return false
-	}
-	return a.HostId == b.HostId && a.Addr == b.Addr && a.PrivateAddr == b.PrivateAddr
-}
-
 func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 	if c.hostDirectory == nil || c.hostMap == nil {
 		return ErrHostNotFound
@@ -510,43 +503,51 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 	}
 
 	routable := false
-	for _, host := range hosts {
-		if host == nil || host.HostId == "" {
+	for _, group := range cacheHostCandidateGroups(hosts) {
+		if group.hostID == "" {
 			continue
 		}
 
-		verified := host
-		if c.discoveryClient != nil {
-			hostState, err := c.discoveryClient.GetHostState(refreshCtx, host)
-			if err != nil {
-				continue
-			}
-			verified = hostState
-		}
-		if verified == nil || verified.HostId == "" {
-			continue
-		}
-
-		known := c.hostMap.Get(verified.HostId)
-		c.mu.RLock()
-		_, clientExists := c.grpcClients[verified.HostId]
-		c.mu.RUnlock()
-		if known != nil && sameHostEndpoint(known, verified) && !clientExists {
-			if err := c.addHost(verified); err != nil {
-				continue
-			}
+		if c.keepExistingCacheHost(group) {
 			routable = true
 			continue
 		}
 
-		c.hostMap.Set(verified)
-		routable = true
+		if host, ok := group.firstReachable(refreshCtx, c.verifyCacheHost); ok {
+			c.hostMap.Set(host)
+			routable = true
+		}
 	}
 
 	if !routable && len(c.hostMap.GetAll()) == 0 {
 		return ErrHostNotFound
 	}
 	return nil
+}
+
+func (c *Client) keepExistingCacheHost(group cacheHostCandidateGroup) bool {
+	known := c.hostMap.Get(group.hostID)
+	if !group.containsEndpoint(known) {
+		return false
+	}
+	if c.hasCacheClient(known.HostId) {
+		return true
+	}
+	return c.addHost(known) == nil
+}
+
+func (c *Client) hasCacheClient(hostID string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, exists := c.grpcClients[hostID]
+	return exists
+}
+
+func (c *Client) verifyCacheHost(ctx context.Context, host *Host) (*Host, error) {
+	if c.discoveryClient == nil {
+		return host, nil
+	}
+	return c.discoveryClient.GetHostState(ctx, host)
 }
 
 func (c *Client) getContentAttempts(length int64) int {

--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -18,7 +18,6 @@ type DiscoveryClient struct {
 	hostMap       *HostMap
 	hostDirectory HostDirectory
 	locality      string
-	mu            sync.Mutex
 }
 
 func NewDiscoveryClient(cfg GlobalConfig, hostMap *HostMap, hostDirectory HostDirectory, locality string) *DiscoveryClient {
@@ -90,8 +89,9 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 		return nil, err
 	}
 
+	selectedHosts := []*Host{}
+	hostGroups := cacheHostCandidateGroups(hosts)
 	var wg sync.WaitGroup
-	filteredHosts := []*Host{}
 	mu := sync.Mutex{}
 	maxConcurrency := d.cfg.MaxDiscoveryConcurrency
 	if maxConcurrency <= 0 {
@@ -99,14 +99,13 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	}
 	sem := make(chan struct{}, maxConcurrency)
 
-	for _, host := range hosts {
-		// Don't try to get the state on peers we're already aware of
-		if existing := d.hostMap.Get(host.HostId); existing != nil && existing.Addr == host.Addr && existing.PrivateAddr == host.PrivateAddr {
+	for _, group := range hostGroups {
+		if group.containsEndpoint(d.hostMap.Get(group.hostID)) {
 			continue
 		}
 
 		wg.Add(1)
-		go func(host *Host) {
+		go func(group cacheHostCandidateGroup) {
 			defer wg.Done()
 			select {
 			case sem <- struct{}{}:
@@ -115,22 +114,86 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 				return
 			}
 
-			hostState, err := d.GetHostState(ctx, host)
-			if err != nil {
+			host, ok := group.firstReachable(ctx, d.GetHostState)
+			if !ok {
 				return
 			}
 
 			mu.Lock()
-			filteredHosts = append(filteredHosts, hostState)
+			selectedHosts = append(selectedHosts, host)
 			mu.Unlock()
 
-			Logger.Debugf("Added host with private address to map: %s", hostState.PrivateAddr)
-		}(host)
-
+			Logger.Debugf("Added host with private address to map: %s", host.PrivateAddr)
+		}(group)
 	}
 
 	wg.Wait()
-	return filteredHosts, nil
+	return selectedHosts, nil
+}
+
+type cacheHostCandidateGroup struct {
+	hostID     string
+	candidates []*Host
+}
+
+type cacheHostVerifier func(context.Context, *Host) (*Host, error)
+
+func cacheHostCandidateGroups(hosts []*Host) []cacheHostCandidateGroup {
+	groupsByID := make(map[string][]*Host, len(hosts))
+	orderedIDs := make([]string, 0, len(hosts))
+
+	for _, host := range hosts {
+		if host == nil || host.HostId == "" {
+			continue
+		}
+		if _, exists := groupsByID[host.HostId]; !exists {
+			orderedIDs = append(orderedIDs, host.HostId)
+		}
+		groupsByID[host.HostId] = append(groupsByID[host.HostId], host)
+	}
+
+	groups := make([]cacheHostCandidateGroup, 0, len(orderedIDs))
+	for _, hostID := range orderedIDs {
+		groups = append(groups, cacheHostCandidateGroup{
+			hostID:     hostID,
+			candidates: groupsByID[hostID],
+		})
+	}
+	return groups
+}
+
+func (g cacheHostCandidateGroup) containsEndpoint(host *Host) bool {
+	if host == nil {
+		return false
+	}
+	for _, candidate := range g.candidates {
+		if sameCacheHostEndpoint(candidate, host) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g cacheHostCandidateGroup) firstReachable(ctx context.Context, verify cacheHostVerifier) (*Host, bool) {
+	for _, candidate := range g.candidates {
+		if candidate == nil || candidate.HostId == "" {
+			continue
+		}
+
+		host, err := verify(ctx, candidate)
+		if err != nil || host == nil || host.HostId == "" {
+			continue
+		}
+		return host, true
+	}
+	return nil, false
+}
+
+func sameCacheHostEndpoint(a *Host, b *Host) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.HostId == b.HostId && a.Addr == b.Addr && a.PrivateAddr == b.PrivateAddr
 }
 
 // GetHostState attempts to connect to the gRPC service and verifies its availability

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -1,0 +1,79 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheHostCandidateGroupsPreserveLogicalHostAndCandidateOrder(t *testing.T) {
+	hosts := []*Host{
+		{HostId: "host-a", PrivateAddr: "10.0.0.1:2049"},
+		{HostId: "host-b", PrivateAddr: "10.0.0.2:2049"},
+		{HostId: "host-a", PrivateAddr: "10.0.0.3:2049"},
+		nil,
+		{PrivateAddr: "10.0.0.4:2049"},
+		{HostId: "host-b", PrivateAddr: "10.0.0.5:2049"},
+	}
+
+	groups := cacheHostCandidateGroups(hosts)
+
+	require.Len(t, groups, 2)
+	require.Equal(t, "host-a", groups[0].hostID)
+	require.Equal(t, "10.0.0.1:2049", groups[0].candidates[0].PrivateAddr)
+	require.Equal(t, "10.0.0.3:2049", groups[0].candidates[1].PrivateAddr)
+	require.Equal(t, "host-b", groups[1].hostID)
+	require.Equal(t, "10.0.0.2:2049", groups[1].candidates[0].PrivateAddr)
+	require.Equal(t, "10.0.0.5:2049", groups[1].candidates[1].PrivateAddr)
+}
+
+func TestCacheHostCandidateGroupContainsEndpoint(t *testing.T) {
+	group := cacheHostCandidateGroup{
+		hostID: "logical-host",
+		candidates: []*Host{
+			{HostId: "logical-host", Addr: "public-a:2049", PrivateAddr: "10.0.0.1:2049"},
+			{HostId: "logical-host", Addr: "public-b:2049", PrivateAddr: "10.0.0.2:2049"},
+		},
+	}
+
+	require.True(t, group.containsEndpoint(&Host{
+		HostId:      "logical-host",
+		Addr:        "public-b:2049",
+		PrivateAddr: "10.0.0.2:2049",
+	}))
+	require.False(t, group.containsEndpoint(&Host{
+		HostId:      "logical-host",
+		Addr:        "public-c:2049",
+		PrivateAddr: "10.0.0.3:2049",
+	}))
+	require.False(t, group.containsEndpoint(&Host{
+		HostId:      "other-host",
+		Addr:        "public-b:2049",
+		PrivateAddr: "10.0.0.2:2049",
+	}))
+}
+
+func TestCacheHostCandidateGroupFirstReachableFallsBackInOrder(t *testing.T) {
+	group := cacheHostCandidateGroup{
+		hostID: "logical-host",
+		candidates: []*Host{
+			{HostId: "logical-host", PrivateAddr: "10.0.0.1:2049"},
+			{HostId: "logical-host", PrivateAddr: "10.0.0.2:2049"},
+		},
+	}
+
+	called := make([]string, 0, 2)
+	host, ok := group.firstReachable(nil, func(_ context.Context, candidate *Host) (*Host, error) {
+		called = append(called, candidate.PrivateAddr)
+		if candidate.PrivateAddr == "10.0.0.1:2049" {
+			return nil, errors.New("unreachable")
+		}
+		return candidate, nil
+	})
+
+	require.True(t, ok)
+	require.Equal(t, "10.0.0.2:2049", host.PrivateAddr)
+	require.Equal(t, []string{"10.0.0.1:2049", "10.0.0.2:2049"}, called)
+}

--- a/pkg/cache/hostmap.go
+++ b/pkg/cache/hostmap.go
@@ -44,7 +44,7 @@ func (hm *HostMap) Set(host *Host) {
 	}
 
 	if exists {
-		Logger.Infof("Updated host @ %s (PrivateAddr=%s, RTT=%s)", host.HostId, host.PrivateAddr, host.RTT)
+		Logger.Debugf("Updated host @ %s (PrivateAddr=%s, RTT=%s)", host.HostId, host.PrivateAddr, host.RTT)
 	} else {
 		Logger.Infof("Added new host @ %s (PrivateAddr=%s, RTT=%s)", host.HostId, host.PrivateAddr, host.RTT)
 	}

--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	grpcServer    *grpc.Server
 	listener      net.Listener
 	s3ClientCache sync.Map
+	draining      atomic.Bool
 	closeOnce     sync.Once
 }
 
@@ -340,9 +341,7 @@ func (cs *Server) StartServer(port uint) error {
 
 func (cs *Server) Close() error {
 	cs.closeOnce.Do(func() {
-		if cs.cancel != nil {
-			cs.cancel()
-		}
+		cs.Drain()
 		if cs.grpcServer != nil {
 			stopped := make(chan struct{})
 			go func() {
@@ -355,6 +354,9 @@ func (cs *Server) Close() error {
 				cs.grpcServer.Stop()
 			}
 		}
+		if cs.cancel != nil {
+			cs.cancel()
+		}
 		if cs.listener != nil {
 			_ = cs.listener.Close()
 		}
@@ -366,7 +368,23 @@ func (cs *Server) Close() error {
 	return nil
 }
 
+func (cs *Server) Drain() {
+	if cs != nil {
+		cs.draining.Store(true)
+	}
+}
+
+func (cs *Server) rejectIfDraining() error {
+	if cs != nil && cs.draining.Load() {
+		return status.Error(codes.Unavailable, "cache server is draining")
+	}
+	return nil
+}
+
 func (cs *Server) GetContent(ctx context.Context, req *proto.CacheGetContentRequest) (*proto.CacheGetContentResponse, error) {
+	if err := cs.rejectIfDraining(); err != nil {
+		return nil, err
+	}
 	atomic.AddInt64(&cachePathStats.serverGRPCGetRequests, 1)
 	if req == nil {
 		atomic.AddInt64(&cachePathStats.serverGRPCGetMisses, 1)
@@ -401,11 +419,17 @@ func (cs *Server) GetContent(ctx context.Context, req *proto.CacheGetContentRequ
 }
 
 func (cs *Server) HasContent(ctx context.Context, req *proto.CacheHasContentRequest) (*proto.CacheHasContentResponse, error) {
+	if err := cs.rejectIfDraining(); err != nil {
+		return nil, err
+	}
 	exists := cs.cas.Exists(req.Hash)
 	return &proto.CacheHasContentResponse{Exists: exists, Ok: true}, nil
 }
 
 func (cs *Server) GetContentStream(req *proto.CacheGetContentRequest, stream proto.Cache_GetContentStreamServer) error {
+	if err := cs.rejectIfDraining(); err != nil {
+		return err
+	}
 	atomic.AddInt64(&cachePathStats.serverStreamRequests, 1)
 	if req == nil {
 		atomic.AddInt64(&cachePathStats.serverStreamErrors, 1)
@@ -644,6 +668,9 @@ func (cs *Server) storeContentInCacheFS(ctx context.Context, path string, hash s
 }
 
 func (cs *Server) StoreContent(stream proto.Cache_StoreContentServer) error {
+	if err := cs.rejectIfDraining(); err != nil {
+		return err
+	}
 	ctx := stream.Context()
 
 	Logger.Debugf("StoreContent[ACK]")
@@ -724,6 +751,9 @@ func (cs *Server) usagePct() float64 {
 }
 
 func (cs *Server) GetState(ctx context.Context, req *proto.CacheGetStateRequest) (*proto.CacheGetStateResponse, error) {
+	if err := cs.rejectIfDraining(); err != nil {
+		return nil, err
+	}
 	return &proto.CacheGetStateResponse{
 		Version:          Version,
 		PrivateIpAddr:    cs.privateIpAddr,
@@ -776,6 +806,13 @@ func (cs *Server) s3ClientForSource(source *proto.CacheSource) (*S3Client, error
 }
 
 func (cs *Server) StoreContentFromSource(ctx context.Context, req *proto.CacheStoreContentFromSourceRequest) (*proto.CacheStoreContentFromSourceResponse, error) {
+	if err := cs.rejectIfDraining(); err != nil {
+		return nil, err
+	}
+	return cs.storeContentFromSource(ctx, req)
+}
+
+func (cs *Server) storeContentFromSource(ctx context.Context, req *proto.CacheStoreContentFromSourceRequest) (*proto.CacheStoreContentFromSourceResponse, error) {
 	if req == nil || req.Source == nil {
 		return &proto.CacheStoreContentFromSourceResponse{Ok: false, ErrorMsg: "source is required"}, nil
 	}
@@ -849,6 +886,9 @@ func (cs *Server) StoreContentFromSource(ctx context.Context, req *proto.CacheSt
 }
 
 func (cs *Server) StoreContentFromSourceWithLock(ctx context.Context, req *proto.CacheStoreContentFromSourceRequest) (*proto.CacheStoreContentFromSourceWithLockResponse, error) {
+	if err := cs.rejectIfDraining(); err != nil {
+		return nil, err
+	}
 	if req == nil || req.Source == nil {
 		return &proto.CacheStoreContentFromSourceWithLockResponse{Ok: false, ErrorMsg: "source is required"}, nil
 	}
@@ -890,7 +930,7 @@ func (cs *Server) StoreContentFromSourceWithLock(ctx context.Context, req *proto
 		}
 	}()
 
-	storeContentFromSourceResp, err := cs.StoreContentFromSource(storeContext, req)
+	storeContentFromSourceResp, err := cs.storeContentFromSource(storeContext, req)
 	if err != nil {
 		Logger.Warnf("StoreContentFromSourceWithLock[ERR] - [source=%s elapsed=%s err=%v]", sourcePath, time.Since(started).Truncate(time.Millisecond), err)
 		return &proto.CacheStoreContentFromSourceWithLockResponse{Hash: "", Ok: false, ErrorMsg: err.Error()}, nil

--- a/pkg/cache/server_test.go
+++ b/pkg/cache/server_test.go
@@ -5,8 +5,11 @@ import (
 	"net"
 	"testing"
 
+	proto "github.com/beam-cloud/beta9/proto"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestNormalizeAdvertiseHostForJoinHostPort(t *testing.T) {
@@ -25,6 +28,19 @@ func TestNormalizeAdvertiseHostLeavesDNSHostUnchanged(t *testing.T) {
 	host := normalizeAdvertiseHost("machine-abc123.tailnet.example")
 	require.Equal(t, "machine-abc123.tailnet.example", host)
 	require.Equal(t, "machine-abc123.tailnet.example:2049", net.JoinHostPort(host, "2049"))
+}
+
+func TestServerDrainRejectsNewRPCs(t *testing.T) {
+	server := &Server{}
+	server.Drain()
+
+	_, err := server.GetState(context.Background(), &proto.CacheGetStateRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	_, err = server.GetContent(context.Background(), &proto.CacheGetContentRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
 }
 
 func TestStoreSyntheticContentInCacheFSCreatesVolumeFilePath(t *testing.T) {

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -49,23 +49,26 @@ const (
 )
 
 type WorkerCacheManager struct {
-	ctx           context.Context
-	cancel        context.CancelFunc
-	config        types.AppConfig
-	poolConfig    types.WorkerPoolConfig
-	workerRepo    pb.WorkerRepositoryServiceClient
-	workerID      string
-	instanceID    string
-	poolName      string
-	podAddr       string
-	nodeID        string
-	locality      string
-	metadataStore cache.CacheMetadataStore
-	client        *cache.Client
-	server        *cache.Server
-	registration  *gatewayCacheRegistration
-	mu            sync.Mutex
-	wg            sync.WaitGroup
+	ctx                context.Context
+	cancel             context.CancelFunc
+	config             types.AppConfig
+	poolConfig         types.WorkerPoolConfig
+	workerRepo         pb.WorkerRepositoryServiceClient
+	workerID           string
+	instanceID         string
+	poolName           string
+	podAddr            string
+	nodeID             string
+	locality           string
+	metadataStore      cache.CacheMetadataStore
+	client             *cache.Client
+	server             *cache.Server
+	registration       *gatewayCacheRegistration
+	registrationCancel context.CancelFunc
+	mu                 sync.Mutex
+	wg                 sync.WaitGroup
+	drainOnce          sync.Once
+	drainErr           error
 }
 
 func NewWorkerCacheManager(ctx context.Context, config types.AppConfig, poolConfig types.WorkerPoolConfig, workerRepo pb.WorkerRepositoryServiceClient, workerID, poolName, podAddr string) *WorkerCacheManager {
@@ -114,10 +117,12 @@ func (m *WorkerCacheManager) Start() (*cache.Client, error) {
 		return nil, err
 	}
 	m.registration = registration
+	registrationCtx, registrationCancel := context.WithCancel(m.ctx)
+	m.registrationCancel = registrationCancel
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
-		runGatewayCacheRegistration(m.ctx, registration)
+		runGatewayCacheRegistration(registrationCtx, registration)
 	}()
 
 	hostDirectory := &gatewayCacheHostDirectory{
@@ -126,7 +131,7 @@ func (m *WorkerCacheManager) Start() (*cache.Client, error) {
 	}
 	client, err := cache.NewClientWithHostDirectory(m.ctx, cacheConfig, metadataStore, hostDirectory, m.locality)
 	if err != nil {
-		_ = registration.unregister(context.Background())
+		_ = m.Drain()
 		_ = server.Close()
 		m.cancel()
 		return nil, err
@@ -163,18 +168,15 @@ func (m *WorkerCacheManager) Start() (*cache.Client, error) {
 }
 
 func (m *WorkerCacheManager) Close() error {
+	var errs error
+	errs = errors.Join(errs, m.Drain())
 	m.cancel()
 
-	var errs error
 	m.mu.Lock()
 	server := m.server
 	client := m.client
-	registration := m.registration
 	m.mu.Unlock()
 
-	if registration != nil {
-		errs = errors.Join(errs, registration.unregister(context.Background()))
-	}
 	if client != nil {
 		errs = errors.Join(errs, client.Cleanup())
 	}
@@ -184,6 +186,34 @@ func (m *WorkerCacheManager) Close() error {
 
 	m.wg.Wait()
 	return errs
+}
+
+func (m *WorkerCacheManager) Drain() error {
+	if m == nil {
+		return nil
+	}
+
+	m.drainOnce.Do(func() {
+		m.mu.Lock()
+		cancel := m.registrationCancel
+		registration := m.registration
+		server := m.server
+		m.mu.Unlock()
+
+		if server != nil {
+			server.Drain()
+		}
+		if cancel != nil {
+			cancel()
+		}
+		m.wg.Wait()
+
+		if registration != nil {
+			m.drainErr = registration.unregister(context.Background())
+		}
+	})
+
+	return m.drainErr
 }
 
 func (m *WorkerCacheManager) enabled() bool {

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -58,6 +59,27 @@ func TestWorkerCacheManagerDisabledWhenPoolDiskCacheDisabled(t *testing.T) {
 	}
 
 	require.False(t, manager.enabled())
+}
+
+func TestWorkerCacheManagerDrainStopsRegistrationLoopOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelCount := 0
+	manager := &WorkerCacheManager{
+		registrationCancel: func() {
+			cancelCount++
+			cancel()
+		},
+	}
+
+	manager.wg.Add(1)
+	go func() {
+		defer manager.wg.Done()
+		<-ctx.Done()
+	}()
+
+	require.NoError(t, manager.Drain())
+	require.NoError(t, manager.Drain())
+	require.Equal(t, 1, cancelCount)
 }
 
 func TestCacheLogicalHostIDDeduplicatesSharedNodeCachePath(t *testing.T) {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -899,6 +899,12 @@ func (s *Worker) shutdown() error {
 	defer s.eventRepo.PushWorkerStoppedEvent(s.workerId)
 
 	var errs error
+	if s.cacheManager != nil {
+		if err := s.cacheManager.Drain(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to drain cache registration: %v", err))
+		}
+	}
+
 	s.waitForActiveContainersBeforeShutdown()
 	s.stopActiveContainersForShutdown()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce noisy cache logs and make cache shutdown safer. Adds drain mode to the cache server and simplifies host discovery to avoid redundant connections.

- **New Features**
  - Added `Server.Drain()` to reject new RPCs with UNAVAILABLE during shutdown. Used in `Close()` and worker shutdown.
  - Added `WorkerCacheManager.Drain()` to stop the registration loop once, wait for it to exit, then unregister.
  - Worker shutdown now drains the cache manager before stopping containers.

- **Refactors**
  - Grouped cache host candidates by logical host ID and pick the first reachable endpoint. Keeps existing connections when endpoints match.
  - Discovery skips verification for already-known endpoints and verifies one candidate per group with bounded concurrency.
  - Reduced host update log level from info to debug.
  - Extracted helpers for cache client checks and host verification. Added focused tests for grouping, fallback, draining, and server behavior.

<sup>Written for commit f89ff5d114f43c836e9dabe5fdcae241f4772732. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

