### PR TITLE
Restore cache endpoints after worker churn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/tj/assert v0.0.3
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/vishvananda/netns v0.0.4
-	github.com/yandex-cloud/geesefs v0.0.0-00010101000000-000000000000
+	github.com/yandex-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349 h1:HIBhVld58bETqMM/XcSQ7Q+qRBoe4v4XqB6lS7W6KOM=
 github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de h1:/iGqPU8OEjVdIeCD0Un5ocuaVf7hIZYpnHto+IU2EKg=
-github.com/beam-cloud/geesefs v0.0.0-20260530182750-092fe0da66de/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4 h1:KrLIWGtlu/qqow1x2smS+k9WK1WM1+RIjX2IIpQd03A=
+github.com/beam-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -551,9 +551,6 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 
 func (c *Client) keepExistingCacheHost(group cacheHostCandidateGroup) bool {
 	known := c.hostMap.Get(group.hostID)
-	if known != nil && !known.HasEndpoint() && group.logicalHost() != nil {
-		return true
-	}
 	if !group.hasEndpoint(known) {
 		return false
 	}

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	proto "github.com/beam-cloud/beta9/proto"
+	rendezvous "github.com/beam-cloud/rendezvous"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 type testHostDirectoryFunc func(context.Context, string) ([]*Host, error)
@@ -163,4 +166,60 @@ func TestDiscoveryKeepsKnownRegisteredEndpoint(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, hosts)
+}
+
+func TestRefreshRoutableHostsReactivatesLogicalOnlyHost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	server, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("logical-host"))
+	require.NoError(t, err)
+	addr, err := server.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	active := &Host{
+		HostId:      "logical-host",
+		PrivateAddr: addr,
+	}
+	client := &Client{
+		ctx:            ctx,
+		clientConfig:   ClientConfig{NTopHosts: 1},
+		globalConfig:   cfg.Global,
+		grpcClients:    make(map[string]proto.CacheClient),
+		grpcConns:      make(map[string]*grpc.ClientConn),
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[string]*localClientCache),
+		hasher:         rendezvous.New[*Host](),
+		hostMap:        NewHostMap(cfg.Global, nil),
+		hostDirectory: testHostDirectoryFunc(func(context.Context, string) ([]*Host, error) {
+			return []*Host{active}, nil
+		}),
+		maxGetContentAttempts: 1,
+	}
+	client.hostMap.onHostAdded = client.addHost
+	defer client.Cleanup()
+
+	client.hostMap.Set(active.LogicalOnly())
+	require.False(t, client.hostMap.Get("logical-host").HasEndpoint())
+
+	require.NoError(t, client.refreshRoutableHosts(ctx))
+
+	refreshed := client.hostMap.Get("logical-host")
+	require.NotNil(t, refreshed)
+	require.True(t, refreshed.HasEndpoint())
+	require.Equal(t, addr, refreshed.PrivateAddr)
+	require.True(t, client.hasCacheClient("logical-host"))
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes host discovery so logical-only cache hosts regain their gRPC endpoint after worker churn, restoring routing and cache client connectivity.

- **Bug Fixes**
  - Removed the guard in `keepExistingCacheHost` that kept a host without an endpoint, allowing `refreshRoutableHosts` to attach a new endpoint when the host returns.
  - Added `TestRefreshRoutableHostsReactivatesLogicalOnlyHost` to ensure logical-only hosts are reactivated with a valid endpoint.

- **Dependencies**
  - Pinned `github.com/yandex-cloud/geesefs` to `v0.0.0-20260530201649-8ba8948bc7e4` and updated the `replace` to `github.com/beam-cloud/geesefs` at the same commit in `go.mod`/`go.sum`.

<sup>Written for commit 19e2d518bccbe21dc18cdc8d7a67d42ed59b29f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

