### PR TITLE
more event sources

### DIFF
--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -187,6 +187,7 @@ func NewEventGroup(g *echo.Group, backendRepo repository.BackendRepository, cont
 	g.GET("/:workspaceId/stubs/:stubId/stream", auth.WithWorkspaceAuth(group.StreamStubEvents))
 	g.GET("/:workspaceId/tasks/:taskId/stream", auth.WithWorkspaceAuth(group.StreamTaskEvents))
 	g.GET("/:workspaceId/apps/:appId/stream", auth.WithWorkspaceAuth(group.StreamAppEvents))
+	g.GET("/:workspaceId/history", auth.WithWorkspaceAuth(group.GetEventHistory))
 	g.GET("/:workspaceId/stream", auth.WithWorkspaceAuth(group.StreamWorkspaceEvents))
 	g.POST("/:workspaceId/containers/batch", auth.WithWorkspaceAuth(group.GetContainerEventsBatch))
 	g.GET("/:workspaceId/tasks/:taskId", auth.WithWorkspaceAuth(group.GetTaskEvents))
@@ -418,6 +419,53 @@ func (g *EventGroup) StreamAppEvents(ctx echo.Context) error {
 	defer stream.Close()
 
 	return g.writeEventStream(ctx, stream)
+}
+
+func (g *EventGroup) GetEventHistory(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+	authInfo := authInfoFromContext(cc)
+	if g.eventRepo == nil {
+		return HTTPInternalServerError("Event repository is unavailable")
+	}
+
+	query, err := eventHistoryQueryFromContext(ctx, authInfo)
+	if err != nil {
+		return err
+	}
+	if query.WorkspaceID == "" {
+		return HTTPNotFound()
+	}
+
+	if query.TaskID != "" {
+		task, err := g.backendRepo.GetTaskWithRelated(ctx.Request().Context(), query.TaskID)
+		if err != nil {
+			return HTTPInternalServerError("Failed to retrieve task")
+		}
+		if task == nil || !hasWorkspaceTaskAccess(task, authInfo, query.WorkspaceID) {
+			return HTTPNotFound()
+		}
+		query.TaskID = task.ExternalId
+		query.StubID = task.Stub.ExternalId
+		query.WorkspaceID = task.Workspace.ExternalId
+		query.AppID = task.App.ExternalId
+	}
+	if query.ContainerID != "" {
+		var err error
+		query, _, err = g.authorizeContainerEventQuery(ctx, query.ContainerID, query)
+		if err != nil {
+			return err
+		}
+	}
+
+	response, err := g.eventRepo.GetEventHistory(ctx.Request().Context(), query)
+	if err != nil {
+		if errors.Is(err, repository.ErrEventReadUnsupported) {
+			return NewHTTPError(http.StatusServiceUnavailable, "Event reads are not configured")
+		}
+		return HTTPInternalServerError("Failed to retrieve event history")
+	}
+
+	return ctx.JSON(http.StatusOK, response)
 }
 
 func (g *EventGroup) GetContainerEventSummary(ctx echo.Context) error {
@@ -707,6 +755,43 @@ func eventQueryFromContext(ctx echo.Context, authInfo *auth.AuthInfo, limit uint
 		TaskID:      ctx.QueryParam("task_id"),
 		EventTypes:  eventQueryTypesFromParam(ctx.QueryParam("event_types")),
 	}
+}
+
+func eventHistoryQueryFromContext(ctx echo.Context, authInfo *auth.AuthInfo) (types.EventQuery, error) {
+	limit, err := eventQueryLimit(ctx)
+	if err != nil {
+		return types.EventQuery{}, HTTPBadRequest("Invalid event limit")
+	}
+	query := types.EventQuery{
+		Limit:       limit,
+		WorkspaceID: requestedEventWorkspaceID(ctx, authInfo),
+		StubID:      ctx.QueryParam("stub_id"),
+		AppID:       ctx.QueryParam("app_id"),
+		TaskID:      ctx.QueryParam("task_id"),
+		ContainerID: ctx.QueryParam("container_id"),
+		EventTypes:  eventQueryTypesFromParam(ctx.QueryParam("event_types")),
+	}
+
+	if raw := ctx.QueryParam("start_time"); raw != "" {
+		start, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return types.EventQuery{}, HTTPBadRequest("Invalid start time")
+		}
+		start = start.UTC()
+		query.StartTime = &start
+	}
+	if raw := ctx.QueryParam("end_time"); raw != "" {
+		end, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return types.EventQuery{}, HTTPBadRequest("Invalid end time")
+		}
+		end = end.UTC()
+		query.EndTime = &end
+	}
+	if query.StartTime != nil && query.EndTime != nil && !query.EndTime.After(*query.StartTime) {
+		return types.EventQuery{}, HTTPBadRequest("Invalid event time range")
+	}
+	return query, nil
 }
 
 func eventStreamQueryFromContext(ctx echo.Context, authInfo *auth.AuthInfo) (types.EventQuery, error) {

--- a/pkg/api/v1/events_test.go
+++ b/pkg/api/v1/events_test.go
@@ -154,3 +154,34 @@ func TestEventStreamQueryFromContextUsesLastEventID(t *testing.T) {
 		t.Fatalf("unexpected resumed seq_num: %#v", query.SeqNum)
 	}
 }
