### PR TITLE
refactor cache locality logic

### DIFF
--- a/benchmarks/b9bench/clip_layer_suite.py
+++ b/benchmarks/b9bench/clip_layer_suite.py
@@ -160,6 +160,39 @@ def create_sandbox(image, args: argparse.Namespace):
     return instance
 
 
+def wait_instance_running(instance, timeout_seconds: float) -> None:
+    from beta9.clients.pod import PodSandboxStatusRequest, PodSandboxStatusResponse
+
+    container_id = instance.container_id
+    deadline = time.monotonic() + timeout_seconds
+    attempts = 0
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        attempts += 1
+        try:
+            response = instance.stub._unary_unary(
+                "/pod.PodService/SandboxStatus",
+                PodSandboxStatusRequest,
+                PodSandboxStatusResponse,
+            )(
+                PodSandboxStatusRequest(container_id=container_id, pid=0),
+                timeout=5,
+            )
+            last = {
+                "ok": bool(response.ok),
+                "status": response.status,
+                "error": response.error_msg,
+            }
+            if response.ok and str(response.status).lower() == "running":
+                return
+        except Exception as exc:
+            last = {"error": str(exc)}
+        if attempts % 30 == 0:
+            log(f"waiting for sandbox RUNNING container={container_id} last={last}")
+        time.sleep(0.5)
+    raise TimeoutError(f"timed out waiting for sandbox RUNNING container={container_id}; last={last}")
+
+
 def read_layer(instance, timeout_seconds: float) -> dict[str, Any]:
     process = instance.process.exec("python3", "-c", READ_CODE, cwd="/")
     exit_code = process.wait(timeout=timeout_seconds)
@@ -737,6 +770,7 @@ def run_iteration(
 ) -> dict[str, Any]:
     log(f"Starting CLIP layer read iteration: {name}")
     instance = create_sandbox(image, args)
+    wait_instance_running(instance, min(args.timeout_seconds, 300))
     worker = worker_for_container(kube, instance.container_id)
     started = time.perf_counter()
     try:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260529181234-f1322f68780f
