### PR TITLE
bump clip and geese

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docs/*.md
 /metrics.jsonl
 /summary.json
 /summary.md
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260529013932-1de9dc7c5f96
+	github.com/beam-cloud/clip v0.0.0-20260529181234-f1322f68780f
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260529071516-27bd3d9c3967
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260529181234-9d5414f087f0
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -128,12 +128,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/clip v0.0.0-20260529013932-1de9dc7c5f96 h1:XjmoEdXZv0+3EBsOp9gyKMAjQNhBaKYwM4iaPr4f6rY=
-github.com/beam-cloud/clip v0.0.0-20260529013932-1de9dc7c5f96/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/geesefs v0.0.0-20260529070132-807108470bf5 h1:XAwPTC2RewEP98LqDhVNI7tpeKBsWZfCKzAaT1tUt+8=
-github.com/beam-cloud/geesefs v0.0.0-20260529070132-807108470bf5/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
-github.com/beam-cloud/geesefs v0.0.0-20260529071516-27bd3d9c3967 h1:UiBid3cacn7T0py+dnlTUGCX9T3GDISqeBsK3H9e0ds=
-github.com/beam-cloud/geesefs v0.0.0-20260529071516-27bd3d9c3967/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/clip v0.0.0-20260529181234-f1322f68780f h1:pwznEi6wGfj7MN0rlPzDmSlHScsp7aGbCrXAwgODFV4=
+github.com/beam-cloud/clip v0.0.0-20260529181234-f1322f68780f/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
+github.com/beam-cloud/geesefs v0.0.0-20260529181234-9d5414f087f0 h1:w39FZqMFa6BN/hh/mbwIuMCe61Vk5j5v0jH/MR7xKgA=
+github.com/beam-cloud/geesefs v0.0.0-20260529181234-9d5414f087f0/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -260,6 +260,52 @@ func (c *imageContentCache) StoreContent(chunks chan []byte, hash string, opts s
 	return actualHash, err
 }
 
+func (c *imageContentCache) StoreContentFromLocalPath(path string, hash string, opts struct{ RoutingKey string }) (actualHash string, err error) {
+	if c == nil || c.client == nil {
+		return "", cache.ErrClientNotFound
+	}
+	if opts.RoutingKey == "" {
+		opts.RoutingKey = hash
+	}
+
+	started := time.Now()
+	c.storeRequests.Add(1)
+	defer func() {
+		elapsed := time.Since(started)
+		if err != nil {
+			c.storeErrors.Add(1)
+			log.Warn().
+				Err(err).
+				Str("image_id", c.imageID).
+				Str("kind", c.kind).
+				Str("hash", shortHash(hash)).
+				Str("routing_key", shortHash(opts.RoutingKey)).
+				Str("path", path).
+				Dur("elapsed", elapsed).
+				Msg("clip image content cache local-path store result")
+		} else if elapsed > imageContentCacheSlowStore {
+			log.Debug().
+				Str("image_id", c.imageID).
+				Str("kind", c.kind).
+				Str("hash", shortHash(hash)).
+				Str("actual_hash", shortHash(actualHash)).
+				Str("routing_key", shortHash(opts.RoutingKey)).
+				Str("path", path).
+				Dur("elapsed", elapsed).
+				Msg("clip image content cache local-path store result")
+		}
+		c.maybeLogSummary()
+	}()
+
+	return c.client.StoreContentFromLocalFile(cache.LocalContentSource{
+		Path:      path,
+		CachePath: path,
+	}, cache.StoreContentOptions{
+		RoutingKey: opts.RoutingKey,
+		Lock:       true,
+	})
+}
+
 func drainImageContentChunks(chunks <-chan []byte) {
 	for range chunks {
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds local-path image caching to speed uploads and improve observability. Also updates storage deps and ignores Riptide artifacts.

- New Features
  - Added image cache method StoreContentFromLocalPath(path, hash, opts).
  - Uses `clip` local file source with locking and routing key defaulting to the hash.
  - Tracks requests/errors and logs slow operations.

- Dependencies
  - Bumped `github.com/beam-cloud/clip` to v0.0.0-20260529181234-f1322f68780f.
  - Updated `github.com/yandex-cloud/geesefs` replace to `github.com/beam-cloud/geesefs` v0.0.0-20260529181234-9d5414f087f.

<sup>Written for commit a0ef68ba4ca4dcea0f0990b3e04771526760ab72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