+
+func TestEventHistoryQueryFromContextParsesFilters(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/?event_types=stub.state.warning,stub.state.degraded&stub_id=stub-1&container_id=container-1&start_time=2026-05-28T10:00:00Z&end_time=2026-05-28T10:05:00Z&limit=25", nil)
+	ctx := e.NewContext(req, httptest.NewRecorder())
+	ctx.SetParamNames("workspaceId")
+	ctx.SetParamValues("workspace-1")
+
+	query, err := eventHistoryQueryFromContext(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := query.WorkspaceID, "workspace-1"; got != want {
+		t.Fatalf("unexpected workspace id: got %q want %q", got, want)
+	}
+	if got, want := query.StubID, "stub-1"; got != want {
+		t.Fatalf("unexpected stub id: got %q want %q", got, want)
+	}
+	if got, want := query.ContainerID, "container-1"; got != want {
+		t.Fatalf("unexpected container id: got %q want %q", got, want)
+	}
+	if got, want := query.Limit, uint64(25); got != want {
+		t.Fatalf("unexpected limit: got %d want %d", got, want)
+	}
+	if query.StartTime == nil || query.EndTime == nil {
+		t.Fatal("expected start and end times")
+	}
+	if got, want := len(query.EventTypes), 2; got != want {
+		t.Fatalf("unexpected event type count: got %d want %d", got, want)
+	}
+}

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -790,6 +790,81 @@ func (c *Client) rawReadInto(ctx context.Context, host *Host, hash string, offse
 	return length, nil
 }
 
+func (c *Client) rawReadPrefixInto(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (read int64, err error) {
+	if len(dst) == 0 {
+		return 0, nil
+	}
+	if host == nil || !c.clientConfig.ReadTransport.Enabled {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, ErrUnableToReachHost
+	}
+	addr := host.Addr
+	if host.PrivateAddr != "" {
+		addr = host.PrivateAddr
+	}
+	if addr == "" {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, ErrUnableToReachHost
+	}
+
+	c.mu.Lock()
+	pool := c.rawReadPools[host.HostId]
+	if pool == nil {
+		pool = newRawReadConnPool(addr, c.clientConfig.ReadTransport.MaxActiveConnsPerHost, c.clientConfig.ReadTransport.MaxIdleConnsPerHost)
+		c.rawReadPools[host.HostId] = pool
+	}
+	c.mu.Unlock()
+
+	conn, err := pool.get(ctx.Done())
+	if err != nil {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, err
+	}
+	reusable := false
+	defer func() {
+		if reusable {
+			pool.put(conn)
+		} else {
+			_ = conn.Close()
+			pool.release()
+		}
+	}()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+		defer conn.SetDeadline(time.Time{})
+	}
+
+	length := int64(len(dst))
+	if err := writeRawReadRequest(conn, hash, offset, length); err != nil {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, err
+	}
+	status, responseLength, err := readRawReadResponseHeader(conn)
+	if err != nil {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, err
+	}
+	if status == rawReadStatusMiss {
+		cacheReadRawFallbackTotal.Inc()
+		atomic.AddInt64(&cachePathStats.clientRawMisses, 1)
+		reusable = true
+		return 0, ErrContentNotFound
+	}
+	if status != rawReadStatusOK || responseLength <= 0 || responseLength > length {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, ErrUnableToReachHost
+	}
+	if _, err := io.ReadFull(conn, dst[:responseLength]); err != nil {
+		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
+		return 0, err
+	}
+	cacheReadRawTransportTotal.Inc()
+	atomic.AddInt64(&cachePathStats.clientRawHits, 1)
+	reusable = true
+	return responseLength, nil
+}
+
 func (c *Client) rawReadIntoWindowed(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (int64, error) {
 	if len(dst) == 0 {
 		return 0, nil
@@ -1065,7 +1140,7 @@ func (c *Client) promoteRemotePageRegionsToClientLocalPageFiles(host *Host, hash
 	}
 
 	promoteLength := promoteEnd - pageStart
-	if maxBytes := c.clientConfig.Prefetch.AheadBytes; maxBytes > 0 && promoteLength > maxBytes {
+	if maxBytes := c.clientConfig.Prefetch.AheadBytes; maxBytes > 0 && length > maxBytes {
 		return nil, false
 	}
 	if promoteLength > int64(int(^uint(0)>>1)) {
@@ -1086,15 +1161,21 @@ func (c *Client) promoteRemotePageRegionsToClientLocalPageFiles(host *Host, hash
 	buf := make([]byte, int(promoteLength))
 	ctx, cancel := context.WithTimeout(c.ctx, getContentRequestTimeout)
 	defer cancel()
+
 	n, err := c.rawReadIntoWindowed(ctx, host, hash, pageStart, buf)
-	if err != nil || n != promoteLength {
-		if err != nil && err != ErrContentNotFound {
-			Logger.Debugf("cache remote page-region raw promotion failed: host=%s hash=%s offset=%d length=%d err=%v", host.HostId, hash, pageStart, promoteLength, err)
+	if err == nil && n == promoteLength {
+		store.PutFullPages(hash, pageStart, buf)
+	} else {
+		n, err = c.rawReadPrefixInto(ctx, host, hash, pageStart, buf)
+		if err != nil || n <= 0 {
+			if err != nil && err != ErrContentNotFound {
+				Logger.Debugf("cache remote page-region raw promotion failed: host=%s hash=%s offset=%d length=%d err=%v", host.HostId, hash, pageStart, promoteLength, err)
+			}
+			return nil, false
 		}
-		return nil, false
+		store.PutPageRange(hash, pageStart, buf[:n])
 	}
 
-	store.PutFullPages(hash, pageStart, buf)
 	views, ok := clientLocalPageFileViewsFromStore(store, hash, offset, length)
 	if !ok {
 		return nil, false

--- a/pkg/cache/raw_transport.go
+++ b/pkg/cache/raw_transport.go
@@ -223,9 +223,9 @@ func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
 		return
 	}
 
-	regions, ok, err := cs.rawReadPageRegions(req)
+	regions, responseLength, ok, err := cs.rawReadPageRegions(req)
 	if err == nil && ok {
-		if err := writeRawReadResponseHeader(conn, rawReadStatusOK, req.length); err != nil {
+		if err := writeRawReadResponseHeader(conn, rawReadStatusOK, responseLength); err != nil {
 			return
 		}
 		usedSendfile := false
@@ -319,29 +319,34 @@ func isRawReadClientAbort(err error) bool {
 	return strings.Contains(msg, "broken pipe") || strings.Contains(msg, "connection reset by peer")
 }
 
-func (cs *Server) rawReadPageRegions(req rawReadRequest) ([]rawReadPageRegion, bool, error) {
+func (cs *Server) rawReadPageRegions(req rawReadRequest) ([]rawReadPageRegion, int64, bool, error) {
 	pageSize := cs.serverConfig.PageSizeBytes
 	if pageSize <= 0 || req.length <= 0 {
-		return nil, false, nil
+		return nil, 0, false, nil
 	}
 	regions := make([]rawReadPageRegion, 0, 1)
 	remaining := req.length
 	currentOffset := req.offset
+	var responseLength int64
 	for remaining > 0 {
 		pageRemaining := pageSize - currentOffset%pageSize
 		readLength := min(remaining, pageRemaining)
 		path, pageOffset, n, ok, err := cs.cas.PageRegion(req.hash, currentOffset, readLength)
 		if err != nil || !ok || n <= 0 {
-			return nil, false, err
-		}
-		if int64(n) != readLength {
-			return nil, false, ErrContentNotFound
+			return nil, 0, false, err
 		}
 		regions = append(regions, rawReadPageRegion{path: path, pageOffset: pageOffset, length: n})
+		responseLength += int64(n)
+		if int64(n) != readLength {
+			// A short page-region read is the CAS representation for the final
+			// partial page. Exact-read clients reject the short response; page
+			// promotion clients use it to install the EOF tail locally.
+			return regions, responseLength, true, nil
+		}
 		currentOffset += int64(n)
 		remaining -= int64(n)
 	}
-	return regions, true, nil
+	return regions, responseLength, true, nil
 }
 
 type rawReadConnPool struct {

--- a/pkg/cache/raw_transport_test.go
+++ b/pkg/cache/raw_transport_test.go
@@ -143,6 +143,71 @@ func TestClientLocalPageFileViewsPromotesRemotePageRegionRange(t *testing.T) {
 	require.Equal(t, content, dst)
 }
 
+func TestClientLocalPageFileViewsPromotesRemoteFinalPartialPage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+			ReadTransport: ServerReadTransportConfig{
+				Enabled:  true,
+				Sendfile: false,
+			},
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	remoteServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	addr, err := remoteServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remoteServer.Close()) })
+
+	content := []byte("abcdefghij")
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+	require.NoError(t, remoteServer.cas.Add(context.Background(), hash, content))
+
+	localStore := newTestStore(t, 4)
+	localStore.currentHost = &Host{HostId: "local-host"}
+
+	remoteHost := remoteServer.Host()
+	require.NotNil(t, remoteHost)
+	remoteHost.Addr = addr
+	remoteHost.PrivateAddr = addr
+
+	client := &Client{
+		ctx:                   ctx,
+		clientConfig:          ClientConfig{NTopHosts: 1, ReadTransport: ClientReadTransportConfig{Enabled: true}},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		localPromotionSem:     make(chan struct{}, 1),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	client.AttachLocalServer(&Server{cas: localStore})
+
+	regions, err := client.ClientLocalPageFileViews(hash, 0, int64(len(content)), ClientOptions{})
+	require.NoError(t, err)
+	require.Len(t, regions, 3)
+	require.Equal(t, 2, regions[2].Length)
+
+	dst := make([]byte, len(content))
+	n, err := localStore.ReadAt(hash, 0, dst)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+}
+
 func TestClientLocalPageFileViewsPromotesRemotePageRegionForSubPageRead(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -207,4 +272,72 @@ func TestClientLocalPageFileViewsPromotesRemotePageRegionForSubPageRead(t *testi
 	require.NoError(t, err)
 	require.Equal(t, int64(4), n)
 	require.Equal(t, []byte("abcd"), dst)
+}
+
+func TestClientLocalPageFileViewsAllowsRoundedPromotionOverPrefetchCap(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+			ReadTransport: ServerReadTransportConfig{
+				Enabled:  true,
+				Sendfile: false,
+			},
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	remoteServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	addr, err := remoteServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remoteServer.Close()) })
+
+	content := []byte("abcdefghijklmnop")
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+	require.NoError(t, remoteServer.cas.Add(context.Background(), hash, content))
+
+	localStore := newTestStore(t, 4)
+	localStore.currentHost = &Host{HostId: "local-host"}
+
+	remoteHost := remoteServer.Host()
+	require.NotNil(t, remoteHost)
+	remoteHost.Addr = addr
+	remoteHost.PrivateAddr = addr
+
+	client := &Client{
+		ctx: ctx,
+		clientConfig: ClientConfig{
+			NTopHosts:     1,
+			ReadTransport: ClientReadTransportConfig{Enabled: true},
+			Prefetch:      ReadPrefetchConfig{AheadBytes: 8},
+		},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		localPromotionSem:     make(chan struct{}, 1),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	client.AttachLocalServer(&Server{cas: localStore})
+
+	regions, err := client.ClientLocalPageFileViews(hash, 6, 8, ClientOptions{})
+	require.NoError(t, err)
+	require.Len(t, regions, 3)
+
+	dst := make([]byte, 12)
+	n, err := localStore.ReadAt(hash, 4, dst)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(dst)), n)
+	require.Equal(t, []byte("efghijklmnop"), dst)
 }

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -365,6 +365,14 @@ func (cas *Store) AddReader(ctx context.Context, reader io.Reader) (string, int6
 }
 
 func (cas *Store) PutFullPages(hash string, offset int64, data []byte) {
+	cas.putPages(hash, offset, data, false)
+}
+
+func (cas *Store) PutPageRange(hash string, offset int64, data []byte) {
+	cas.putPages(hash, offset, data, true)
+}
+
+func (cas *Store) putPages(hash string, offset int64, data []byte, includePartialTail bool) {
 	if hash == "" || offset < 0 || len(data) == 0 || cas.serverConfig.PageSizeBytes <= 0 || cas.diskCachedUsageExceeded {
 		return
 	}
@@ -374,7 +382,11 @@ func (cas *Store) PutFullPages(hash string, offset int64, data []byte) {
 		return
 	}
 	fullPages := int64(len(data)) / pageSize
-	if fullPages <= 0 {
+	pageCount := fullPages
+	if includePartialTail && int64(len(data))%pageSize != 0 {
+		pageCount++
+	}
+	if pageCount <= 0 {
 		return
 	}
 	if err := os.MkdirAll(cas.pageDir(hash), 0755); err != nil {
@@ -382,13 +394,23 @@ func (cas *Store) PutFullPages(hash string, offset int64, data []byte) {
 		return
 	}
 
-	for page := int64(0); page < fullPages; page++ {
+	for page := int64(0); page < pageCount; page++ {
 		start := page * pageSize
 		end := start + pageSize
+		if end > int64(len(data)) {
+			end = int64(len(data))
+		}
+		if end <= start {
+			return
+		}
 		pageIdx := (offset / pageSize) + page
 		pagePath := cas.pagePath(hash, pageIdx)
 		pageLock := cas.pageLock(hash, pageIdx)
 		pageLock.Lock()
+		if _, info, err := cas.existingPagePath(hash, pageIdx); err == nil && info.Size() >= end-start {
+			pageLock.Unlock()
+			continue
+		}
 		err := writeCacheChunkAtomic(pagePath, data[start:end])
 		pageLock.Unlock()
 		if err != nil {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -224,6 +224,7 @@ type TailscaleRepository interface {
 
 type EventRepository interface {
 	GetContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error)
+	GetEventHistory(ctx context.Context, query types.EventQuery) (*types.EventHistoryResponse, error)
 	GetLogs(ctx context.Context, query types.LogQuery) (*types.LogsResponse, error)
 	GetStubMetricsTimeseries(ctx context.Context, query types.EventQuery, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error)
 	GetWorkspaceMetricsTimeseries(ctx context.Context, query types.EventQuery, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -20,6 +20,7 @@ type eventSink interface {
 
 type eventReader interface {
 	GetContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error)
+	GetEventHistory(ctx context.Context, query types.EventQuery) (*types.EventHistoryResponse, error)
 	GetLogs(ctx context.Context, query types.LogQuery) (*types.LogsResponse, error)
 	GetStubMetricsTimeseries(ctx context.Context, query types.EventQuery, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error)
 	GetWorkspaceMetricsTimeseries(ctx context.Context, query types.EventQuery, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error)
@@ -168,6 +169,13 @@ func (r *EventClientRepo) GetContainerEvents(ctx context.Context, containerID st
 		return nil, ErrEventReadUnsupported
 	}
 	return r.reader.GetContainerEvents(ctx, containerID, query)
+}
+
+func (r *EventClientRepo) GetEventHistory(ctx context.Context, query types.EventQuery) (*types.EventHistoryResponse, error) {
+	if r.reader == nil {
+		return nil, ErrEventReadUnsupported
+	}
+	return r.reader.GetEventHistory(ctx, query)
 }
 
 func (r *EventClientRepo) GetLogs(ctx context.Context, query types.LogQuery) (*types.LogsResponse, error) {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -20,6 +20,7 @@ import (
 const (
 	defaultS2EventStreamPrefix = "events"
 	defaultS2EventReadLimit    = 10000
+	s2EventHistoryReadLimit    = uint64(1000)
 	s2EventQueueSize           = 16384
 	s2EventBatchSize           = 256
 	s2EventRetentionSeconds    = int64(30 * 24 * 60 * 60)
@@ -238,6 +239,38 @@ func (r *S2EventRepository) GetContainerEvents(ctx context.Context, containerID 
 	return response, nil
 }
 
+func (r *S2EventRepository) GetEventHistory(ctx context.Context, query types.EventQuery) (*types.EventHistoryResponse, error) {
+	limit := query.Limit
+	if limit == 0 {
+		limit = defaultS2EventReadLimit
+	}
+
+	if err := r.ensureBasin(ctx); err != nil {
+		return nil, err
+	}
+
+	streams, err := r.resolveEventHistoryStreams(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &types.EventHistoryResponse{
+		Events:  []types.ContainerEventRecord{},
+		Streams: make([]string, 0, len(streams)),
+	}
+	for _, streamName := range streams {
+		if uint64(len(response.Events)) >= limit {
+			break
+		}
+		if err := r.readEventHistoryStream(ctx, streamName, query, limit, response); err != nil {
+			return nil, err
+		}
+	}
+
+	sortContainerEventRecords(response.Events)
+	return response, nil
+}
+
 func (r *S2EventRepository) StreamContainerEvents(ctx context.Context, containerID string, query types.EventQuery) (EventStream, error) {
 	if query.WorkspaceID == "" || query.StubID == "" {
 		return nil, fmt.Errorf("workspace id and stub id are required to stream container events")
@@ -351,6 +384,37 @@ func (r *S2EventRepository) resolveContainerStreams(ctx context.Context, contain
 	return streams, nil
 }
 
+func (r *S2EventRepository) resolveEventHistoryStreams(ctx context.Context, query types.EventQuery) ([]s2.StreamName, error) {
+	addIfExists := func(streamName s2.StreamName) ([]s2.StreamName, error) {
+		if streamName == "" {
+			return nil, nil
+		}
+		exists, err := r.streamExists(ctx, streamName)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+		return []s2.StreamName{streamName}, nil
+	}
+
+	switch {
+	case query.ContainerID != "" && query.WorkspaceID != "":
+		return r.resolveContainerStreams(ctx, query.ContainerID, query)
+	case query.TaskID != "":
+		return addIfExists(r.taskStreamName(query.TaskID))
+	case query.AppID != "" && query.WorkspaceID != "":
+		return addIfExists(r.appStreamName(query.WorkspaceID, query.AppID))
+	case query.StubID != "" && query.WorkspaceID != "":
+		return addIfExists(r.stubStreamName(query.WorkspaceID, query.StubID))
+	case query.WorkspaceID != "":
+		return addIfExists(r.workspaceStreamName(query.WorkspaceID))
+	default:
+		return nil, nil
+	}
+}
+
 func (r *S2EventRepository) streamExists(ctx context.Context, streamName s2.StreamName) (bool, error) {
 	limit := 1
 	resp, err := r.basin.Streams.List(ctx, &s2.ListStreamsArgs{
@@ -385,6 +449,82 @@ func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName 
 			continue
 		}
 		response.Events = append(response.Events, eventRecord)
+	}
+	return nil
+}
+
+func (r *S2EventRepository) readEventHistoryStream(ctx context.Context, streamName s2.StreamName, query types.EventQuery, limit uint64, response *types.EventHistoryResponse) error {
+	response.Streams = append(response.Streams, string(streamName))
+
+	var nextSeqNum *uint64
+	if query.SeqNum != nil {
+		seq := *query.SeqNum
+		nextSeqNum = &seq
+	}
+	var startTimestamp *uint64
+	if query.StartTime != nil {
+		ts := uint64(query.StartTime.UTC().UnixMilli())
+		startTimestamp = &ts
+	} else if query.Timestamp != nil {
+		ts := *query.Timestamp
+		startTimestamp = &ts
+	}
+	var until *uint64
+	if query.EndTime != nil {
+		ts := uint64(query.EndTime.UTC().UnixMilli())
+		until = &ts
+	} else if query.Until != nil {
+		ts := *query.Until
+		until = &ts
+	}
+
+	for uint64(len(response.Events)) < limit {
+		count := s2EventHistoryReadLimit
+		if remaining := limit - uint64(len(response.Events)); remaining < count {
+			count = remaining
+		}
+		opts := &s2.ReadOptions{
+			Count: &count,
+			Until: until,
+		}
+		if nextSeqNum != nil {
+			opts.SeqNum = nextSeqNum
+		} else if startTimestamp != nil {
+			opts.Timestamp = startTimestamp
+		} else {
+			seq := uint64(0)
+			opts.SeqNum = &seq
+		}
+
+		batch, err := r.basin.Stream(streamName).Read(ctx, opts)
+		if err != nil {
+			if isS2RangeNotSatisfiable(err) {
+				return nil
+			}
+			return fmt.Errorf("read event history from s2 stream %q: %w", streamName, err)
+		}
+		if len(batch.Records) == 0 {
+			return nil
+		}
+
+		for _, record := range batch.Records {
+			eventRecord, ok := containerEventRecordFromS2(record, query, &types.ContainerEventsResponse{})
+			if !ok || !eventRecordMatchesQuery(eventRecord, query) {
+				continue
+			}
+			response.Events = append(response.Events, eventRecord)
+			if uint64(len(response.Events)) >= limit {
+				break
+			}
+		}
+
+		last := batch.Records[len(batch.Records)-1]
+		seq := last.SeqNum + 1
+		nextSeqNum = &seq
+		startTimestamp = nil
+		if len(batch.Records) < int(count) {
+			return nil
+		}
 	}
 	return nil
 }
@@ -496,11 +636,44 @@ func eventQueryAllowsType(query types.EventQuery, eventType string) bool {
 		return true
 	}
 	for _, allowed := range query.EventTypes {
-		if strings.TrimSpace(allowed) == eventType {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == eventType {
+			return true
+		}
+		if strings.HasSuffix(allowed, "*") && strings.HasPrefix(eventType, strings.TrimSuffix(allowed, "*")) {
 			return true
 		}
 	}
 	return false
+}
+
+func eventRecordMatchesQuery(record types.ContainerEventRecord, query types.EventQuery) bool {
+	if query.WorkspaceID != "" && record.WorkspaceID != query.WorkspaceID {
+		return false
+	}
+	if query.StubID != "" && record.StubID != query.StubID {
+		return false
+	}
+	if query.AppID != "" && record.AppID != query.AppID {
+		return false
+	}
+	if query.TaskID != "" && record.TaskID != query.TaskID {
+		return false
+	}
+	if query.ContainerID != "" && record.ContainerID != query.ContainerID {
+		return false
+	}
+	eventTime := record.Timestamp
+	if eventTime.IsZero() {
+		eventTime = record.StartTime
+	}
+	if query.StartTime != nil && !eventTime.IsZero() && eventTime.Before(query.StartTime.UTC()) {
+		return false
+	}
+	if query.EndTime != nil && !eventTime.IsZero() && !eventTime.Before(query.EndTime.UTC()) {
+		return false
+	}
+	return true
 }
 
 func s2TimestampMillisToNanos(timestamp uint64) uint64 {
@@ -642,6 +815,9 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 	if metadata.WorkspaceID != "" && metadata.StubID != "" {
 		add(r.stubStreamName(metadata.WorkspaceID, metadata.StubID))
 	}
+	if isStubEvent(eventType) && metadata.WorkspaceID != "" {
+		add(r.workspaceStreamName(metadata.WorkspaceID))
+	}
 	if isWorkspaceContainerRealtimeEvent(eventType) && metadata.WorkspaceID != "" {
 		add(r.workspaceStreamName(metadata.WorkspaceID))
 	}
@@ -656,6 +832,10 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 
 func isTaskEvent(eventType string) bool {
 	return eventType == types.EventTaskCreated || eventType == types.EventTaskUpdated
+}
+
+func isStubEvent(eventType string) bool {
+	return strings.HasPrefix(eventType, "stub.")
 }
 
 func isWorkspaceContainerRealtimeEvent(eventType string) bool {

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -71,6 +71,28 @@ func TestS2ContainerMetricsAlsoUseWorkspaceAggregateStream(t *testing.T) {
 	}
 }
 
+func TestS2StubEventsAlsoUseWorkspaceAggregateStream(t *testing.T) {
+	repo := &S2EventRepository{streamPrefix: "events"}
+
+	streams := repo.streamNamesForEvent("stub.state.degraded", eventMetadata{
+		WorkspaceID: "workspace-123",
+		StubID:      "stub-456",
+	})
+
+	want := []s2.StreamName{
+		"events/workspaces/workspace-123/stubs/stub-456",
+		"events/workspaces/workspace-123",
+	}
+	if len(streams) != len(want) {
+		t.Fatalf("unexpected stub stream count: got %d want %d: %#v", len(streams), len(want), streams)
+	}
+	for i := range want {
+		if streams[i] != want[i] {
+			t.Fatalf("unexpected stub stream at %d: got %q want %q", i, streams[i], want[i])
+		}
+	}
+}
+
 func TestS2ContainerLogsUseDifferentiatedLogStreams(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 
@@ -361,6 +383,42 @@ func TestEventQueryAllowsType(t *testing.T) {
 	}
 	if !eventQueryAllowsType(types.EventQuery{}, types.EventContainerLog) {
 		t.Fatal("empty event type filter should allow all events")
+	}
+	if !eventQueryAllowsType(types.EventQuery{EventTypes: []string{"stub.state.*"}}, "stub.state.degraded") {
+		t.Fatal("expected wildcard event type to be allowed")
+	}
+}
+
+func TestEventRecordMatchesQueryFiltersByScopeAndTime(t *testing.T) {
+	start := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	query := types.EventQuery{
+		WorkspaceID: "workspace-1",
+		StubID:      "stub-1",
+		TaskID:      "task-1",
+		StartTime:   &start,
+		EndTime:     &end,
+	}
+
+	record := types.ContainerEventRecord{
+		WorkspaceID: "workspace-1",
+		StubID:      "stub-1",
+		TaskID:      "task-1",
+		Timestamp:   start.Add(time.Minute),
+	}
+	if !eventRecordMatchesQuery(record, query) {
+		t.Fatal("expected scoped record inside time range to match")
+	}
+
+	record.WorkspaceID = ""
+	if eventRecordMatchesQuery(record, query) {
+		t.Fatal("expected missing workspace metadata to be rejected")
+	}
+
+	record.WorkspaceID = "workspace-1"
+	record.Timestamp = end
+	if eventRecordMatchesQuery(record, query) {
+		t.Fatal("expected end time to be exclusive")
 	}
 }
 

--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -239,37 +239,28 @@ func (s *GeeseStorage) Mount(localPath string) error {
 		flags.ExternalCacheDirectIO = s.config.CacheDirectIO
 	}
 
-	fs, mfs, err := core.MountFuse(context.Background(), s.config.BucketName, flags)
+	mountCtx, cancel := context.WithTimeout(context.Background(), defaultGeeseFSMountTimeout)
+	defer cancel()
+
+	fs, mfs, err := core.MountFuse(mountCtx, s.config.BucketName, flags)
 	if err != nil {
 		log.Error().Err(err).Str("local_path", localPath).Msg("geesefs: mount process exited with error")
 		return err
 	}
 
-	// Poll until the filesystem is mounted or we timeout
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	timeout := time.After(defaultGeeseFSMountTimeout)
-
-	done := make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-timeout:
-				done <- false
-				return
-			case <-ticker.C:
-				if isMounted(localPath) {
-					done <- true
-					return
-				}
-			}
+	for {
+		if isMounted(localPath) {
+			break
 		}
-	}()
 
-	// Wait for confirmation or timeout
-	if !<-done {
-		return fmt.Errorf("failed to mount GeeseFS filesystem to: '%s'", localPath)
+		select {
+		case <-mountCtx.Done():
+			return fmt.Errorf("failed to mount GeeseFS filesystem to: '%s': %w", localPath, mountCtx.Err())
+		case <-ticker.C:
+		}
 	}
 
 	log.Info().Str("local_path", localPath).Msg("geesefs: filesystem mounted")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,12 +1,16 @@
 package storage
 
 import (
+	"bufio"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/beam-cloud/beta9/pkg/cache"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -23,16 +27,54 @@ type Storage interface {
 	Mode() string
 }
 
-// isMounted uses stat to check if the specified FUSE mount point is available
+// IsMounted reports whether mountPoint is present in mountinfo without touching
+// the mounted filesystem. FUSE calls like statfs can block if the daemon is wedged.
+func IsMounted(mountPoint string) bool {
+	return isMounted(mountPoint)
+}
+
 func isMounted(mountPoint string) bool {
-	var statfs unix.Statfs_t
-	if err := unix.Statfs(mountPoint, &statfs); err != nil {
+	file, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
 		return false
 	}
+	defer file.Close()
 
-	// FUSE filesystems usually have a magic number 0x65735546 (FUSE_SUPER_MAGIC)
-	const FUSE_SUPER_MAGIC = 0x65735546
-	return statfs.Type == FUSE_SUPER_MAGIC
+	return mountInfoContains(file, mountPoint)
+}
+
+func mountInfoContains(reader io.Reader, mountPoint string) bool {
+	target := cleanMountInfoPath(mountPoint)
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 {
+			continue
+		}
+
+		if cleanMountInfoPath(unescapeMountInfoPath(fields[4])) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanMountInfoPath(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}
+
+func unescapeMountInfoPath(path string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\`,
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	)
+	return replacer.Replace(path)
 }
 
 func NewStorage(config types.StorageConfig, cacheClient *cache.Client) (Storage, error) {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,0 +1,26 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMountInfoContains(t *testing.T) {
+	mountInfo := strings.NewReader(strings.Join([]string{
+		"31 23 0:27 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw",
+		"74 34 0:65 / /storage/workspace\\040name rw,nosuid,nodev,relatime - fuse.geesefs geesefs rw,user_id=0,group_id=0",
+		"75 34 0:66 / /storage/other rw,nosuid,nodev,relatime - fuse.geesefs geesefs rw,user_id=0,group_id=0",
+	}, "\n"))
+
+	if !mountInfoContains(mountInfo, "/storage/workspace name") {
+		t.Fatal("expected escaped mountinfo path to match requested mount point")
+	}
+}
+
+func TestMountInfoContainsDoesNotMatchPrefix(t *testing.T) {
+	mountInfo := strings.NewReader("75 34 0:66 / /storage/workspace-extra rw,nosuid,nodev,relatime - fuse.geesefs geesefs rw\n")
+
+	if mountInfoContains(mountInfo, "/storage/workspace") {
+		t.Fatal("did not expect mountinfo prefix to match requested mount point")
+	}
+}

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -613,18 +613,21 @@ type EventPlatformLogSchema struct {
 }
 
 type EventQuery struct {
-	Limit       uint64   `json:"limit,omitempty"`
-	WorkspaceID string   `json:"workspace_id,omitempty"`
-	StubID      string   `json:"stub_id,omitempty"`
-	AppID       string   `json:"app_id,omitempty"`
-	TaskID      string   `json:"task_id,omitempty"`
-	EventTypes  []string `json:"event_types,omitempty"`
-	SeqNum      *uint64  `json:"seq_num,omitempty"`
-	Timestamp   *uint64  `json:"timestamp,omitempty"`
-	TailOffset  *int64   `json:"tail_offset,omitempty"`
-	Until       *uint64  `json:"until,omitempty"`
-	WaitSeconds *int32   `json:"wait,omitempty"`
-	Clamp       *bool    `json:"clamp,omitempty"`
+	Limit       uint64     `json:"limit,omitempty"`
+	WorkspaceID string     `json:"workspace_id,omitempty"`
+	StubID      string     `json:"stub_id,omitempty"`
+	AppID       string     `json:"app_id,omitempty"`
+	TaskID      string     `json:"task_id,omitempty"`
+	ContainerID string     `json:"container_id,omitempty"`
+	EventTypes  []string   `json:"event_types,omitempty"`
+	StartTime   *time.Time `json:"start_time,omitempty"`
+	EndTime     *time.Time `json:"end_time,omitempty"`
+	SeqNum      *uint64    `json:"seq_num,omitempty"`
+	Timestamp   *uint64    `json:"timestamp,omitempty"`
+	TailOffset  *int64     `json:"tail_offset,omitempty"`
+	Until       *uint64    `json:"until,omitempty"`
+	WaitSeconds *int32     `json:"wait,omitempty"`
+	Clamp       *bool      `json:"clamp,omitempty"`
 }
 
 type LogQuery struct {
@@ -748,6 +751,11 @@ type ContainerEventsResponse struct {
 	Events         []ContainerEventRecord `json:"events"`
 	Missing        []string               `json:"missing"`
 	Streams        []string               `json:"streams,omitempty"`
+}
+
+type EventHistoryResponse struct {
+	Events  []ContainerEventRecord `json:"events"`
+	Streams []string               `json:"streams,omitempty"`
 }
 
 func ContainerEventDomain(id ContainerEventID) EventDomain {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -38,12 +38,12 @@ import (
 )
 
 const (
-	imageBundlePath                string = "/dev/shm/images"
-	imageTmpDir                    string = "/tmp"
-	metricsSourceLabel                    = "image_client"
-	pullLazyBackoff                       = 1000 * time.Millisecond
-	embeddedImageCacheWaitTimeout         = 2 * time.Minute
-	embeddedImageCacheWaitInterval        = 250 * time.Millisecond
+	imageBundlePath                   string = "/dev/shm/images"
+	imageTmpDir                       string = "/tmp"
+	metricsSourceLabel                       = "image_client"
+	pullLazyBackoff                          = 1000 * time.Millisecond
+	embeddedImageCacheLockWaitTimeout        = 2 * time.Second
+	embeddedImageCacheWaitInterval           = 250 * time.Millisecond
 )
 
 var (
@@ -911,6 +911,11 @@ func (c *ImageClient) pullImageArchiveFromEmbeddedCache(ctx context.Context, arc
 					"reason": "store_lock_contended",
 				})
 				return false, waitErr
+			} else {
+				c.recordImageLifecycle(request, types.ContainerLifecycleImageEmbeddedCacheWait, waitStart, time.Since(waitStart), false, map[string]string{
+					"reason": "store_lock_contended",
+				})
+				return false, nil
 			}
 		}
 		return false, err
@@ -935,7 +940,7 @@ func (c *ImageClient) pullImageArchiveFromEmbeddedCache(ctx context.Context, arc
 }
 
 func (c *ImageClient) waitForImageArchiveContentCache(ctx context.Context, archivePath, imageId string) (bool, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, embeddedImageCacheWaitTimeout)
+	waitCtx, cancel := context.WithTimeout(ctx, embeddedImageCacheLockWaitTimeout)
 	defer cancel()
 
 	ticker := time.NewTicker(embeddedImageCacheWaitInterval)
@@ -953,10 +958,13 @@ func (c *ImageClient) waitForImageArchiveContentCache(ctx context.Context, archi
 
 		select {
 		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
 			if lastErr != nil {
 				return false, lastErr
 			}
-			return false, waitCtx.Err()
+			return false, nil
 		case <-ticker.C:
 		}
 	}

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -88,6 +88,36 @@ func (c *ContainerMountManager) SetupContainerMounts(ctx context.Context, reques
 	return nil
 }
 
+func (c *ContainerMountManager) RequiresWorkspaceStorageMount(request *types.ContainerRequest) bool {
+	if request == nil || !request.StorageAvailable() {
+		return false
+	}
+
+	if request.IsBuildRequest() {
+		return true
+	}
+
+	directCodeDownload := workspaceStorageDownloadAvailable(request.Workspace.Storage)
+	for _, mount := range request.Mounts {
+		if mount.MountPath == types.WorkerUserCodeVolume {
+			if !directCodeDownload {
+				return true
+			}
+			continue
+		}
+
+		if mount.MountType == storage.StorageModeMountPoint {
+			continue
+		}
+
+		if workspaceStorageMountPath(request, mount) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (c *ContainerMountManager) setupUserCodeMount(ctx context.Context, request *types.ContainerRequest) (string, error) {
 	destPath := types.TempContainerWorkspace(request.ContainerId)
 	readyPath := filepath.Join(filepath.Dir(destPath), ".workspace-ready")
@@ -174,6 +204,18 @@ func (c *ContainerMountManager) extractStubCode(ctx context.Context, request *ty
 
 	objectPath := filepath.Join(types.DefaultObjectPath, request.Workspace.Name, objectID)
 	return common.ExtractObjectFile(ctx, objectPath, destPath)
+}
+
+func workspaceStorageMountPath(request *types.ContainerRequest, mount types.Mount) bool {
+	if strings.HasPrefix(mount.MountPath, types.WorkerContainerVolumePath) ||
+		strings.HasPrefix(mount.MountPath, types.WorkerUserOutputVolume) {
+		return true
+	}
+
+	workspaceVolumeRoot := path.Join(types.DefaultVolumesPath, request.Workspace.Name)
+	workspaceOutputRoot := path.Join(types.DefaultOutputsPath, request.Workspace.Name)
+	return strings.HasPrefix(mount.LocalPath, workspaceVolumeRoot) ||
+		strings.HasPrefix(mount.LocalPath, workspaceOutputRoot)
 }
 
 func workspaceStorageDownloadAvailable(storage *types.WorkspaceStorage) bool {

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -156,17 +156,17 @@ func (c *ContainerMountManager) ensureStubCodeCache(ctx context.Context, request
 func (c *ContainerMountManager) extractStubCode(ctx context.Context, request *types.ContainerRequest, destPath string) error {
 	objectID := request.Stub.Object.ExternalId
 	if request.StorageAvailable() {
-		workspaceObjectPath := filepath.Join(c.storageConfig.WorkspaceStorage.BaseMountPath, request.Workspace.Name, types.DefaultObjectPrefix, objectID)
-		if pathExists(workspaceObjectPath) {
-			return common.ExtractObjectFile(ctx, workspaceObjectPath, destPath)
-		}
-
 		if workspaceStorageDownloadAvailable(request.Workspace.Storage) {
 			log.Info().
 				Str("container_id", request.ContainerId).
 				Str("object_id", objectID).
-				Msg("downloading stub code from workspace storage")
+				Msg("downloading stub code directly from workspace storage")
 			return getAndExtractStubCodeToPath(ctx, request, destPath)
+		}
+
+		workspaceObjectPath := filepath.Join(c.storageConfig.WorkspaceStorage.BaseMountPath, request.Workspace.Name, types.DefaultObjectPrefix, objectID)
+		if pathExists(workspaceObjectPath) {
+			return common.ExtractObjectFile(ctx, workspaceObjectPath, destPath)
 		}
 
 		return fmt.Errorf("workspace object not available at %s and direct download is not configured", workspaceObjectPath)

--- a/pkg/worker/mount_test.go
+++ b/pkg/worker/mount_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/storage"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -124,6 +125,54 @@ func TestSetupContainerMountsPrefersDirectWorkspaceStorageForStubCode(t *testing
 	require.Equal(t, "direct\n", string(workspaceBytes))
 }
 
+func TestRequiresWorkspaceStorageMount(t *testing.T) {
+	manager := NewContainerMountManager(types.AppConfig{})
+
+	t.Run("direct storage user code only", func(t *testing.T) {
+		request := stubCodeMountRequest("container-direct-code", "workspace", "object")
+		request.Workspace.Storage = directWorkspaceStorage()
+
+		require.False(t, manager.RequiresWorkspaceStorageMount(request))
+	})
+
+	t.Run("legacy storage user code", func(t *testing.T) {
+		request := stubCodeMountRequest("container-legacy-code", "workspace", "object")
+
+		require.True(t, manager.RequiresWorkspaceStorageMount(request))
+	})
+
+	t.Run("workspace volume", func(t *testing.T) {
+		request := stubCodeMountRequest("container-volume", "workspace", "object")
+		request.Workspace.Storage = directWorkspaceStorage()
+		request.Mounts = append(request.Mounts, types.Mount{
+			MountPath: types.WorkerContainerVolumePath + "/data",
+			LocalPath: filepath.Join(types.DefaultVolumesPath, request.Workspace.Name, "data"),
+		})
+
+		require.True(t, manager.RequiresWorkspaceStorageMount(request))
+	})
+
+	t.Run("mountpoint storage", func(t *testing.T) {
+		request := stubCodeMountRequest("container-mountpoint", "workspace", "object")
+		request.Workspace.Storage = directWorkspaceStorage()
+		request.Mounts = []types.Mount{{
+			MountPath: "/mnt/s3",
+			MountType: storage.StorageModeMountPoint,
+		}}
+
+		require.False(t, manager.RequiresWorkspaceStorageMount(request))
+	})
+
+	t.Run("build request", func(t *testing.T) {
+		sourceImage := "alpine"
+		request := stubCodeMountRequest("container-build", "workspace", "object")
+		request.Workspace.Storage = directWorkspaceStorage()
+		request.BuildOptions.SourceImage = &sourceImage
+
+		require.True(t, manager.RequiresWorkspaceStorageMount(request))
+	})
+}
+
 func stubCodeMountRequest(containerID, workspaceName, objectID string) *types.ContainerRequest {
 	storageID := uint(1)
 	return &types.ContainerRequest{
@@ -138,6 +187,21 @@ func stubCodeMountRequest(containerID, workspaceName, objectID string) *types.Co
 		Mounts: []types.Mount{{
 			MountPath: types.WorkerUserCodeVolume,
 		}},
+	}
+}
+
+func directWorkspaceStorage() *types.WorkspaceStorage {
+	storageID := uint(1)
+	bucket := "bucket"
+	accessKey := "access"
+	secretKey := "secret"
+	region := "us-east-1"
+	return &types.WorkspaceStorage{
+		Id:         &storageID,
+		BucketName: &bucket,
+		AccessKey:  &accessKey,
+		SecretKey:  &secretKey,
+		Region:     &region,
 	}
 }
 

--- a/pkg/worker/mount_test.go
+++ b/pkg/worker/mount_test.go
@@ -2,9 +2,12 @@ package worker
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,6 +70,60 @@ func TestStubCodeCacheKeyDoesNotCollideAcrossWorkspaceObjectPairs(t *testing.T) 
 	require.NotContains(t, key2, string(filepath.Separator))
 }
 
+func TestSetupContainerMountsPrefersDirectWorkspaceStorageForStubCode(t *testing.T) {
+	manager := NewContainerMountManager(types.AppConfig{
+		Storage: types.StorageConfig{
+			WorkspaceStorage: types.WorkspaceStorageConfig{
+				BaseMountPath: t.TempDir(),
+			},
+		},
+	})
+	manager.codeCacheRoot = t.TempDir()
+
+	workspace := "workspace-direct"
+	objectID := "object-direct"
+	mountedObjectPath := filepath.Join(manager.storageConfig.WorkspaceStorage.BaseMountPath, workspace, types.DefaultObjectPrefix, objectID)
+	require.NoError(t, writeZipObject(mountedObjectPath, map[string]string{
+		"main.py": "mounted\n",
+	}))
+
+	directObject, err := zipObjectBytes(map[string]string{
+		"main.py": "direct\n",
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(directObject)
+	}))
+	t.Cleanup(server.Close)
+
+	request := stubCodeMountRequest("container-direct", workspace, objectID)
+	bucket := "bucket"
+	accessKey := "access"
+	secretKey := "secret"
+	region := "us-east-1"
+	endpoint := server.URL
+	storageID := uint(1)
+	request.Workspace.Storage = &types.WorkspaceStorage{
+		Id:          &storageID,
+		BucketName:  &bucket,
+		AccessKey:   &accessKey,
+		SecretKey:   &secretKey,
+		Region:      &region,
+		EndpointUrl: &endpoint,
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(types.TempContainerWorkspace(request.ContainerId))) })
+
+	require.NoError(t, manager.SetupContainerMounts(context.Background(), request, discardLogger()))
+
+	workspacePath := request.Mounts[0].LocalPath
+	workspaceBytes, err := os.ReadFile(filepath.Join(workspacePath, "main.py"))
+	require.NoError(t, err)
+	require.Equal(t, "direct\n", string(workspaceBytes))
+}
+
 func stubCodeMountRequest(containerID, workspaceName, objectID string) *types.ContainerRequest {
 	storageID := uint(1)
 	return &types.ContainerRequest{
@@ -113,4 +170,24 @@ func writeZipObject(path string, files map[string]string) error {
 	}
 
 	return nil
+}
+
+func zipObjectBytes(files map[string]string) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for name, contents := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			_ = writer.Close()
+			return nil, err
+		}
+		if _, err := entry.Write([]byte(contents)); err != nil {
+			_ = writer.Close()
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
 }

--- a/pkg/worker/storage_manager.go
+++ b/pkg/worker/storage_manager.go
@@ -26,7 +26,8 @@ type WorkspaceStorageManager struct {
 	config             types.StorageConfig
 	poolConfig         types.WorkerPoolConfig
 	containerInstances *common.SafeMap[*ContainerInstance]
-	mu                 sync.Mutex
+	mountLocks         map[string]*sync.Mutex
+	mountLocksMu       sync.Mutex
 	cacheClient        *cache.Client
 }
 
@@ -37,7 +38,7 @@ func NewWorkspaceStorageManager(ctx context.Context, config types.StorageConfig,
 		config:             config,
 		poolConfig:         poolConfig,
 		containerInstances: containerInstances,
-		mu:                 sync.Mutex{},
+		mountLocks:         make(map[string]*sync.Mutex),
 		cacheClient:        cacheClient,
 	}
 
@@ -52,27 +53,38 @@ func NewWorkspaceStorageManager(ctx context.Context, config types.StorageConfig,
 }
 
 func (sm *WorkspaceStorageManager) Create(workspaceName string, storage storage.Storage) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+	unlock := sm.lockWorkspaceMount(workspaceName)
+	defer unlock()
 
 	sm.mounts.Set(workspaceName, storage)
 }
 
 func (sm *WorkspaceStorageManager) Mount(workspaceName string, workspaceStorage *types.WorkspaceStorage) (storage.Storage, error) {
+	mountPath := path.Join(sm.config.WorkspaceStorage.BaseMountPath, workspaceName)
 	mount, ok := sm.mounts.Get(workspaceName)
-	if ok {
+	if ok && workspaceMountHealthy(mount, mountPath) {
 		return mount, nil
 	}
 
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+	unlock := sm.lockWorkspaceMount(workspaceName)
+	defer unlock()
 
 	mount, ok = sm.mounts.Get(workspaceName)
 	if ok {
-		return mount, nil
-	}
+		if workspaceMountHealthy(mount, mountPath) {
+			return mount, nil
+		}
 
-	mountPath := path.Join(sm.config.WorkspaceStorage.BaseMountPath, workspaceName)
+		log.Warn().
+			Str("workspace_name", workspaceName).
+			Str("local_path", mountPath).
+			Msg("workspace storage mount is registered but not mounted, remounting")
+		if err := mount.Unmount(mountPath); err != nil {
+			log.Warn().Err(err).Str("workspace_name", workspaceName).Str("local_path", mountPath).Msg("failed to unmount stale workspace storage")
+		}
+		sm.mounts.Delete(workspaceName)
+		_ = os.RemoveAll(mountPath)
+	}
 
 	var err error
 	switch sm.poolConfig.StorageMode {
@@ -162,8 +174,8 @@ func (sm *WorkspaceStorageManager) Unmount(workspaceName string) error {
 		return nil
 	}
 
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+	unlock := sm.lockWorkspaceMount(workspaceName)
+	defer unlock()
 
 	mount, ok = sm.mounts.Get(workspaceName)
 	if !ok {
@@ -188,6 +200,28 @@ func (sm *WorkspaceStorageManager) Unmount(workspaceName string) error {
 	sm.mounts.Delete(workspaceName)
 
 	return nil
+}
+
+func (sm *WorkspaceStorageManager) lockWorkspaceMount(workspaceName string) func() {
+	sm.mountLocksMu.Lock()
+	lock, ok := sm.mountLocks[workspaceName]
+	if !ok {
+		lock = &sync.Mutex{}
+		sm.mountLocks[workspaceName] = lock
+	}
+	sm.mountLocksMu.Unlock()
+
+	lock.Lock()
+	return lock.Unlock
+}
+
+func workspaceMountHealthy(mount storage.Storage, mountPath string) bool {
+	switch mount.Mode() {
+	case storage.StorageModeGeese, storage.StorageModeJuiceFS, storage.StorageModeMountPoint:
+		return storage.IsMounted(mountPath)
+	default:
+		return true
+	}
 }
 
 func (sm *WorkspaceStorageManager) Cleanup() error {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -568,7 +568,7 @@ func (s *Worker) runContainerRequest(request *types.ContainerRequest) {
 	}
 
 	run := func() error {
-		if request.StorageAvailable() {
+		if s.containerMountManager.RequiresWorkspaceStorageMount(request) {
 			log.Info().Str("container_id", containerId).Msg("mounting workspace storage")
 			if _, err := s.storageManager.Mount(request.Workspace.Name, request.Workspace.Storage); err != nil {
 				log.Error().Str("container_id", containerId).Str("workspace_id", request.Workspace.ExternalId).Err(err).Msg("unable to mount workspace storage")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a historical events API and expands event routing so more sources write to workspace streams. Also improves cache page promotion, mount health, and prefers direct workspace storage for stub code.

- New Features
  - New GET `/api/v1/events/:workspaceId/history` to read past events with filters: `stub_id`, `app_id`, `task_id`, `container_id`, `event_types` (supports wildcard suffix), `start_time`, `end_time`, `limit`.
  - S2 backend implements `GetEventHistory` with paging, time bounds, and scope resolution (workspace, stub, app, task, container). Results are sorted and include the source streams.
  - Stub events now also emit to the workspace stream for better aggregation.
  - Event type filter accepts wildcards (e.g., `stub.state.*`).

- Bug Fixes
  - Cache raw transport handles final partial pages and promotes them locally; adds prefix raw-read and `PutPageRange`. Allows page-aligned promotion even when it exceeds the prefetch cap.
  - Storage and worker: prefer direct workspace storage download for stub code and mount only when needed; add per-workspace mount locks and non-blocking mount health checks via `/proc/self/mountinfo` with a GeeseFS mount timeout; remount stale mounts; shorten and make image-cache contention waits non-fatal.

<sup>Written for commit aba63631794c7e4ad932e73f47f766808eecd0b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1588?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