+	github.com/beam-cloud/clip v0.0.0-20260530184218-20cd1b117192
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260529181234-9d5414f087f0
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -128,10 +128,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/clip v0.0.0-20260529181234-f1322f68780f h1:pwznEi6wGfj7MN0rlPzDmSlHScsp7aGbCrXAwgODFV4=
-github.com/beam-cloud/clip v0.0.0-20260529181234-f1322f68780f/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/geesefs v0.0.0-20260529181234-9d5414f087f0 h1:w39FZqMFa6BN/hh/mbwIuMCe61Vk5j5v0jH/MR7xKgA=
-github.com/beam-cloud/geesefs v0.0.0-20260529181234-9d5414f087f0/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/clip v0.0.0-20260530184218-20cd1b117192 h1:oLpUmXc1t8DNtX0v1IoGQlbfN0bW27VIu2blihXFJ7Q=
+github.com/beam-cloud/clip v0.0.0-20260530184218-20cd1b117192/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
+github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de h1:/iGqPU8OEjVdIeCD0Un5ocuaVf7hIZYpnHto+IU2EKg=
+github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -274,6 +274,33 @@ func (c *Client) GetNearbyHosts() ([]*Host, error) {
 }
 
 func (c *Client) addHost(host *Host) error {
+	if host == nil || host.HostId == "" {
+		return ErrHostNotFound
+	}
+	if !host.HasEndpoint() {
+		logicalHost := host.LogicalOnly()
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if oldConn, ok := c.grpcConns[host.HostId]; ok {
+			_ = oldConn.Close()
+			delete(c.grpcConns, host.HostId)
+		}
+		delete(c.grpcClients, host.HostId)
+		if oldPool, ok := c.rawReadPools[host.HostId]; ok {
+			oldPool.close()
+			delete(c.rawReadPools, host.HostId)
+		}
+		c.hasher.Remove(host)
+		c.hasher.Add(logicalHost)
+		for hash, entry := range c.localHostCache {
+			if entry.host != nil && entry.host.HostId == host.HostId {
+				delete(c.localHostCache, hash)
+			}
+		}
+		return nil
+	}
+
 	addr := host.Addr
 	if host.PrivateAddr != "" {
 		addr = host.PrivateAddr
@@ -425,8 +452,11 @@ func (c *Client) removeHost(host *Host) {
 		return
 	}
 
+	logicalHost := host.LogicalOnly()
 	if c.hostMap != nil {
-		if !c.hostMap.Remove(host) {
+		var ok bool
+		logicalHost, ok = c.hostMap.DeactivateEndpoint(host)
+		if !ok {
 			return
 		}
 	}
@@ -435,6 +465,7 @@ func (c *Client) removeHost(host *Host) {
 	defer c.mu.Unlock()
 
 	c.hasher.Remove(host)
+	c.hasher.Add(logicalHost)
 	if conn, ok := c.grpcConns[host.HostId]; ok {
 		_ = conn.Close()
 		delete(c.grpcConns, host.HostId)
@@ -504,6 +535,11 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 		if host, ok := group.firstReachable(refreshCtx, c.verifyCacheHost); ok {
 			c.hostMap.Set(host)
 			routable = true
+			continue
+		}
+		if logicalHost := group.logicalHost(); logicalHost != nil {
+			c.hostMap.Set(logicalHost)
+			routable = true
 		}
 	}
 
@@ -515,6 +551,9 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 
 func (c *Client) keepExistingCacheHost(group cacheHostCandidateGroup) bool {
 	known := c.hostMap.Get(group.hostID)
+	if known != nil && !known.HasEndpoint() && group.logicalHost() != nil {
+		return true
+	}
 	if !group.hasEndpoint(known) {
 		return false
 	}
@@ -1062,16 +1101,22 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 	atomic.AddInt64(&cachePathStats.clientReadIntoRequests, 1)
 	atomic.AddInt64(&cachePathStats.clientReadIntoBytes, length)
 
-	if n, ok := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts); ok {
+	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts); err == nil {
 		return n, nil
+	} else if c.hostDirectory == nil || c.hostMap == nil {
+		return 0, err
 	}
 
 	return c.readContentIntoAfterHostRefresh(ctx, hash, offset, dst, opts)
 }
 
-func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, bool) {
+func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
 	length := int64(len(dst))
 	checked := make(map[string]struct{})
+	var primaryErr error
+	var sawMiss bool
+	var sawUnavailable bool
+	var lastErr error
 	for attempt := 0; attempt < c.getContentAttempts(length); attempt++ {
 		host, err := c.getHostForRequest(&ClientRequest{
 			rt:        ClientRequestTypeRetrieval,
@@ -1090,6 +1135,10 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 				})
 			}
 			if err != nil {
+				if attempt == 0 {
+					primaryErr = err
+				}
+				lastErr = err
 				continue
 			}
 		}
@@ -1097,35 +1146,72 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 		checked[host.HostId] = struct{}{}
 		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
 		if err == nil && n == length {
-			return n, true
+			return n, nil
+		}
+		if attempt == 0 {
+			primaryErr = err
+		}
+		if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
+			sawUnavailable = true
+		} else if errors.Is(err, ErrContentNotFound) {
+			sawMiss = true
+		}
+		if err != nil {
+			lastErr = err
 		}
 	}
 
 	for _, host := range c.remainingHostsForRequest(checked) {
 		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
 		if err == nil && n == length {
-			return n, true
+			return n, nil
+		}
+		if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
+			sawUnavailable = true
+		} else if errors.Is(err, ErrContentNotFound) {
+			sawMiss = true
+		}
+		if err != nil {
+			lastErr = err
 		}
 	}
 
-	return 0, false
+	if primaryErr != nil {
+		if errors.Is(primaryErr, ErrSelectedHostUnavailable) || errors.Is(primaryErr, ErrUnableToReachHost) || errors.Is(primaryErr, ErrHostNotFound) {
+			return 0, ErrSelectedHostUnavailable
+		}
+		if errors.Is(primaryErr, ErrContentNotFound) {
+			return 0, ErrContentNotFound
+		}
+		return 0, primaryErr
+	}
+	if sawUnavailable {
+		return 0, ErrSelectedHostUnavailable
+	}
+	if sawMiss {
+		return 0, ErrContentNotFound
+	}
+	if lastErr != nil {
+		return 0, lastErr
+	}
+	return 0, ErrContentNotFound
 }
 
 func (c *Client) readContentIntoAfterHostRefresh(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
 	if c.hostDirectory == nil || c.hostMap == nil {
-		return 0, ErrContentNotFound
+		return 0, ErrHostNotFound
 	}
 
 	c.removeLocalHostCache(hash)
 	if err := c.refreshRoutableHosts(ctx); err != nil && ctx.Err() != nil {
 		return 0, err
 	}
-	if n, ok := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts); ok {
+	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts); err == nil {
 		Logger.Debugf("cache read-into recovered after host refresh: hash=%s routing_key=%s offset=%d length=%d", hash, opts.RoutingKey, offset, len(dst))
 		return n, nil
+	} else {
+		return 0, err
 	}
-
-	return 0, ErrContentNotFound
 }
 
 func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (int64, error) {
@@ -1154,6 +1240,11 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 		}
 	}
 
