### PR TITLE
add hrw test harness

### DIFF
--- a/benchmarks/b9bench/cache_tools/hrw_routing.go
+++ b/benchmarks/b9bench/cache_tools/hrw_routing.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	rendezvous "github.com/beam-cloud/rendezvous"
+)
+
+type host struct {
+	HostID         string `json:"hostId"`
+	RegistrationID string `json:"registrationId,omitempty"`
+	NodeID         string `json:"nodeId,omitempty"`
+	NodeName       string `json:"nodeName,omitempty"`
+	Addr           string `json:"addr,omitempty"`
+	PrivateAddr    string `json:"privateAddr,omitempty"`
+	Pod            string `json:"pod,omitempty"`
+}
+
+func (h *host) Bytes() []byte {
+	return []byte(h.HostID)
+}
+
+type route struct {
+	Key   string  `json:"key"`
+	Hosts []*host `json:"hosts"`
+}
+
+func main() {
+	hostsJSON := flag.String("hosts-json", "", "JSON array of cache hosts")
+	keysCSV := flag.String("keys", "", "comma-separated routing keys")
+	n := flag.Int("n", 1, "number of HRW hosts per key")
+	flag.Parse()
+
+	if *hostsJSON == "" || *keysCSV == "" {
+		fmt.Fprintln(os.Stderr, "hosts-json and keys are required")
+		os.Exit(2)
+	}
+
+	var hosts []*host
+	if err := json.Unmarshal([]byte(*hostsJSON), &hosts); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	hash := rendezvous.New[*host]()
+	for _, host := range hosts {
+		if host != nil && host.HostID != "" {
+			hash.Add(host)
+		}
+	}
+
+	var routes []route
+	for _, key := range strings.Split(*keysCSV, ",") {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		routes = append(routes, route{Key: key, Hosts: hash.GetN(*n, key)})
+	}
+
+	_ = json.NewEncoder(os.Stdout).Encode(routes)
+}

--- a/benchmarks/b9bench/clip_layer_suite.py
+++ b/benchmarks/b9bench/clip_layer_suite.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from b9bench.cache_suite import Kube, run
+from b9bench.cache_suite import Kube, find_redis_pod, redis_cli, run
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -45,6 +45,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--size-mib", type=int, default=128)
     parser.add_argument("--timeout-seconds", type=float, default=1200)
     parser.add_argument("--read-timeout-seconds", type=float, default=240)
+    parser.add_argument("--cache-pool-name", default=os.getenv("BENCH_CACHE_POOL_NAME", "default"))
+    parser.add_argument("--cache-locality", default=os.getenv("BENCH_CACHE_LOCALITY", "default"))
     parser.add_argument("--reset-workers-between", dest="reset_workers_between", action="store_true")
     parser.add_argument("--no-reset-workers-between", dest="reset_workers_between", action="store_false")
     parser.set_defaults(reset_workers_between=True)
@@ -289,6 +291,241 @@ def embedded_cache_page_proof(kube: Kube, hashes: list[str]) -> dict[str, Any]:
     return proof
 
 
