### PR TITLE
Make cache-through degrade safely on host churn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260530184218-20cd1b117192
+	github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/clip v0.0.0-20260530184218-20cd1b117192 h1:oLpUmXc1t8DNtX0v1IoGQlbfN0bW27VIu2blihXFJ7Q=
-github.com/beam-cloud/clip v0.0.0-20260530184218-20cd1b117192/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
+github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349 h1:HIBhVld58bETqMM/XcSQ7Q+qRBoe4v4XqB6lS7W6KOM=
+github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
 github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de h1:/iGqPU8OEjVdIeCD0Un5ocuaVf7hIZYpnHto+IU2EKg=
 github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1651,12 +1651,23 @@ func (c *Client) storeContentFromChunks(chunks chan []byte, hash string, cachePa
 		routingKey = hash
 	}
 
-	client, _, err := c.getGRPCClient(&ClientRequest{
-		rt:        ClientRequestTypeStorage,
-		hash:      hash,
-		key:       routingKey,
-		hostIndex: 0,
-	})
+	var client proto.CacheClient
+	var err error
+	for hostIndex := 0; hostIndex < c.storeHostAttempts(); hostIndex++ {
+		client, _, err = c.getGRPCClient(&ClientRequest{
+			rt:        ClientRequestTypeStorage,
+			hash:      hash,
+			key:       routingKey,
+			hostIndex: hostIndex,
+		})
+		if err == nil {
+			break
+		}
+		if isStoreHostUnavailable(err) {
+			_ = c.refreshRoutableHosts(ctx)
+			continue
+		}
+	}
 	if err != nil {
 		return "", err
 	}
