### PR TITLE
force staged write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260527214224-760e93d697c4
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260527224805-2174081693d0
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260525151107-d50a98ecfb52 h1:1DJ0e7GzYTGEFRsQv1KAy7uI+Rmkn2V/WD07b702G5w=
 github.com/beam-cloud/clip v0.0.0-20260525151107-d50a98ecfb52/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/geesefs v0.0.0-20260527214224-760e93d697c4 h1:sls9yWqPQDiK/6kzalKEwjHo+KV3s5XXH2tzqJ2UwFo=
-github.com/beam-cloud/geesefs v0.0.0-20260527214224-760e93d697c4/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260527224805-2174081693d0 h1:GdqrArk02hqEjLx1mMzurld+p5t3i4r4iOyYkkmlZIA=
+github.com/beam-cloud/geesefs v0.0.0-20260527224805-2174081693d0/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -3,10 +3,13 @@ package cache
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -631,9 +634,41 @@ func cacheFSMetadataMatchesFileInfo(metadata *FSMetadata, info os.FileInfo) bool
 }
 
 func (c *Client) IsCachedNearby(hash string, routingKey string) (bool, error) {
-	hostsToCheck := c.clientConfig.NTopHosts
+	if routingKey == "" {
+		routingKey = hash
+	}
 
-	for hostIndex := 0; hostIndex < hostsToCheck; hostIndex++ {
+	checked := make(map[string]struct{})
+	checkHost := func(host *Host) (bool, error) {
+		if host == nil || host.HostId == "" {
+			return false, nil
+		}
+		if _, ok := checked[host.HostId]; ok {
+			return false, nil
+		}
+		checked[host.HostId] = struct{}{}
+
+		c.mu.RLock()
+		client, exists := c.grpcClients[host.HostId]
+		c.mu.RUnlock()
+		if !exists {
+			return false, nil
+		}
+
+		resp, err := client.HasContent(c.ctx, &proto.CacheHasContentRequest{Hash: hash})
+		if err != nil {
+			c.removeHost(host)
+			return false, err
+		}
+		if resp.Exists {
+			return true, nil
+		}
+
+		c.removeLocalHostCache(hash)
+		return false, nil
+	}
+
+	for hostIndex := 0; hostIndex < c.clientConfig.NTopHosts; hostIndex++ {
 		client, host, err := c.getGRPCClient(&ClientRequest{
 			rt:        ClientRequestTypeRetrieval,
 			hash:      hash,
@@ -644,6 +679,7 @@ func (c *Client) IsCachedNearby(hash string, routingKey string) (bool, error) {
 			continue
 		}
 
+		checked[host.HostId] = struct{}{}
 		resp, err := client.HasContent(c.ctx, &proto.CacheHasContentRequest{Hash: hash})
 		if err != nil {
 			c.removeHost(host)
@@ -655,6 +691,13 @@ func (c *Client) IsCachedNearby(hash string, routingKey string) (bool, error) {
 		}
 
 		c.removeLocalHostCache(hash)
+	}
+
+	for _, host := range c.remainingHostsForRequest(checked) {
+		exists, _ := checkHost(host)
+		if exists {
+			return true, nil
+		}
 	}
 
 	return false, nil
@@ -901,6 +944,7 @@ func (c *Client) ClientLocalPageFileViews(hash string, offset int64, length int6
 		}
 	}
 
+	checked := make(map[string]struct{})
 	for attempt := 0; attempt < c.getContentAttempts(length); attempt++ {
 		host, err := c.getHostForRequest(&ClientRequest{
 			rt:        ClientRequestTypeRetrieval,
@@ -923,30 +967,40 @@ func (c *Client) ClientLocalPageFileViews(hash string, offset int64, length int6
 			}
 		}
 
-		c.mu.RLock()
-		localServer := c.localServers[host.HostId]
-		c.mu.RUnlock()
-		if localServer == nil || localServer.cas == nil {
-			if views, ok := c.promoteRemotePageRegionsToClientLocalPageFiles(host, hash, offset, length); ok {
-				return views, nil
-			}
-			continue
-		}
-
-		if views, ok := clientLocalPageFileViewsFromStore(localServer.cas, hash, offset, length); ok {
-			cacheReadClientLocalPageFileTotal.Inc()
-			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
-			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
+		checked[host.HostId] = struct{}{}
+		if views, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
 			return views, nil
 		}
+	}
 
-		if views, ok := c.promoteRemotePageRegionsToClientLocalPageFiles(host, hash, offset, length); ok {
+	for _, host := range c.remainingHostsForRequest(checked) {
+		if views, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
 			return views, nil
 		}
 	}
 
 	atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
 	return nil, ErrContentNotFound
+}
+
+func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offset int64, length int64) ([]ClientLocalPageFileView, bool) {
+	if host == nil {
+		return nil, false
+	}
+
+	c.mu.RLock()
+	localServer := c.localServers[host.HostId]
+	c.mu.RUnlock()
+	if localServer != nil && localServer.cas != nil {
+		if views, ok := clientLocalPageFileViewsFromStore(localServer.cas, hash, offset, length); ok {
+			cacheReadClientLocalPageFileTotal.Inc()
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
+			return views, true
+		}
+	}
+
+	return c.promoteRemotePageRegionsToClientLocalPageFiles(host, hash, offset, length)
 }
 
 func (c *Client) clientLocalPageFileViewsFromAttachedStores(hash string, offset int64, length int64) ([]ClientLocalPageFileView, bool) {
@@ -1089,6 +1143,8 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 			}
 		}
 	}
+
+	checked := make(map[string]struct{})
 	for attempt := 0; attempt < c.getContentAttempts(length); attempt++ {
 		host, err := c.getHostForRequest(&ClientRequest{
 			rt:        ClientRequestTypeRetrieval,
@@ -1111,77 +1167,120 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 			}
 		}
 
-		c.mu.RLock()
-		localServer := c.localServers[host.HostId]
-		c.mu.RUnlock()
-		if localServer != nil && localServer.cas != nil {
-			n, err := localServer.cas.ReadAt(hash, offset, dst)
-			if err == nil && n == length {
-				cacheReadLocalTotal.Inc()
-				atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
-				return n, nil
-			}
-			if err == ErrContentNotFound {
-				atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
-				c.removeLocalHostCache(hash)
-				continue
-			}
-			if err != nil {
-				atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
-				continue
-			}
+		checked[host.HostId] = struct{}{}
+		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
+		if err == nil && n == length {
+			return n, nil
 		}
+	}
 
-		if c.clientConfig.ReadTransport.Enabled {
-			n, err := c.rawReadIntoWindowed(ctx, host, hash, offset, dst)
-			if err == nil && n == length {
-				c.promoteReadChunkToLocal(hash, offset, dst[:int(n)])
-				return n, nil
-			}
-			if err == ErrContentNotFound {
-				c.removeLocalHostCache(hash)
-				continue
-			}
-			if err != nil {
-				cacheReadRawFallbackTotal.Inc()
-			}
+	for _, host := range c.remainingHostsForRequest(checked) {
+		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
+		if err == nil && n == length {
+			return n, nil
 		}
-
-		c.mu.RLock()
-		client, exists := c.grpcClients[host.HostId]
-		c.mu.RUnlock()
-		if !exists {
-			c.removeLocalHostCache(hash)
-			_ = c.refreshRoutableHosts(ctx)
-			continue
-		}
-
-		start := time.Now()
-		getContentResponse, err := client.GetContent(ctx, &proto.CacheGetContentRequest{Hash: hash, Offset: offset, Length: length}, c.dataCallOptions()...)
-		if err != nil {
-			atomic.AddInt64(&cachePathStats.clientGRPCErrors, 1)
-			if c.globalConfig.GRPCPayloadCodecV2 {
-				cacheReadGRPCCodecV2FallbackTotal.Inc()
-			}
-			c.removeHost(host)
-			continue
-		}
-		if !getContentResponse.Ok || int64(len(getContentResponse.Content)) != length {
-			atomic.AddInt64(&cachePathStats.clientGRPCMisses, 1)
-			c.removeLocalHostCache(hash)
-			continue
-		}
-
-		copy(dst, getContentResponse.Content)
-		atomic.AddInt64(&cachePathStats.clientGRPCHits, 1)
-		if c.globalConfig.GRPCPayloadCodecV2 {
-			cacheReadGRPCCodecV2Total.Inc()
-		}
-		Logger.Debugf("Elapsed time to get content: %v", time.Since(start))
-		return length, nil
 	}
 
 	return 0, ErrContentNotFound
+}
+
+func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (int64, error) {
+	if host == nil {
+		return 0, ErrHostNotFound
+	}
+
+	length := int64(len(dst))
+	c.mu.RLock()
+	localServer := c.localServers[host.HostId]
+	c.mu.RUnlock()
+	if localServer != nil && localServer.cas != nil {
+		n, err := localServer.cas.ReadAt(hash, offset, dst)
+		if err == nil && n == length {
+			cacheReadLocalTotal.Inc()
+			atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
+			return n, nil
+		}
+		if err == ErrContentNotFound {
+			atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
+			c.removeLocalHostCache(hash)
+			return 0, err
+		}
+		if err != nil {
+			atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
+		}
+	}
+
+	if c.clientConfig.ReadTransport.Enabled {
+		n, err := c.rawReadIntoWindowed(ctx, host, hash, offset, dst)
+		if err == nil && n == length {
+			c.promoteReadChunkToLocal(hash, offset, dst[:int(n)])
+			return n, nil
+		}
+		if err == ErrContentNotFound {
+			c.removeLocalHostCache(hash)
+			return 0, err
+		}
+		if err != nil {
+			cacheReadRawFallbackTotal.Inc()
+		}
+	}
+
+	c.mu.RLock()
+	client, exists := c.grpcClients[host.HostId]
+	c.mu.RUnlock()
+	if !exists {
+		c.removeLocalHostCache(hash)
+		_ = c.refreshRoutableHosts(ctx)
+		return 0, ErrHostNotFound
+	}
+
+	start := time.Now()
+	getContentResponse, err := client.GetContent(ctx, &proto.CacheGetContentRequest{Hash: hash, Offset: offset, Length: length}, c.dataCallOptions()...)
+	if err != nil {
+		atomic.AddInt64(&cachePathStats.clientGRPCErrors, 1)
+		if c.globalConfig.GRPCPayloadCodecV2 {
+			cacheReadGRPCCodecV2FallbackTotal.Inc()
+		}
+		c.removeHost(host)
+		return 0, err
+	}
+	if !getContentResponse.Ok || int64(len(getContentResponse.Content)) != length {
+		atomic.AddInt64(&cachePathStats.clientGRPCMisses, 1)
+		c.removeLocalHostCache(hash)
+		return 0, ErrContentNotFound
+	}
+
+	copy(dst, getContentResponse.Content)
+	atomic.AddInt64(&cachePathStats.clientGRPCHits, 1)
+	if c.globalConfig.GRPCPayloadCodecV2 {
+		cacheReadGRPCCodecV2Total.Inc()
+	}
+	Logger.Debugf("Elapsed time to get content: %v", time.Since(start))
+	return length, nil
+}
+
+func (c *Client) remainingHostsForRequest(checked map[string]struct{}) []*Host {
+	if c.hostMap == nil {
+		return nil
+	}
+
+	hosts := c.hostMap.GetAll()
+	sort.Slice(hosts, func(i, j int) bool {
+		return hosts[i].HostId < hosts[j].HostId
+	})
+
+	out := hosts[:0]
+	for _, host := range hosts {
+		if host == nil || host.HostId == "" {
+			continue
+		}
+		if _, ok := checked[host.HostId]; ok {
+			continue
+		}
+		checked[host.HostId] = struct{}{}
+		out = append(out, host)
+	}
+	return out
 }
 
 func (c *Client) promoteReadChunkToLocal(hash string, offset int64, data []byte) {
@@ -1393,6 +1492,134 @@ func (c *Client) StoreContent(chunks chan []byte, hash string, opts struct {
 	RoutingKey string
 }) (string, error) {
 	return c.storeContentFromChunks(chunks, hash, "", opts.RoutingKey)
+}
+
+// StoreContentWithLocalReplica tees streamed content into the
+// rendezvous-selected cache host and the writer's local disk cache at the same
+// time. This preserves churn safety without serializing a full second copy.
+func (c *Client) StoreContentWithLocalReplica(chunks chan []byte, hash string, opts StoreContentOptions) (string, error) {
+	localStore := c.localReplicaStoreForWrite()
+	if !c.clientConfig.PreferLocalCacheHost || localStore == nil {
+		return c.StoreContent(chunks, hash, struct{ RoutingKey string }{RoutingKey: opts.RoutingKey})
+	}
+
+	routingKey := opts.RoutingKey
+	if routingKey == "" {
+		routingKey = hash
+	}
+
+	ctx, cancel := context.WithTimeout(c.ctx, storeContentRequestTimeout)
+	defer cancel()
+
+	lockPath := routingKey
+	if lockPath == "" {
+		lockPath = hash
+	}
+
+	return c.withStoreFromContentLock(ctx, lockPath, opts.Lock, func() (string, error) {
+		return c.storeContentWithLocalReplica(ctx, localStore, chunks, hash, routingKey)
+	})
+}
+
+func (c *Client) localReplicaStoreForWrite() *Store {
+	for _, store := range c.localStoresSnapshot() {
+		if store != nil {
+			return store
+		}
+	}
+	return nil
+}
+
+func (c *Client) storeContentWithLocalReplica(ctx context.Context, localStore *Store, chunks <-chan []byte, expectedHash string, routingKey string) (string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type storeResult struct {
+		hash string
+		size int64
+		err  error
+	}
+
+	remoteReader, remoteWriter := io.Pipe()
+	localReader, localWriter := io.Pipe()
+
+	remoteDone := make(chan storeResult, 1)
+	go func() {
+		hash, err := c.storeContentFromReaderWithContext(ctx, remoteReader, routingKey, "", nil)
+		remoteDone <- storeResult{hash: hash, err: err}
+	}()
+
+	localDone := make(chan storeResult, 1)
+	go func() {
+		hash, size, err := localStore.AddReader(ctx, localReader)
+		localDone <- storeResult{hash: hash, size: size, err: err}
+	}()
+
+	hasher := sha256.New()
+	var size int64
+	var writeErr error
+	for chunk := range chunks {
+		if len(chunk) == 0 {
+			continue
+		}
+		if _, err := hasher.Write(chunk); err != nil {
+			writeErr = err
+			break
+		}
+		if _, err := remoteWriter.Write(chunk); err != nil {
+			writeErr = err
+			break
+		}
+		if _, err := localWriter.Write(chunk); err != nil {
+			writeErr = err
+			break
+		}
+		size += int64(len(chunk))
+	}
+
+	if writeErr != nil {
+		cancel()
+		_ = remoteWriter.CloseWithError(writeErr)
+		_ = localWriter.CloseWithError(writeErr)
+		drainContentChunks(chunks)
+	} else {
+		_ = remoteWriter.Close()
+		_ = localWriter.Close()
+	}
+
+	remoteResult := <-remoteDone
+	localResult := <-localDone
+	if writeErr != nil {
+		return remoteResult.hash, writeErr
+	}
+	if remoteResult.err != nil {
+		return remoteResult.hash, remoteResult.err
+	}
+	if localResult.err != nil {
+		return remoteResult.hash, localResult.err
+	}
+
+	actualHash := hex.EncodeToString(hasher.Sum(nil))
+	if expectedHash != "" && actualHash != expectedHash {
+		return remoteResult.hash, fmt.Errorf("stored content hash mismatch: expected %s, got %s", expectedHash, actualHash)
+	}
+	if remoteResult.hash != actualHash {
+		return remoteResult.hash, fmt.Errorf("remote content hash mismatch: expected %s, got %s", actualHash, remoteResult.hash)
+	}
+	if localResult.hash != actualHash {
+		return remoteResult.hash, fmt.Errorf("local replica hash mismatch: expected %s, got %s", actualHash, localResult.hash)
+	}
+	if localResult.size != size {
+		return remoteResult.hash, fmt.Errorf("local replica size mismatch: expected %d, got %d", size, localResult.size)
+	}
+
+	Logger.Debugf("StoreContentWithLocalReplica[OK] - [expected=%s actual=%s routing_key=%s size=%d]", expectedHash, remoteResult.hash, routingKey, size)
+	return remoteResult.hash, nil
+}
+
+func drainContentChunks(chunks <-chan []byte) {
+	for range chunks {
+	}
 }
 
 func (c *Client) StoreContentAtPath(content []byte, cachePath string, opts StoreContentOptions) (string, error) {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
@@ -70,6 +72,40 @@ func TestReadContentIntoUsesAttachedLocalServerOnlyForSelectedHost(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(content)), n)
 	require.Equal(t, content, dst)
+}
+
+func TestReadContentIntoFallsBackToReachableReplicaOutsideTopHosts(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("local-cache-content")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	localHost := &Host{HostId: "local-host"}
+	store.currentHost = localHost
+	client := &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{{HostId: "remote-host"}}},
+		hostMap:               NewHostMap(GlobalConfig{}, nil),
+		maxGetContentAttempts: 1,
+	}
+	client.hostMap.Set(localHost)
+	client.AttachLocalServer(&Server{cas: store})
+
+	dst := make([]byte, len(content))
+	n, err := client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+
+	regions, err := client.ClientLocalPageFileViews(hash, 3, 6, ClientOptions{})
+	require.NoError(t, err)
+	require.Len(t, regions, 2)
 }
 
 func TestReadContentIntoPrefersAttachedLocalReplica(t *testing.T) {
@@ -303,6 +339,75 @@ func TestStoreContentFromLocalFileUsesMatchingCacheMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, hash, got)
 	require.Empty(t, metadataStore.locks)