+def cache_hosts_snapshot(kube: Kube, pool_name: str, locality: str) -> dict[str, Any]:
+    redis_pod = find_redis_pod(kube.config.namespace)
+    if not redis_pod:
+        return cache_hosts_from_worker_logs(kube)
+
+    index_pattern = f"cache:coordinator:host_index:*:{locality}"
+    index_keys = [
+        line.strip()
+        for line in (redis_cli(kube.config.namespace, redis_pod, "KEYS", index_pattern) or "").splitlines()
+        if line.strip()
+    ]
+    if not index_keys:
+        index_keys = [f"cache:coordinator:host_index:{pool_name}:{locality}"]
+
+    logical_host_ids: list[str] = []
+    seen = set()
+    for index_key in index_keys:
+        members = redis_cli(kube.config.namespace, redis_pod, "SMEMBERS", index_key) or ""
+        for line in members.splitlines():
+            logical_host_id = line.strip()
+            if logical_host_id and logical_host_id not in seen:
+                seen.add(logical_host_id)
+                logical_host_ids.append(logical_host_id)
+
+    hosts: list[dict[str, Any]] = []
+    for logical_host_id in logical_host_ids:
+        for registration_id in registration_ids(kube.config.namespace, redis_pod, logical_host_id):
+            raw = redis_cli(
+                kube.config.namespace,
+                redis_pod,
+                "GET",
+                f"cache:coordinator:host:{logical_host_id}:registration:{registration_id}",
+            )
+            if not raw:
+                continue
+            try:
+                registration = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            hosts.append(
+                {
+                    "hostId": registration.get("logical_host_id")
+                    or registration.get("logicalHostId")
+                    or logical_host_id,
+                    "registrationId": registration.get("registration_id")
+                    or registration.get("registrationId")
+                    or registration_id,
+                    "poolName": registration.get("pool_name")
+                    or registration.get("poolName")
+                    or pool_name,
+                    "nodeId": registration.get("node_id") or registration.get("nodeId") or "",
+                    "nodeName": registration.get("node_id") or registration.get("nodeId") or "",
+                    "cachePathId": registration.get("cache_path_id")
+                    or registration.get("cachePathId")
+                    or "",
+                    "addr": registration.get("addr") or "",
+                    "privateAddr": registration.get("private_addr")
+                    or registration.get("privateAddr")
+                    or "",
+                    "source": "coordinator",
+                }
+            )
+            break
+    if hosts:
+        return {"available": True, "source": "coordinator", "indexKeys": index_keys, "hosts": hosts}
+    return cache_hosts_from_worker_logs(kube)
+
+
+def registration_ids(namespace: str, redis_pod: str, logical_host_id: str) -> list[str]:
+    active = redis_cli(
+        namespace,
+        redis_pod,
+        "GET",
+        f"cache:coordinator:host:{logical_host_id}:active_registration",
+    )
+    ids = [active.strip()] if active and active.strip() else []
+    ids.extend(
+        registration_id.strip()
+        for registration_id in (
+            redis_cli(namespace, redis_pod, "SMEMBERS", f"cache:coordinator:host:{logical_host_id}:registrations")
+            or ""
+        ).splitlines()
+        if registration_id.strip() and registration_id.strip() not in ids
+    )
+    return ids
+
+
+def cache_hosts_from_worker_logs(kube: Kube) -> dict[str, Any]:
+    hosts_by_id: dict[str, dict[str, Any]] = {}
+    for pod in kube.running_workers():
+        proc = run(
+            [
+                "kubectl",
+                "-n",
+                kube.config.namespace,
+                "logs",
+                pod["name"],
+                "-c",
+                "worker",
+                "--since",
+                "2h",
+                "--tail",
+                "10000",
+            ],
+            check=False,
+            timeout=30,
+        )
+        if proc.returncode != 0:
+            continue
+        latest: dict[str, Any] | None = None
+        for line in proc.stdout.splitlines():
+            if "Registered cache host" not in line:
+                continue
+            start = line.find("{")
+            end = line.rfind("}")
+            if start < 0 or end <= start:
+                continue
+            try:
+                latest = json.loads(line[start : end + 1])
+            except json.JSONDecodeError:
+                continue
+        if not latest:
+            continue
+        host_id = latest.get("logical_host_id") or latest.get("logicalHostId")
+        registration_id = latest.get("registration_id") or latest.get("registrationId")
+        addr = latest.get("addr") or ""
+        if not host_id or not registration_id:
+            continue
+        hosts_by_id[host_id] = {
+            "hostId": host_id,
+            "registrationId": registration_id,
+            "poolName": latest.get("pool_name") or latest.get("poolName") or "",
+            "nodeId": latest.get("node_id") or latest.get("nodeId") or pod.get("nodeName", ""),
+            "nodeName": pod.get("nodeName", ""),
+            "cachePathId": latest.get("cache_path_id") or latest.get("cachePathId") or "",
+            "addr": addr,
+            "privateAddr": addr,
+            "pod": pod.get("name", ""),
+            "source": "worker_logs",
+        }
+    hosts = list(hosts_by_id.values())
+    return {"available": bool(hosts), "source": "worker_logs", "hosts": hosts}
+
+
+def hrw_routing_proof(
+    kube: Kube,
+    hashes: list[str],
+    page_proof: dict[str, Any],
+    artifact_dir: Path,
+    pool_name: str,
+    locality: str,
+) -> dict[str, Any]:
+    proof: dict[str, Any] = {
+        "ok": False,
+        "hashes": hashes,
+        "hostsSnapshot": cache_hosts_snapshot(kube, pool_name, locality),
+        "routes": [],
+    }
+    hosts = proof["hostsSnapshot"].get("hosts") or []
+    if not hashes:
+        proof["error"] = "no hashes provided"
+        return proof
+    if not hosts:
+        proof["error"] = "no active cache hosts found"
+        return proof
+
+    go = shutil.which("go")
+    if not go:
+        proof["error"] = "go not found"
+        return proof
+
+    env = dict(os.environ)
+    bundled_goroot = "/opt/homebrew/Cellar/go/1.24.2/libexec"
+    if Path(bundled_goroot).exists():
+        env["GOROOT"] = bundled_goroot
+
+    proc = subprocess.run(
+        [
+            go,
+            "run",
+            "./benchmarks/b9bench/cache_tools/hrw_routing.go",
+            "--hosts-json",
+            json.dumps(hosts, sort_keys=True),
+            "--keys",
+            ",".join(hashes),
+            "--n",
+            "1",
+        ],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    if proc.returncode != 0:
+        proof["error"] = proc.stderr.strip()[-1000:] or f"hrw helper exited {proc.returncode}"
+        return proof
+
+    routes = json.loads(proc.stdout)
+    pages_by_hash_node: dict[tuple[str, str], int] = {}
+    for worker in page_proof.get("workers") or []:
+        node = worker.get("nodeName") or ""
+        for row in worker.get("rows") or []:
+            pages_by_hash_node[(row.get("hash") or "", node)] = int(row.get("pages") or 0)
+
+    checked = []
+    ok = True
+    for route in routes:
+        key = route.get("key") or ""
+        selected = (route.get("hosts") or [{}])[0]
+        node = selected.get("nodeName") or selected.get("nodeId") or ""
+        pages = pages_by_hash_node.get((key, node), 0)
+        item = {
+            "hash": key,
+            "selectedHostId": selected.get("hostId") or "",
+            "selectedRegistrationId": selected.get("registrationId") or "",
+            "selectedNode": node,
+            "selectedPod": selected.get("pod") or "",
+            "pagesOnSelectedNode": pages,
+            "ok": pages > 0,
+        }
+        checked.append(item)
+        ok = ok and item["ok"]
+
+    proof["routes"] = checked
+    proof["ok"] = ok
+    if not ok:
+        (artifact_dir / "clip-hrw-routing-proof.json").write_text(
+            json.dumps(proof, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return proof
+
+
 def clip_disk_cache_presence(kube: Kube, hashes: list[str]) -> dict[str, Any]:
     proof: dict[str, Any] = {"hashes": hashes, "workers": []}
     if not hashes:
@@ -349,31 +586,6 @@ def extract_archive_hashes(kube: Kube, image_id: str, artifact_dir: Path) -> lis
     workers = kube.running_workers()
     if not workers:
         return []
-    archive = artifact_dir / f"{image_id}.clip"
-    copied = False
-    for pod in workers:
-        proc = subprocess.run(
-            [
-                "kubectl",
-                "-n",
-                kube.config.namespace,
-                "cp",
-                "-c",
-                "worker",
-                f"{pod['name']}:/images/cache/{image_id}.clip",
-                str(archive),
-            ],
-            cwd=REPO_ROOT,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            timeout=60,
-        )
-        if proc.returncode == 0 and archive.exists():
-            copied = True
-            break
-    if not copied:
-        return []
     go = shutil.which("go")
     if not go:
         return []
@@ -381,18 +593,46 @@ def extract_archive_hashes(kube: Kube, image_id: str, artifact_dir: Path) -> lis
     bundled_goroot = "/opt/homebrew/Cellar/go/1.24.2/libexec"
     if Path(bundled_goroot).exists():
         env["GOROOT"] = bundled_goroot
-    proc = subprocess.run(
-        [go, "run", "./benchmarks/b9bench/cache_tools/clip_hashes.go", str(archive)],
-        cwd=REPO_ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        timeout=120,
-        env=env,
-    )
-    if proc.returncode != 0:
-        return []
-    return list(json.loads(proc.stdout))
+
+    for suffix in (".rclip", ".clip"):
+        archive = artifact_dir / f"{image_id}{suffix}"
+        for pod in workers:
+            proc = subprocess.run(
+                [
+                    "kubectl",
+                    "-n",
+                    kube.config.namespace,
+                    "cp",
+                    "-c",
+                    "worker",
+                    f"{pod['name']}:/images/cache/{image_id}{suffix}",
+                    str(archive),
+                ],
+                cwd=REPO_ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=60,
+            )
+            if proc.returncode != 0 or not archive.exists():
+                continue
+
+            parse = subprocess.run(
+                [go, "run", "./benchmarks/b9bench/cache_tools/clip_hashes.go", str(archive)],
+                cwd=REPO_ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=120,
+                env=env,
+            )
+            if parse.returncode == 0:
+                return list(json.loads(parse.stdout))
+            (artifact_dir / f"{image_id}{suffix}.clip_hashes.err").write_text(
+                parse.stderr,
+                encoding="utf-8",
+            )
+    return []
 
 
 def terminate(instance) -> None:
@@ -417,6 +657,7 @@ def main() -> int:
         "startedAt": utc_now(),
         "probeId": probe_id,
         "sizeMiB": args.size_mib,
+        "resetWorkersBetween": args.reset_workers_between,
         "iterations": [],
         "validationFailures": validation_failures,
     }
@@ -435,6 +676,14 @@ def main() -> int:
         report["iterations"].append(first)
         first_hashes = first.get("logSummary", {}).get("decompressedHashes") or report["decompressedHashes"]
         first["embeddedCachePageProof"] = embedded_cache_page_proof(kube, first_hashes)
+        first["hrwRoutingProof"] = hrw_routing_proof(
+            kube,
+            first_hashes,
+            first["embeddedCachePageProof"],
+            artifact_dir,
+            args.cache_pool_name,
+            args.cache_locality,
+        )
         first["clipDiskCachePresence"] = clip_disk_cache_presence(kube, first_hashes)
 
         if args.reset_workers_between:
@@ -442,15 +691,26 @@ def main() -> int:
             if not report["workerReset"].get("ok"):
                 validation_failures.append(f"worker reset failed: {report['workerReset']}")
             kube.wait_running_workers(min_count=1, timeout=max(180, args.timeout_seconds / 4))
-            if args.clear_clip_disk_cache:
-                report["postResetClipDiskCacheClear"] = clear_clip_decompressed_disk_cache(kube, report["decompressedHashes"])
-                report["postResetClipDiskCachePresence"] = clip_disk_cache_presence(kube, report["decompressedHashes"])
+
+        second_hashes = first_hashes or report["decompressedHashes"]
+        if args.clear_clip_disk_cache:
+            report["preSecondClipDiskCacheClear"] = clear_clip_decompressed_disk_cache(kube, second_hashes)
+            report["preSecondClipDiskCachePresence"] = clip_disk_cache_presence(kube, second_hashes)
 
         second_since = utc_now()
-        second = run_iteration(kube, image, image_id, "after_worker_kill", args, artifact_dir, second_since)
+        second_name = "after_worker_kill" if args.reset_workers_between else "stable_second_read"
+        second = run_iteration(kube, image, image_id, second_name, args, artifact_dir, second_since)
         report["iterations"].append(second)
-        second_hashes = second.get("logSummary", {}).get("decompressedHashes") or first_hashes or report["decompressedHashes"]
+        second_hashes = second.get("logSummary", {}).get("decompressedHashes") or second_hashes
         second["embeddedCachePageProof"] = embedded_cache_page_proof(kube, second_hashes)
+        second["hrwRoutingProof"] = hrw_routing_proof(
+            kube,
+            second_hashes,
+            second["embeddedCachePageProof"],
+            artifact_dir,
+            args.cache_pool_name,
+            args.cache_locality,
+        )
         second["clipDiskCachePresence"] = clip_disk_cache_presence(kube, second_hashes)
 
         validate_report(report, validation_failures)
@@ -502,7 +762,7 @@ def run_iteration(
 def validate_report(report: dict[str, Any], failures: list[str]) -> None:
     iterations = report.get("iterations") or []
     if len(iterations) < 2:
-        failures.append("expected cold and after-worker-kill iterations")
+        failures.append("expected cold and second read iterations")
         return
     cold, after = iterations[0], iterations[1]
     for item in iterations:
@@ -514,22 +774,27 @@ def validate_report(report: dict[str, Any], failures: list[str]) -> None:
     if not cold.get("embeddedCachePageProof", {}).get("ok"):
         failures.append("cold iteration did not materialize embedded cache pages")
     if not after.get("embeddedCachePageProof", {}).get("ok"):
-        failures.append("after-worker-kill iteration could not find embedded cache pages")
+        failures.append(f"{after.get('name')} iteration could not find embedded cache pages")
+    if not cold.get("hrwRoutingProof", {}).get("ok"):
+        failures.append("cold iteration did not materialize pages on HRW-selected cache hosts")
+    if not after.get("hrwRoutingProof", {}).get("ok"):
+        failures.append(f"{after.get('name')} iteration did not find pages on HRW-selected cache hosts")
 
     cold_logs = cold.get("logSummary") or {}
     after_logs = after.get("logSummary") or {}
     if not report.get("decompressedHashes"):
         failures.append("could not extract OCI decompressed layer hashes from clip archive")
-    if cold.get("clipDiskCachePresence", {}).get("present"):
-        failures.append("cold iteration left CLIP local decompressed disk cache present")
+    if report.get("preSecondClipDiskCachePresence", {}).get("present"):
+        failures.append("CLIP local decompressed disk cache was still present before second iteration")
     if after.get("clipDiskCachePresence", {}).get("present"):
-        failures.append("after-worker-kill iteration used/materialized CLIP local decompressed disk cache")
+        failures.append(f"{after.get('name')} iteration used/materialized CLIP local decompressed disk cache")
     if after_logs.get("ociCacheMisses", 0) > 0 or after_logs.get("layerDecompressed", 0) > 0:
-        failures.append("after-worker-kill iteration fell back to OCI registry/decompression")
-    cold_worker = ((cold.get("worker") or {}).get("name") or "")
-    after_worker = ((after.get("worker") or {}).get("name") or "")
-    if cold_worker and after_worker and cold_worker == after_worker:
-        failures.append(f"worker did not change across reset: {cold_worker}")
+        failures.append(f"{after.get('name')} iteration fell back to OCI registry/decompression")
+    if report.get("resetWorkersBetween", True):
+        cold_worker = ((cold.get("worker") or {}).get("name") or "")
+        after_worker = ((after.get("worker") or {}).get("name") or "")
+        if cold_worker and after_worker and cold_worker == after_worker:
+            failures.append(f"worker did not change across reset: {cold_worker}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/b9bench/runner.py
+++ b/benchmarks/b9bench/runner.py
@@ -599,11 +599,13 @@ class ClipLayerSuiteProbe(ScriptProbeBase):
             read = item.get("read") or {}
             logs = item.get("logSummary") or {}
             page_proof = item.get("embeddedCachePageProof") or {}
+            hrw_proof = item.get("hrwRoutingProof") or {}
             clip_disk = item.get("clipDiskCachePresence") or {}
             name = str(item.get("name") or "read")
             is_after_kill = name == "after_worker_kill"
+            is_second_read = is_after_kill or name == "stable_second_read"
             cloud_read = logs.get("ociCacheMisses", 0) > 0 or logs.get("layerDecompressed", 0) > 0
-            cache_hit = bool(page_proof.get("ok") and not clip_disk.get("present") and not cloud_read)
+            cache_hit = bool(page_proof.get("ok") and hrw_proof.get("ok") and not clip_disk.get("present") and not cloud_read)
             self.sink.emit(
                 Measurement(
                     run_id=self.run_id,
@@ -618,23 +620,28 @@ class ClipLayerSuiteProbe(ScriptProbeBase):
                     tags={
                         "suite_kind": suite.kind,
                         "requires_sha": True,
-                        "requires_cache_hit": is_after_kill,
-                        "reject_cloud_read": is_after_kill,
+                        "requires_cache_hit": is_second_read,
+                        "reject_cloud_read": is_second_read,
                         "requires_remote_worker": is_after_kill,
-                        "cache_state": "after_worker_kill" if is_after_kill else "cold",
+                        "cache_state": name if is_second_read else "cold",
                     },
                     evidence={
                         "sha_ok": bool(read.get("ok")),
                         "cache_hit": cache_hit,
                         "cache_source": "embedded_disk"
-                        if page_proof.get("ok")
+                        if page_proof.get("ok") and hrw_proof.get("ok")
                         else "unknown",
+                        "hrw_routed": bool(hrw_proof.get("ok")),
+                        "hrw_routes": hrw_proof.get("routes") or [],
                         "cloud_read": cloud_read,
                         "remote_worker": self._worker_changed(iterations)
                         if is_after_kill
                         else False,
                         "worker": ((item.get("worker") or {}).get("name") or ""),
-                        "decompressed_hashes": logs.get("decompressedHashes") or [],
+                        "decompressed_hashes": logs.get("decompressedHashes")
+                        or page_proof.get("hashes")
+                        or report.get("decompressedHashes")
+                        or [],
                         "artifact_output": str(
                             self.sink.artifact_dir / f"{slug(suite.name)}.json"
                         ),

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -556,16 +556,16 @@ func (c *Client) dataCallOptions() []grpc.CallOption {
 	return []grpc.CallOption{grpc.ForceCodecV2(cachegrpc.New(c.globalConfig.GRPCPayloadCodecMinBytes))}
 }
 
-func (c *Client) IsPathCachedNearby(ctx context.Context, path string) bool {
+func (c *Client) IsPathCachedReachable(ctx context.Context, path string) bool {
 	metadata, err := c.metadataStore.GetFsNode(ctx, GenerateFsID(path))
 	if err != nil {
 		Logger.Errorf("error getting fs node: %v, path: %s", err, path)
 		return false
 	}
 
-	exists, err := c.IsCachedNearby(metadata.Hash, path)
+	exists, err := c.IsCachedReachable(metadata.Hash, path)
 	if err != nil {
-		Logger.Errorf("error checking if content is cached nearby: %v, hash: %s", err, metadata.Hash)
+		Logger.Errorf("error checking if content is cached on a reachable cache host: %v, hash: %s", err, metadata.Hash)
 		return false
 	}
 
@@ -594,7 +594,7 @@ func (c *Client) cachedLocalFileHash(ctx context.Context, cachePath string, info
 	if routingKey == "" {
 		routingKey = cachePath
 	}
-	exists, err := c.IsCachedNearby(metadata.Hash, routingKey)
+	exists, err := c.IsCachedOnSelectedHost(metadata.Hash, routingKey)
 	if err != nil || !exists {
 		return "", false
 	}
@@ -612,7 +612,11 @@ func cacheFSMetadataMatchesFileInfo(metadata *FSMetadata, info os.FileInfo) bool
 		metadata.Mtimensec == uint32(modTime.Nanosecond())
 }
 
-func (c *Client) IsCachedNearby(hash string, routingKey string) (bool, error) {
+// IsCachedReachable reports whether hash exists on any currently reachable cache
+// host. It checks the HRW read order first, then scans remaining known hosts as
+// a recovery path for placement drift or host churn. Do not use it to decide
+// whether a cache-through write can be skipped.
+func (c *Client) IsCachedReachable(hash string, routingKey string) (bool, error) {
 	if routingKey == "" {
 		routingKey = hash
 	}
@@ -680,6 +684,39 @@ func (c *Client) IsCachedNearby(hash string, routingKey string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// IsCachedOnSelectedHost checks only the HRW-selected storage host for routingKey.
+// This is intentionally stricter than IsCachedReachable: cache-through writers use
+// it to avoid treating a fallback replica as proof that the primary placement is
+// already populated.
+func (c *Client) IsCachedOnSelectedHost(hash string, routingKey string) (bool, error) {
+	if routingKey == "" {
+		routingKey = hash
+	}
+
+	client, host, err := c.getGRPCClient(&ClientRequest{
+		rt:        ClientRequestTypeStorage,
+		hash:      hash,
+		key:       routingKey,
+		hostIndex: 0,
+	})
+	if err != nil {
+		if err == ErrHostNotFound {
+			_ = c.refreshRoutableHosts(c.ctx)
+		}
+		return false, err
+	}
+
+	resp, err := client.HasContent(c.ctx, &proto.CacheHasContentRequest{Hash: hash})
+	if err != nil {
+		c.removeHost(host)
+		return false, err
+	}
+	if !resp.Exists {
+		c.removeLocalHostCache(hash)
+	}
+	return resp.Exists, nil
 }
 
 func (c *Client) rawReadInto(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (read int64, err error) {
@@ -1424,7 +1461,7 @@ func (c *Client) waitForStoredContent(ctx context.Context, hash string, routingK
 	defer ticker.Stop()
 
 	for {
-		exists, err := c.IsCachedNearby(hash, routingKey)
+		exists, err := c.IsCachedOnSelectedHost(hash, routingKey)
 		if err == nil && exists {
 			return true
 		}

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -505,6 +505,108 @@ func TestStoreContentFromLocalFileWithHashWritesSelectedRemoteHost(t *testing.T)
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestStoreContentFromLocalFileRepairsSelectedHostWhenFallbackHasContent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Client: ClientConfig{
+			NTopHosts:            2,
+			PreferLocalCacheHost: true,
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	selectedServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("selected-host"))
+	require.NoError(t, err)
+	selectedAddr, err := selectedServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, selectedServer.Close()) })
+
+	fallbackCfg := cfg
+	fallbackCfg.Server.DiskCacheDir = t.TempDir()
+	fallbackServer, err := NewServerWithOptions(ctx, fallbackCfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("fallback-host"))
+	require.NoError(t, err)
+	fallbackAddr, err := fallbackServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fallbackServer.Close()) })
+
+	selectedHost := selectedServer.Host()
+	require.NotNil(t, selectedHost)
+	selectedHost.Addr = selectedAddr
+	selectedHost.PrivateAddr = selectedAddr
+
+	fallbackHost := fallbackServer.Host()
+	require.NotNil(t, fallbackHost)
+	fallbackHost.Addr = fallbackAddr
+	fallbackHost.PrivateAddr = fallbackAddr
+
+	content := []byte("cache-through-must-repair-selected-host")
+	sum := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(sum[:])
+	sourcePath := filepath.Join(t.TempDir(), "source.bin")
+	require.NoError(t, os.WriteFile(sourcePath, content, 0644))
+	info, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+
+	_, _, err = fallbackServer.cas.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+	require.False(t, selectedServer.cas.Exists(expectedHash))
+	require.True(t, fallbackServer.cas.Exists(expectedHash))
+
+	cachePath := "/workspace/source.bin"
+	metadataStore := NewMockCacheMetadataStore()
+	require.NoError(t, metadataStore.SetFsNode(ctx, GenerateFsID(cachePath), &FSMetadata{
+		Path:      cachePath,
+		Hash:      expectedHash,
+		Size:      uint64(info.Size()),
+		Mtime:     uint64(info.ModTime().Unix()),
+		Mtimensec: uint32(info.ModTime().Nanosecond()),
+	}))
+
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          cfg.Client,
+		globalConfig:          cfg.Global,
+		metadataStore:         metadataStore,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{selectedHost, fallbackHost}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(selectedHost))
+	require.NoError(t, client.addHost(fallbackHost))
+	defer client.Cleanup()
+
+	got, err := client.StoreContentFromLocalFile(LocalContentSource{
+		Path:      sourcePath,
+		CachePath: cachePath,
+	}, StoreContentOptions{
+		RoutingKey: expectedHash,
+		Lock:       true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
+
+	require.Eventually(t, func() bool {
+		selected := make([]byte, len(content))
+		n, err := selectedServer.cas.ReadAt(expectedHash, 0, selected)
+		return err == nil && n == int64(len(content)) && bytes.Equal(content, selected)
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestStoreContentFromReaderRetriesSeekableReaderAfterStreamError(t *testing.T) {
 	ctx := context.Background()
 	firstHost := &Host{HostId: "first-host"}

--- a/pkg/worker/file_cache.go
+++ b/pkg/worker/file_cache.go
@@ -141,7 +141,7 @@ func (cm *FileCacheManager) initWorkspace(workspaceName string) (string, error) 
 	workspaceVolumePath := filepath.Join(types.DefaultVolumesPath, workspaceName)
 	fileName := fmt.Sprintf("%s/.cache", workspaceVolumePath)
 
-	if cm.CacheAvailable() && cm.client.IsPathCachedNearby(context.Background(), fileName) {
+	if cm.CacheAvailable() && cm.client.IsPathCachedReachable(context.Background(), fileName) {
 		return workspaceVolumePath, nil
 	}
 

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -145,7 +145,7 @@ func (c *imageContentCache) ContentExists(hash string, opts struct{ RoutingKey s
 		c.maybeLogSummary()
 	}()
 
-	return c.client.IsCachedNearby(hash, opts.RoutingKey)
+	return c.client.IsCachedOnSelectedHost(hash, opts.RoutingKey)
 }
 
 func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, length int64, opts struct{ RoutingKey string }) (views []clipStorage.ClientLocalPageFileView, err error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an HRW routing test harness to `b9bench` and enforces checks against the HRW-selected host in the cache client. Improves reporting/metrics and fixes cache-through behavior to repair the selected host when only a fallback replica has content.

- New Features
  - Added `benchmarks/b9bench/cache_tools/hrw_routing.go` using `github.com/beam-cloud/rendezvous` to map keys to HRW-selected hosts.
  - `clip_layer_suite`: snapshots cache hosts from Redis or worker logs and produces an HRW routing proof that matches layer hashes to selected hosts; supports `.rclip` and `.clip`; new flags `--cache-pool-name` and `--cache-locality`.
  - Metrics: require HRW routing success for cache hits and emit `hrw_routed` and `hrw_routes`; second read is tagged as `after_worker_kill` or `stable_second_read`.

- Bug Fixes
  - Cache client: `IsPathCachedNearby` renamed to `IsPathCachedReachable` and broadened to check HRW first, then other reachable hosts; added `IsCachedOnSelectedHost` for strict HRW checks used by cache-through paths.
  - Write-through paths now validate only the HRW-selected host (`image_cache.ContentExists`, wait-for-store, and local file hashing), preventing drift.
  - Added test ensuring the client repairs the selected host when a fallback already has the content.

<sup>Written for commit bb3f18e9e72bcaf5424722143d2df2d4a881194b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