@@ -1703,38 +1714,43 @@ func (c *Client) storeContentFromReaderWithContext(ctx context.Context, reader i
 	seeker, retryable := reader.(io.Seeker)
 	var lastErr error
 	for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
-		if retryable {
-			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
-				return "", err
+		for hostIndex := 0; hostIndex < c.storeHostAttempts(); hostIndex++ {
+			if retryable {
+				if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+					return "", err
+				}
+			} else if attempt > 0 || hostIndex > 0 {
+				break
 			}
-		} else if attempt > 0 {
-			break
-		}
 
-		_, host, err := c.getGRPCClient(&ClientRequest{
-			rt:        ClientRequestTypeStorage,
-			hash:      routingKey,
-			key:       routingKey,
-			hostIndex: 0,
-		})
-		if err != nil {
+			_, host, err := c.getGRPCClient(&ClientRequest{
+				rt:        ClientRequestTypeStorage,
+				hash:      routingKey,
+				key:       routingKey,
+				hostIndex: hostIndex,
+			})
+			if err != nil {
+				lastErr = err
+				if isStoreHostUnavailable(err) {
+					_ = c.refreshRoutableHosts(ctx)
+				}
+				continue
+			}
+
+			hash, err := c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
+			if err == nil {
+				return hash, nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
 			lastErr = err
-			if err == ErrHostNotFound {
-				_ = c.refreshRoutableHosts(ctx)
+			c.removeHost(host)
+			_ = c.refreshRoutableHosts(ctx)
+			if !retryable {
+				break
 			}
-			continue
 		}
-
-		hash, err := c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
-		if err == nil {
-			return hash, nil
-		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", ctxErr
-		}
-		lastErr = err
-		c.removeHost(host)
-		_ = c.refreshRoutableHosts(ctx)
 		if !retryable {
 			break
 		}
@@ -1954,58 +1970,74 @@ func (c *Client) StoreContentFromS3Source(source S3ContentSource, opts StoreCont
 func (c *Client) storeContentFromSource(ctx context.Context, req *proto.CacheStoreContentFromSourceRequest, hash, routingKey string, lock bool) (string, error) {
 	var lastErr error
 	for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
-		client, host, err := c.getGRPCClient(&ClientRequest{
-			rt:        ClientRequestTypeStorage,
-			hash:      hash,
-			key:       routingKey,
-			hostIndex: 0,
-		})
-		if err != nil {
-			lastErr = err
-			if err == ErrHostNotFound {
-				_ = c.refreshRoutableHosts(ctx)
+		for hostIndex := 0; hostIndex < c.storeHostAttempts(); hostIndex++ {
+			client, host, err := c.getGRPCClient(&ClientRequest{
+				rt:        ClientRequestTypeStorage,
+				hash:      hash,
+				key:       routingKey,
+				hostIndex: hostIndex,
+			})
+			if err != nil {
+				lastErr = err
+				if isStoreHostUnavailable(err) {
+					_ = c.refreshRoutableHosts(ctx)
+				}
+				continue
 			}
-			continue
-		}
 
-		if lock {
-			resp, err := client.StoreContentFromSourceWithLock(ctx, req)
+			if lock {
+				resp, err := client.StoreContentFromSourceWithLock(ctx, req)
+				if err != nil {
+					lastErr = err
+					c.removeHost(host)
+					_ = c.refreshRoutableHosts(ctx)
+					continue
+				}
+
+				if resp == nil {
+					return "", ErrUnableToPopulateContent
+				}
+				if resp.FailedToAcquireLock {
+					return "", ErrUnableToAcquireLock
+				}
+				if !resp.Ok {
+					return "", ErrUnableToPopulateContent
+				}
+				return resp.Hash, nil
+			}
+
+			resp, err := client.StoreContentFromSource(ctx, req)
 			if err != nil {
 				lastErr = err
 				c.removeHost(host)
 				_ = c.refreshRoutableHosts(ctx)
 				continue
 			}
-
-			if resp == nil {
-				return "", ErrUnableToPopulateContent
-			}
-			if resp.FailedToAcquireLock {
-				return "", ErrUnableToAcquireLock
-			}
-			if !resp.Ok {
+			if resp == nil || !resp.Ok {
 				return "", ErrUnableToPopulateContent
 			}
 			return resp.Hash, nil
 		}
-
-		resp, err := client.StoreContentFromSource(ctx, req)
-		if err != nil {
-			lastErr = err
-			c.removeHost(host)
-			_ = c.refreshRoutableHosts(ctx)
-			continue
-		}
-		if resp == nil || !resp.Ok {
-			return "", ErrUnableToPopulateContent
-		}
-		return resp.Hash, nil
 	}
 
 	if lastErr != nil {
 		return "", lastErr
 	}
 	return "", ErrHostNotFound
+}
+
+func (c *Client) storeHostAttempts() int {
+	if c == nil || c.clientConfig.NTopHosts <= 0 {
+		return 1
+	}
+	return c.clientConfig.NTopHosts
+}
+
+func isStoreHostUnavailable(err error) bool {
+	return errors.Is(err, ErrHostNotFound) ||
+		errors.Is(err, ErrSelectedHostUnavailable) ||
+		errors.Is(err, ErrUnableToReachHost) ||
+		errors.Is(err, ErrClientNotFound)
 }
 
 func (c *Client) HostsAvailable() bool {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -741,6 +741,32 @@ func TestStoreContentFromReaderRetriesSeekableReaderAfterStreamError(t *testing.
 	require.Equal(t, content, secondStream.sent.Bytes())
 }
 
+func TestStoreContentFromReaderFallsBackWhenSelectedHostUnavailable(t *testing.T) {
+	ctx := context.Background()
+	selectedHost := &Host{HostId: "selected-host"}
+	fallbackHost := &Host{HostId: "fallback-host", PrivateAddr: "fallback-host:2049"}
+	fallbackStream := &fakeStoreContentStream{}
+	client := &Client{
+		ctx:                   ctx,
+		clientConfig:          ClientConfig{NTopHosts: 2},
+		grpcClients:           map[string]proto.CacheClient{"fallback-host": &fakeStoreCacheClient{stream: fallbackStream}},
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{selectedHost, fallbackHost}},
+		maxGetContentAttempts: 1,
+	}
+
+	content := []byte("fallback-cache-through-when-primary-endpoint-is-gone")
+	sum := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(sum[:])
+
+	got, err := client.storeContentFromReaderWithContext(ctx, bytes.NewReader(content), expectedHash, "/cache/file.bin", nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
+	require.Equal(t, content, fallbackStream.sent.Bytes())
+}
+
 type fakeStoreCacheClient struct {
 	stream proto.Cache_StoreContentClient
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make cache-through writes resilient to host churn by falling back across the top N cache hosts and refreshing routing on failures. This reduces write failures when the selected host is gone or unreachable.

- **Bug Fixes**
  - Try up to `NTopHosts` for store operations (`storeContentFromChunks`, `storeContentFromReaderWithContext`, `storeContentFromSource`).
  - Classify store host errors via `isStoreHostUnavailable` and refresh routable hosts; remove failing hosts.
  - Do not retry non-seekable readers across hosts to avoid data loss.
  - Add test to verify fallback when the initially selected host is unavailable.

- **Dependencies**
  - Bump `github.com/beam-cloud/clip` to `v0.0.0-20260530193418-6c040c276349`.

<sup>Written for commit dd5cd2cde7ed3da3b99fe114c708fa23f1f6e238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

