### PR TITLE
Pin geesefs object-source cache fill fix

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -2900,7 +2900,12 @@ class CacheBenchmark:
                 "path": entry["path"],
                 "proof": self.cache.wait_ready(
                     entry,
-                    timeout_seconds=min(120, self.config.cache_proof_timeout_seconds),
+                    timeout_seconds=self.config.cache_proof_timeout_seconds,
+                    required=(
+                        self.config.reset_workers_after_prepare
+                        and self.config.require_read_path_proof
+                        and not self.config.force_read_through_after_prepare
+                    ),
                     context="prepare cache proof",
                 ),
             }
@@ -3078,6 +3083,14 @@ class CacheBenchmark:
                 ) = self._ensure_workspace_fuse_mounted(sandbox, token, paths, entry)
 
             if not ready.get("ready"):
+                if (
+                    self.config.require_read_path_proof
+                    and not self.config.force_read_through_after_prepare
+                ):
+                    raise RuntimeError(
+                        f"embedded cache proof not ready for {entry['path']} "
+                        "before hot-read measurement"
+                    )
                 log(
                     f"Embedded cache proof not ready for {entry['path']}; "
                     "running one verified read-through warmup before measuring hot cache"

--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260530205416-d45959c45f88
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349 h1:HIBhVld58bETqMM/XcSQ7Q+qRBoe4v4XqB6lS7W6KOM=
 github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4 h1:KrLIWGtlu/qqow1x2smS+k9WK1WM1+RIjX2IIpQd03A=
-github.com/beam-cloud/geesefs v0.0.0-20260530201649-8ba8948bc7e4/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260530205416-d45959c45f88 h1:EgqeucLJURXFX63Pew9z95uJR7enl6YI7o/OlS2mcBg=
+github.com/beam-cloud/geesefs v0.0.0-20260530205416-d45959c45f88/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins `github.com/yandex-cloud/geesefs` to a version with the object-source cache fill fix and updates the benchmark to enforce cache proof requirements. This prevents hot-read measurements when proofs are missing and avoids premature timeouts.

- **Bug Fixes**
  - Use the configured `cache_proof_timeout_seconds` without a 120s cap.
  - Pass `required` to `wait_ready` when proofs are mandatory (reset-after-prepare + require-read-path-proof + not force-read-through).
  - If a proof is required and not ready, fail fast before hot-read measurement; otherwise run a single verified warmup.

- **Dependencies**
  - Pin `github.com/yandex-cloud/geesefs` to the Beam fork `github.com/beam-cloud/geesefs` that includes the object-source cache fill fix.

<sup>Written for commit 06f9a2b5bc30fe5bed09f57022b186ce5bbdef8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

