### PR TITLE
feat: event sink

### DIFF
--- a/benchmarks/sandbox_parallel.py
+++ b/benchmarks/sandbox_parallel.py
@@ -12,49 +12,57 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
-from startup import (
-    API_PREFIX,
-    api_url,
-    authorize,
-    cluster_snapshot,
-    delete_workers,
-    env_bool,
-    env_float,
-    env_int,
-    find_redis_pod,
-    format_ms,
-    grpc_addr,
-    http_json,
-    install_overlay,
-    load_cached_token,
-    log,
-    percentile,
-    prepare_local_image,
-    require_tools,
-    redis_hgetall,
-    save_cached_token,
-    start_grpc_port_forward_if_needed,
-    start_http_port_forward_if_needed,
-    wait_http,
-)
-from sandbox_startup_report import (
-    DEFAULT_EVENT_LIMIT,
-    DEFAULT_EVENT_POLL_MS,
-    DEFAULT_EVENT_WAIT_SECONDS,
-    DEFAULT_TOP_LIFECYCLE,
-    default_markdown_path,
-    render_console_summary,
-    write_startup_report,
-)
+try:
+    from . import sandbox_startup_report as startup_report_mod
+    from . import startup as startup_mod
+except ImportError:  # pragma: no cover - script execution path
+    import sandbox_startup_report as startup_report_mod
+    import startup as startup_mod
+
+
+API_PREFIX = startup_mod.API_PREFIX
+api_url = startup_mod.api_url
+authorize = startup_mod.authorize
+cluster_snapshot = startup_mod.cluster_snapshot
+delete_workers = startup_mod.delete_workers
+env_bool = startup_mod.env_bool
+env_float = startup_mod.env_float
+env_int = startup_mod.env_int
+find_redis_pod = startup_mod.find_redis_pod
+format_ms = startup_mod.format_ms
+grpc_addr = startup_mod.grpc_addr
+http_json = startup_mod.http_json
+install_overlay = startup_mod.install_overlay
+load_cached_token = startup_mod.load_cached_token
+log = startup_mod.log
+percentile = startup_mod.percentile
+prepare_local_image = startup_mod.prepare_local_image
+require_tools = startup_mod.require_tools
+redis_hgetall = startup_mod.redis_hgetall
+save_cached_token = startup_mod.save_cached_token
+start_grpc_port_forward_if_needed = startup_mod.start_grpc_port_forward_if_needed
+start_http_port_forward_if_needed = startup_mod.start_http_port_forward_if_needed
+wait_http = startup_mod.wait_http
+
+DEFAULT_EVENT_LIMIT = startup_report_mod.DEFAULT_EVENT_LIMIT
+DEFAULT_EVENT_POLL_MS = startup_report_mod.DEFAULT_EVENT_POLL_MS
+DEFAULT_EVENT_WAIT_SECONDS = startup_report_mod.DEFAULT_EVENT_WAIT_SECONDS
+DEFAULT_TOP_LIFECYCLE = startup_report_mod.DEFAULT_TOP_LIFECYCLE
+default_markdown_path = startup_report_mod.default_markdown_path
+render_console_summary = startup_report_mod.render_console_summary
+write_startup_report = startup_report_mod.write_startup_report
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HEALTH_PATH = "/api/v1/health"
+DEFAULT_SANDBOX_EXEC = "sh -lc 'printf \"%s\\n\" \"$BETA9_BENCH_EXPECTED_OUTPUT\"'"
+DEFAULT_SANDBOX_EXPECTED_OUTPUT = "beta9-sandbox-ready-{index}"
+DEFAULT_EXEC_OUTPUT_TAIL_BYTES = 4096
 TABLE_HEADER = "\n".join(
     (
         "",
-        " run   kind container                                           create   running  proc_rdy exec_done   status",
-        "---- ------ ---------------------------------------------- --------- --------- --------- --------- --------",
+        " run   kind container                                           create   running  proc_rdy exec_done    check   status",
+        "---- ------ ---------------------------------------------- --------- --------- --------- --------- -------- --------",
     )
 )
 
@@ -89,8 +97,10 @@ def parse_args():
     parser.add_argument("--sandbox-memory", default=os.getenv("BENCH_SANDBOX_MEMORY", "192"))
     parser.add_argument("--sandbox-keep-warm-seconds", type=int, default=env_int("BENCH_SANDBOX_KEEP_WARM_SECONDS", 600))
     parser.add_argument("--sandbox-image-uri", default=os.getenv("BENCH_SANDBOX_IMAGE_URI", os.getenv("BENCH_BOOTSTRAP_IMAGE_URI", "registry.localhost:5000/beta9-bench-alpine:latest")))
-    parser.add_argument("--sandbox-exec", default=os.getenv("BENCH_SANDBOX_EXEC", "true"))
+    parser.add_argument("--sandbox-exec", default=os.getenv("BENCH_SANDBOX_EXEC", DEFAULT_SANDBOX_EXEC))
     parser.add_argument("--sandbox-exec-cwd", default=os.getenv("BENCH_SANDBOX_EXEC_CWD", "/"))
+    parser.add_argument("--sandbox-expected-output", default=os.getenv("BENCH_SANDBOX_EXPECTED_OUTPUT", DEFAULT_SANDBOX_EXPECTED_OUTPUT))
+    parser.add_argument("--sandbox-output-tail-bytes", type=int, default=env_int("BENCH_SANDBOX_OUTPUT_TAIL_BYTES", DEFAULT_EXEC_OUTPUT_TAIL_BYTES))
     parser.add_argument("--sandbox-create-retries", type=int, default=env_int("BENCH_SANDBOX_CREATE_RETRIES", 20))
     parser.add_argument("--sandbox-ready-timeout-seconds", type=float, default=env_float("BENCH_SANDBOX_READY_TIMEOUT_SECONDS", 120))
     parser.add_argument("--sandbox-ready-retry-ms", type=int, default=env_int("BENCH_SANDBOX_READY_RETRY_MS", 500))
@@ -131,7 +141,7 @@ def parse_args():
 
     parser.add_argument("--wait-exec-complete", dest="wait_exec_complete", action="store_true")
     parser.add_argument("--no-wait-exec-complete", dest="wait_exec_complete", action="store_false")
-    parser.set_defaults(wait_exec_complete=env_bool("BENCH_SANDBOX_WAIT_EXEC_COMPLETE", False))
+    parser.set_defaults(wait_exec_complete=env_bool("BENCH_SANDBOX_WAIT_EXEC_COMPLETE", True))
 
     args = parser.parse_args()
     if not args.token_cache:
@@ -150,6 +160,8 @@ def parse_args():
         raise SystemExit("BENCH_SANDBOX_CREATE_RETRIES cannot be negative")
     if args.sandbox_ready_timeout_seconds <= 0:
         raise SystemExit("BENCH_SANDBOX_READY_TIMEOUT_SECONDS must be greater than 0")
+    if args.sandbox_output_tail_bytes < 0:
+        raise SystemExit("BENCH_SANDBOX_OUTPUT_TAIL_BYTES cannot be negative")
     if args.prewarm_idle_timeout_seconds <= 0:
         raise SystemExit("BENCH_SANDBOX_PREWARM_IDLE_TIMEOUT_SECONDS must be greater than 0")
     args.bootstrap_image_uri = args.sandbox_image_uri
@@ -170,6 +182,55 @@ def parse_sdk_memory(value):
     if raw.isdigit():
         return int(raw)
     return raw
+
+
+def expected_exec_output(args, sample):
+    template = str(args.sandbox_expected_output or "")
+    if not template:
+        return ""
+    try:
+        return template.format(
+            index=sample.get("index", ""),
+            container_id=sample.get("containerId", ""),
+            stub_id=sample.get("stubId", ""),
+            warmup=str(bool(sample.get("warmup"))).lower(),
+        )
+    except (IndexError, KeyError, ValueError) as exc:
+        raise ValueError(f"invalid sandbox expected output template {template!r}: {exc}") from exc
+
+
+def text_tail(value, max_bytes):
+    text = value if isinstance(value, str) else str(value or "")
+    encoded = text.encode("utf-8", errors="replace")
+    if max_bytes <= 0 or len(encoded) <= max_bytes:
+        return text, False, len(encoded)
+    return encoded[-max_bytes:].decode("utf-8", errors="replace"), True, len(encoded)
+
+
+def verify_exec_output(result, stdout, expected_output):
+    result["execExpectedOutput"] = expected_output
+    if result.get("execExitCode") is None:
+        result["execVerified"] = False
+        result["execOutputMatched"] = None
+        result["execVerificationError"] = "exec completion was not observed"
+        return
+
+    exit_ok = result.get("execExitCode") == 0
+    if not expected_output:
+        result["execVerified"] = exit_ok
+        result["execOutputMatched"] = None
+        if not exit_ok:
+            result["execVerificationError"] = f"exit code {result.get('execExitCode')}"
+        return
+
+    actual = stdout.rstrip("\r\n")
+    matched = actual == expected_output
+    result["execOutputMatched"] = matched
+    result["execVerified"] = exit_ok and matched
+    if not exit_ok:
+        result["execVerificationError"] = f"exit code {result.get('execExitCode')}"
+    elif not matched:
+        result["execVerificationError"] = f"stdout mismatch: expected {expected_output!r}, got {actual!r}"
 
 
 def parse_host_port(address):
@@ -352,21 +413,27 @@ def exec_readiness(args, instance, command, request_start_ns, sample=None):
     deadline = time.monotonic() + args.sandbox_ready_timeout_seconds
     attempts = 0
     errors = []
+    expected_output = expected_exec_output(args, sample or {})
+    env = {"BETA9_BENCH_EXPECTED_OUTPUT": expected_output}
 
     while True:
         attempts += 1
         exec_start_ns = time.monotonic_ns()
         try:
-            process = instance.process.exec(command, cwd=args.sandbox_exec_cwd)
+            process = instance.process.exec(command, cwd=args.sandbox_exec_cwd, env=env)
             exec_accepted_ns = time.monotonic_ns()
             result = {
                 "execAttempts": attempts,
                 "execErrors": errors,
+                "execCommand": command,
                 "execAcceptedMs": (exec_accepted_ns - exec_start_ns) / 1_000_000,
                 "processReadyMs": (exec_accepted_ns - request_start_ns) / 1_000_000,
                 "execCompleteMs": None,
                 "execPid": process.pid,
                 "execExitCode": None,
+                "execExpectedOutput": expected_output,
+                "execOutputMatched": None,
+                "execVerified": False,
             }
             if args.wait_exec_complete:
                 remaining_seconds = deadline - time.monotonic()
@@ -376,6 +443,23 @@ def exec_readiness(args, instance, command, request_start_ns, sample=None):
                 exec_done_ns = time.monotonic_ns()
                 result["execCompleteMs"] = (exec_done_ns - request_start_ns) / 1_000_000
                 result["execExitCode"] = exit_code
+                stdout = process.stdout.read()
+                stderr = process.stderr.read()
+                stdout_tail, stdout_truncated, stdout_bytes = text_tail(stdout, args.sandbox_output_tail_bytes)
+                stderr_tail, stderr_truncated, stderr_bytes = text_tail(stderr, args.sandbox_output_tail_bytes)
+                result.update(
+                    {
+                        "execStdout": stdout_tail,
+                        "execStderr": stderr_tail,
+                        "execStdoutBytes": stdout_bytes,
+                        "execStderrBytes": stderr_bytes,
+                        "execStdoutTruncated": stdout_truncated,
+                        "execStderrTruncated": stderr_truncated,
+                    }
+                )
+                verify_exec_output(result, stdout, expected_output)
+            else:
+                result["execVerificationError"] = "exec completion was not requested"
             return result
         except Exception as exc:
             errors.append(str(exc))
