### PR TITLE
add network probe to benchmarks

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 import argparse
+import base64
 import json
 import os
 import re
+import select
 import shlex
+import subprocess
 import sys
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +29,7 @@ from benchmarks.sandbox_parallel import (  # noqa: E402
     cleanup_sandbox,
     create_sandbox_with_retries,
     import_sdk,
+    parse_host_port,
     parse_sdk_cpu,
     parse_sdk_memory,
     wait_running as wait_instance_running,
@@ -88,6 +94,36 @@ FUSE_RESPONSE_RE = re.compile(
 
 def now_rfc3339() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def resolve_workspace_storage_config(explicit: str, profile: str, beta9_config: str) -> str:
+    if explicit:
+        return explicit
+
+    normalized = (profile or "default").strip().lower()
+    candidates: list[Path] = []
+    if normalized in {"staging", "stage"}:
+        candidates.append(REPO_ROOT / "config.stage.yaml")
+    elif normalized in {"local", "default"}:
+        candidates.append(REPO_ROOT / "config.local.yaml")
+    else:
+        candidates.append(REPO_ROOT / f"config.{normalized}.yaml")
+
+    if beta9_config:
+        beta9_path = Path(beta9_config).expanduser()
+        if beta9_path.suffix in {".yaml", ".yml"}:
+            candidates.append(beta9_path)
+
+    candidates.extend(
+        (
+            REPO_ROOT / "config.local.yaml",
+            REPO_ROOT / "pkg" / "common" / "config.default.yaml",
+        )
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return str(candidates[0])
 
 
 def parse_json_output(stdout: str) -> dict[str, Any]:
@@ -162,6 +198,8 @@ class WorkloadSpec:
 
 @dataclass
 class BenchmarkConfig:
+    profile: str
+    beta9_config: str
     namespace: str
     gateway_url: str
     grpc_addr: str
@@ -175,6 +213,7 @@ class BenchmarkConfig:
     volume_name: str
     volume_mount_path: str
     volume_subdir: str
+    worker_workspace_root: str
     cache_mount_path: str
     cache_pool_name: str
     cache_locality: str
@@ -182,6 +221,8 @@ class BenchmarkConfig:
     worker_dd_block_size: str
     remote_cache_proof_chunk_bytes: int
     remote_cache_proof_concurrency: int
+    remote_network_probe: bool
+    remote_network_probe_bytes: int
     direct_cache_disk_probe_size_mb: int
     sandbox_cpu: str
     sandbox_memory: str
@@ -230,6 +271,14 @@ class BenchmarkConfig:
             description="Run the beta9 embedded cache correctness/performance benchmark."
         )
         add = parser.add_argument
+        add(
+            "--profile",
+            default=os.getenv("BENCH_PROFILE") or os.getenv("BETA9_PROFILE") or "default",
+        )
+        add(
+            "--beta9-config",
+            default=os.getenv("BENCH_CONFIG") or os.getenv("BETA9_CONFIG") or "",
+        )
         add("--namespace", default=os.getenv("BENCH_NAMESPACE", "beta9"))
         add(
             "--gateway-url",
@@ -268,6 +317,10 @@ class BenchmarkConfig:
         )
         add("--volume-subdir", default=os.getenv("BENCH_CACHE_VOLUME_SUBDIR", ""))
         add(
+            "--worker-workspace-root",
+            default=os.getenv("BENCH_WORKER_WORKSPACE_ROOT", "/storage"),
+        )
+        add(
             "--cache-mount-path",
             default=os.getenv("BENCH_CACHE_MOUNT_PATH", DEFAULT_CACHE_MOUNT_PATH),
         )
@@ -285,12 +338,23 @@ class BenchmarkConfig:
         add(
             "--remote-cache-proof-chunk-bytes",
             type=int,
-            default=env_int("BENCH_CACHE_REMOTE_PROOF_CHUNK_BYTES", 1024 * 1024),
+            default=env_int("BENCH_CACHE_REMOTE_PROOF_CHUNK_BYTES", 4 * 1024 * 1024),
         )
         add(
             "--remote-cache-proof-concurrency",
             type=int,
-            default=env_int("BENCH_CACHE_REMOTE_PROOF_CONCURRENCY", 1),
+            default=env_int("BENCH_CACHE_REMOTE_PROOF_CONCURRENCY", 16),
+        )
+        add_bool(
+            parser,
+            "remote-network-probe",
+            "BENCH_CACHE_REMOTE_NETWORK_PROBE",
+            False,
+        )
+        add(
+            "--remote-network-probe-bytes",
+            type=int,
+            default=env_int("BENCH_CACHE_REMOTE_NETWORK_PROBE_BYTES", 4 * 1024 * 1024 * 1024),
         )
         add(
             "--direct-cache-disk-probe-size-mb",
@@ -371,9 +435,7 @@ class BenchmarkConfig:
         )
         add(
             "--workspace-storage-config",
-            default=os.getenv(
-                "BENCH_WORKSPACE_STORAGE_CONFIG", str(REPO_ROOT / "config.local.yaml")
-            ),
+            default=os.getenv("BENCH_WORKSPACE_STORAGE_CONFIG", ""),
             help="local beta9 config YAML used to resolve default workspace storage for remote-object proof",
         )
         add(
@@ -445,6 +507,11 @@ class BenchmarkConfig:
 
         data = vars(parser.parse_args())
         data["workloads"] = WorkloadSpec.parse_plan(data["file_plan"])
+        data["workspace_storage_config"] = resolve_workspace_storage_config(
+            data["workspace_storage_config"],
+            data["profile"],
+            data["beta9_config"],
+        )
         if not data["volume_subdir"]:
             data["volume_subdir"] = f"run-{int(time.time())}-{os.urandom(4).hex()}"
         if not data["token_cache"]:
@@ -487,6 +554,34 @@ class CacheProbeTools:
         source = build_dir / "raw_read.go"
         output = build_dir / f"raw-read-linux-{goarch}"
         source.write_text(self._read("raw_read.go"), encoding="utf-8")
+        proc = run(
+            [
+                "env",
+                "-u",
+                "GOROOT",
+                "GOOS=linux",
+                f"GOARCH={goarch}",
+                "CGO_ENABLED=0",
+                "go",
+                "build",
+                "-trimpath",
+                "-o",
+                str(output),
+                str(source),
+            ],
+            check=False,
+            timeout=120,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr or proc.stdout)
+        return output
+
+    def build_network_probe(self, goarch: str) -> Path:
+        build_dir = Path(tempfile.gettempdir()) / "b9bench-cache-netprobe"
+        build_dir.mkdir(parents=True, exist_ok=True)
+        source = build_dir / "net_probe.go"
+        output = build_dir / f"net-probe-linux-{goarch}"
+        source.write_text(self._read("net_probe.go"), encoding="utf-8")
         proc = run(
             [
                 "env",
@@ -555,6 +650,20 @@ class Kube:
                 pod["name"],
             ),
         )
+
+    def worker_pod_for_container(self, container_id: str) -> Optional[dict[str, str]]:
+        if not container_id:
+            return None
+
+        for pod in self.running_workers():
+            proc = self.worker_exec(
+                pod["name"],
+                ["test", "-d", f"/tmp/{container_id}"],
+                timeout=5,
+            )
+            if proc.returncode == 0:
+                return pod
+        return None
 
     def worker_pods(self) -> list[dict[str, str]]:
         proc = run(
@@ -1046,9 +1155,14 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
             result["ok"] = result["ok"] or proof.get("ok", False)
         return result
 
-    def worker_dd(self, worker_path: str, expected_size: int) -> dict[str, Any]:
+    def worker_dd(
+        self,
+        worker_path: str,
+        expected_size: int,
+        pods: Optional[list[dict[str, str]]] = None,
+    ) -> dict[str, Any]:
         source = self.tools.source("dd_probe.py")
-        for pod in self.kube.running_workers():
+        for pod in pods or self.kube.running_workers():
             proc = self.kube.worker_exec(
                 pod["name"],
                 [
@@ -1073,7 +1187,11 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
         return {"ok": False, "error": "no worker dd probe succeeded"}
 
     def worker_hot_read(
-        self, worker_root: str, entry: dict[str, Any], geesefs_path: str
+        self,
+        worker_root: str,
+        entry: dict[str, Any],
+        geesefs_path: str,
+        pods: Optional[list[dict[str, str]]] = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         source = self.tools.source("read_file.py")
         command = [
@@ -1101,7 +1219,7 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
         )
         last_error = ""
         while True:
-            for pod in self.kube.running_workers():
+            for pod in pods or self.kube.running_workers():
                 started = time.monotonic_ns()
                 proc = self.kube.worker_exec(
                     pod["name"],
@@ -1261,13 +1379,182 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
         payload.update(
             {
                 "sourcePod": source_pod["name"],
+                "sourceNode": source_pod.get("nodeName", ""),
                 "targetPod": (target_pod or {}).get("name", ""),
+                "targetNode": (target_pod or {}).get("nodeName", "")
+                or target_host.get("nodeName", ""),
                 "targetHost": target_host,
                 "differentWorkerPod": bool(target_pod)
                 and source_pod["name"] != target_pod["name"],
+                "differentNode": bool(target_pod)
+                and source_pod.get("nodeName", "")
+                != target_pod.get("nodeName", ""),
             }
         )
+        if self.config.remote_network_probe and target_pod:
+            payload["networkProbe"] = self.remote_network_probe(
+                source_pod,
+                target_pod,
+                min(int(entry["size"]), int(self.config.remote_network_probe_bytes)),
+            )
         return payload
+
+    def remote_network_probe(
+        self, source_pod: dict[str, Any], target_pod: dict[str, Any], size: int
+    ) -> dict[str, Any]:
+        if size <= 0:
+            return {"ok": False, "error": "network probe size must be positive"}
+        source_arch = self.kube.node_arch(source_pod.get("nodeName", ""))
+        target_arch = self.kube.node_arch(target_pod.get("nodeName", ""))
+        source_binary = self.tools.build_network_probe(source_arch)
+        target_binary = self.tools.build_network_probe(target_arch)
+        source_path = f"/tmp/beta9-cache-net-probe-{source_arch}"
+        target_path = f"/tmp/beta9-cache-net-probe-{target_arch}"
+        for pod, binary, remote_path in (
+            (source_pod, source_binary, source_path),
+            (target_pod, target_binary, target_path),
+        ):
+            cp = run(
+                [
+                    "kubectl",
+                    "-n",
+                    self.config.namespace,
+                    "cp",
+                    str(binary),
+                    f"{pod['name']}:{remote_path}",
+                    "-c",
+                    "worker",
+                ],
+                check=False,
+                timeout=60,
+            )
+            if cp.returncode != 0:
+                return {"ok": False, "error": cp.stderr or cp.stdout}
+            self.kube.worker_exec(pod["name"], ["chmod", "+x", remote_path], timeout=10)
+
+        port = 39000 + ((os.getpid() + time.time_ns()) % 2000)
+        server_cmd = [
+            "kubectl",
+            "-n",
+            self.config.namespace,
+            "exec",
+            target_pod["name"],
+            "-c",
+            "worker",
+            "--",
+            target_path,
+            "--mode",
+            "server",
+            "--addr",
+            f"[::]:{port}",
+            "--concurrency",
+            str(self.config.remote_cache_proof_concurrency),
+            "--chunk-bytes",
+            str(self.config.remote_cache_proof_chunk_bytes),
+        ]
+        server = subprocess.Popen(
+            server_cmd,
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=1,
+        )
+        server_stdout: list[str] = []
+        server_stderr: list[str] = []
+        try:
+            ready_deadline = time.monotonic() + 15
+            while time.monotonic() < ready_deadline:
+                if server.poll() is not None:
+                    break
+                readable, _, _ = select.select([server.stdout], [], [], 0.2) if server.stdout else ([], [], [])
+                if readable:
+                    line = server.stdout.readline()
+                    server_stdout.append(line)
+                    if line.startswith("ready "):
+                        break
+            else:
+                server.kill()
+                out, err = server.communicate(timeout=5)
+                return {
+                    "ok": False,
+                    "error": "network probe server did not become ready",
+                    "serverStdout": ("".join(server_stdout) + (out or ""))[-2000:],
+                    "serverStderr": (err or "")[-2000:],
+                }
+
+            if not server_stdout or not server_stdout[-1].startswith("ready "):
+                out, err = server.communicate(timeout=5)
+                return {
+                    "ok": False,
+                    "error": f"network probe server exited before ready: {server.returncode}",
+                    "serverStdout": ("".join(server_stdout) + (out or ""))[-2000:],
+                    "serverStderr": (err or "")[-2000:],
+                }
+
+            target_ip = target_pod.get("podIP") or self._pod_ip(target_pod["name"])
+            if not target_ip:
+                return {"ok": False, "error": "target pod IP not found"}
+            client = self.kube.worker_exec(
+                source_pod["name"],
+                [
+                    source_path,
+                    "--mode",
+                    "client",
+                    "--addr",
+                    f"[{target_ip}]:{port}",
+                    "--bytes",
+                    str(size),
+                    "--concurrency",
+                    str(self.config.remote_cache_proof_concurrency),
+                    "--chunk-bytes",
+                    str(self.config.remote_cache_proof_chunk_bytes),
+                ],
+                timeout=max(120, int(self.config.exec_timeout_seconds)),
+            )
+            try:
+                out, err = server.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                server.kill()
+                out, err = server.communicate(timeout=5)
+            server_stdout.append(out or "")
+            server_stderr.append(err or "")
+            payload = (
+                parse_json_output(client.stdout)
+                if client.returncode == 0
+                else {"ok": False, "error": client.stderr or client.stdout}
+            )
+            payload.update(
+                {
+                    "sourcePod": source_pod["name"],
+                    "sourceNode": source_pod.get("nodeName", ""),
+                    "targetPod": target_pod["name"],
+                    "targetNode": target_pod.get("nodeName", ""),
+                    "serverStdout": "".join(server_stdout)[-2000:],
+                    "serverStderr": "".join(server_stderr)[-2000:],
+                }
+            )
+            return payload
+        finally:
+            if server.poll() is None:
+                server.kill()
+
+    def _pod_ip(self, pod_name: str) -> str:
+        proc = run(
+            [
+                "kubectl",
+                "-n",
+                self.config.namespace,
+                "get",
+                "pod",
+                pod_name,
+                "-o",
+                "jsonpath={.status.podIP}",
+            ],
+            check=False,
+            timeout=10,
+        )
+        return proc.stdout.strip() if proc.returncode == 0 else ""
 
     def cache_hosts_snapshot(self) -> dict[str, Any]:
         redis_pod = find_redis_pod(self.config.namespace)
@@ -1460,14 +1747,27 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
         target_pod = next(
             (pod for pod in workers if pod.get("podIP") == target_ip), None
         )
-        source_pod = next(
-            (
-                pod
-                for pod in workers
-                if not target_pod or pod["name"] != target_pod["name"]
-            ),
-            None,
-        )
+        target_node = (target_pod or {}).get("nodeName") or target_host.get("nodeName", "")
+        source_pod = None
+        if target_node:
+            source_pod = next(
+                (
+                    pod
+                    for pod in workers
+                    if pod["name"] != (target_pod or {}).get("name", "")
+                    and pod.get("nodeName", "") != target_node
+                ),
+                None,
+            )
+        if source_pod is None:
+            source_pod = next(
+                (
+                    pod
+                    for pod in workers
+                    if not target_pod or pod["name"] != target_pod["name"]
+                ),
+                None,
+            )
         return source_pod, target_pod
 
     @staticmethod
@@ -1737,7 +2037,7 @@ class BenchmarkPaths:
     @property
     def worker_volume_root(self) -> str:
         return str(
-            Path("/workspace/data")
+            Path(self.config.worker_workspace_root)
             / self.workspace_name
             / "volumes"
             / self.volume_id
@@ -1772,6 +2072,21 @@ def storage_value(storage: dict[str, Any], *keys: str) -> str:
         value = storage.get(key)
         if value:
             return str(value)
+    return ""
+
+
+def first_metadata_hash(metadata: dict[str, str]) -> str:
+    for key in (
+        "--content-sha256",
+        "content-sha256",
+        "sha256",
+        "content_sha256",
+        "x-amz-meta---content-sha256",
+        "x-amz-meta-content-sha256",
+    ):
+        value = str(metadata.get(key, "")).strip()
+        if value:
+            return value
     return ""
 
 
@@ -1859,9 +2174,21 @@ class Reporter:
                     row["sizeMiB"] >= self.config.min_throughput_size_mb
                     and remote.get("mbps", 0) < self.config.min_remote_cache_socket_mbps
                 ):
-                    failures.append(
-                        f"{row['accessType']}:{row['sizeMiB']}MiB remote cache read {remote.get('mbps', 0):.2f} MB/s below {self.config.min_remote_cache_socket_mbps:.2f} MB/s"
-                    )
+                    network = remote.get("networkProbe") or {}
+                    network_mbps = float(network.get("mbps") or 0)
+                    if network.get("ok") and network_mbps > 0:
+                        required_mbps = min(
+                            self.config.min_remote_cache_socket_mbps,
+                            network_mbps * 0.9,
+                        )
+                        if remote.get("mbps", 0) < required_mbps:
+                            failures.append(
+                                f"{row['accessType']}:{row['sizeMiB']}MiB remote cache read {remote.get('mbps', 0):.2f} MB/s below measured network target {required_mbps:.2f} MB/s (network {network_mbps:.2f} MB/s)"
+                            )
+                    else:
+                        failures.append(
+                            f"{row['accessType']}:{row['sizeMiB']}MiB remote cache read {remote.get('mbps', 0):.2f} MB/s below {self.config.min_remote_cache_socket_mbps:.2f} MB/s"
+                        )
             remote_object = row.get("remoteObject")
             if self.config.require_remote_object_proof and (
                 not remote_object or not remote_object.get("ok")
@@ -1887,12 +2214,14 @@ class Reporter:
             f"- Namespace: `{report['config']['namespace']}`",
             f"- Volume: `{report['config']['volumeName']}` mounted at `/{report['config']['volumeMountPath']}`",
             "",
-            "| Access | Size | Hot MB/s | File-read MB/s | Read Method | SHA OK | Cache Ready | Remote Object | Cache Path | Worker dd MB/s | Sandbox dd MB/s | Remote MB/s | Direct Disk MB/s |",
-            "| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: |",
+            "| Access | Size | Hot MB/s | File-read MB/s | Read Method | SHA OK | Cache Ready | Remote Object | Cache Path | Worker dd MB/s | Sandbox dd MB/s | Remote MB/s | Network MB/s | Direct Disk MB/s |",
+            "| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |",
         ]
         direct = report.get("directDiskProbe") or {}
         for row in report["rows"]:
             read = row.get("hotRead") or {}
+            remote = row.get("remoteRead") or {}
+            network = remote.get("networkProbe") or {}
             cache_path = (
                 "hot("
                 + self._cache_path_label(row.get("readPathProof") or {})
@@ -1910,7 +2239,8 @@ class Reporter:
                 f"`{cache_path}` | "
                 f"{(row.get('workerDD') or {}).get('mbps', 0):.2f} | "
                 f"{(row.get('sandboxDD') or {}).get('mbps', 0):.2f} | "
-                f"{(row.get('remoteRead') or {}).get('mbps', 0):.2f} | "
+                f"{remote.get('mbps', 0):.2f} | "
+                f"{network.get('mbps', 0):.2f} | "
                 f"{direct.get('mbps', 0):.2f} |"
             )
         lines.extend(["", "## Validation Failures", ""])
@@ -2119,76 +2449,88 @@ class CacheBenchmark:
             "reason": "preserve embedded cache pages for hot-read measurement",
         }
         workspace_mount_probe = None
-        if access_type == "workspace_fuse":
-            workspace_mount_probe = self._ensure_workspace_fuse_mounted(
-                sandbox, token, paths, entry
-            )
+        workspace_mount_instance = None
+        workspace_worker_pods = None
+        try:
+            if access_type == "workspace_fuse":
+                (
+                    workspace_mount_instance,
+                    workspace_mount_probe,
+                    workspace_worker_pods,
+                ) = self._ensure_workspace_fuse_mounted(sandbox, token, paths, entry)
 
-        mounted_eviction = self.cache.evict_mounted_file(worker_path, entry["size"])
+            mounted_eviction = self.cache.evict_mounted_file(worker_path, entry["size"])
 
-        if access_type == "workspace_fuse":
-            hot_payload, hot_sample = self.cache.worker_hot_read(
-                paths.worker_volume_root,
-                entry,
-                geesefs_path,
+            if access_type == "workspace_fuse":
+                hot_payload, hot_sample = self.cache.worker_hot_read(
+                    paths.worker_volume_root,
+                    entry,
+                    geesefs_path,
+                    pods=workspace_worker_pods,
+                )
+            else:
+                hot_payload, hot_sample = self.runner.hot_read(
+                    sandbox,
+                    token,
+                    paths.root_for_access(access_type),
+                    entry,
+                    geesefs_path,
+                )
+            cas_proof = self.cache.object_proof(entry["sha256"])
+            remote_object = self._remote_object_proof(workspace, paths, entry)
+            worker_dd = None
+            if self.config.worker_dd_reads:
+                self.cache.evict_mounted_file(worker_path, entry["size"])
+                worker_dd = self.cache.worker_dd(
+                    worker_path, entry["size"], pods=workspace_worker_pods
+                )
+            sandbox_dd = None
+            sandbox_dd_sample = None
+            if self.config.sandbox_dd_reads and access_type == "volume_mount":
+                sandbox_dd, sandbox_dd_sample = self.runner.sandbox_dd(
+                    sandbox,
+                    token,
+                    paths.root_for_access(access_type),
+                    entry,
+                    geesefs_path,
+                )
+            remote = (
+                self.cache.remote_read(entry, cas_proof)
+                if self.config.require_remote_read
+                else None
             )
-        else:
-            hot_payload, hot_sample = self.runner.hot_read(
-                sandbox,
-                token,
-                paths.root_for_access(access_type),
-                entry,
-                geesefs_path,
-            )
-        cas_proof = self.cache.object_proof(entry["sha256"])
-        remote_object = self._remote_object_proof(workspace, paths, entry)
-        worker_dd = None
-        if self.config.worker_dd_reads:
-            self.cache.evict_mounted_file(worker_path, entry["size"])
-            worker_dd = self.cache.worker_dd(worker_path, entry["size"])
-        sandbox_dd = None
-        sandbox_dd_sample = None
-        if self.config.sandbox_dd_reads and access_type == "volume_mount":
-            sandbox_dd, sandbox_dd_sample = self.runner.sandbox_dd(
-                sandbox,
-                token,
-                paths.root_for_access(access_type),
-                entry,
-                geesefs_path,
-            )
-        remote = (
-            self.cache.remote_read(entry, cas_proof)
-            if self.config.require_remote_read
-            else None
-        )
-        row = {
-            "accessType": access_type,
-            "pattern": entry["pattern"],
-            "sizeMiB": entry["sizeMiB"],
-            "path": entry["path"],
-            "hash": entry["sha256"],
-            "cacheReady": ready,
-            "cachePageEviction": cache_page_eviction,
-            "casProof": cas_proof,
-            "remoteObject": remote_object,
-            "workspaceMountProbe": workspace_mount_probe,
-            "mountedFileEviction": mounted_eviction,
-            "hotRead": hot_payload,
-            "hotSample": hot_sample,
-            "readPathProof": hot_sample.get("readPathProof"),
-            "shaOK": bool(cas_proof.get("matchesHash"))
-            and (
-                not self.config.verify_reads
-                or hot_payload.get("digest") == entry["sha256"]
-            ),
-            "workerDD": worker_dd,
-            "sandboxDD": sandbox_dd,
-            "sandboxDDSample": sandbox_dd_sample,
-            "ddReadPathProof": (sandbox_dd_sample or {}).get("readPathProof"),
-            "remoteRead": remote,
-        }
-        self._print_row(row)
-        return row
+            row = {
+                "accessType": access_type,
+                "pattern": entry["pattern"],
+                "sizeMiB": entry["sizeMiB"],
+                "path": entry["path"],
+                "hash": entry["sha256"],
+                "cacheReady": ready,
+                "cachePageEviction": cache_page_eviction,
+                "casProof": cas_proof,
+                "remoteObject": remote_object,
+                "workspaceMountProbe": workspace_mount_probe,
+                "mountedFileEviction": mounted_eviction,
+                "hotRead": hot_payload,
+                "hotSample": hot_sample,
+                "readPathProof": hot_sample.get("readPathProof"),
+                "shaOK": bool(cas_proof.get("matchesHash"))
+                and (
+                    not self.config.verify_reads
+                    or hot_payload.get("digest") == entry["sha256"]
+                ),
+                "workerDD": worker_dd,
+                "sandboxDD": sandbox_dd,
+                "sandboxDDSample": sandbox_dd_sample,
+                "ddReadPathProof": (sandbox_dd_sample or {}).get("readPathProof"),
+                "remoteRead": remote,
+            }
+            self._print_row(row)
+            return row
+        finally:
+            if workspace_mount_instance is not None:
+                sample = (workspace_mount_probe or {}).get("sample") or {}
+                self.runner._cleanup_sandbox_bounded(workspace_mount_instance, sample)
 
     def _ensure_workspace_fuse_mounted(
         self,
@@ -2196,32 +2538,82 @@ class CacheBenchmark:
         token: str,
         paths: BenchmarkPaths,
         entry: dict[str, Any],
-    ) -> dict[str, Any]:
+    ) -> tuple[Any, dict[str, Any], Optional[list[dict[str, str]]]]:
         script = (
             "import json, os, sys\n"
             "path = os.path.join(sys.argv[1], sys.argv[2])\n"
             "st = os.stat(path)\n"
             "print(json.dumps({'ok': True, 'path': path, 'size': st.st_size}))\n"
         )
-        payload, sample = self.runner.run_json(
-            sandbox,
-            token,
-            [
-                "python3",
-                "-c",
-                script,
-                paths.volume_container_root,
-                entry["path"],
-            ],
-            "workspace-fuse-mount-probe",
-        )
-        return {"payload": payload, "sample": sample}
+        instance = None
+        sample: dict[str, Any] = {
+            "label": "workspace-fuse-mount-holder",
+            "startedAt": now_rfc3339(),
+        }
+        started = time.monotonic_ns()
+        try:
+            instance, create_info = create_sandbox_with_retries(self.config, sandbox)
+            sample.update(create_info)
+            sample["containerId"] = instance.container_id
+            sample["stubId"] = instance.stub_id
+            if not instance.ok:
+                raise RuntimeError(
+                    instance.error_msg or "Sandbox.create returned ok=false"
+                )
+            if self.config.wait_running:
+                sample["running"] = wait_instance_running(
+                    self.config, token, instance.container_id, started
+                )
+
+            process = instance.process.exec(
+                [
+                    "python3",
+                    "-c",
+                    script,
+                    paths.volume_container_root,
+                    entry["path"],
+                ],
+                cwd="/",
+            )
+            exit_code = process.wait(timeout=self.config.exec_timeout_seconds)
+            sample["exitCode"] = exit_code
+            sample["stdout"] = process.stdout.read()
+            sample["stderr"] = process.stderr.read()
+            if exit_code != 0:
+                raise RuntimeError(
+                    sample["stderr"]
+                    or sample["stdout"]
+                    or f"command exited {exit_code}"
+                )
+
+            payload = parse_json_output(sample["stdout"])
+            sample["ok"] = bool(payload.get("ok", True))
+            sample["payload"] = payload
+            pod = self.kube.worker_pod_for_container(instance.container_id)
+            if pod is None:
+                raise RuntimeError(
+                    f"unable to find worker pod for mounted workspace container {instance.container_id}"
+                )
+            pods = [pod]
+            sample["workerPod"] = pod
+            return instance, {"payload": payload, "sample": sample}, pods
+        except Exception:
+            if instance is not None:
+                self.runner._cleanup_sandbox_bounded(instance, sample)
+            raise
+        finally:
+            sample["totalMs"] = (time.monotonic_ns() - started) / 1_000_000
+            sample["finishedAt"] = now_rfc3339()
 
     def _remote_object_proof(
         self, workspace: dict[str, Any], paths: BenchmarkPaths, entry: dict[str, Any]
     ) -> Optional[dict[str, Any]]:
         if not self.config.require_remote_object_proof:
             return None
+        presigned = self._remote_object_proof_presigned(paths, entry)
+        if presigned.get("ok"):
+            return presigned
+
         storage = self._resolve_remote_storage(workspace)
         endpoint = storage.get("endpoint_url", "")
         region = storage.get("region", "")
@@ -2275,7 +2667,114 @@ class CacheBenchmark:
             else {"ok": False, "error": proc.stderr or proc.stdout}
         )
         payload["fullReadRequested"] = full_read
+        payload["storageSource"] = storage.get("source", "")
+        payload["storageConfig"] = self.config.workspace_storage_config
+        if presigned:
+            payload["presignedFallbackError"] = presigned.get("error", "")
         return payload
+
+    def _remote_object_proof_presigned(
+        self, paths: BenchmarkPaths, entry: dict[str, Any]
+    ) -> dict[str, Any]:
+        sdk_src = str(REPO_ROOT / "sdk" / "src")
+        if sdk_src not in sys.path:
+            sys.path.insert(0, sdk_src)
+        try:
+            from beta9.channel import ServiceClient
+            from beta9.clients.volume import (
+                CreatePresignedUrlRequest,
+                PresignedUrlMethod,
+            )
+            from beta9.config import ConfigContext
+        except Exception as exc:
+            return {"ok": False, "error": f"import SDK volume client: {exc}"}
+
+        volume_path = str(Path(self.config.volume_subdir) / entry["path"])
+        full_read = entry["sizeMiB"] <= self.config.remote_object_full_read_max_mb
+        started = time.monotonic_ns()
+        out: dict[str, Any] = {
+            "ok": False,
+            "storageSource": "gateway_presigned_volume",
+            "volumeName": self.config.volume_name,
+            "volumePath": volume_path,
+            "expectedBytes": entry["size"],
+            "expectedSha256": entry["sha256"],
+            "fullRead": full_read,
+        }
+        try:
+            gateway_host, gateway_port = parse_host_port(resolved_grpc_addr(self.config))
+            sdk_context = ConfigContext(
+                token=self.config.token,
+                gateway_host=gateway_host,
+                gateway_port=gateway_port,
+            )
+            with ServiceClient(sdk_context) as client:
+                head = client.volume.create_presigned_url(
+                    CreatePresignedUrlRequest(
+                        volume_name=self.config.volume_name,
+                        volume_path=volume_path,
+                        expires=int(max(60, self.config.cache_proof_timeout_seconds)),
+                        method=PresignedUrlMethod.HeadObject,
+                    )
+                )
+                if not head.ok:
+                    out["error"] = f"presign HEAD failed: {head.err_msg}"
+                    return out
+                status, headers, _ = self._request_presigned(head.url, "HEAD")
+                out["statusCode"] = status
+                out["bytes"] = int(headers.get("content-length") or -1)
+                out["sizeOK"] = out["bytes"] == entry["size"]
+                out["metadata"] = {
+                    key: value
+                    for key, value in headers.items()
+                    if key.startswith("x-amz-meta-") or key in {"etag", "content-length"}
+                }
+                metadata_hash = first_metadata_hash(out["metadata"])
+                out["metadataHash"] = metadata_hash
+                out["hashOK"] = not metadata_hash or metadata_hash == entry["sha256"]
+
+                if full_read:
+                    get = client.volume.create_presigned_url(
+                        CreatePresignedUrlRequest(
+                            volume_name=self.config.volume_name,
+                            volume_path=volume_path,
+                            expires=int(max(60, self.config.cache_proof_timeout_seconds)),
+                            method=PresignedUrlMethod.GetObject,
+                        )
+                    )
+                    if not get.ok:
+                        out["error"] = f"presign GET failed: {get.err_msg}"
+                        return out
+                    _, _, body = self._request_presigned(get.url, "GET")
+                    import hashlib
+
+                    digest = hashlib.sha256(body).hexdigest()
+                    out["fullReadSha256"] = digest
+                    out["hashOK"] = digest == entry["sha256"]
+
+                out["ok"] = bool(out.get("sizeOK")) and bool(out.get("hashOK", True))
+                if not out["ok"] and not out.get("error"):
+                    out["error"] = "remote object size/hash check failed"
+                return out
+        except Exception as exc:
+            out["error"] = str(exc)
+            return out
+        finally:
+            out["durationMs"] = (time.monotonic_ns() - started) / 1_000_000
+
+    def _request_presigned(
+        self, url: str, method: str
+    ) -> tuple[int, dict[str, str], bytes]:
+        request = urllib.request.Request(url, method=method)
+        timeout = max(60, self.config.cache_proof_timeout_seconds)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read() if method != "HEAD" else b""
+                headers = {k.lower(): v for k, v in response.headers.items()}
+                return int(response.status), headers, body
+        except urllib.error.HTTPError as exc:
+            body = exc.read()
+            raise RuntimeError(f"{method} presigned object failed: HTTP {exc.code} {body[:200]!r}") from exc
 
     def _resolve_remote_storage(self, workspace: dict[str, Any]) -> dict[str, str]:
         storage = workspace.get("storage") or {}
@@ -2305,19 +2804,25 @@ class CacheBenchmark:
                 resolved[key] = value
                 resolved["source"] = "cli_or_env"
 
+        default_configs = self._default_workspace_storage_configs()
         if not self._has_complete_remote_storage(resolved):
-            local_config = self._load_default_workspace_storage_config()
-            for key, value in local_config.items():
-                if value and not resolved.get(key):
-                    resolved[key] = value
-                    resolved["source"] = "local_config"
-        else:
-            local_config = self._load_default_workspace_storage_config()
+            for default_config in default_configs:
+                updated = False
+                for key, value in default_config.items():
+                    if value and not resolved.get(key):
+                        resolved[key] = value
+                        updated = True
+                if updated:
+                    resolved["source"] = default_config.get("source", "config")
+                if self._has_complete_remote_storage(resolved):
+                    break
 
-        host_endpoint = local_config.get("host_endpoint_url", "")
-        if host_endpoint and self._endpoint_needs_host_alias(resolved.get("endpoint_url", "")):
-            resolved["endpoint_url"] = host_endpoint
-            resolved["source"] = resolved.get("source", "workspace_api") + "+host_endpoint"
+        for default_config in default_configs:
+            host_endpoint = default_config.get("host_endpoint_url", "")
+            if host_endpoint and self._endpoint_needs_host_alias(resolved.get("endpoint_url", "")):
+                resolved["endpoint_url"] = host_endpoint
+                resolved["source"] = resolved.get("source", "workspace_api") + "+host_endpoint"
+                break
 
         if not resolved.get("bucket_name") and resolved.get("bucket_prefix"):
             workspace_external_id = str(
@@ -2341,12 +2846,69 @@ class CacheBenchmark:
     def _endpoint_needs_host_alias(endpoint: str) -> bool:
         return "://localstack" in endpoint or endpoint.startswith("localstack:")
 
+    def _default_workspace_storage_configs(self) -> list[dict[str, str]]:
+        configs = []
+        cluster_config = self._load_cluster_workspace_storage_config()
+        if cluster_config:
+            configs.append(cluster_config)
+        local_config = self._load_default_workspace_storage_config()
+        if local_config:
+            configs.append(local_config)
+        return configs
+
+    def _load_cluster_workspace_storage_config(self) -> dict[str, str]:
+        proc = run(
+            [
+                "kubectl",
+                "-n",
+                self.config.namespace,
+                "get",
+                "secret",
+                "beta9-config",
+                "-o",
+                "json",
+            ],
+            check=False,
+            timeout=20,
+        )
+        if proc.returncode != 0:
+            return {}
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return {}
+        data = payload.get("data") or {}
+        if not isinstance(data, dict):
+            return {}
+        for key in (".config.yaml", "config.yaml", "config.local.yaml", "config.stage.yaml"):
+            encoded = data.get(key)
+            if not encoded:
+                continue
+            try:
+                decoded = base64.b64decode(encoded).decode("utf-8")
+            except Exception:
+                continue
+            config = self._workspace_storage_config_from_yaml(decoded, "cluster_secret")
+            if config:
+                return config
+        return {}
+
     def _load_default_workspace_storage_config(self) -> dict[str, str]:
         path = Path(self.config.workspace_storage_config).expanduser()
         if not path.exists():
             return {}
         try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            return self._workspace_storage_config_from_yaml(
+                path.read_text(encoding="utf-8"),
+                f"local_config:{path}",
+            )
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _workspace_storage_config_from_yaml(raw: str, source: str) -> dict[str, str]:
+        try:
+            data = yaml.safe_load(raw) or {}
         except Exception:
             return {}
         storage = (
@@ -2364,14 +2926,21 @@ class CacheBenchmark:
             "bucket_prefix": str(storage.get("defaultBucketPrefix") or ""),
             "access_key": str(storage.get("defaultAccessKey") or ""),
             "secret_key": str(storage.get("defaultSecretKey") or ""),
+            "source": source,
         }
 
     def _report_config(self, volume_id: str) -> dict[str, Any]:
         return {
+            "profile": self.config.profile,
             "namespace": self.config.namespace,
             "gatewayUrl": self.config.gateway_url,
             "grpcAddr": resolved_grpc_addr(self.config),
             "filePlan": self.config.file_plan,
+            "workspaceStorageConfig": self.config.workspace_storage_config,
+            "remoteCacheProofChunkBytes": self.config.remote_cache_proof_chunk_bytes,
+            "remoteCacheProofConcurrency": self.config.remote_cache_proof_concurrency,
+            "remoteNetworkProbe": self.config.remote_network_probe,
+            "remoteNetworkProbeBytes": self.config.remote_network_probe_bytes,
             "volumeName": self.config.volume_name,
             "volumeId": volume_id,
             "volumeMountPath": self.config.volume_mount_path,

--- a/benchmarks/b9bench/cache_tools/net_probe.go
+++ b/benchmarks/b9bench/cache_tools/net_probe.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+func main() {
+	mode := flag.String("mode", "", "server or client")
+	addr := flag.String("addr", "", "listen or dial address")
+	totalBytes := flag.Int64("bytes", 0, "total bytes to transfer")
+	concurrency := flag.Int("concurrency", 1, "connection count")
+	chunkBytes := flag.Int("chunk-bytes", 4*1024*1024, "transfer chunk size")
+	flag.Parse()
+
+	if *mode == "server" {
+		if err := runServer(*addr, *concurrency, *chunkBytes); err != nil {
+			fail(err)
+		}
+		return
+	}
+	if *mode == "client" {
+		if err := runClient(*addr, *totalBytes, *concurrency, *chunkBytes); err != nil {
+			fail(err)
+		}
+		return
+	}
+	fail(fmt.Errorf("--mode must be server or client"))
+}
+
+func runServer(addr string, concurrency int, chunkBytes int) error {
+	if addr == "" {
+		addr = "[::]:39099"
+	}
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if chunkBytes <= 0 {
+		chunkBytes = 4 * 1024 * 1024
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	fmt.Printf("ready %s\n", ln.Addr().String())
+	os.Stdout.Sync()
+
+	started := time.Now()
+	var total int64
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		conn, err := ln.Accept()
+		if err != nil {
+			return err
+		}
+		wg.Add(1)
+		go func(conn net.Conn) {
+			defer wg.Done()
+			defer conn.Close()
+			n, err := readRequestedBytes(conn)
+			if err != nil {
+				return
+			}
+			buf := make([]byte, chunkBytes)
+			var sent int64
+			for sent < n {
+				toWrite := int64(len(buf))
+				if remaining := n - sent; remaining < toWrite {
+					toWrite = remaining
+				}
+				written, err := conn.Write(buf[:toWrite])
+				if written > 0 {
+					sent += int64(written)
+					atomic.AddInt64(&total, int64(written))
+				}
+				if err != nil {
+					return
+				}
+			}
+		}(conn)
+	}
+	wg.Wait()
+	durationMs := float64(time.Since(started).Nanoseconds()) / 1_000_000
+	bytes := atomic.LoadInt64(&total)
+	mb := float64(bytes) / 1048576
+	out := map[string]any{
+		"ok":          true,
+		"mode":        "server",
+		"bytes":       bytes,
+		"durationMs":  durationMs,
+		"mbps":        mb / (durationMs / 1000),
+		"concurrency": concurrency,
+		"chunkBytes":  chunkBytes,
+	}
+	return json.NewEncoder(os.Stdout).Encode(out)
+}
+
+func runClient(addr string, totalBytes int64, concurrency int, chunkBytes int) error {
+	if addr == "" {
+		return fmt.Errorf("--addr is required")
+	}
+	if totalBytes <= 0 {
+		return fmt.Errorf("--bytes must be > 0")
+	}
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if chunkBytes <= 0 {
+		chunkBytes = 4 * 1024 * 1024
+	}
+
+	perConn := splitBytes(totalBytes, concurrency)
+	started := time.Now()
+	var received int64
+	var wg sync.WaitGroup
+	errCh := make(chan error, concurrency)
+	for _, n := range perConn {
+		wg.Add(1)
+		go func(n int64) {
+			defer wg.Done()
+			conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer conn.Close()
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				_ = tcp.SetNoDelay(true)
+				_ = tcp.SetReadBuffer(16 * 1024 * 1024)
+				_ = tcp.SetWriteBuffer(16 * 1024 * 1024)
+			}
+			if err := writeRequestedBytes(conn, n); err != nil {
+				errCh <- err
+				return
+			}
+			buf := make([]byte, chunkBytes)
+			var got int64
+			for got < n {
+				toRead := int64(len(buf))
+				if remaining := n - got; remaining < toRead {
+					toRead = remaining
+				}
+				read, err := io.ReadFull(conn, buf[:toRead])
+				if read > 0 {
+					got += int64(read)
+					atomic.AddInt64(&received, int64(read))
+				}
+				if err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}(n)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	durationMs := float64(time.Since(started).Nanoseconds()) / 1_000_000
+	bytes := atomic.LoadInt64(&received)
+	mb := float64(bytes) / 1048576
+	out := map[string]any{
+		"ok":          bytes == totalBytes,
+		"mode":        "client",
+		"bytes":       bytes,
+		"durationMs":  durationMs,
+		"mbps":        mb / (durationMs / 1000),
+		"concurrency": concurrency,
+		"chunkBytes":  chunkBytes,
+	}
+	return json.NewEncoder(os.Stdout).Encode(out)
+}
+
+func splitBytes(total int64, concurrency int) []int64 {
+	out := make([]int64, concurrency)
+	base := total / int64(concurrency)
+	rem := total % int64(concurrency)
+	for i := range out {
+		out[i] = base
+		if int64(i) < rem {
+			out[i]++
+		}
+	}
+	return out
+}
+
+func writeRequestedBytes(w io.Writer, n int64) error {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(n))
+	_, err := w.Write(buf[:])
+	return err
+}
+
+func readRequestedBytes(r io.Reader) (int64, error) {
+	var buf [8]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return int64(binary.BigEndian.Uint64(buf[:])), nil
+}
+
+func fail(err error) {
+	out := map[string]any{"ok": false, "error": err.Error()}
+	_ = json.NewEncoder(os.Stdout).Encode(out)
+	os.Exit(1)
+}

--- a/benchmarks/b9bench/runner.py
+++ b/benchmarks/b9bench/runner.py
@@ -225,7 +225,12 @@ class CacheSuiteProbe(ScriptProbeBase):
             suite.defaults,
             suite.args,
             self.config.extra_args,
-            {"output": str(suite_json), "report": str(suite_md)},
+            {
+                "profile": self.config.profile,
+                "beta9_config": str(self.config.config_path),
+                "output": str(suite_json),
+                "report": str(suite_md),
+            },
         )
         if not args.get("file_plan"):
             file_plan = suite.file_plan
@@ -291,6 +296,28 @@ class CacheSuiteProbe(ScriptProbeBase):
                 "remote_cache_socket_read",
                 requires_remote=True,
             )
+            remote = row.get("remoteRead") or {}
+            network = remote.get("networkProbe") or {}
+            if network:
+                self.sink.emit(
+                    self._measurement(
+                        suite,
+                        scenario,
+                        row,
+                        "remote_network_read",
+                        mbps=float(network.get("mbps") or 0),
+                        duration_ms=float(network.get("durationMs") or 0),
+                        status="ok" if network.get("ok") else "failed",
+                        error=str(network.get("error") or ""),
+                        extra_evidence={
+                            "source_worker": network.get("sourcePod"),
+                            "source_node": network.get("sourceNode"),
+                            "target_worker": network.get("targetPod"),
+                            "target_node": network.get("targetNode"),
+                        },
+                        source_key="remoteNetwork",
+                    )
+                )
             hot = row.get("hotRead") or {}
             if hot.get("fileReadMBps"):
                 self.sink.emit(
@@ -349,8 +376,13 @@ class CacheSuiteProbe(ScriptProbeBase):
                     "remote_worker": bool(payload.get("differentWorkerPod"))
                     if requires_remote
                     else None,
+                    "remote_node": bool(payload.get("differentNode"))
+                    if requires_remote
+                    else None,
                     "source_worker": payload.get("sourcePod"),
+                    "source_node": payload.get("sourceNode"),
                     "target_worker": payload.get("targetPod"),
+                    "target_node": payload.get("targetNode"),
                 },
                 requires_remote=requires_remote,
                 source_key=source_key,
@@ -417,6 +449,10 @@ class CacheSuiteProbe(ScriptProbeBase):
         }
         if extra_evidence:
             evidence.update({key: value for key, value in extra_evidence.items() if value is not None})
+        if source_key == "remoteRead":
+            network = (row.get("remoteRead") or {}).get("networkProbe") or {}
+            if network.get("ok") and network.get("mbps"):
+                evidence["network_ceiling_mbps"] = float(network.get("mbps") or 0)
         tags = scenario.metric_tags
         tags.update(
             {

--- a/benchmarks/b9bench/suite_defs/cache-staging.yaml
+++ b/benchmarks/b9bench/suite_defs/cache-staging.yaml
@@ -1,10 +1,11 @@
-name: cache-default
+name: cache-staging
 kind: cache
 runner: cache
-description: Embedded cache correctness and throughput suite with strict path evidence.
+description: Staging embedded-cache proof with 1GiB/4GiB volume and workspace reads.
 defaults:
   verify_reads: true
   require_remote_read: true
+  require_remote_object_proof: true
   require_read_path_proof: true
   direct_cache_disk_probe: true
   require_direct_cache_disk_probe: true
@@ -12,12 +13,15 @@ defaults:
   sandbox_dd_reads: true
   sandbox_cpu: "4"
   sandbox_memory: "8192"
+  worker_workspace_root: /storage
   cleanup_cache_before_run: true
   cleanup_cache_after_run: true
   reset_workers: false
   reset_workers_after_prepare: true
   remote_cache_proof_chunk_bytes: 4194304
   remote_cache_proof_concurrency: 16
+  remote_network_probe: true
+  remote_network_probe_bytes: 4294967296
   min_hot_file_read_mbps: 2000
   min_remote_cache_socket_mbps: 2000
   min_throughput_size_mb: 1024
@@ -48,7 +52,7 @@ scenarios:
     pattern: sequential
     size_mib: 1024
     cache_state: strict_disk
-    probes: [sandbox_read, worker_dd, sandbox_dd, remote_cache_socket, cache_path]
+    probes: [worker_read, worker_dd, remote_cache_socket, cache_path]
     thresholds:
       python_file_read_min_mbps: 2000
       remote_cache_socket_read_min_mbps: 2000
@@ -58,7 +62,7 @@ scenarios:
     pattern: sequential
     size_mib: 4096
     cache_state: strict_disk
-    probes: [sandbox_read, worker_dd, sandbox_dd, remote_cache_socket, cache_path]
+    probes: [worker_read, worker_dd, remote_cache_socket, cache_path]
     thresholds:
       python_file_read_min_mbps: 2000
       remote_cache_socket_read_min_mbps: 2000

--- a/benchmarks/b9bench/test_b9bench.py
+++ b/benchmarks/b9bench/test_b9bench.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from benchmarks.b9bench.config import resolve_run_config
 from benchmarks.b9bench.config import http_url_from_gateway
+from benchmarks.b9bench.cache_suite import CacheBenchmark, resolve_workspace_storage_config
 from benchmarks.b9bench.model import Measurement, ScenarioSpec
 from benchmarks.b9bench.payload import deterministic_payload_range, deterministic_sha256
 from benchmarks.b9bench.reports import MetricSink
@@ -34,6 +35,32 @@ class B9BenchTests(unittest.TestCase):
         self.assertIn("volume_mount:sequential:32", suite.file_plan)
         self.assertIn("workspace_fuse:sequential:32", suite.file_plan)
 
+    def test_staging_cache_profile_uses_stage_workspace_storage_config(self):
+        root = Path(__file__).resolve().parents[2]
+        self.assertEqual(
+            Path(resolve_workspace_storage_config("", "staging", "")).name,
+            "config.stage.yaml",
+        )
+        self.assertTrue((root / "config.stage.yaml").exists())
+
+    def test_workspace_storage_config_parser_keeps_source(self):
+        parsed = CacheBenchmark._workspace_storage_config_from_yaml(
+            """
+storage:
+  workspaceStorage:
+    defaultEndpointUrl: https://s3.example.com
+    defaultRegion: us-east-1
+    defaultBucketPrefix: workspace-stage
+    defaultAccessKey: access
+    defaultSecretKey: secret
+""",
+            "cluster_secret",
+        )
+
+        self.assertEqual(parsed["endpoint_url"], "https://s3.example.com")
+        self.assertEqual(parsed["bucket_prefix"], "workspace-stage")
+        self.assertEqual(parsed["source"], "cluster_secret")
+
     def test_validator_requires_cache_hit_when_requested(self):
         measurement = Measurement(
             run_id="run",
@@ -48,6 +75,52 @@ class B9BenchTests(unittest.TestCase):
         failures = Validator().validate([measurement])
         self.assertEqual(len(failures), 1)
         self.assertIn("missing embedded-cache hit proof", failures[0])
+
+    def test_validator_uses_network_ceiling_for_remote_cache_reads(self):
+        measurement = Measurement(
+            run_id="run",
+            suite="cache",
+            scenario="s",
+            measurement="remote_cache_socket_read",
+            timestamp="now",
+            mbps=1450,
+            status="ok",
+            tags={"min_mbps": 2000},
+            evidence={"network_ceiling_mbps": 1500},
+        )
+        self.assertEqual(Validator().validate([measurement]), [])
+
+    def test_validator_fails_remote_cache_below_network_ceiling(self):
+        measurement = Measurement(
+            run_id="run",
+            suite="cache",
+            scenario="s",
+            measurement="remote_cache_socket_read",
+            timestamp="now",
+            mbps=1000,
+            status="ok",
+            tags={"min_mbps": 2000},
+            evidence={"network_ceiling_mbps": 1500},
+        )
+        failures = Validator().validate([measurement])
+        self.assertEqual(len(failures), 1)
+        self.assertIn("measured network target", failures[0])
+
+    def test_validator_fails_zero_throughput_when_threshold_is_set(self):
+        measurement = Measurement(
+            run_id="run",
+            suite="cache",
+            scenario="s",
+            measurement="python_file_read",
+            timestamp="now",
+            mbps=0,
+            status="ok",
+            tags={"min_mbps": 1},
+            evidence={"sha_ok": True},
+        )
+        failures = Validator().validate([measurement])
+        self.assertEqual(len(failures), 1)
+        self.assertIn("below 1.00 MB/s", failures[0])
 
     def test_metric_sink_writes_jsonl_and_summary(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/benchmarks/b9bench/validators.py
+++ b/benchmarks/b9bench/validators.py
@@ -38,7 +38,19 @@ class Validator:
                 f"{measurement.suite}/{measurement.scenario}/{measurement.measurement}: cloud read observed during hot cache scenario"
             )
         min_mbps = tags.get("min_mbps")
-        if min_mbps is not None and measurement.mbps and measurement.mbps < float(min_mbps):
+        if min_mbps is not None and measurement.mbps < float(min_mbps):
+            if measurement.measurement == "remote_cache_socket_read":
+                network_mbps = float(evidence.get("network_ceiling_mbps") or 0)
+                if network_mbps > 0:
+                    required_mbps = min(float(min_mbps), network_mbps * 0.9)
+                    if measurement.mbps >= required_mbps:
+                        return failures
+                    failures.append(
+                        f"{measurement.suite}/{measurement.scenario}/{measurement.measurement}: "
+                        f"{measurement.mbps:.2f} MB/s below measured network target "
+                        f"{required_mbps:.2f} MB/s (network {network_mbps:.2f} MB/s)"
+                    )
+                    return failures
             failures.append(
                 f"{measurement.suite}/{measurement.scenario}/{measurement.measurement}: "
                 f"{measurement.mbps:.2f} MB/s below {float(min_mbps):.2f} MB/s"

--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260527224805-2174081693d0
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260528123439-47bd49178239
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/beam-cloud/clip v0.0.0-20260525151107-d50a98ecfb52 h1:1DJ0e7GzYTGEFRs
 github.com/beam-cloud/clip v0.0.0-20260525151107-d50a98ecfb52/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
 github.com/beam-cloud/geesefs v0.0.0-20260527224805-2174081693d0 h1:GdqrArk02hqEjLx1mMzurld+p5t3i4r4iOyYkkmlZIA=
 github.com/beam-cloud/geesefs v0.0.0-20260527224805-2174081693d0/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260528123439-47bd49178239 h1:SbaUTi2PaCvBchAMxpPbp7Pbvpivp6ukosfND3I95ig=
+github.com/beam-cloud/geesefs v0.0.0-20260528123439-47bd49178239/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1534,6 +1534,12 @@ func (c *Client) storeContentWithLocalReplica(ctx context.Context, localStore *S
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	remoteHost, err := c.storeReplicaHost(routingKey)
+	if err != nil {
+		drainContentChunks(chunks)
+		return "", err
+	}
+
 	type storeResult struct {
 		hash string
 		size int64
@@ -1545,7 +1551,7 @@ func (c *Client) storeContentWithLocalReplica(ctx context.Context, localStore *S
 
 	remoteDone := make(chan storeResult, 1)
 	go func() {
-		hash, err := c.storeContentFromReaderWithContext(ctx, remoteReader, routingKey, "", nil)
+		hash, err := c.storeContentFromReaderToHostWithContext(ctx, remoteHost, remoteReader, "", nil)
 		remoteDone <- storeResult{hash: hash, err: err}
 	}()
 
@@ -1615,6 +1621,51 @@ func (c *Client) storeContentWithLocalReplica(ctx context.Context, localStore *S
 
 	Logger.Debugf("StoreContentWithLocalReplica[OK] - [expected=%s actual=%s routing_key=%s size=%d]", expectedHash, remoteResult.hash, routingKey, size)
 	return remoteResult.hash, nil
+}
+
+func (c *Client) storeReplicaHost(routingKey string) (*Host, error) {
+	localHostIDs := c.localHostIDsSnapshot()
+	hostCount := c.clientConfig.NTopHosts
+	if c.hostMap != nil {
+		hostCount = max(hostCount, len(c.hostMap.GetAll()))
+	}
+	if hostCount < 1 {
+		hostCount = 1
+	}
+
+	c.mu.RLock()
+	hosts := c.hasher.GetN(hostCount, routingKey)
+	c.mu.RUnlock()
+	if len(hosts) == 0 {
+		return nil, ErrHostNotFound
+	}
+
+	primary := hosts[0]
+	if _, isLocal := localHostIDs[primary.HostId]; !isLocal {
+		return primary, nil
+	}
+
+	for _, host := range hosts[1:] {
+		if host == nil {
+			continue
+		}
+		if _, isLocal := localHostIDs[host.HostId]; !isLocal {
+			return host, nil
+		}
+	}
+
+	return primary, nil
+}
+
+func (c *Client) localHostIDsSnapshot() map[string]struct{} {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	hostIDs := make(map[string]struct{}, len(c.localServers))
+	for hostID := range c.localServers {
+		hostIDs[hostID] = struct{}{}
+	}
+	return hostIDs
 }
 
 func drainContentChunks(chunks <-chan []byte) {
@@ -1805,7 +1856,7 @@ func (c *Client) storeContentFromChunks(chunks chan []byte, hash string, cachePa
 }
 
 func (c *Client) storeContentFromReaderWithContext(ctx context.Context, reader io.Reader, routingKey string, cachePath string, fileMetadata *proto.CacheFSMetadata) (string, error) {
-	client, _, err := c.getGRPCClient(&ClientRequest{
+	_, host, err := c.getGRPCClient(&ClientRequest{
 		rt:        ClientRequestTypeStorage,
 		hash:      routingKey,
 		key:       routingKey,
@@ -1813,6 +1864,21 @@ func (c *Client) storeContentFromReaderWithContext(ctx context.Context, reader i
 	})
 	if err != nil {
 		return "", err
+	}
+
+	return c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
+}
+
+func (c *Client) storeContentFromReaderToHostWithContext(ctx context.Context, host *Host, reader io.Reader, cachePath string, fileMetadata *proto.CacheFSMetadata) (string, error) {
+	if host == nil {
+		return "", ErrHostNotFound
+	}
+
+	c.mu.RLock()
+	client, exists := c.grpcClients[host.HostId]
+	c.mu.RUnlock()
+	if !exists {
+		return "", ErrHostNotFound
 	}
 
 	stream, err := client.StoreContent(ctx)

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -410,6 +410,82 @@ func TestStoreContentWithLocalReplicaWritesRemoteAndLocal(t *testing.T) {
 	require.Equal(t, content, local)
 }
 
+func TestStoreContentWithLocalReplicaSkipsLocalPrimaryForRemoteReplica(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	localServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("local-host"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, localServer.Close()) })
+
+	remoteServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	addr, err := remoteServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remoteServer.Close()) })
+
+	remoteHost := remoteServer.Host()
+	require.NotNil(t, remoteHost)
+	remoteHost.Addr = addr
+	remoteHost.PrivateAddr = addr
+
+	localHost := localServer.Host()
+	require.NotNil(t, localHost)
+
+	client := &Client{
+		ctx:                   ctx,
+		clientConfig:          ClientConfig{NTopHosts: 2, PreferLocalCacheHost: true},
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{localHost, remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(remoteHost))
+	defer client.Cleanup()
+	client.AttachLocalServer(localServer)
+	client.AttachLocalStore(localServer.cas)
+
+	content := []byte("cache-through-local-primary")
+	sum := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(sum[:])
+	chunks := make(chan []byte, 2)
+	chunks <- content[:11]
+	chunks <- content[11:]
+	close(chunks)
+
+	got, err := client.StoreContentWithLocalReplica(chunks, expectedHash, StoreContentOptions{RoutingKey: "/cache/local-primary"})
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
+
+	remote := make([]byte, len(content))
+	n, err := remoteServer.cas.ReadAt(expectedHash, 0, remote)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, remote)
+
+	local := make([]byte, len(content))
+	n, err = localServer.cas.ReadAt(expectedHash, 0, local)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, local)
+}
+
 type failFirstUnlockRegistry struct {
 	*MockCacheMetadataStore
 	removeCalls int

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -774,42 +774,29 @@ func (r *EventClientRepo) PushCloneStubEvent(workspaceId string, stub *types.Stu
 }
 
 func (r *EventClientRepo) PushTaskUpdatedEvent(task *types.TaskWithRelated) {
-	event := types.EventTaskSchema{
-		ID:          task.ExternalId,
-		Status:      task.Status,
-		ContainerID: task.ContainerId,
-		CreatedAt:   task.CreatedAt.Time,
-		StubID:      task.Stub.ExternalId,
-		WorkspaceID: task.Workspace.ExternalId,
-		AppID:       task.App.ExternalId,
-	}
-
-	if task.StartedAt.Valid {
-		event.StartedAt = &task.StartedAt.Time
-	}
-
-	if task.EndedAt.Valid {
-		event.EndedAt = &task.EndedAt.Time
-	}
-
-	if task.ExternalWorkspace != nil && task.ExternalWorkspace.ExternalId != nil {
-		event.ExternalWorkspaceID = *task.ExternalWorkspace.ExternalId
-	}
-
 	r.pushEvent(
 		types.EventTaskUpdated,
 		types.EventTaskSchemaVersion,
-		event,
+		eventTaskSchemaFromTask(task),
 	)
 }
 
 func (r *EventClientRepo) PushTaskCreatedEvent(task *types.TaskWithRelated) {
+	r.pushEvent(
+		types.EventTaskCreated,
+		types.EventTaskSchemaVersion,
+		eventTaskSchemaFromTask(task),
+	)
+}
+
+func eventTaskSchemaFromTask(task *types.TaskWithRelated) types.EventTaskSchema {
 	event := types.EventTaskSchema{
 		ID:          task.ExternalId,
 		Status:      task.Status,
 		ContainerID: task.ContainerId,
 		CreatedAt:   task.CreatedAt.Time,
 		StubID:      task.Stub.ExternalId,
+		StubType:    task.Stub.Type,
 		WorkspaceID: task.Workspace.ExternalId,
 		AppID:       task.App.ExternalId,
 	}
@@ -826,11 +813,17 @@ func (r *EventClientRepo) PushTaskCreatedEvent(task *types.TaskWithRelated) {
 		event.ExternalWorkspaceID = *task.ExternalWorkspace.ExternalId
 	}
 
-	r.pushEvent(
-		types.EventTaskCreated,
-		types.EventTaskSchemaVersion,
-		event,
-	)
+	if task.Deployment.ExternalId != nil {
+		event.DeploymentID = *task.Deployment.ExternalId
+	}
+	if task.Deployment.Name != nil {
+		event.DeploymentName = *task.Deployment.Name
+	}
+	if task.Deployment.Version != nil {
+		event.DeploymentVersion = fmt.Sprint(*task.Deployment.Version)
+	}
+
+	return event
 }
 
 func (r *EventClientRepo) PushStubStateUnhealthy(workspaceId string, stubId string, currentState string, previousState string, reason string, failedContainers []string) {

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -153,6 +153,42 @@ func TestS2TaskUpdateEventsUseTaskStreamWhenContainerScoped(t *testing.T) {
 	}
 }
 
+func TestTaskEventSchemaIncludesStubTypeAndDeploymentContext(t *testing.T) {
+	version := uint(7)
+	deploymentID := "deployment-123"
+	deploymentName := "api"
+	task := &types.TaskWithRelated{
+		Task: types.Task{
+			ExternalId:  "task-123",
+			Status:      types.TaskStatusRunning,
+			ContainerId: "container-123",
+			CreatedAt:   types.Time{Time: time.Unix(0, 0).UTC()},
+		},
+	}
+	task.Workspace.ExternalId = "workspace-123"
+	task.Stub.ExternalId = "stub-123"
+	task.Stub.Type = types.StubType(types.StubTypeASGIDeployment)
+	task.App.ExternalId = "app-123"
+	task.Deployment.ExternalId = &deploymentID
+	task.Deployment.Name = &deploymentName
+	task.Deployment.Version = &version
+
+	event := eventTaskSchemaFromTask(task)
+
+	if event.StubType != types.StubType(types.StubTypeASGIDeployment) {
+		t.Fatalf("unexpected stub type: got %q", event.StubType)
+	}
+	if event.DeploymentID != deploymentID {
+		t.Fatalf("unexpected deployment id: got %q want %q", event.DeploymentID, deploymentID)
+	}
+	if event.DeploymentName != deploymentName {
+		t.Fatalf("unexpected deployment name: got %q want %q", event.DeploymentName, deploymentName)
+	}
+	if event.DeploymentVersion != "7" {
+		t.Fatalf("unexpected deployment version: got %q want %q", event.DeploymentVersion, "7")
+	}
+}
+
 func TestS2PlatformLogsUseInternalPlatformStreams(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -124,8 +124,12 @@ type EventTaskSchema struct {
 	WorkspaceID         string     `json:"workspace_id"`
 	ExternalWorkspaceID string     `json:"external_workspace_id"`
 	StubID              string     `json:"stub_id"`
+	StubType            StubType   `json:"stub_type,omitempty"`
 	CreatedAt           time.Time  `json:"created_at"`
 	AppID               string     `json:"app_id"`
+	DeploymentID        string     `json:"deployment_id,omitempty"`
+	DeploymentName      string     `json:"deployment_name,omitempty"`
+	DeploymentVersion   string     `json:"deployment_version,omitempty"`
 }
 
 var EventStubStateSchemaVersion = "1.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a cross-worker network probe to b9bench to measure network ceiling and use it to validate remote cache performance. Also improve remote object proofs, workspace storage config resolution, and fix remote replica host selection; task events now include deployment context.

- New Features
  - Added TCP network probe (`benchmarks/b9bench/cache_tools/net_probe.go`) and integrated it into remote cache reads; emits Network MB/s and adjusts validation using the measured ceiling.
  - New flags: `--remote-network-probe`, `--remote-network-probe-bytes`, higher defaults for `--remote-cache-proof-chunk-bytes` and `--remote-cache-proof-concurrency`.
  - Markdown and metrics include network results; validator uses network ceiling when checking remote cache throughput.
  - Remote object proof can use presigned URLs via the SDK (HEAD/GET), with metadata hash support and better error reporting.
  - Workspace storage config resolution supports profile, explicit config, and cluster `beta9-config` secret; staging profile prefers `config.stage.yaml`.
  - Workspace FUSE: hold a mount with a dedicated sandbox, target the correct worker pod, and allow `--worker-workspace-root`.
  - New `cache-staging.yaml` suite with network probe enabled; `cache-default.yaml` updates concurrency/chunk defaults.

- Refactors
  - Cache client: choose a non-local host for the remote replica even when the primary hash lands on a local host; added `storeReplicaHost`, `storeContentFromReaderToHostWithContext`; tests cover behavior.
  - Events: factored `eventTaskSchemaFromTask`; task events now include `StubType` and deployment fields (`DeploymentID`, `DeploymentName`, `DeploymentVersion`); tests added.
  - Runner passes `profile` and `beta9_config` through to suites; report includes new config fields.
  - Dependency: updated `github.com/beam-cloud/geesefs` replace target.

<sup>Written for commit 6befbcdfb9ce3a3ff94c50fd9981595c7cd9d76e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1584?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