+	if !host.HasEndpoint() {
+		c.removeLocalHostCache(hash)
+		return 0, ErrSelectedHostUnavailable
+	}
+
 	if c.clientConfig.ReadTransport.Enabled {
 		n, err := c.rawReadIntoWindowed(ctx, host, hash, offset, dst)
 		if err == nil && n == length {
@@ -1173,8 +1264,7 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	c.mu.RUnlock()
 	if !exists {
 		c.removeLocalHostCache(hash)
-		_ = c.refreshRoutableHosts(ctx)
-		return 0, ErrHostNotFound
+		return 0, ErrSelectedHostUnavailable
 	}
 
 	start := time.Now()
@@ -1185,7 +1275,7 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 			cacheReadGRPCCodecV2FallbackTotal.Inc()
 		}
 		c.removeHost(host)
-		return 0, err
+		return 0, ErrSelectedHostUnavailable
 	}
 	if !getContentResponse.Ok || int64(len(getContentResponse.Content)) != length {
 		atomic.AddInt64(&cachePathStats.clientGRPCMisses, 1)
@@ -1338,6 +1428,12 @@ func (c *Client) getGRPCClient(request *ClientRequest) (proto.CacheClient, *Host
 	if err != nil {
 		return nil, nil, err
 	}
+	if !host.HasEndpoint() {
+		c.mu.Lock()
+		delete(c.localHostCache, request.hash)
+		c.mu.Unlock()
+		return nil, host, ErrSelectedHostUnavailable
+	}
 
 	c.mu.RLock()
 	client, exists := c.grpcClients[host.HostId]
@@ -1347,7 +1443,7 @@ func (c *Client) getGRPCClient(request *ClientRequest) (proto.CacheClient, *Host
 		delete(c.localHostCache, request.hash)
 		c.mu.Unlock()
 
-		return nil, nil, ErrHostNotFound
+		return nil, host, ErrSelectedHostUnavailable
 	}
 
 	return client, host, nil

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -66,7 +66,7 @@ func TestReadContentIntoUsesAttachedLocalServerOnlyForSelectedHost(t *testing.T)
 
 	dst := make([]byte, len(content))
 	_, err = client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
-	require.ErrorIs(t, err, ErrContentNotFound)
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 
 	client.removeLocalHostCache(hash)
 	client.hasher = &orderedTestHasher{hosts: []*Host{localHost}}
@@ -74,6 +74,32 @@ func TestReadContentIntoUsesAttachedLocalServerOnlyForSelectedHost(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(content)), n)
 	require.Equal(t, content, dst)
+}
+
+func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T) {
+	logicalHost := &Host{
+		HostId:      "logical-host",
+		PoolName:    "default",
+		Locality:    "test",
+		NodeID:      "node-a",
+		CachePathID: "path",
+	}
+	client := &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{logicalHost}},
+		maxGetContentAttempts: 1,
+	}
+
+	dst := make([]byte, 8)
+	_, err := client.ReadContentInto(context.Background(), "hash", 0, dst, ClientOptions{RoutingKey: "hash"})
+
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
 func TestReadContentIntoFallsBackToReachableReplicaOutsideTopHosts(t *testing.T) {
@@ -689,8 +715,8 @@ func TestStoreContentFromLocalFileRepairsSelectedHostWhenFallbackHasContent(t *t
 
 func TestStoreContentFromReaderRetriesSeekableReaderAfterStreamError(t *testing.T) {
 	ctx := context.Background()
-	firstHost := &Host{HostId: "first-host"}
-	secondHost := &Host{HostId: "second-host"}
+	firstHost := &Host{HostId: "first-host", PrivateAddr: "first-host:2049"}
+	secondHost := &Host{HostId: "second-host", PrivateAddr: "second-host:2049"}
 	firstStream := &fakeStoreContentStream{failOnSend: true}
 	secondStream := &fakeStoreContentStream{}
 	client := &Client{

--- a/pkg/cache/coordinator.go
+++ b/pkg/cache/coordinator.go
@@ -32,6 +32,14 @@ type CoordinatorHost struct {
 	CapacityUsagePct float64
 }
 
+func (h CoordinatorHost) LogicalOnly() CoordinatorHost {
+	h.RegistrationID = ""
+	h.Addr = ""
+	h.PrivateAddr = ""
+	h.CapacityUsagePct = 0
+	return h
+}
+
 type CoordinatorRepository interface {
 	SetCacheRegistration(ctx context.Context, host CoordinatorHost, ttl time.Duration) error
 	GetActiveCacheRegistration(ctx context.Context, logicalHostID string) (registrationID string, found bool, err error)
@@ -39,6 +47,7 @@ type CoordinatorRepository interface {
 	ListCacheLogicalHosts(ctx context.Context, poolName, locality string) ([]string, error)
 	ListCacheRegistrations(ctx context.Context, logicalHostID string) ([]string, error)
 	GetCacheRegistration(ctx context.Context, logicalHostID, registrationID string) (CoordinatorHost, bool, error)
+	GetCacheLogicalHost(ctx context.Context, logicalHostID string) (CoordinatorHost, bool, error)
 	RemoveCacheRegistration(ctx context.Context, logicalHostID, registrationID string) error
 	CountCacheRegistrations(ctx context.Context, logicalHostID string) (int64, error)
 	RemoveCacheLogicalHost(ctx context.Context, poolName, locality, logicalHostID string) error
@@ -152,6 +161,13 @@ func (c *Coordinator) logicalHosts(ctx context.Context, poolName, locality, logi
 	}
 
 	if len(hosts) == 0 {
+		logicalHost, ok, err := c.repository.GetCacheLogicalHost(ctx, logicalHostID)
+		if err != nil {
+			return nil, err
+		}
+		if ok && logicalHost.Locality == locality && (poolName == "" || logicalHost.PoolName == poolName) {
+			return []CoordinatorHost{logicalHost.LogicalOnly()}, nil
+		}
 		return nil, c.pruneLogicalHost(ctx, poolName, locality, logicalHostID)
 	}
 

--- a/pkg/cache/coordinator_test.go
+++ b/pkg/cache/coordinator_test.go
@@ -12,6 +12,7 @@ import (
 type memoryCoordinatorRepository struct {
 	index         map[string]map[string]struct{}
 	registrations map[string]map[string]CoordinatorHost
+	logicalHosts  map[string]CoordinatorHost
 	active        map[string]string
 }
 
@@ -19,6 +20,7 @@ func newMemoryCoordinatorRepository() *memoryCoordinatorRepository {
 	return &memoryCoordinatorRepository{
 		index:         map[string]map[string]struct{}{},
 		registrations: map[string]map[string]CoordinatorHost{},
+		logicalHosts:  map[string]CoordinatorHost{},
 		active:        map[string]string{},
 	}
 }
@@ -34,6 +36,7 @@ func (r *memoryCoordinatorRepository) SetCacheRegistration(ctx context.Context, 
 		r.registrations[host.LogicalHostID] = map[string]CoordinatorHost{}
 	}
 	r.registrations[host.LogicalHostID][host.RegistrationID] = host
+	r.logicalHosts[host.LogicalHostID] = host.LogicalOnly()
 	return nil
 }
 
@@ -88,6 +91,11 @@ func (r *memoryCoordinatorRepository) GetCacheRegistration(ctx context.Context, 
 	return host, ok, nil
 }
 
+func (r *memoryCoordinatorRepository) GetCacheLogicalHost(ctx context.Context, logicalHostID string) (CoordinatorHost, bool, error) {
+	host, ok := r.logicalHosts[logicalHostID]
+	return host.LogicalOnly(), ok, nil
+}
+
 func (r *memoryCoordinatorRepository) RemoveCacheRegistration(ctx context.Context, logicalHostID, registrationID string) error {
 	delete(r.registrations[logicalHostID], registrationID)
 	if r.active[logicalHostID] == registrationID {
@@ -103,6 +111,7 @@ func (r *memoryCoordinatorRepository) CountCacheRegistrations(ctx context.Contex
 func (r *memoryCoordinatorRepository) RemoveCacheLogicalHost(ctx context.Context, poolName, locality, logicalHostID string) error {
 	delete(r.index[fmt.Sprintf("%s:%s", poolName, locality)], logicalHostID)
 	delete(r.registrations, logicalHostID)
+	delete(r.logicalHosts, logicalHostID)
 	delete(r.active, logicalHostID)
 	return nil
 }
@@ -211,6 +220,35 @@ func TestCoordinatorPromotesRegisteringRegistrationWhenActiveRegistrationIsGone(
 	host.PrivateAddr = "10.0.0.2:2049"
 	require.NoError(t, coordinator.RegisterHost(ctx, host, 30*time.Second))
 	require.Equal(t, "worker-b", repo.active[host.LogicalHostID])
+}
+
+func TestCoordinatorListsLogicalHostWhenNoEndpointRegistrationIsActive(t *testing.T) {
+	repo := newMemoryCoordinatorRepository()
+	coordinator := NewCoordinator(repo)
+	ctx := context.Background()
+
+	host := CoordinatorHost{
+		LogicalHostID:  "cache-host-default-node-a-path-0",
+		RegistrationID: "worker-a",
+		PoolName:       "default",
+		Locality:       "default",
+		NodeID:         "node-a",
+		CachePathID:    "path",
+		Addr:           "10.0.0.1:2049",
+		PrivateAddr:    "10.0.0.1:2049",
+	}
+	require.NoError(t, coordinator.RegisterHost(ctx, host, 30*time.Second))
+
+	require.NoError(t, repo.RemoveCacheRegistration(ctx, host.LogicalHostID, host.RegistrationID))
+
+	hosts, err := coordinator.ListHosts(ctx, "default", "default")
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, host.LogicalHostID, hosts[0].LogicalHostID)
+	require.Equal(t, host.NodeID, hosts[0].NodeID)
+	require.Equal(t, host.CachePathID, hosts[0].CachePathID)
+	require.Empty(t, hosts[0].RegistrationID)
+	require.Empty(t, hosts[0].PrivateAddr)
 }
 
 func TestCoordinatorCanListCacheHostsAcrossWorkerPools(t *testing.T) {

--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -116,6 +116,11 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 
 			host, ok := group.firstReachable(ctx, d.GetHostState)
 			if !ok {
+				if logicalHost := group.logicalHost(); logicalHost != nil {
+					mu.Lock()
+					selectedHosts = append(selectedHosts, logicalHost)
+					mu.Unlock()
+				}
 				return
 			}
 
@@ -167,10 +172,13 @@ func cacheHostCandidateGroups(hosts []*Host) []cacheHostCandidateGroup {
 // node/cache-path scoped, so switching between healthy endpoints on the same
 // node only churns connections and can cancel in-flight cache streams.
 func (g cacheHostCandidateGroup) hasEndpoint(host *Host) bool {
-	if host == nil {
+	if host == nil || !host.HasEndpoint() {
 		return false
 	}
 	for _, candidate := range g.candidates {
+		if !candidate.HasEndpoint() {
+			continue
+		}
 		if sameCacheHostEndpoint(candidate, host) {
 			return true
 		}
@@ -178,9 +186,22 @@ func (g cacheHostCandidateGroup) hasEndpoint(host *Host) bool {
 	return false
 }
 
+func (g cacheHostCandidateGroup) logicalHost() *Host {
+	for _, candidate := range g.candidates {
+		if candidate == nil || candidate.HostId == "" {
+			continue
+		}
+		return candidate.LogicalOnly()
+	}
+	return nil
+}
+
 func (g cacheHostCandidateGroup) firstReachable(ctx context.Context, verify cacheHostVerifier) (*Host, bool) {
 	for _, candidate := range g.candidates {
 		if candidate == nil || candidate.HostId == "" {
+			continue
+		}
+		if !candidate.HasEndpoint() {
 			continue
 		}
 
@@ -194,7 +215,7 @@ func (g cacheHostCandidateGroup) firstReachable(ctx context.Context, verify cach
 }
 
 func sameCacheHostEndpoint(a *Host, b *Host) bool {
-	if a == nil || b == nil {
+	if a == nil || b == nil || !a.HasEndpoint() || !b.HasEndpoint() {
 		return false
 	}
 	return a.HostId == b.HostId && a.Addr == b.Addr && a.PrivateAddr == b.PrivateAddr

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -84,6 +84,33 @@ func TestCacheHostCandidateGroupFirstReachableFallsBackInOrder(t *testing.T) {
 	require.Equal(t, []string{"10.0.0.1:2049", "10.0.0.2:2049"}, called)
 }
 
+func TestCacheHostCandidateGroupLogicalHostIgnoresEndpointFields(t *testing.T) {
+	group := cacheHostCandidateGroup{
+		hostID: "logical-host",
+		candidates: []*Host{
+			{
+				HostId:         "logical-host",
+				RegistrationID: "worker-a",
+				PoolName:       "default",
+				Locality:       "default",
+				NodeID:         "node-a",
+				CachePathID:    "path",
+				PrivateAddr:    "10.0.0.1:2049",
+			},
+		},
+	}
+
+	host := group.logicalHost()
+
+	require.NotNil(t, host)
+	require.Equal(t, "logical-host", host.HostId)
+	require.Equal(t, "node-a", host.NodeID)
+	require.Equal(t, "path", host.CachePathID)
+	require.Empty(t, host.RegistrationID)
+	require.Empty(t, host.PrivateAddr)
+	require.False(t, host.HasEndpoint())
+}
+
 func TestDiscoveryKeepsKnownRegisteredEndpoint(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/cache/errors.go
+++ b/pkg/cache/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrUnableToReachHost       = errors.New("unable to reach host")
 	ErrInvalidHostVersion      = errors.New("invalid host version")
 	ErrContentNotFound         = errors.New("content not found")
+	ErrSelectedHostUnavailable = errors.New("selected cache host unavailable")
 	ErrClientNotFound          = errors.New("client not found")
 	ErrCacheLockHeld           = errors.New("cache lock held")
 	ErrUnableToPopulateContent = errors.New("unable to populate content from original source")

--- a/pkg/cache/hostmap.go
+++ b/pkg/cache/hostmap.go
@@ -62,7 +62,7 @@ func (hm *HostMap) Set(host *Host) {
 		if exists {
 			hm.hosts[host.HostId] = existing
 		} else {
-			delete(hm.hosts, host.HostId)
+			hm.hosts[host.HostId] = host.LogicalOnly()
 		}
 		hm.mu.Unlock()
 	}
@@ -88,6 +88,29 @@ func (hm *HostMap) Remove(host *Host) bool {
 	Logger.Infof("Removed host @ %s (PrivateAddr=%s, RTT=%s)", host.HostId, host.PrivateAddr, host.RTT)
 	delete(hm.hosts, host.HostId)
 	return true
+}
+
+func (hm *HostMap) DeactivateEndpoint(host *Host) (*Host, bool) {
+	if host == nil || host.HostId == "" {
+		return nil, false
+	}
+
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	existing, exists := hm.hosts[host.HostId]
+	if !exists {
+		return nil, false
+	}
+	if !sameCacheHostEndpoint(existing, host) {
+		Logger.Debugf("Ignored stale host deactivation @ %s (stale PrivateAddr=%s active PrivateAddr=%s)", host.HostId, host.PrivateAddr, existing.PrivateAddr)
+		return nil, false
+	}
+
+	logicalHost := existing.LogicalOnly()
+	hm.hosts[host.HostId] = logicalHost
+	Logger.Infof("Deactivated cache host endpoint @ %s (PrivateAddr=%s)", host.HostId, host.PrivateAddr)
+	return logicalHost, true
 }
 
 func (hm *HostMap) Members() mapset.Set[string] {

--- a/pkg/cache/hostmap_test.go
+++ b/pkg/cache/hostmap_test.go
@@ -66,14 +66,19 @@ func TestHostMapSetRestoresExistingHostWhenUpdateFails(t *testing.T) {
 	require.Equal(t, "10.0.0.1:2049", hostMap.Get("logical-host").PrivateAddr)
 }
 
-func TestHostMapSetRemovesNewHostWhenInitialAddFails(t *testing.T) {
+func TestHostMapSetKeepsLogicalHostWhenInitialEndpointAddFails(t *testing.T) {
 	hostMap := NewHostMap(GlobalConfig{}, func(host *Host) error {
 		return errors.New("dial failed")
 	})
 
-	hostMap.Set(&Host{HostId: "logical-host", PrivateAddr: "10.0.0.1:2049"})
+	hostMap.Set(&Host{HostId: "logical-host", NodeID: "node-a", CachePathID: "path", PrivateAddr: "10.0.0.1:2049"})
 
-	require.Empty(t, hostMap.GetAll())
+	require.Len(t, hostMap.GetAll(), 1)
+	host := hostMap.Get("logical-host")
+	require.NotNil(t, host)
+	require.False(t, host.HasEndpoint())
+	require.Equal(t, "node-a", host.NodeID)
+	require.Equal(t, "path", host.CachePathID)
 }
 
 func TestHostMapRemoveIgnoresStaleEndpointForSameLogicalHost(t *testing.T) {
@@ -85,4 +90,19 @@ func TestHostMapRemoveIgnoresStaleEndpointForSameLogicalHost(t *testing.T) {
 
 	require.False(t, removed)
 	require.Equal(t, active.PrivateAddr, hostMap.Get("logical-host").PrivateAddr)
+}
+
+func TestHostMapDeactivateEndpointKeepsLogicalHost(t *testing.T) {
+	hostMap := NewHostMap(GlobalConfig{}, nil)
+	active := &Host{HostId: "logical-host", NodeID: "node-a", CachePathID: "path", PrivateAddr: "10.0.0.2:2049"}
+	hostMap.Set(active)
+
+	logical, ok := hostMap.DeactivateEndpoint(active)
+
+	require.True(t, ok)
+	require.NotNil(t, logical)
+	require.False(t, logical.HasEndpoint())
+	require.Equal(t, "node-a", logical.NodeID)
+	require.Equal(t, "path", logical.CachePathID)
+	require.Equal(t, logical, hostMap.Get("logical-host"))
 }

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -360,6 +360,23 @@ type Host struct {
 	CapacityUsagePct float64       `redis:"capacity_usage_pct" json:"capacity_usage_pct"`
 }
 
+func (h *Host) HasEndpoint() bool {
+	return h != nil && (h.Addr != "" || h.PrivateAddr != "")
+}
+
+func (h *Host) LogicalOnly() *Host {
+	if h == nil {
+		return nil
+	}
+	logical := *h
+	logical.RegistrationID = ""
+	logical.Addr = ""
+	logical.PrivateAddr = ""
+	logical.RTT = 0
+	logical.CapacityUsagePct = 0
+	return &logical
+}
+
 // Bytes is needed for the rendezvous hasher
 func (h *Host) Bytes() []byte {
 	// HRW placement is intentionally based only on the stable logical cache

--- a/pkg/repository/cache_redis.go
+++ b/pkg/repository/cache_redis.go
@@ -39,8 +39,15 @@ func (r *CacheRedisRepository) SetCacheRegistration(ctx context.Context, host ca
 	if err != nil {
 		return err
 	}
+	logicalPayload, err := json.Marshal(cacheCoordinatorHostRecord(host.LogicalOnly()))
+	if err != nil {
+		return err
+	}
 
 	if err := r.rdb.SAdd(ctx, cacheCoordinatorIndexKey(host.PoolName, host.Locality), host.LogicalHostID).Err(); err != nil {
+		return err
+	}
+	if err := r.rdb.Set(ctx, cacheCoordinatorLogicalHostKey(host.LogicalHostID), logicalPayload, cacheCoordinatorLogicalHostTTL(ttl)).Err(); err != nil {
 		return err
 	}
 	if err := r.rdb.SAdd(ctx, cacheCoordinatorRegistrationSetKey(host.LogicalHostID), host.RegistrationID).Err(); err != nil {
@@ -120,6 +127,23 @@ func (r *CacheRedisRepository) GetCacheRegistration(ctx context.Context, logical
 	return cache.CoordinatorHost(record), true, nil
 }
 
+func (r *CacheRedisRepository) GetCacheLogicalHost(ctx context.Context, logicalHostID string) (cache.CoordinatorHost, bool, error) {
+	payload, err := r.rdb.Get(ctx, cacheCoordinatorLogicalHostKey(logicalHostID)).Bytes()
+	if err == redis.Nil {
+		return cache.CoordinatorHost{}, false, nil
+	}
+	if err != nil {
+		return cache.CoordinatorHost{}, false, err
+	}
+
+	record := cacheCoordinatorHostRecord{}
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return cache.CoordinatorHost{}, false, err
+	}
+
+	return cache.CoordinatorHost(record).LogicalOnly(), true, nil
+}
+
 func (r *CacheRedisRepository) RemoveCacheRegistration(ctx context.Context, logicalHostID, registrationID string) error {
 	if err := r.rdb.Del(ctx, cacheCoordinatorRegistrationKey(logicalHostID, registrationID)).Err(); err != nil {
 		return err
@@ -143,7 +167,7 @@ func (r *CacheRedisRepository) RemoveCacheLogicalHost(ctx context.Context, poolN
 	if err := r.rdb.SRem(ctx, cacheCoordinatorIndexKey(poolName, locality), logicalHostID).Err(); err != nil {
 		return err
 	}
-	return r.rdb.Del(ctx, cacheCoordinatorActiveRegistrationKey(logicalHostID), cacheCoordinatorRegistrationSetKey(logicalHostID)).Err()
+	return r.rdb.Del(ctx, cacheCoordinatorActiveRegistrationKey(logicalHostID), cacheCoordinatorRegistrationSetKey(logicalHostID), cacheCoordinatorLogicalHostKey(logicalHostID)).Err()
 }
 
 func cacheCoordinatorIndexKey(poolName, locality string) string {
@@ -154,10 +178,22 @@ func cacheCoordinatorRegistrationSetKey(logicalHostID string) string {
 	return fmt.Sprintf("%s:host:%s:registrations", cacheCoordinatorKeyPrefix, logicalHostID)
 }
 
+func cacheCoordinatorLogicalHostKey(logicalHostID string) string {
+	return fmt.Sprintf("%s:host:%s:logical", cacheCoordinatorKeyPrefix, logicalHostID)
+}
+
 func cacheCoordinatorRegistrationKey(logicalHostID, registrationID string) string {
 	return fmt.Sprintf("%s:host:%s:registration:%s", cacheCoordinatorKeyPrefix, logicalHostID, registrationID)
 }
 
 func cacheCoordinatorActiveRegistrationKey(logicalHostID string) string {
 	return fmt.Sprintf("%s:host:%s:active_registration", cacheCoordinatorKeyPrefix, logicalHostID)
+}
+
+func cacheCoordinatorLogicalHostTTL(registrationTTL time.Duration) time.Duration {
+	ttl := registrationTTL * 4
+	if ttl < 2*time.Minute {
+		return 2 * time.Minute
+	}
+	return ttl
 }

--- a/pkg/repository/cache_redis_test.go
+++ b/pkg/repository/cache_redis_test.go
@@ -45,9 +45,17 @@ func TestCacheRedisRepositoryUsesReadableCoordinatorHostIndexKeys(t *testing.T) 
 	keys := server.Keys()
 	require.Contains(t, keys, "cache:coordinator:host_index:default:default")
 	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:registrations")
+	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:logical")
 	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:registration:worker-a")
 	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:active_registration")
 	for _, key := range keys {
 		require.NotContains(t, key, "cache:coordinator:index:")
 	}
+
+	logicalHost, ok, err := repo.GetCacheLogicalHost(ctx, host.LogicalHostID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, host.LogicalHostID, logicalHost.LogicalHostID)
+	require.Empty(t, logicalHost.RegistrationID)
+	require.Empty(t, logicalHost.PrivateAddr)
 }

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -57,7 +58,7 @@ func (c *imageContentCache) GetContent(hash string, offset int64, length int64, 
 		return nil, err
 	}
 	if n != length {
-		return nil, cache.ErrContentNotFound
+		return nil, fmt.Errorf("%w: short read", clipStorage.ErrContentCacheMiss)
 	}
 
 	return dst[:n], nil
@@ -107,7 +108,27 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 	ctx, cancel := context.WithTimeout(context.Background(), imageContentCacheReadTimeout)
 	defer cancel()
 
-	return c.client.ReadContentInto(ctx, hash, offset, dest, cache.ClientOptions{RoutingKey: opts.RoutingKey})
+	read, err = c.client.ReadContentInto(ctx, hash, offset, dest, cache.ClientOptions{RoutingKey: opts.RoutingKey})
+	if err != nil {
+		return read, imageContentCacheError(err)
+	}
+	return read, nil
+}
+
+func imageContentCacheError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, cache.ErrContentNotFound) {
+		return fmt.Errorf("%w: %w", clipStorage.ErrContentCacheMiss, err)
+	}
+	if errors.Is(err, cache.ErrSelectedHostUnavailable) ||
+		errors.Is(err, cache.ErrUnableToReachHost) ||
+		errors.Is(err, cache.ErrHostNotFound) ||
+		errors.Is(err, cache.ErrClientNotFound) {
+		return fmt.Errorf("%w: %w", clipStorage.ErrContentCacheUnavailable, err)
+	}
+	return err
 }
 
 func (c *imageContentCache) ContentExists(hash string, opts struct{ RoutingKey string }) (exists bool, err error) {

--- a/pkg/worker/image_cache_test.go
+++ b/pkg/worker/image_cache_test.go
@@ -1,0 +1,19 @@
+package worker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/cache"
+	clipStorage "github.com/beam-cloud/clip/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageContentCacheErrorClassifiesMissAndUnavailable(t *testing.T) {
+	require.ErrorIs(t, imageContentCacheError(cache.ErrContentNotFound), clipStorage.ErrContentCacheMiss)
+	require.ErrorIs(t, imageContentCacheError(cache.ErrSelectedHostUnavailable), clipStorage.ErrContentCacheUnavailable)
+	require.ErrorIs(t, imageContentCacheError(cache.ErrUnableToReachHost), clipStorage.ErrContentCacheUnavailable)
+
+	other := errors.New("other")
+	require.Same(t, other, imageContentCacheError(other))
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored cache locality to separate logical hosts from endpoint registrations. This keeps hosts routable when an endpoint is down, improves selection/fallbacks, and returns clearer errors for misses vs. unavailable hosts.

- **Refactors**
  - Added `LogicalOnly()` and `HasEndpoint()` to `pkg/cache` hosts; added `DeactivateEndpoint` in `HostMap` to keep the logical host when an endpoint goes away.
  - Discovery and coordinator return logical hosts when no reachable/active endpoint exists; `pkg/repository` now stores a logical-host record with TTL and exposes `GetCacheLogicalHost`.
  - Client routing updates: preserve logical hosts on add/remove, skip non-endpoint hosts, and use logical hosts during refresh; `ReadContentInto` now distinguishes `ErrSelectedHostUnavailable` from `ErrContentNotFound`.
  - `pkg/worker` maps cache errors to `@clip` storage classes: misses -> `ErrContentCacheMiss`, unavailable -> `ErrContentCacheUnavailable`.
  - Benchmarks wait for the sandbox to be RUNNING before reads to reduce flakes.

- **Dependencies**
  - Bumped `github.com/beam-cloud/clip`.
  - Bumped `github.com/beam-cloud/geesefs`.

<sup>Written for commit bae7ed966278ac2eed0a8b4d4e9122ebfeb87cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