+}
+
+func TestStoreContentWithLocalReplicaWritesRemoteAndLocal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	remoteServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	addr, err := remoteServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remoteServer.Close()) })
+
+	remoteHost := remoteServer.Host()
+	require.NotNil(t, remoteHost)
+	remoteHost.Addr = addr
+	remoteHost.PrivateAddr = addr
+
+	localStore := newTestStore(t, 4)
+	client := &Client{
+		ctx:                   ctx,
+		clientConfig:          ClientConfig{NTopHosts: 1, PreferLocalCacheHost: true},
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(remoteHost))
+	defer client.Cleanup()
+	client.AttachLocalStore(localStore)
+
+	content := []byte("cache-through-local-replica")
+	sum := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(sum[:])
+	chunks := make(chan []byte, 2)
+	chunks <- content[:9]
+	chunks <- content[9:]
+	close(chunks)
+
+	got, err := client.StoreContentWithLocalReplica(chunks, expectedHash, StoreContentOptions{RoutingKey: "/cache/object"})
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
+
+	remote := make([]byte, len(content))
+	n, err := remoteServer.cas.ReadAt(expectedHash, 0, remote)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, remote)
+
+	local := make([]byte, len(content))
+	n, err = localStore.ReadAt(expectedHash, 0, local)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, local)
 }
 
 type failFirstUnlockRegistry struct {

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -64,7 +64,7 @@ storage:
       fuseReadAheadKB: 32768
       readAheadParallelKB: 4096
       mountOptions: []
-      stagedWriteModeEnabled: false
+      stagedWriteModeEnabled: true
       stagedWritePath: /tmp/geesefs-staged-write
       stagedWriteDebounce: 30s
       cacheStreamingEnabled: false

--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ const (
 	defaultGeeseFSFileMode         = 0644
 	defaultGeeseFSMountTimeout     = 30 * time.Second
 	defaultGeeseFSRequestTimeout   = 60 * time.Second
+	defaultGeeseFSFlushTimeout     = 60 * time.Second
 	defaultGeeseFSUnmountTimeout   = 10 * time.Second
 	defaultGeeseFSFuseReadAheadKb  = 32768
 	defaultGeeseFSReadAheadKb      = 32768
@@ -67,7 +69,7 @@ func (c *geeseContentCache) GetContentStream(hash string, offset int64, length i
 }
 
 func (c *geeseContentCache) StoreContent(chunks chan []byte, hash string, opts struct{ RoutingKey string }) (string, error) {
-	return c.client.StoreContent(chunks, hash, opts)
+	return c.client.StoreContentWithLocalReplica(chunks, hash, cache.StoreContentOptions{RoutingKey: opts.RoutingKey})
 }
 
 func (c *geeseContentCache) StoreContentFromS3(source struct {
@@ -176,10 +178,13 @@ func (s *GeeseStorage) Mount(localPath string) error {
 		{PartSize: 128 * 1024 * 1024, PartCount: 8000},
 	}
 
-	// Staged writes route large writes through local temp files before flushing.
-	// Keep them disabled for workspace storage so benchmark and production reads
-	// validate the normal geesefs/S3/cache path instead of temp-file side effects.
 	flags.StagedWriteModeEnabled = s.config.StagedWriteModeEnabled
+	if s.cacheClient != nil && s.config.CacheThroughEnabled && !s.config.DisableVolumeCaching {
+		// Cache-through needs a stable local source for large files. The buffered
+		// multipart path can publish object metadata before the async hash/cache
+		// pipeline has finished, which makes hot reads race or miss after churn.
+		flags.StagedWriteModeEnabled = true
+	}
 	flags.StagedWritePath = s.config.StagedWritePath
 	flags.StagedWriteDebounce = s.config.StagedWriteDebounce
 	flags.EventCallback = func(event cfg.EventType, data map[string]interface{}) {
@@ -369,14 +374,14 @@ func (s *GeeseStorage) Unmount(localPath string) error {
 		select {
 		case <-flushed:
 			log.Info().Str("local_path", localPath).Msg("geesefs: files flushed")
-		case <-time.After(defaultGeeseFSUnmountTimeout):
-			errs = errors.Join(errs, fmt.Errorf("timed out waiting for geesefs files to flush after %s", defaultGeeseFSUnmountTimeout))
-			log.Warn().Str("local_path", localPath).Dur("timeout", defaultGeeseFSUnmountTimeout).Msg("geesefs: flush wait timed out during unmount")
+		case <-time.After(defaultGeeseFSFlushTimeout):
+			errs = errors.Join(errs, fmt.Errorf("timed out waiting for geesefs files to flush after %s", defaultGeeseFSFlushTimeout))
+			log.Warn().Str("local_path", localPath).Dur("timeout", defaultGeeseFSFlushTimeout).Msg("geesefs: flush wait timed out during unmount")
 		}
 	}
 
 	if s.mfs != nil {
-		if err := s.mfs.Unmount(); err != nil {
+		if err := unmountGeeseFS(s.mfs, localPath); err != nil {
 			errs = errors.Join(errs, err)
 		}
 	}
@@ -386,6 +391,47 @@ func (s *GeeseStorage) Unmount(localPath string) error {
 	s.mfs = nil
 	s.fs = nil
 
+	return errs
+}
+
+func unmountGeeseFS(mfs core.MountedFS, localPath string) error {
+	unmounted := make(chan error, 1)
+	go func() {
+		unmounted <- mfs.Unmount()
+	}()
+
+	select {
+	case err := <-unmounted:
+		return err
+	case <-time.After(defaultGeeseFSUnmountTimeout):
+		log.Warn().Str("local_path", localPath).Dur("timeout", defaultGeeseFSUnmountTimeout).Msg("geesefs: normal unmount timed out, forcing lazy unmount")
+		forceErr := forceUnmount(localPath)
+		select {
+		case err := <-unmounted:
+			return errors.Join(forceErr, err)
+		case <-time.After(2 * time.Second):
+			return errors.Join(forceErr, fmt.Errorf("timed out waiting for geesefs unmount after force unmount"))
+		}
+	}
+}
+
+func forceUnmount(localPath string) error {
+	var errs error
+	for _, args := range [][]string{
+		{"fusermount3", "-uz", localPath},
+		{"fusermount", "-uz", localPath},
+		{"umount", "-l", localPath},
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		if err := cmd.Run(); err != nil {
+			cancel()
+			errs = errors.Join(errs, fmt.Errorf("%s: %w", strings.Join(args, " "), err))
+		} else {
+			cancel()
+			return nil
+		}
+	}
 	return errs
 }
 

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -230,7 +230,7 @@ func (c *imageContentCache) StoreContent(chunks chan []byte, hash string, opts s
 		}
 	}()
 
-	actualHash, err := c.client.StoreContent(countingChunks, hash, opts)
+	actualHash, err := c.client.StoreContentWithLocalReplica(countingChunks, hash, cache.StoreContentOptions{RoutingKey: opts.RoutingKey})
 	close(done)
 	elapsed := time.Since(started)
 	if err != nil {

--- a/pkg/worker/storage_manager.go
+++ b/pkg/worker/storage_manager.go
@@ -107,7 +107,7 @@ func (sm *WorkspaceStorageManager) Mount(workspaceName string, workspaceStorage 
 				ReadAheadParallelKB:    sm.config.WorkspaceStorage.Geese.ReadAheadParallelKB,
 				FuseReadAheadKB:        sm.config.WorkspaceStorage.Geese.FuseReadAheadKB,
 				DisableVolumeCaching:   sm.config.WorkspaceStorage.Geese.DisableVolumeCaching,
-				StagedWriteModeEnabled: false,
+				StagedWriteModeEnabled: sm.config.WorkspaceStorage.Geese.StagedWriteModeEnabled,
 				StagedWritePath:        sm.config.WorkspaceStorage.Geese.StagedWritePath,
 				StagedWriteDebounce:    sm.config.WorkspaceStorage.Geese.StagedWriteDebounce,
 				CacheStreamingEnabled:  sm.config.WorkspaceStorage.Geese.CacheStreamingEnabled,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable staged writes and add a write-through local replica for cache uploads to make writes churn-safe and hot reads consistent. Also improves read fallback across hosts and hardens `geesefs` unmount behavior.

- New Features
  - Added `StoreContentWithLocalReplica` in `pkg/cache` to tee uploads to the selected cache host and a local store; used by `pkg/storage/geese.go` and `pkg/worker/image_cache.go`.
  - Staged write mode now defaults to enabled; `geesefs` auto-enables it when cache-through is on.
  - Read path can fall back to any reachable replica beyond `NTopHosts` and prefers attached local stores; new helpers consolidate host selection.

- Bug Fixes
  - Prevents hot-read misses after churn by avoiding premature visibility of large writes.
  - More reliable unmounts: longer flush wait and lazy force unmount via `fusermount3`/`fusermount`/`umount` if normal unmount times out.
  - Better cache host/content checks and local cache invalidation on misses.

<sup>Written for commit 528fdfd156ba23b69b780ed0cc915376fc053b13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1582?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