@@ -421,7 +505,12 @@ def run_sandbox_iteration(args, sandbox, token, index, warmup=False, start_event
         exec_info = exec_readiness(args, instance, command, request_start_ns, sample)
         sample.update(exec_info)
         if args.wait_exec_complete and sample["execExitCode"] != 0:
-            raise RuntimeError(f"Sandbox readiness command exited {sample['execExitCode']}")
+            raise RuntimeError(
+                f"Sandbox readiness command exited {sample['execExitCode']}; "
+                f"stderr={sample.get('execStderr', '')!r}"
+            )
+        if args.wait_exec_complete and not sample.get("execVerified"):
+            raise RuntimeError(sample.get("execVerificationError") or "sandbox readiness command was not verified")
 
         sample["ok"] = True
     except Exception as exc:
@@ -460,6 +549,30 @@ def measured_failed_samples(samples):
     return [sample for sample in samples if sample.get("warmup") is False and not sample.get("ok")]
 
 
+def summarize_exec_verification(samples):
+    measured = [sample for sample in samples if sample.get("warmup") is False]
+    completed = [sample for sample in measured if sample.get("execExitCode") is not None]
+    verified = [sample for sample in measured if sample.get("execVerified")]
+    mismatched = [sample for sample in measured if sample.get("execOutputMatched") is False]
+    return {
+        "count": len(measured),
+        "completed": len(completed),
+        "verified": len(verified),
+        "mismatched": len(mismatched),
+        "failed": len(measured) - len(verified),
+    }
+
+
+def exec_check_label(sample):
+    if sample.get("execVerified"):
+        return "yes"
+    if sample.get("execExitCode") is not None:
+        return "no"
+    if sample.get("execAttempts"):
+        return "retry"
+    return "-"
+
+
 def print_sample(sample):
     status = "ok" if sample.get("ok") else "failed"
     print(
@@ -470,6 +583,7 @@ def print_sample(sample):
         f"{format_ms(sample.get('runningObservedMs')):>9} "
         f"{format_ms(sample.get('processReadyMs')):>9} "
         f"{format_ms(sample.get('execCompleteMs')):>9} "
+        f"{exec_check_label(sample):>8} "
         f"{status:>8}",
         flush=True,
     )
@@ -505,6 +619,14 @@ def print_summary(summary):
             f"ok={batch['okCount']}/{batch['count']} "
             f"wall={format_ms(batch['wallMs'])}ms "
             f"throughput={batch['throughputPerSecond']:.2f}/s"
+        )
+    verification = summary.get("execVerification")
+    if verification:
+        print(
+            f"  {'sandbox command check':<28} "
+            f"verified={verification['verified']}/{verification['count']} "
+            f"completed={verification['completed']} "
+            f"mismatched={verification['mismatched']}"
         )
 
 
@@ -669,6 +791,7 @@ def main():
         "runningObservedMs": summarize_metric(samples, "runningObservedMs"),
         "processReadyMs": summarize_metric(samples, "processReadyMs"),
         "execCompleteMs": summarize_metric(samples, "execCompleteMs"),
+        "execVerification": summarize_exec_verification(samples),
         "batch": batch,
     }
     print_summary(summary)
@@ -694,6 +817,8 @@ def main():
             "sandboxImageUri": args.sandbox_image_uri,
             "sandboxExec": args.sandbox_exec,
             "sandboxExecCwd": args.sandbox_exec_cwd,
+            "sandboxExpectedOutput": args.sandbox_expected_output,
+            "sandboxOutputTailBytes": args.sandbox_output_tail_bytes,
             "prepareSandbox": args.prepare_sandbox,
             "waitRunning": args.wait_running,
             "waitExecComplete": args.wait_exec_complete,

--- a/benchmarks/sandbox_startup_report.py
+++ b/benchmarks/sandbox_startup_report.py
@@ -177,7 +177,14 @@ def interactive_samples(samples: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if sample.get("ok")
         and sample.get("execCompleteMs") is not None
         and sample.get("execExitCode") in (None, 0)
+        and sample_command_verified(sample)
     ]
+
+
+def sample_command_verified(sample: dict[str, Any]) -> bool:
+    if "execVerified" in sample:
+        return bool(sample.get("execVerified"))
+    return True
 
 
 def sample_metric_summary(samples: list[dict[str, Any]], key: str) -> dict[str, float] | None:
@@ -307,9 +314,10 @@ def build_startup_report(
     if not bottleneck:
         bottleneck = select_primary_bottleneck(server_phases, len(samples))
     coverage = build_event_coverage(samples, events, event_items)
+    exec_verification = build_exec_verification(samples)
     image_drilldown = build_image_drilldown(event_items, server_phases, len(samples))
     slowest = build_slowest_containers(samples, event_by_container)
-    data_quality = build_data_quality(samples, coverage, event_items, event_error, bottleneck)
+    data_quality = build_data_quality(samples, coverage, event_items, event_error, bottleneck, exec_verification)
     tti = client_timings.get("execCompleteMs")
 
     verdict_text = f"{len(interactive)}/{len(samples)} sandboxes interactive"
@@ -327,6 +335,7 @@ def build_startup_report(
         "timeToInteractive": tti,
         "primaryBottleneck": bottleneck,
         "eventCoverage": coverage,
+        "execVerification": exec_verification,
         "clientTimings": client_timings,
         "serverPhases": server_phases,
         "imageDrilldown": image_drilldown,
@@ -340,9 +349,32 @@ def build_client_timings(benchmark: dict[str, Any], samples: list[dict[str, Any]
     existing = benchmark.get("summary") or {}
     timings: dict[str, Any] = {}
     for key, _ in CLIENT_TIMINGS:
-        timings[key] = existing.get(key) or sample_metric_summary(samples, key)
+        source_samples = interactive_samples(samples) if key == "execCompleteMs" else samples
+        timings[key] = existing.get(key) or sample_metric_summary(source_samples, key)
     timings["batch"] = existing.get("batch")
     return timings
+
+
+def build_exec_verification(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    verified = [sample for sample in samples if sample.get("execVerified") is True]
+    failed = [sample for sample in samples if sample.get("execVerified") is False]
+    unknown = [sample for sample in samples if "execVerified" not in sample]
+    completed = [sample for sample in samples if sample.get("execExitCode") is not None]
+    mismatched = [sample for sample in samples if sample.get("execOutputMatched") is False]
+    nonzero = [
+        sample
+        for sample in samples
+        if sample.get("execExitCode") is not None and sample.get("execExitCode") != 0
+    ]
+    return {
+        "count": len(samples),
+        "completed": len(completed),
+        "verified": len(verified),
+        "failed": len(failed),
+        "unknown": len(unknown),
+        "mismatched": len(mismatched),
+        "nonzeroExit": len(nonzero),
+    }
 
 
 def build_server_phases(events: dict[str, Any] | None, measured_count: int) -> list[dict[str, Any]]:
@@ -727,8 +759,17 @@ def build_data_quality(
     event_items: list[dict[str, Any]],
     event_error: str,
     bottleneck: dict[str, Any] | None,
+    exec_verification: dict[str, Any],
 ) -> list[str]:
     notes = []
+    if exec_verification.get("failed"):
+        notes.append(
+            f"{exec_verification['failed']} sandbox readiness command check(s) failed."
+        )
+    if exec_verification.get("unknown"):
+        notes.append(
+            f"{exec_verification['unknown']} sample(s) did not include command verification metadata."
+        )
     if event_error:
         notes.append(f"Events API issue: {event_error}")
     if not coverage.get("eventsAvailable"):
@@ -763,11 +804,15 @@ def render_console_summary(report: dict[str, Any]) -> str:
     tti = report.get("timeToInteractive")
     bottleneck = report.get("primaryBottleneck")
     coverage = report.get("eventCoverage") or {}
+    verification = report.get("execVerification") or {}
     lines = [
         "",
         "Sandbox startup report:",
         f"  Verdict: {report['verdict']['text']}",
         f"  Time to interactive: {summary_inline(tti)}",
+        "  Command check: "
+        f"{verification.get('verified', 0)}/{verification.get('count', 0)} verified "
+        f"(completed={verification.get('completed', 0)}, failed={verification.get('failed', 0)})",
     ]
     if bottleneck:
         lines.append(
@@ -810,11 +855,15 @@ def render_console_summary(report: dict[str, Any]) -> str:
 def render_markdown(report: dict[str, Any]) -> str:
     bottleneck = report.get("primaryBottleneck")
     coverage = report.get("eventCoverage") or {}
+    verification = report.get("execVerification") or {}
     lines = [
         "# Sandbox Startup Benchmark Report",
         "",
         f"Verdict: {report['verdict']['text']}",
         f"Time to interactive: {summary_inline(report.get('timeToInteractive'))}",
+        "Command check: "
+        f"{verification.get('verified', 0)}/{verification.get('count', 0)} verified "
+        f"(completed={verification.get('completed', 0)}, failed={verification.get('failed', 0)})",
         "Primary bottleneck: "
         + (
             f"{bottleneck['eventId']} p95={format_ms(bottleneck.get('p95Ms'))}ms count={bottleneck.get('count', 0)}"

--- a/benchmarks/test_sandbox_parallel.py
+++ b/benchmarks/test_sandbox_parallel.py
@@ -1,0 +1,76 @@
+import argparse
+import unittest
+
+from benchmarks.sandbox_parallel import (
+    DEFAULT_SANDBOX_EXPECTED_OUTPUT,
+    expected_exec_output,
+    summarize_exec_verification,
+    text_tail,
+    verify_exec_output,
+)
+
+
+class SandboxParallelTests(unittest.TestCase):
+    def test_expected_exec_output_formats_sample_fields(self):
+        args = argparse.Namespace(
+            sandbox_expected_output=DEFAULT_SANDBOX_EXPECTED_OUTPUT + "-{container_id}-{stub_id}-{warmup}"
+        )
+        sample = {
+            "index": 7,
+            "containerId": "sandbox-1",
+            "stubId": "stub-1",
+            "warmup": False,
+        }
+
+        self.assertEqual(
+            expected_exec_output(args, sample),
+            "beta9-sandbox-ready-7-sandbox-1-stub-1-false",
+        )
+
+    def test_verify_exec_output_requires_exit_zero_and_stdout_match(self):
+        result = {"execExitCode": 0}
+
+        verify_exec_output(result, "ready-token\n", "ready-token")
+
+        self.assertTrue(result["execVerified"])
+        self.assertTrue(result["execOutputMatched"])
+
+    def test_verify_exec_output_records_stdout_mismatch(self):
+        result = {"execExitCode": 0}
+
+        verify_exec_output(result, "wrong\n", "ready-token")
+
+        self.assertFalse(result["execVerified"])
+        self.assertFalse(result["execOutputMatched"])
+        self.assertIn("stdout mismatch", result["execVerificationError"])
+
+    def test_text_tail_preserves_byte_count_and_truncation(self):
+        text, truncated, byte_count = text_tail("abcdef", 3)
+
+        self.assertEqual(text, "def")
+        self.assertTrue(truncated)
+        self.assertEqual(byte_count, 6)
+
+    def test_summarize_exec_verification_counts_failures(self):
+        summary = summarize_exec_verification(
+            [
+                {"warmup": True, "execVerified": False},
+                {"warmup": False, "execVerified": True, "execExitCode": 0},
+                {
+                    "warmup": False,
+                    "execVerified": False,
+                    "execExitCode": 0,
+                    "execOutputMatched": False,
+                },
+            ]
+        )
+
+        self.assertEqual(summary["count"], 2)
+        self.assertEqual(summary["completed"], 2)
+        self.assertEqual(summary["verified"], 1)
+        self.assertEqual(summary["mismatched"], 1)
+        self.assertEqual(summary["failed"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/test_sandbox_startup_report.py
+++ b/benchmarks/test_sandbox_startup_report.py
@@ -38,6 +38,38 @@ class SandboxStartupReportTests(unittest.TestCase):
         self.assertEqual(report["timeToInteractive"]["count"], 2)
         self.assertEqual(report["timeToInteractive"]["p50"], 150)
 
+    def test_unverified_exec_is_not_interactive(self):
+        benchmark = {
+            "summary": {},
+            "samples": [
+                {
+                    "warmup": False,
+                    "ok": True,
+                    "execCompleteMs": 100,
+                    "execExitCode": 0,
+                    "execVerified": True,
+                },
+                {
+                    "warmup": False,
+                    "ok": True,
+                    "execCompleteMs": 120,
+                    "execExitCode": 0,
+                    "execVerified": False,
+                    "execOutputMatched": False,
+                },
+            ],
+        }
+
+        report = build_startup_report(benchmark)
+
+        self.assertEqual(report["verdict"]["interactive"], 1)
+        self.assertEqual(report["timeToInteractive"]["count"], 1)
+        self.assertEqual(report["execVerification"]["verified"], 1)
+        self.assertEqual(report["execVerification"]["failed"], 1)
+        self.assertTrue(
+            any("readiness command" in note for note in report["dataQuality"])
+        )
+
     def test_primary_bottleneck_ignores_low_coverage_outlier(self):
         phases = [
             {

--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -29,6 +29,7 @@ type ContainerEventsBatchRequest struct {
 	TaskIDs              []string                     `json:"task_ids"`
 	Targets              []ContainerEventsBatchTarget `json:"targets,omitempty"`
 	Limit                uint64                       `json:"limit,omitempty"`
+	EventTypes           []string                     `json:"event_types,omitempty"`
 	IncludeEvents        bool                         `json:"include_events,omitempty"`
 	TopLifecycle         int                          `json:"top_lifecycle,omitempty"`
 	RequiredLifecycleIDs []string                     `json:"required_lifecycle_ids,omitempty"`
@@ -178,8 +179,10 @@ func NewEventGroup(g *echo.Group, backendRepo repository.BackendRepository, cont
 	}
 
 	g.GET("/:workspaceId/containers/:containerId", auth.WithWorkspaceAuth(group.GetContainerEvents))
+	g.GET("/:workspaceId/containers/:containerId/stream", auth.WithWorkspaceAuth(group.StreamContainerEvents))
 	g.GET("/:workspaceId/containers/:containerId/summary", auth.WithWorkspaceAuth(group.GetContainerEventSummary))
 	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId", auth.WithWorkspaceAuth(group.GetContainerEvents))
+	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId/stream", auth.WithWorkspaceAuth(group.StreamContainerEvents))
 	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId/summary", auth.WithWorkspaceAuth(group.GetContainerEventSummary))
 	g.POST("/:workspaceId/containers/batch", auth.WithWorkspaceAuth(group.GetContainerEventsBatch))
 	g.GET("/:workspaceId/tasks/:taskId", auth.WithWorkspaceAuth(group.GetTaskEvents))
@@ -207,6 +210,67 @@ func (g *EventGroup) GetContainerEvents(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, events)
+}
+
+func (g *EventGroup) StreamContainerEvents(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+	containerID := ctx.Param("containerId")
+	if containerID == "" {
+		return HTTPBadRequest("Missing container ID")
+	}
+	if g.eventRepo == nil {
+		return HTTPInternalServerError("Event repository is unavailable")
+	}
+
+	query, err := eventStreamQueryFromContext(ctx, authInfoFromContext(cc))
+	if err != nil {
+		return HTTPBadRequest("Invalid event stream query")
+	}
+	query, _, err = g.authorizeContainerEventQuery(ctx, containerID, query)
+	if err != nil {
+		return err
+	}
+	if query.WorkspaceID == "" || query.StubID == "" {
+		return HTTPNotFound()
+	}
+
+	stream, err := g.eventRepo.StreamContainerEvents(ctx.Request().Context(), containerID, query)
+	if err != nil {
+		if errors.Is(err, repository.ErrEventReadUnsupported) {
+			return NewHTTPError(http.StatusServiceUnavailable, "Event streams are not configured")
+		}
+		return HTTPInternalServerError("Failed to stream container events")
+	}
+	defer stream.Close()
+
+	response := ctx.Response()
+	response.Header().Set("Content-Type", "text/event-stream")
+	response.Header().Set("Cache-Control", "no-cache")
+	response.Header().Set("Connection", "keep-alive")
+	response.WriteHeader(http.StatusOK)
+
+	flusher, _ := response.Writer.(http.Flusher)
+	for stream.Next() {
+		record := stream.Record()
+		payload, err := json.Marshal(record)
+		if err != nil {
+			continue
+		}
+		if err := writeSSEEvent(response.Writer, "event", strconv.FormatUint(record.SeqNum, 10), payload); err != nil {
+			return nil
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	if err := stream.Err(); err != nil && ctx.Request().Context().Err() == nil {
+		payload, _ := json.Marshal(map[string]string{"error": err.Error()})
+		_ = writeSSEEvent(response.Writer, "error", "", payload)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	return nil
 }
 
 func (g *EventGroup) GetContainerEventSummary(ctx echo.Context) error {
@@ -278,6 +342,7 @@ func (g *EventGroup) GetContainerEventsBatch(ctx echo.Context) error {
 				WorkspaceID: task.Workspace.ExternalId,
 				StubID:      task.Stub.ExternalId,
 				TaskID:      task.ExternalId,
+				EventTypes:  eventQueryTypes(req.EventTypes),
 			})
 			if err != nil {
 				items = append(items, ContainerEventSummary{ContainerID: task.ContainerId, TaskID: target.TaskID, Error: err.Error()})
@@ -296,6 +361,7 @@ func (g *EventGroup) GetContainerEventsBatch(ctx echo.Context) error {
 			Limit:       req.Limit,
 			WorkspaceID: workspaceID,
 			StubID:      target.StubID,
+			EventTypes:  eventQueryTypes(req.EventTypes),
 		})
 		if err != nil {
 			items = append(items, ContainerEventSummary{ContainerID: target.ContainerID, StubID: target.StubID, Error: err.Error()})
@@ -371,6 +437,7 @@ func (g *EventGroup) GetTaskEvents(ctx echo.Context) error {
 		WorkspaceID: task.Workspace.ExternalId,
 		StubID:      task.Stub.ExternalId,
 		TaskID:      task.ExternalId,
+		EventTypes:  eventQueryTypesFromParam(ctx.QueryParam("event_types")),
 	})
 	if err != nil {
 		return err
@@ -387,21 +454,9 @@ func (g *EventGroup) loadContainerEvents(ctx echo.Context, containerID string, q
 		return nil, HTTPInternalServerError("Event repository is unavailable")
 	}
 
-	state, stateErr := g.containerRepo.GetContainerState(containerID)
-	if stateErr == nil && state != nil {
-		if !eventWorkspaceAccessAllowed(authInfo, routeWorkspaceID, state.WorkspaceId) {
-			return nil, HTTPNotFound()
-		}
-		if query.WorkspaceID == "" {
-			query.WorkspaceID = state.WorkspaceId
-		}
-		if query.StubID == "" {
-			query.StubID = state.StubId
-		}
-	} else if query.StubID == "" {
-		if stubID, ok := common.ExtractStubIdFromStubScopedContainerId(containerID); ok {
-			query.StubID = stubID
-		}
+	query, state, err := g.authorizeContainerEventQuery(ctx, containerID, query)
+	if err != nil {
+		return nil, err
 	}
 
 	events, err := g.eventRepo.GetContainerEvents(ctx.Request().Context(), containerID, query)
@@ -412,7 +467,7 @@ func (g *EventGroup) loadContainerEvents(ctx echo.Context, containerID string, q
 		return nil, HTTPInternalServerError("Failed to retrieve container events")
 	}
 
-	if stateErr == nil && state != nil {
+	if state != nil {
 		if events.WorkspaceID == "" {
 			events.WorkspaceID = state.WorkspaceId
 		}
@@ -434,6 +489,33 @@ func (g *EventGroup) loadContainerEvents(ctx echo.Context, containerID string, q
 	}
 
 	return events, nil
+}
+
+func (g *EventGroup) authorizeContainerEventQuery(ctx echo.Context, containerID string, query types.EventQuery) (types.EventQuery, *types.ContainerState, error) {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+	authInfo := authInfoFromContext(cc)
+	routeWorkspaceID := requestedEventWorkspaceID(ctx, authInfo)
+
+	state, stateErr := g.containerRepo.GetContainerState(containerID)
+	if stateErr == nil && state != nil {
+		if !eventWorkspaceAccessAllowed(authInfo, routeWorkspaceID, state.WorkspaceId) {
+			return query, nil, HTTPNotFound()
+		}
+		if query.WorkspaceID == "" {
+			query.WorkspaceID = state.WorkspaceId
+		}
+		if query.StubID == "" {
+			query.StubID = state.StubId
+		}
+		return query, state, nil
+	}
+
+	if query.StubID == "" {
+		if stubID, ok := common.ExtractStubIdFromStubScopedContainerId(containerID); ok {
+			query.StubID = stubID
+		}
+	}
+	return query, nil, nil
 }
 
 func hasWorkspaceTaskAccess(task *types.TaskWithRelated, authInfo *auth.AuthInfo, routeWorkspaceID string) bool {
@@ -476,7 +558,113 @@ func eventQueryFromContext(ctx echo.Context, authInfo *auth.AuthInfo, limit uint
 		WorkspaceID: requestedEventWorkspaceID(ctx, authInfo),
 		StubID:      firstNonEmpty(ctx.Param("stubId"), ctx.QueryParam("stub_id")),
 		TaskID:      ctx.QueryParam("task_id"),
+		EventTypes:  eventQueryTypesFromParam(ctx.QueryParam("event_types")),
 	}
+}
+
+func eventStreamQueryFromContext(ctx echo.Context, authInfo *auth.AuthInfo) (types.EventQuery, error) {
+	limit, err := eventQueryLimit(ctx)
+	if err != nil {
+		return types.EventQuery{}, err
+	}
+
+	query := eventQueryFromContext(ctx, authInfo, limit)
+	startSelectors := 0
+
+	if raw := ctx.QueryParam("seq_num"); raw != "" {
+		seqNum, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return types.EventQuery{}, err
+		}
+		query.SeqNum = &seqNum
+		startSelectors++
+	}
+
+	if raw := ctx.QueryParam("tail_offset"); raw != "" {
+		tailOffset, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || tailOffset < 0 {
+			return types.EventQuery{}, fmt.Errorf("invalid tail offset")
+		}
+		query.TailOffset = &tailOffset
+		startSelectors++
+	}
+
+	if startSelectors > 1 {
+		return types.EventQuery{}, fmt.Errorf("multiple stream start selectors")
+	}
+
+	if raw := ctx.Request().Header.Get("Last-Event-ID"); query.SeqNum == nil && query.TailOffset == nil && raw != "" {
+		lastSeqNum, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return types.EventQuery{}, err
+		}
+		nextSeqNum := lastSeqNum + 1
+		query.SeqNum = &nextSeqNum
+	}
+
+	if raw := ctx.QueryParam("wait"); raw != "" {
+		wait, err := strconv.ParseInt(raw, 10, 32)
+		if err != nil || wait < 0 {
+			return types.EventQuery{}, fmt.Errorf("invalid wait")
+		}
+		waitSeconds := int32(wait)
+		query.WaitSeconds = &waitSeconds
+	}
+
+	if raw := ctx.QueryParam("clamp"); raw != "" {
+		clamp, err := strconv.ParseBool(raw)
+		if err != nil {
+			return types.EventQuery{}, err
+		}
+		query.Clamp = &clamp
+	}
+	if query.SeqNum != nil && query.Clamp == nil {
+		clamp := true
+		query.Clamp = &clamp
+	}
+
+	return query, nil
+}
+
+func eventQueryTypesFromParam(raw string) []string {
+	return eventQueryTypes(strings.Split(raw, ","))
+}
+
+func eventQueryTypes(values []string) []string {
+	eventTypes := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		eventTypes = append(eventTypes, value)
+	}
+	return eventTypes
+}
+
+func writeSSEEvent(w http.ResponseWriter, eventName string, id string, data []byte) error {
+	if id != "" {
+		if _, err := fmt.Fprintf(w, "id: %s\n", id); err != nil {
+			return err
+		}
+	}
+	if eventName != "" {
+		if _, err := fmt.Fprintf(w, "event: %s\n", eventName); err != nil {
+			return err
+		}
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprint(w, "\n")
+	return err
 }
 
 func isClusterAdmin(authInfo *auth.AuthInfo) bool {

--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -184,6 +184,7 @@ func NewEventGroup(g *echo.Group, backendRepo repository.BackendRepository, cont
 	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId", auth.WithWorkspaceAuth(group.GetContainerEvents))
 	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId/stream", auth.WithWorkspaceAuth(group.StreamContainerEvents))
 	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId/summary", auth.WithWorkspaceAuth(group.GetContainerEventSummary))
+	g.GET("/:workspaceId/stubs/:stubId/stream", auth.WithWorkspaceAuth(group.StreamStubEvents))
 	g.POST("/:workspaceId/containers/batch", auth.WithWorkspaceAuth(group.GetContainerEventsBatch))
 	g.GET("/:workspaceId/tasks/:taskId", auth.WithWorkspaceAuth(group.GetTaskEvents))
 
@@ -243,6 +244,10 @@ func (g *EventGroup) StreamContainerEvents(ctx echo.Context) error {
 	}
 	defer stream.Close()
 
+	return g.writeEventStream(ctx, stream)
+}
+
+func (g *EventGroup) writeEventStream(ctx echo.Context, stream repository.EventStream) error {
 	response := ctx.Response()
 	response.Header().Set("Content-Type", "text/event-stream")
 	response.Header().Set("Cache-Control", "no-cache")
@@ -250,6 +255,13 @@ func (g *EventGroup) StreamContainerEvents(ctx echo.Context) error {
 	response.WriteHeader(http.StatusOK)
 
 	flusher, _ := response.Writer.(http.Flusher)
+	if _, err := fmt.Fprint(response.Writer, ": connected\n\n"); err != nil {
+		return nil
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
+
 	for stream.Next() {
 		record := stream.Record()
 		payload, err := json.Marshal(record)
@@ -271,6 +283,37 @@ func (g *EventGroup) StreamContainerEvents(ctx echo.Context) error {
 		}
 	}
 	return nil
+}
+
+func (g *EventGroup) StreamStubEvents(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+	stubID := ctx.Param("stubId")
+	if stubID == "" {
+		return HTTPBadRequest("Missing stub ID")
+	}
+	if g.eventRepo == nil {
+		return HTTPInternalServerError("Event repository is unavailable")
+	}
+
+	query, err := eventStreamQueryFromContext(ctx, authInfoFromContext(cc))
+	if err != nil {
+		return HTTPBadRequest("Invalid event stream query")
+	}
+	query.StubID = stubID
+	if query.WorkspaceID == "" {
+		return HTTPNotFound()
+	}
+
+	stream, err := g.eventRepo.StreamStubEvents(ctx.Request().Context(), query)
+	if err != nil {
+		if errors.Is(err, repository.ErrEventReadUnsupported) {
+			return NewHTTPError(http.StatusServiceUnavailable, "Event streams are not configured")
+		}
+		return HTTPInternalServerError("Failed to stream stub events")
+	}
+	defer stream.Close()
+
+	return g.writeEventStream(ctx, stream)
 }
 
 func (g *EventGroup) GetContainerEventSummary(ctx echo.Context) error {

--- a/pkg/api/v1/events_test.go
+++ b/pkg/api/v1/events_test.go
@@ -1,6 +1,12 @@
 package apiv1
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
 
 func TestSummarizeContainerEventsBatchReturnsCoverageAndBottleneck(t *testing.T) {
 	items := []ContainerEventSummary{
@@ -91,5 +97,60 @@ func TestNormalizeContainerEventsBatchTargets(t *testing.T) {
 	}
 	if got, want := targets[1].TaskID, "task-1"; got != want {
 		t.Fatalf("unexpected normalized task id: got %q want %q", got, want)
+	}
+}
+
+func TestEventQueryTypesNormalizesValues(t *testing.T) {
+	eventTypes := eventQueryTypes([]string{" container.event ", "", "container.lifecycle", "container.event"})
+
+	if got, want := len(eventTypes), 2; got != want {
+		t.Fatalf("unexpected event type count: got %d want %d", got, want)
+	}
+	if got, want := eventTypes[0], "container.event"; got != want {
+		t.Fatalf("unexpected first event type: got %q want %q", got, want)
+	}
+	if got, want := eventTypes[1], "container.lifecycle"; got != want {
+		t.Fatalf("unexpected second event type: got %q want %q", got, want)
+	}
+}
+
+func TestEventStreamQueryFromContextParsesS2ReadOptions(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/?event_types=container.event,container.lifecycle&seq_num=7&wait=30&limit=10", nil)
+	ctx := e.NewContext(req, httptest.NewRecorder())
+
+	query, err := eventStreamQueryFromContext(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if query.SeqNum == nil || *query.SeqNum != 7 {
+		t.Fatalf("unexpected seq_num: %#v", query.SeqNum)
+	}
+	if query.WaitSeconds == nil || *query.WaitSeconds != 30 {
+		t.Fatalf("unexpected wait: %#v", query.WaitSeconds)
+	}
+	if query.Clamp == nil || !*query.Clamp {
+		t.Fatalf("expected seq_num streams to clamp by default")
+	}
+	if got, want := query.Limit, uint64(10); got != want {
+		t.Fatalf("unexpected limit: got %d want %d", got, want)
+	}
+	if got, want := len(query.EventTypes), 2; got != want {
+		t.Fatalf("unexpected event type count: got %d want %d", got, want)
+	}
+}
+
+func TestEventStreamQueryFromContextUsesLastEventID(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Last-Event-ID", "41")
+	ctx := e.NewContext(req, httptest.NewRecorder())
+
+	query, err := eventStreamQueryFromContext(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if query.SeqNum == nil || *query.SeqNum != 42 {
+		t.Fatalf("unexpected resumed seq_num: %#v", query.SeqNum)
 	}
 }

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -22,6 +22,8 @@ database:
     apiKey: ""
     basin: beta9-events
     streamPrefix: events
+events:
+  callbacks: []
 storage:
   mode: juicefs
   fsName: beta9-fs

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -225,6 +225,7 @@ type TailscaleRepository interface {
 type EventRepository interface {
 	GetContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error)
 	StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error)
+	StreamStubEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	PushContainerResourceMetricsEvent(workerID string, request *types.ContainerRequest, metrics types.EventContainerMetricsData)
 	PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema)
 	PushContainerEvent(event types.EventContainerEventSchema)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -224,6 +224,7 @@ type TailscaleRepository interface {
 
 type EventRepository interface {
 	GetContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error)
+	StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error)
 	PushContainerResourceMetricsEvent(workerID string, request *types.ContainerRequest, metrics types.EventContainerMetricsData)
 	PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema)
 	PushContainerEvent(event types.EventContainerEventSchema)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -22,9 +22,21 @@ type eventReader interface {
 	GetContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error)
 }
 
+type EventStream interface {
+	Next() bool
+	Record() types.ContainerEventRecord
+	Err() error
+	Close() error
+}
+
+type eventStreamer interface {
+	StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error)
+}
+
 type EventClientRepo struct {
-	sinks  []eventSink
-	reader eventReader
+	sinks    []eventSink
+	reader   eventReader
+	streamer eventStreamer
 }
 
 var ErrEventReadUnsupported = errors.New("event read unsupported")
@@ -42,14 +54,23 @@ func NewEventClientRepo(config types.AppConfig) EventRepository {
 	sinks := []eventSink{}
 
 	var reader eventReader
+	var streamer eventStreamer
 	if s2Sink, err := NewS2EventRepository(config.Database.S2); err != nil {
 		log.Warn().Err(err).Msg("s2 event repository unavailable")
 	} else if s2Sink != nil {
 		sinks = append(sinks, s2Sink)
 		reader = s2Sink
+		streamer = s2Sink
 	}
 
-	return &EventClientRepo{sinks: sinks, reader: reader}
+	for _, callback := range config.Events.Callbacks {
+		if strings.TrimSpace(callback.URL) == "" {
+			continue
+		}
+		sinks = append(sinks, newEventHTTPSink(callback))
+	}
+
+	return &EventClientRepo{sinks: sinks, reader: reader, streamer: streamer}
 }
 
 func (r *EventClientRepo) createEventObject(eventName string, schemaVersion string, data interface{}) (cloudevents.Event, error) {
@@ -96,6 +117,13 @@ func (r *EventClientRepo) GetContainerEvents(ctx context.Context, containerID st
 		return nil, ErrEventReadUnsupported
 	}
 	return r.reader.GetContainerEvents(ctx, containerID, query)
+}
+
+func (r *EventClientRepo) StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error) {
+	if r.streamer == nil {
+		return nil, ErrEventReadUnsupported
+	}
+	return r.streamer.StreamContainerEvents(ctx, containerID, query)
 }
 
 func (r *EventClientRepo) PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema) {

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -31,6 +31,7 @@ type EventStream interface {
 
 type eventStreamer interface {
 	StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error)
+	StreamStubEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 }
 
 type EventClientRepo struct {
@@ -124,6 +125,13 @@ func (r *EventClientRepo) StreamContainerEvents(ctx context.Context, containerID
 		return nil, ErrEventReadUnsupported
 	}
 	return r.streamer.StreamContainerEvents(ctx, containerID, query)
+}
+
+func (r *EventClientRepo) StreamStubEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
+	if r.streamer == nil {
+		return nil, ErrEventReadUnsupported
+	}
+	return r.streamer.StreamStubEvents(ctx, query)
 }
 
 func (r *EventClientRepo) PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema) {

--- a/pkg/repository/events_http_sink.go
+++ b/pkg/repository/events_http_sink.go
@@ -1,0 +1,153 @@
+package repository
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultEventHTTPTimeout = 5 * time.Second
+	eventHTTPQueueSize      = 4096
+)
+
+type eventHTTPSink struct {
+	config types.EventCallbackConfig
+	client *http.Client
+	queue  chan cloudevents.Event
+}
+
+func newEventHTTPSink(config types.EventCallbackConfig) *eventHTTPSink {
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = defaultEventHTTPTimeout
+	}
+
+	sink := &eventHTTPSink{
+		config: config,
+		client: &http.Client{Timeout: timeout},
+		queue:  make(chan cloudevents.Event, eventHTTPQueueSize),
+	}
+	go sink.run()
+	return sink
+}
+
+func (s *eventHTTPSink) PushEvent(event cloudevents.Event) error {
+	if !eventHTTPMatches(s.config.EventTypes, event.Type()) {
+		return nil
+	}
+
+	select {
+	case s.queue <- event:
+		return nil
+	default:
+		return fmt.Errorf("event callback queue is full")
+	}
+}
+
+func (s *eventHTTPSink) run() {
+	for event := range s.queue {
+		if err := s.deliver(event); err != nil {
+			log.Debug().Err(err).Str("event_type", event.Type()).Str("url", s.config.URL).Msg("failed to deliver event http callback")
+		}
+	}
+}
+
+func (s *eventHTTPSink) deliver(event cloudevents.Event) error {
+	body, err := s.payload(event)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.config.URL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range s.config.Headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("event callback returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (s *eventHTTPSink) payload(event cloudevents.Event) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(s.config.Format)) {
+	case "", "cloud_event", "cloudevent", "json":
+		return json.Marshal(event)
+	case "slack":
+		return json.Marshal(map[string]string{"text": slackEventText(event)})
+	default:
+		return nil, fmt.Errorf("unsupported event callback format %q", s.config.Format)
+	}
+}
+
+func eventHTTPMatches(filters []string, eventType string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	for _, filter := range filters {
+		filter = strings.TrimSpace(filter)
+		switch {
+		case filter == "":
+			continue
+		case filter == "*", filter == eventType:
+			return true
+		case strings.HasSuffix(filter, "*") && strings.HasPrefix(eventType, strings.TrimSuffix(filter, "*")):
+			return true
+		}
+	}
+	return false
+}
+
+func slackEventText(event cloudevents.Event) string {
+	metadata := eventMetadataFromCloudEvent(event)
+	parts := []string{fmt.Sprintf("beta9 event `%s`", event.Type())}
+	if metadata.WorkspaceID != "" {
+		parts = append(parts, "workspace `"+metadata.WorkspaceID+"`")
+	}
+	if metadata.StubID != "" {
+		parts = append(parts, "stub `"+metadata.StubID+"`")
+	}
+	if metadata.ContainerID != "" {
+		parts = append(parts, "container `"+metadata.ContainerID+"`")
+	}
+	if metadata.TaskID != "" {
+		parts = append(parts, "task `"+metadata.TaskID+"`")
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(event.Data(), &data); err == nil {
+		if id, ok := data["id"].(string); ok && id != "" {
+			parts = append(parts, "id `"+id+"`")
+		}
+		if status, ok := data["status"].(string); ok && status != "" {
+			parts = append(parts, "status `"+status+"`")
+		}
+		if reason, ok := data["reason"].(string); ok && reason != "" && reason != "UNKNOWN" {
+			parts = append(parts, "reason `"+reason+"`")
+		}
+		if message, ok := data["message"].(string); ok && message != "" {
+			parts = append(parts, message)
+		}
+	}
+
+	return strings.Join(parts, " | ")
+}

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -130,15 +130,17 @@ func (r *S2EventRepository) appendEventBatch(events []cloudevents.Event) error {
 
 	recordsByStream := map[s2.StreamName][]s2.AppendRecord{}
 	for _, event := range events {
-		record, streamName, err := r.appendRecordForEvent(event)
+		record, streamNames, err := r.appendRecordForEvent(event)
 		if err != nil {
 			log.Debug().Err(err).Str("event_type", event.Type()).Msg("failed to build s2 event record")
 			continue
 		}
-		if streamName == "" {
+		if len(streamNames) == 0 {
 			continue
 		}
-		recordsByStream[streamName] = append(recordsByStream[streamName], record)
+		for _, streamName := range streamNames {
+			recordsByStream[streamName] = append(recordsByStream[streamName], record)
+		}
 	}
 
 	var streamErrs []error
@@ -168,16 +170,16 @@ func (r *S2EventRepository) appendEventBatch(events []cloudevents.Event) error {
 	return errors.Join(streamErrs...)
 }
 
-func (r *S2EventRepository) appendRecordForEvent(event cloudevents.Event) (s2.AppendRecord, s2.StreamName, error) {
+func (r *S2EventRepository) appendRecordForEvent(event cloudevents.Event) (s2.AppendRecord, []s2.StreamName, error) {
 	body, err := json.Marshal(event)
 	if err != nil {
-		return s2.AppendRecord{}, "", fmt.Errorf("marshal cloud event: %w", err)
+		return s2.AppendRecord{}, nil, fmt.Errorf("marshal cloud event: %w", err)
 	}
 
 	metadata := eventMetadataFromCloudEvent(event)
-	streamName := r.streamNameForEvent(event.Type(), metadata)
-	if streamName == "" {
-		return s2.AppendRecord{}, "", nil
+	streamNames := r.streamNamesForEvent(event.Type(), metadata)
+	if len(streamNames) == 0 {
+		return s2.AppendRecord{}, nil, nil
 	}
 
 	timestamp := uint64(event.Time().UnixMilli())
@@ -185,7 +187,7 @@ func (r *S2EventRepository) appendRecordForEvent(event cloudevents.Event) (s2.Ap
 		Timestamp: &timestamp,
 		Headers:   s2HeadersForEvent(event, metadata),
 		Body:      body,
-	}, streamName, nil
+	}, streamNames, nil
 }
 
 func (r *S2EventRepository) GetContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error) {
@@ -241,11 +243,23 @@ func (r *S2EventRepository) StreamContainerEvents(ctx context.Context, container
 		return nil, fmt.Errorf("workspace id and stub id are required to stream container events")
 	}
 
+	streamName := r.containerStreamName(query.WorkspaceID, query.StubID, containerID)
+	return r.streamEvents(ctx, streamName, containerID, query)
+}
+
+func (r *S2EventRepository) StreamStubEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
+	if query.WorkspaceID == "" || query.StubID == "" {
+		return nil, fmt.Errorf("workspace id and stub id are required to stream stub events")
+	}
+
+	streamName := r.stubStreamName(query.WorkspaceID, query.StubID)
+	return r.streamEvents(ctx, streamName, "", query)
+}
+
+func (r *S2EventRepository) streamEvents(ctx context.Context, streamName s2.StreamName, containerID string, query types.EventQuery) (EventStream, error) {
 	if err := r.ensureBasin(ctx); err != nil {
 		return nil, err
 	}
-
-	streamName := r.containerStreamName(query.WorkspaceID, query.StubID, containerID)
 	if err := r.ensureStream(ctx, streamName); err != nil {
 		return nil, err
 	}
@@ -259,10 +273,10 @@ func (r *S2EventRepository) StreamContainerEvents(ctx context.Context, container
 	}
 	session, err := r.basin.Stream(streamName).ReadSession(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("stream container events from s2 stream %q: %w", streamName, err)
+		return nil, fmt.Errorf("stream events from s2 stream %q: %w", streamName, err)
 	}
 
-	return &s2ContainerEventStream{
+	return &s2EventStream{
 		session: session,
 		query:   query,
 		response: &types.ContainerEventsResponse{
@@ -346,7 +360,7 @@ func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName 
 	return nil
 }
 
-type s2ContainerEventStream struct {
+type s2EventStream struct {
 	session *s2.ReadSession
 	query   types.EventQuery
 
@@ -354,7 +368,7 @@ type s2ContainerEventStream struct {
 	current  types.ContainerEventRecord
 }
 
-func (s *s2ContainerEventStream) Next() bool {
+func (s *s2EventStream) Next() bool {
 	for s.session.Next() {
 		eventRecord, ok := containerEventRecordFromS2(s.session.Record(), s.query, s.response)
 		if !ok {
@@ -366,15 +380,15 @@ func (s *s2ContainerEventStream) Next() bool {
 	return false
 }
 
-func (s *s2ContainerEventStream) Record() types.ContainerEventRecord {
+func (s *s2EventStream) Record() types.ContainerEventRecord {
 	return s.current
 }
 
-func (s *s2ContainerEventStream) Err() error {
+func (s *s2EventStream) Err() error {
 	return s.session.Err()
 }
 
-func (s *s2ContainerEventStream) Close() error {
+func (s *s2EventStream) Close() error {
 	return s.session.Close()
 }
 
@@ -551,6 +565,27 @@ func (r *S2EventRepository) streamNameForEvent(eventType string, metadata eventM
 	default:
 		return r.typeStreamName(eventType)
 	}
+}
+
+func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata eventMetadata) []s2.StreamName {
+	streams := []s2.StreamName{}
+	add := func(stream s2.StreamName) {
+		if stream == "" {
+			return
+		}
+		for _, existing := range streams {
+			if existing == stream {
+				return
+			}
+		}
+		streams = append(streams, stream)
+	}
+
+	add(r.streamNameForEvent(eventType, metadata))
+	if metadata.WorkspaceID != "" && metadata.StubID != "" {
+		add(r.stubStreamName(metadata.WorkspaceID, metadata.StubID))
+	}
+	return streams
 }
 
 func (r *S2EventRepository) containerStreamName(workspaceID, stubID, containerID string) s2.StreamName {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -236,6 +236,43 @@ func (r *S2EventRepository) GetContainerEvents(ctx context.Context, containerID 
 	return response, nil
 }
 
+func (r *S2EventRepository) StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error) {
+	if query.WorkspaceID == "" || query.StubID == "" {
+		return nil, fmt.Errorf("workspace id and stub id are required to stream container events")
+	}
+
+	if err := r.ensureBasin(ctx); err != nil {
+		return nil, err
+	}
+
+	streamName := r.containerStreamName(query.WorkspaceID, query.StubID, containerID)
+	if err := r.ensureStream(ctx, streamName); err != nil {
+		return nil, err
+	}
+
+	opts := &s2.ReadOptions{
+		SeqNum:     query.SeqNum,
+		TailOffset: query.TailOffset,
+		Count:      countOption(query.Limit),
+		Wait:       query.WaitSeconds,
+		Clamp:      query.Clamp,
+	}
+	session, err := r.basin.Stream(streamName).ReadSession(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("stream container events from s2 stream %q: %w", streamName, err)
+	}
+
+	return &s2ContainerEventStream{
+		session: session,
+		query:   query,
+		response: &types.ContainerEventsResponse{
+			ContainerID: containerID,
+			WorkspaceID: query.WorkspaceID,
+			StubID:      query.StubID,
+		},
+	}, nil
+}
+
 func (r *S2EventRepository) resolveContainerStreams(ctx context.Context, containerID string, query types.EventQuery) ([]s2.StreamName, error) {
 	if query.WorkspaceID != "" && query.StubID != "" {
 		streamName := r.containerStreamName(query.WorkspaceID, query.StubID, containerID)
@@ -300,36 +337,122 @@ func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName 
 
 	response.Streams = append(response.Streams, string(streamName))
 	for _, record := range batch.Records {
-		eventRecord := types.ContainerEventRecord{
-			SeqNum:     record.SeqNum,
-			StoredAtNs: s2TimestampMillisToNanos(record.Timestamp),
-			CloudEvent: append([]byte(nil), record.Body...),
-		}
-
-		var envelope struct {
-			Type string          `json:"type"`
-			Time time.Time       `json:"time"`
-			Data json.RawMessage `json:"data"`
-		}
-		if err := json.Unmarshal(record.Body, &envelope); err != nil {
-			log.Debug().Err(err).Str("container_id", response.ContainerID).Msg("failed to unmarshal cloud event envelope")
-			if query.TaskID != "" {
-				continue
-			}
-			response.Events = append(response.Events, eventRecord)
-			continue
-		}
-
-		eventRecord.Type = envelope.Type
-		eventRecord.Timestamp = envelope.Time
-		eventRecord.Data = envelope.Data
-		augmentContainerEventResponse(response, &eventRecord)
-		if query.TaskID != "" && eventRecord.TaskID != query.TaskID {
+		eventRecord, ok := containerEventRecordFromS2(record, query, response)
+		if !ok {
 			continue
 		}
 		response.Events = append(response.Events, eventRecord)
 	}
 	return nil
+}
+
+type s2ContainerEventStream struct {
+	session *s2.ReadSession
+	query   types.EventQuery
+
+	response *types.ContainerEventsResponse
+	current  types.ContainerEventRecord
+}
+
+func (s *s2ContainerEventStream) Next() bool {
+	for s.session.Next() {
+		eventRecord, ok := containerEventRecordFromS2(s.session.Record(), s.query, s.response)
+		if !ok {
+			continue
+		}
+		s.current = eventRecord
+		return true
+	}
+	return false
+}
+
+func (s *s2ContainerEventStream) Record() types.ContainerEventRecord {
+	return s.current
+}
+
+func (s *s2ContainerEventStream) Err() error {
+	return s.session.Err()
+}
+
+func (s *s2ContainerEventStream) Close() error {
+	return s.session.Close()
+}
+
+func containerEventRecordFromS2(record s2.SequencedRecord, query types.EventQuery, response *types.ContainerEventsResponse) (types.ContainerEventRecord, bool) {
+	eventRecord := types.ContainerEventRecord{
+		SeqNum:     record.SeqNum,
+		StoredAtNs: s2TimestampMillisToNanos(record.Timestamp),
+		CloudEvent: append([]byte(nil), record.Body...),
+	}
+
+	var envelope struct {
+		Type        string          `json:"type"`
+		Time        time.Time       `json:"time"`
+		Data        json.RawMessage `json:"data"`
+		ContainerID string          `json:"containerid"`
+		WorkspaceID string          `json:"workspaceid"`
+		TaskID      string          `json:"taskid"`
+		StubID      string          `json:"stubid"`
+		WorkerID    string          `json:"workerid"`
+	}
+	if err := json.Unmarshal(record.Body, &envelope); err != nil {
+		log.Debug().Err(err).Str("container_id", response.ContainerID).Msg("failed to unmarshal cloud event envelope")
+		if query.TaskID != "" {
+			return types.ContainerEventRecord{}, false
+		}
+		return eventRecord, true
+	}
+
+	eventRecord.Type = envelope.Type
+	eventRecord.Timestamp = envelope.Time
+	eventRecord.Data = envelope.Data
+	eventRecord.ContainerID = envelope.ContainerID
+	eventRecord.WorkspaceID = envelope.WorkspaceID
+	eventRecord.TaskID = envelope.TaskID
+	eventRecord.StubID = envelope.StubID
+	eventRecord.WorkerID = envelope.WorkerID
+	if !eventQueryAllowsType(query, eventRecord.Type) {
+		return types.ContainerEventRecord{}, false
+	}
+	augmentContainerEventResponse(response, &eventRecord)
+	if eventRecord.ContainerID == "" {
+		eventRecord.ContainerID = envelope.ContainerID
+	}
+	if eventRecord.WorkspaceID == "" {
+		eventRecord.WorkspaceID = envelope.WorkspaceID
+	}
+	if eventRecord.TaskID == "" {
+		eventRecord.TaskID = envelope.TaskID
+	}
+	if eventRecord.StubID == "" {
+		eventRecord.StubID = envelope.StubID
+	}
+	if eventRecord.WorkerID == "" {
+		eventRecord.WorkerID = envelope.WorkerID
+	}
+	if query.TaskID != "" && eventRecord.TaskID != query.TaskID {
+		return types.ContainerEventRecord{}, false
+	}
+	return eventRecord, true
+}
+
+func countOption(limit uint64) *uint64 {
+	if limit == 0 {
+		return nil
+	}
+	return &limit
+}
+
+func eventQueryAllowsType(query types.EventQuery, eventType string) bool {
+	if len(query.EventTypes) == 0 {
+		return true
+	}
+	for _, allowed := range query.EventTypes {
+		if strings.TrimSpace(allowed) == eventType {
+			return true
+		}
+	}
+	return false
 }
 
 func s2TimestampMillisToNanos(timestamp uint64) uint64 {

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -107,6 +107,20 @@ func TestEventMetadataExtensionsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEventQueryAllowsType(t *testing.T) {
+	query := types.EventQuery{EventTypes: []string{types.EventContainerEvent, types.EventTaskUpdated}}
+
+	if !eventQueryAllowsType(query, types.EventTaskUpdated) {
+		t.Fatal("expected task.updated to be allowed")
+	}
+	if eventQueryAllowsType(query, types.EventContainerLog) {
+		t.Fatal("expected container.log to be filtered")
+	}
+	if !eventQueryAllowsType(types.EventQuery{}, types.EventContainerLog) {
+		t.Fatal("empty event type filter should allow all events")
+	}
+}
+
 func TestEventMetadataPoolNameRoundTrip(t *testing.T) {
 	repo := &EventClientRepo{}
 	event, err := repo.createEventObject(types.EventWorkerPoolDegraded, types.EventWorkerPoolStateSchemaVersion, types.EventWorkerPoolStateSchema{

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -24,6 +24,26 @@ func TestS2ContainerStreamNameUsesWorkspaceStubContainer(t *testing.T) {
 	}
 }
 
+func TestS2ContainerEventsAlsoUseStubAggregateStream(t *testing.T) {
+	repo := &S2EventRepository{streamPrefix: "events"}
+
+	streams := repo.streamNamesForEvent(types.EventContainerLifecycle, eventMetadata{
+		WorkspaceID: "workspace-123",
+		StubID:      "stub-456",
+		ContainerID: "container-789",
+	})
+
+	if got, want := len(streams), 2; got != want {
+		t.Fatalf("unexpected stream count: got %d want %d: %#v", got, want, streams)
+	}
+	if got, want := string(streams[0]), "events/workspaces/workspace-123/stubs/stub-456/containers/container-789"; got != want {
+		t.Fatalf("unexpected container stream name: got %q want %q", got, want)
+	}
+	if got, want := string(streams[1]), "events/workspaces/workspace-123/stubs/stub-456"; got != want {
+		t.Fatalf("unexpected stub stream name: got %q want %q", got, want)
+	}
+}
+
 func TestS2ContainerScopedEventsDoNotFallbackToNonCanonicalStreams(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 

--- a/pkg/repository/events_test.go
+++ b/pkg/repository/events_test.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -17,6 +19,92 @@ type captureEventSink struct {
 func (s *captureEventSink) PushEvent(event cloudevents.Event) error {
 	s.events = append(s.events, event)
 	return nil
+}
+
+func TestEventHTTPSinkDeliversCloudEvent(t *testing.T) {
+	type callbackRequest struct {
+		body []byte
+		err  string
+	}
+	requests := make(chan callbackRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("X-Test"), "yes"; got != want {
+			requests <- callbackRequest{err: "unexpected header: got " + got + " want " + want}
+			return
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			requests <- callbackRequest{err: err.Error()}
+			return
+		}
+		raw, err := json.Marshal(body)
+		if err != nil {
+			requests <- callbackRequest{err: err.Error()}
+			return
+		}
+		requests <- callbackRequest{body: raw}
+	}))
+	defer server.Close()
+
+	repo := &EventClientRepo{}
+	event, err := repo.createEventObject(types.EventContainerEvent, types.EventContainerEventSchemaVersion, types.EventContainerEventSchema{
+		ID:          types.ContainerEventRuntimeExited,
+		ContainerID: "container-1",
+		WorkspaceID: "workspace-1",
+		StubID:      "stub-1",
+		Message:     "runtime exited",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink := newEventHTTPSink(types.EventCallbackConfig{
+		URL:        server.URL,
+		EventTypes: []string{"container.*"},
+		Headers:    map[string]string{"X-Test": "yes"},
+	})
+	defer close(sink.queue)
+
+	if err := sink.PushEvent(event); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case req := <-requests:
+		if req.err != "" {
+			t.Fatal(req.err)
+		}
+		var delivered struct {
+			Type string `json:"type"`
+			Data struct {
+				ContainerID string `json:"container_id"`
+				Message     string `json:"message"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(req.body, &delivered); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := delivered.Type, types.EventContainerEvent; got != want {
+			t.Fatalf("unexpected event type: got %q want %q", got, want)
+		}
+		if got, want := delivered.Data.ContainerID, "container-1"; got != want {
+			t.Fatalf("unexpected container id: got %q want %q", got, want)
+		}
+		if got, want := delivered.Data.Message, "runtime exited"; got != want {
+			t.Fatalf("unexpected message: got %q want %q", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event callback")
+	}
+}
+
+func TestEventHTTPSinkSkipsUnmatchedEvents(t *testing.T) {
+	if !eventHTTPMatches([]string{"container.*"}, types.EventContainerEvent) {
+		t.Fatal("expected wildcard callback filter to match container event")
+	}
+	if eventHTTPMatches([]string{"task.*"}, types.EventContainerEvent) {
+		t.Fatal("expected task wildcard callback filter to skip container event")
+	}
 }
 
 func TestPushContainerTaskEventBuildsCanonicalEvent(t *testing.T) {

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -194,6 +194,10 @@ func (r *WorkerRedisRepository) RemoveWorker(workerId string) error {
 }
 
 func (r *WorkerRedisRepository) UpdateWorkerStatus(workerId string, status types.WorkerStatus) error {
+	return r.updateWorkerStatus(workerId, status, false)
+}
+
+func (r *WorkerRedisRepository) updateWorkerStatus(workerId string, status types.WorkerStatus, reconcileCapacity bool) error {
 	err := r.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerWorkerLock(workerId), common.RedisLockOptions{TtlS: 10, Retries: 3})
 	if err != nil {
 		return err
@@ -204,6 +208,12 @@ func (r *WorkerRedisRepository) UpdateWorkerStatus(workerId string, status types
 	worker, err := r.getWorkerFromKey(stateKey)
 	if err != nil {
 		return err
+	}
+
+	if reconcileCapacity && status == types.WorkerStatusAvailable {
+		if err := r.reconcileWorkerCapacity(context.TODO(), worker); err != nil {
+			return err
+		}
 	}
 
 	// Update worker status
@@ -223,6 +233,132 @@ func (r *WorkerRedisRepository) UpdateWorkerStatus(workerId string, status types
 	return nil
 }
 
+type workerReservedCapacity struct {
+	cpu    int64
+	memory int64
+	gpu    uint32
+}
+
+func (r *WorkerRedisRepository) reconcileWorkerCapacity(ctx context.Context, worker *types.Worker) error {
+	if worker == nil {
+		return nil
+	}
+
+	usage, err := r.getWorkerReservedCapacity(ctx, worker.Id)
+	if err != nil {
+		return err
+	}
+
+	if worker.TotalCpu > 0 {
+		worker.FreeCpu = maxInt64(worker.TotalCpu-usage.cpu, 0)
+	}
+	if worker.TotalMemory > 0 {
+		worker.FreeMemory = maxInt64(worker.TotalMemory-usage.memory, 0)
+	}
+	if worker.TotalGpuCount > 0 {
+		if usage.gpu >= worker.TotalGpuCount {
+			worker.FreeGpuCount = 0
+		} else {
+			worker.FreeGpuCount = worker.TotalGpuCount - usage.gpu
+		}
+	}
+
+	return nil
+}
+
+func (r *WorkerRedisRepository) getWorkerReservedCapacity(ctx context.Context, workerId string) (workerReservedCapacity, error) {
+	var usage workerReservedCapacity
+
+	queuedRequests, err := r.rdb.LRange(ctx, common.RedisKeys.SchedulerWorkerRequests(workerId), 0, -1)
+	if err != nil {
+		return usage, fmt.Errorf("failed to list queued requests for worker <%s>: %w", workerId, err)
+	}
+
+	for _, rawRequest := range queuedRequests {
+		var request types.ContainerRequest
+		if err := json.Unmarshal([]byte(rawRequest), &request); err != nil {
+			return usage, fmt.Errorf("failed to deserialize queued request for worker <%s>: %w", workerId, err)
+		}
+		usage.addRequest(&request)
+	}
+
+	containerStateKeys, err := r.rdb.SMembers(ctx, common.RedisKeys.SchedulerContainerWorkerIndex(workerId)).Result()
+	if err != nil {
+		return usage, fmt.Errorf("failed to list active containers for worker <%s>: %w", workerId, err)
+	}
+
+	for _, key := range containerStateKeys {
+		state, exists, err := r.getIndexedContainerState(ctx, workerId, key)
+		if err != nil {
+			return usage, err
+		}
+		if !exists || state.Status == types.ContainerStatusStopping {
+			continue
+		}
+
+		usage.addContainerState(state)
+	}
+
+	return usage, nil
+}
+
+func (r *WorkerRedisRepository) getIndexedContainerState(ctx context.Context, workerId string, key string) (*types.ContainerState, bool, error) {
+	res, err := r.rdb.HGetAll(ctx, key).Result()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get indexed container state <%s> for worker <%s>: %w", key, workerId, err)
+	}
+	if len(res) == 0 {
+		if err := r.rdb.SRem(ctx, common.RedisKeys.SchedulerContainerWorkerIndex(workerId), key).Err(); err != nil {
+			return nil, false, fmt.Errorf("failed to remove stale container index entry <%s> for worker <%s>: %w", key, workerId, err)
+		}
+		return nil, false, nil
+	}
+
+	state := &types.ContainerState{}
+	if err := common.ToStruct(res, state); err != nil {
+		return nil, false, fmt.Errorf("failed to deserialize indexed container state <%s> for worker <%s>: %w", key, workerId, err)
+	}
+
+	return state, true, nil
+}
+
+func (c *workerReservedCapacity) addRequest(request *types.ContainerRequest) {
+	if request == nil {
+		return
+	}
+
+	c.cpu += request.Cpu
+	c.memory += capacityMemoryForRequest(request)
+	c.gpu += gpuCountForCapacity(request.Gpu, request.GpuRequest, request.GpuCount)
+}
+
+func (c *workerReservedCapacity) addContainerState(state *types.ContainerState) {
+	if state == nil {
+		return
+	}
+
+	c.cpu += state.Cpu
+	c.memory += capacityMemoryForRequest(&types.ContainerRequest{Memory: state.Memory})
+	c.gpu += gpuCountForCapacity(state.Gpu, nil, state.GpuCount)
+}
+
+func gpuCountForCapacity(gpu string, gpuRequest []string, gpuCount uint32) uint32 {
+	if gpu == "" && len(gpuRequest) == 0 {
+		return 0
+	}
+	if gpuCount == 0 {
+		return 1
+	}
+	return gpuCount
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func (r *WorkerRedisRepository) SetWorkerKeepAlive(workerId string) error {
 	stateKey := common.RedisKeys.SchedulerWorkerState(workerId)
 
@@ -236,7 +372,7 @@ func (r *WorkerRedisRepository) SetWorkerKeepAlive(workerId string) error {
 }
 
 func (r *WorkerRedisRepository) ToggleWorkerAvailable(workerId string) error {
-	return r.UpdateWorkerStatus(workerId, types.WorkerStatusAvailable)
+	return r.updateWorkerStatus(workerId, types.WorkerStatusAvailable, true)
 }
 
 // getWorkers retrieves a list of worker objects from the Redis store that match a given pattern.
@@ -523,72 +659,116 @@ func capacityMemoryForRequest(request *types.ContainerRequest) int64 {
 	return (request.Memory*125 + 99) / 100
 }
 
-func (r *WorkerRedisRepository) UpdateWorkerCapacity(worker *types.Worker, request *types.ContainerRequest, CapacityUpdateType types.CapacityUpdateType) error {
+func (r *WorkerRedisRepository) UpdateWorkerCapacity(worker *types.Worker, request *types.ContainerRequest, capacityUpdateType types.CapacityUpdateType) error {
 	err := r.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerWorkerLock(worker.Id), common.RedisLockOptions{TtlS: 10, Retries: 3})
 	if err != nil {
 		return err
 	}
 	defer r.lock.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id))
 
-	key := common.RedisKeys.SchedulerWorkerState(worker.Id)
-
-	// Retrieve current worker capacity
-	currentWorker, err := r.getWorkerFromKey(key)
+	updatedWorker, err := r.updateWorkerCapacityLocked(context.TODO(), worker.Id, request, capacityUpdateType)
 	if err != nil {
-		return fmt.Errorf("failed to get worker state <%v>: %v", key, err)
-	}
-
-	if currentWorker == nil {
-		return fmt.Errorf("worker state <%s> not found", key)
-	}
-
-	updatedWorker := &types.Worker{}
-	if err := common.CopyStruct(currentWorker, updatedWorker); err != nil {
-		return fmt.Errorf("failed to copy worker struct: %v", err)
-	}
-
-	switch CapacityUpdateType {
-	case types.AddCapacity:
-		updatedWorker.FreeCpu = updatedWorker.FreeCpu + request.Cpu
-		updatedWorker.FreeMemory = updatedWorker.FreeMemory + capacityMemoryForRequest(request)
-
-		if request.Gpu != "" {
-			updatedWorker.FreeGpuCount += request.GpuCount
-		}
-
-	case types.RemoveCapacity:
-		cpu := request.Cpu
-		memory := capacityMemoryForRequest(request)
-		if updatedWorker.FreeCpu < cpu || updatedWorker.FreeMemory < memory {
-			return errors.New("unable to schedule container, worker out of cpu, memory, or gpu")
-		}
-
-		if request.Gpu != "" {
-			if updatedWorker.FreeGpuCount < request.GpuCount {
-				return errors.New("unable to schedule container, worker out of cpu, memory, or gpu")
-			}
-			updatedWorker.FreeGpuCount -= request.GpuCount
-		}
-
-		updatedWorker.FreeCpu -= cpu
-		updatedWorker.FreeMemory -= memory
-
-	default:
-		return errors.New("invalid capacity update type")
-	}
-
-	// Update the worker capacity with the new values
-	updatedWorker.ResourceVersion++
-	err = r.rdb.HSet(context.TODO(), key, common.ToSlice(updatedWorker)).Err()
-	if err != nil {
-		return fmt.Errorf("failed to update worker capacity <%s>: %v", key, err)
+		return err
 	}
 
 	*worker = *updatedWorker
 	return nil
 }
 
+func (r *WorkerRedisRepository) updateWorkerCapacityLocked(ctx context.Context, workerId string, request *types.ContainerRequest, capacityUpdateType types.CapacityUpdateType) (*types.Worker, error) {
+	updatedWorker, err := r.workerWithCapacityChange(workerId, request, capacityUpdateType)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.setWorkerCapacityLocked(ctx, updatedWorker); err != nil {
+		return nil, err
+	}
+
+	return updatedWorker, nil
+}
+
+func (r *WorkerRedisRepository) workerWithCapacityChange(workerId string, request *types.ContainerRequest, capacityUpdateType types.CapacityUpdateType) (*types.Worker, error) {
+	key := common.RedisKeys.SchedulerWorkerState(workerId)
+
+	// Retrieve current worker capacity
+	currentWorker, err := r.getWorkerFromKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get worker state <%v>: %v", key, err)
+	}
+
+	if currentWorker == nil {
+		return nil, fmt.Errorf("worker state <%s> not found", key)
+	}
+
+	updatedWorker := &types.Worker{}
+	if err := common.CopyStruct(currentWorker, updatedWorker); err != nil {
+		return nil, fmt.Errorf("failed to copy worker struct: %v", err)
+	}
+
+	if err := applyWorkerCapacityChange(updatedWorker, request, capacityUpdateType); err != nil {
+		return nil, err
+	}
+
+	return updatedWorker, nil
+}
+
+func applyWorkerCapacityChange(worker *types.Worker, request *types.ContainerRequest, capacityUpdateType types.CapacityUpdateType) error {
+	switch capacityUpdateType {
+	case types.AddCapacity:
+		worker.FreeCpu += request.Cpu
+		worker.FreeMemory += capacityMemoryForRequest(request)
+		worker.FreeGpuCount += gpuCountForCapacity(request.Gpu, request.GpuRequest, request.GpuCount)
+		capWorkerFreeCapacity(worker)
+	case types.RemoveCapacity:
+		cpu := request.Cpu
+		memory := capacityMemoryForRequest(request)
+		gpuCount := gpuCountForCapacity(request.Gpu, request.GpuRequest, request.GpuCount)
+		if worker.FreeCpu < cpu || worker.FreeMemory < memory {
+			return errors.New("unable to schedule container, worker out of cpu, memory, or gpu")
+		}
+
+		if gpuCount > 0 {
+			if worker.FreeGpuCount < gpuCount {
+				return errors.New("unable to schedule container, worker out of cpu, memory, or gpu")
+			}
+			worker.FreeGpuCount -= gpuCount
+		}
+
+		worker.FreeCpu -= cpu
+		worker.FreeMemory -= memory
+	default:
+		return errors.New("invalid capacity update type")
+	}
+
+	return nil
+}
+
+func capWorkerFreeCapacity(worker *types.Worker) {
+	if worker.TotalCpu > 0 && worker.FreeCpu > worker.TotalCpu {
+		worker.FreeCpu = worker.TotalCpu
+	}
+	if worker.TotalMemory > 0 && worker.FreeMemory > worker.TotalMemory {
+		worker.FreeMemory = worker.TotalMemory
+	}
+	if worker.TotalGpuCount > 0 && worker.FreeGpuCount > worker.TotalGpuCount {
+		worker.FreeGpuCount = worker.TotalGpuCount
+	}
+}
+
+func (r *WorkerRedisRepository) setWorkerCapacityLocked(ctx context.Context, worker *types.Worker) error {
+	key := common.RedisKeys.SchedulerWorkerState(worker.Id)
+	worker.ResourceVersion++
+
+	if err := r.rdb.HSet(ctx, key, common.ToSlice(worker)).Err(); err != nil {
+		return fmt.Errorf("failed to update worker capacity <%s>: %v", key, err)
+	}
+
+	return nil
+}
+
 func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, request *types.ContainerRequest) error {
+	ctx := context.TODO()
 	queuedRequest := *request
 	queuedRequest.Timestamp = time.Now()
 
@@ -598,21 +778,33 @@ func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, r
 		return fmt.Errorf("failed to serialize request: %w", err)
 	}
 
-	// Update the worker capacity first
-	err = r.UpdateWorkerCapacity(worker, request, types.RemoveCapacity)
+	if err := r.lock.Acquire(ctx, common.RedisKeys.SchedulerWorkerLock(worker.Id), common.RedisLockOptions{TtlS: 10, Retries: 3}); err != nil {
+		return err
+	}
+	defer r.lock.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id))
+
+	updatedWorker, err := r.updateWorkerCapacityLocked(ctx, worker.Id, request, types.RemoveCapacity)
 	if err != nil {
 		return err
 	}
 
 	// Push the serialized ContainerRequest
-	err = r.rdb.RPush(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id), requestJSON).Err()
-	if err != nil {
-		if rollbackErr := r.UpdateWorkerCapacity(worker, request, types.AddCapacity); rollbackErr != nil {
+	if err := r.rdb.RPush(ctx, common.RedisKeys.SchedulerWorkerRequests(worker.Id), requestJSON).Err(); err != nil {
+		rollbackWorker := &types.Worker{}
+		if copyErr := common.CopyStruct(updatedWorker, rollbackWorker); copyErr != nil {
+			return errors.Join(fmt.Errorf("failed to push request: %w", err), fmt.Errorf("failed to copy worker for queue push rollback: %w", copyErr))
+		}
+		if rollbackErr := applyWorkerCapacityChange(rollbackWorker, request, types.AddCapacity); rollbackErr != nil {
+			return errors.Join(fmt.Errorf("failed to push request: %w", err), fmt.Errorf("failed to restore worker capacity after queue push error: %w", rollbackErr))
+		}
+		if rollbackErr := r.setWorkerCapacityLocked(ctx, rollbackWorker); rollbackErr != nil {
 			return errors.Join(fmt.Errorf("failed to push request: %w", err), fmt.Errorf("failed to restore worker capacity after queue push error: %w", rollbackErr))
 		}
 		return fmt.Errorf("failed to push request: %w", err)
 	}
-	metrics.RecordWorkerQueueDepth(worker.Id, r.rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+
+	*worker = *updatedWorker
+	metrics.RecordWorkerQueueDepth(worker.Id, r.rdb.LLen(ctx, common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
 
 	log.Info().Str("container_id", request.ContainerId).Str("worker_id", worker.Id).Msg("request for container added")
 

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -120,6 +121,113 @@ func TestToggleWorkerAvailable(t *testing.T) {
 	assert.Equal(t, newWorker.FreeMemory, worker.FreeMemory)
 	assert.Equal(t, newWorker.Gpu, worker.Gpu)
 	assert.Equal(t, types.WorkerStatusAvailable, worker.Status)
+}
+
+func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+
+	worker := &types.Worker{
+		Id:            "worker-reconcile-capacity",
+		Status:        types.WorkerStatusPending,
+		TotalCpu:      4000,
+		TotalMemory:   1024,
+		TotalGpuCount: 2,
+		FreeCpu:       0,
+		FreeMemory:    0,
+		FreeGpuCount:  0,
+		Gpu:           "A10G",
+	}
+	err = repo.AddWorker(worker)
+	assert.Nil(t, err)
+
+	queuedRequest := &types.ContainerRequest{
+		ContainerId: "container-reconcile-queued",
+		Cpu:         1000,
+		Memory:      100,
+	}
+	queuedJSON, err := json.Marshal(queuedRequest)
+	assert.Nil(t, err)
+	err = rdb.RPush(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id), queuedJSON).Err()
+	assert.Nil(t, err)
+
+	runningState := &types.ContainerState{
+		ContainerId: "container-reconcile-running",
+		Status:      types.ContainerStatusRunning,
+		Cpu:         1000,
+		Memory:      100,
+		Gpu:         "A10G",
+		GpuCount:    1,
+	}
+	runningStateKey := common.RedisKeys.SchedulerContainerState(runningState.ContainerId)
+	err = rdb.HSet(context.TODO(), runningStateKey, common.ToSlice(runningState)).Err()
+	assert.Nil(t, err)
+	err = rdb.SAdd(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), runningStateKey).Err()
+	assert.Nil(t, err)
+	staleStateKey := common.RedisKeys.SchedulerContainerState("container-reconcile-missing")
+	err = rdb.SAdd(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), staleStateKey).Err()
+	assert.Nil(t, err)
+
+	err = repo.ToggleWorkerAvailable(worker.Id)
+	assert.Nil(t, err)
+
+	updatedWorker, err := repo.GetWorkerById(worker.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, types.WorkerStatusAvailable, updatedWorker.Status)
+	assert.Equal(t, int64(2000), updatedWorker.FreeCpu)
+	assert.Equal(t, int64(774), updatedWorker.FreeMemory)
+	assert.Equal(t, uint32(1), updatedWorker.FreeGpuCount)
+	assert.Equal(t, int64(1), updatedWorker.ResourceVersion)
+
+	staleIndexExists, err := rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), staleStateKey).Result()
+	assert.Nil(t, err)
+	assert.False(t, staleIndexExists)
+}
+
+func TestToggleWorkerAvailableCapsReconciledCapacityAtZero(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+
+	worker := &types.Worker{
+		Id:            "worker-reconcile-over-reserved",
+		Status:        types.WorkerStatusPending,
+		TotalCpu:      1000,
+		TotalMemory:   125,
+		TotalGpuCount: 1,
+		FreeCpu:       1000,
+		FreeMemory:    125,
+		FreeGpuCount:  1,
+		Gpu:           "A10G",
+	}
+	err = repo.AddWorker(worker)
+	assert.Nil(t, err)
+
+	queuedRequest := &types.ContainerRequest{
+		ContainerId: "container-reconcile-over-reserved",
+		Cpu:         2000,
+		Memory:      200,
+		Gpu:         "A10G",
+		GpuCount:    2,
+	}
+	queuedJSON, err := json.Marshal(queuedRequest)
+	assert.Nil(t, err)
+	err = rdb.RPush(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id), queuedJSON).Err()
+	assert.Nil(t, err)
+
+	err = repo.ToggleWorkerAvailable(worker.Id)
+	assert.Nil(t, err)
+
+	updatedWorker, err := repo.GetWorkerById(worker.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), updatedWorker.FreeCpu)
+	assert.Equal(t, int64(0), updatedWorker.FreeMemory)
+	assert.Equal(t, uint32(0), updatedWorker.FreeGpuCount)
 }
 
 func TestUpdateWorkerCapacityForGPUWorker(t *testing.T) {
@@ -283,6 +391,43 @@ func TestCapacityMemoryForRequest(t *testing.T) {
 	assert.Equal(t, int64(-1), capacityMemoryForRequest(&types.ContainerRequest{Memory: -1}))
 	assert.Equal(t, int64(125), capacityMemoryForRequest(&types.ContainerRequest{Memory: 100}))
 	assert.Equal(t, int64(2), capacityMemoryForRequest(&types.ContainerRequest{Memory: 1}))
+}
+
+func TestUpdateWorkerCapacityAddDoesNotExceedTotalCapacity(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:            "worker-capacity-cap",
+		Status:        types.WorkerStatusAvailable,
+		TotalCpu:      1000,
+		TotalMemory:   125,
+		TotalGpuCount: 1,
+		FreeCpu:       900,
+		FreeMemory:    100,
+		FreeGpuCount:  0,
+		Gpu:           "A10G",
+	}
+	err = repo.AddWorker(worker)
+	assert.Nil(t, err)
+
+	request := &types.ContainerRequest{
+		ContainerId: "container-capacity-cap",
+		Cpu:         500,
+		Memory:      100,
+		Gpu:         "A10G",
+		GpuCount:    2,
+	}
+	err = repo.UpdateWorkerCapacity(worker, request, types.AddCapacity)
+	assert.Nil(t, err)
+
+	updatedWorker, err := repo.GetWorkerById(worker.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1000), updatedWorker.FreeCpu)
+	assert.Equal(t, int64(125), updatedWorker.FreeMemory)
+	assert.Equal(t, uint32(1), updatedWorker.FreeGpuCount)
 }
 
 func TestGetAllWorkers(t *testing.T) {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -14,6 +14,7 @@ type AppConfig struct {
 	DebugMode      bool                 `key:"debugMode" json:"debug_mode"`
 	PrettyLogs     bool                 `key:"prettyLogs" json:"pretty_logs"`
 	Database       DatabaseConfig       `key:"database" json:"database"`
+	Events         EventsConfig         `key:"events" json:"events"`
 	GatewayService GatewayServiceConfig `key:"gateway" json:"gateway_service"`
 	FileService    FileServiceConfig    `key:"fileService" json:"file_service"`
 	ImageService   ImageServiceConfig   `key:"imageService" json:"image_service"`
@@ -77,6 +78,18 @@ type S2Config struct {
 	ApiKey       string `key:"apiKey" json:"api_key"`
 	Basin        string `key:"basin" json:"basin"`
 	StreamPrefix string `key:"streamPrefix" json:"stream_prefix"`
+}
+
+type EventsConfig struct {
+	Callbacks []EventCallbackConfig `key:"callbacks" json:"callbacks"`
+}
+
+type EventCallbackConfig struct {
+	URL        string            `key:"url" json:"url"`
+	Format     string            `key:"format" json:"format"`
+	EventTypes []string          `key:"eventTypes" json:"event_types"`
+	Headers    map[string]string `key:"headers" json:"headers"`
+	Timeout    time.Duration     `key:"timeout" json:"timeout"`
 }
 
 type GRPCConfig struct {

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -590,10 +590,15 @@ type EventContainerLogSchema struct {
 }
 
 type EventQuery struct {
-	Limit       uint64 `json:"limit,omitempty"`
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	StubID      string `json:"stub_id,omitempty"`
-	TaskID      string `json:"task_id,omitempty"`
+	Limit       uint64   `json:"limit,omitempty"`
+	WorkspaceID string   `json:"workspace_id,omitempty"`
+	StubID      string   `json:"stub_id,omitempty"`
+	TaskID      string   `json:"task_id,omitempty"`
+	EventTypes  []string `json:"event_types,omitempty"`
+	SeqNum      *uint64  `json:"seq_num,omitempty"`
+	TailOffset  *int64   `json:"tail_offset,omitempty"`
+	WaitSeconds *int32   `json:"wait,omitempty"`
+	Clamp       *bool    `json:"clamp,omitempty"`
 }
 
 type ContainerEventRecord struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add real-time event delivery with new SSE streams and an HTTP callback sink, plus event type filters. Also improves worker capacity accuracy and makes the sandbox benchmark verify command output.

- New Features
  - Event streams (SSE): `GET /api/v1/:workspaceId/containers/:containerId/stream` and `GET /api/v1/:workspaceId/stubs/:stubId/stream` with `event_types`, `seq_num`, `tail_offset`, `wait`, and `clamp` support; resumes via `Last-Event-ID`.
  - Event HTTP sink: configurable callbacks via `events.callbacks` (URL, headers, timeout, formats `cloud_event` or `slack`, wildcard type filters), delivered asynchronously.
  - S2 backend: streams events and filters by type; writes container events to both container and stub aggregate streams.
  - Benchmarks: sandbox command verification (expected stdout), stdout/stderr tail capture, and report/summary updates; new unit tests.

- Bug Fixes
  - Worker capacity: reconcile free CPU/memory/GPU on `ToggleWorkerAvailable` using queued requests and active container index; cap at totals; atomic queue push with rollback; tests added.

<sup>Written for commit 6f1e93fc8f71a32c71fa441c6c3df05d47cfd24f. Summary will update on new commits. <a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1579?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

