### PR TITLE
dont immediately remove hosts

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -945,6 +945,24 @@ class Kube:
         arch = (proc.stdout or "").strip().lower()
         return "arm64" if arch in {"arm64", "aarch64"} else "amd64"
 
+    def node_names(self) -> set[str]:
+        proc = run(
+            ["kubectl", "get", "nodes", "-o", "json"],
+            check=False,
+            timeout=15,
+        )
+        if proc.returncode != 0:
+            return set()
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return set()
+        return {
+            item.get("metadata", {}).get("name", "")
+            for item in payload.get("items", [])
+            if item.get("metadata", {}).get("name", "")
+        }
+
 
 class ReadPathParser:
     @staticmethod
@@ -1263,6 +1281,7 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
             worker.get("nodeName") or "": int(worker.get("chunks") or 0)
             for worker in page_proof.get("workers") or []
         }
+        live_nodes = self.kube.node_names()
         routes = json.loads(proc.stdout)
         checked = []
         ok = True
@@ -1270,14 +1289,20 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
             selected = (route.get("hosts") or [{}])[0]
             node = selected.get("nodeName") or selected.get("nodeId") or ""
             pages = pages_by_node.get(node, 0)
+            endpoint_available = bool(
+                selected.get("endpointAvailable", bool(selected.get("privateAddr") or selected.get("addr")))
+            )
+            node_gone = bool(node and live_nodes and node not in live_nodes)
             item = {
                 "hash": route.get("key") or "",
                 "selectedHostId": selected.get("hostId") or "",
                 "selectedRegistrationId": selected.get("registrationId") or "",
                 "selectedNode": node,
                 "selectedPod": selected.get("pod") or "",
+                "selectedEndpointAvailable": endpoint_available,
+                "selectedNodeGone": node_gone,
                 "pagesOnSelectedNode": pages,
-                "ok": pages > 0,
+                "ok": pages > 0 or node_gone,
             }
             if remote_read:
                 target_host = remote_read.get("targetHost") or {}
@@ -1870,6 +1895,37 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                     logical_host_ids.append(logical_host_id)
         hosts = []
         for logical_host_id in logical_host_ids:
+            logical_raw = redis_cli(
+                self.config.namespace,
+                redis_pod,
+                "GET",
+                f"cache:coordinator:host:{logical_host_id}:logical",
+            )
+            logical: dict[str, Any] = {}
+            if logical_raw:
+                try:
+                    logical = json.loads(logical_raw)
+                except json.JSONDecodeError:
+                    logical = {}
+            logical_host = {
+                "hostId": logical.get("logical_host_id")
+                or logical.get("logicalHostId")
+                or logical_host_id,
+                "registrationId": "",
+                "poolName": logical.get("pool_name")
+                or logical.get("poolName")
+                or self.config.cache_pool_name,
+                "nodeId": logical.get("node_id") or logical.get("nodeId") or "",
+                "nodeName": logical.get("node_id") or logical.get("nodeId") or "",
+                "cachePathId": logical.get("cache_path_id")
+                or logical.get("cachePathId")
+                or "",
+                "addr": "",
+                "privateAddr": "",
+                "endpointAvailable": False,
+                "source": "coordinator_logical",
+            }
+            added_registration = False
             registration_ids = self._registration_ids(redis_pod, logical_host_id)
             for registration_id in registration_ids:
                 raw = redis_cli(
@@ -1908,10 +1964,14 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                         "privateAddr": registration.get("private_addr")
                         or registration.get("privateAddr")
                         or "",
+                        "endpointAvailable": True,
                         "source": "coordinator",
                     }
                 )
+                added_registration = True
                 break
+            if not added_registration and logical_host["nodeName"]:
+                hosts.append(logical_host)
         if hosts:
             return {"available": True, "indexKeys": index_keys, "hosts": hosts}
         return self.cache_hosts_from_worker_logs()
@@ -1972,6 +2032,7 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                         "addr": addr,
                         "privateAddr": addr,
                         "pod": pod_name,
+                        "endpointAvailable": True,
                         "source": "worker_logs",
                     }
                 )
@@ -2711,11 +2772,13 @@ class Reporter:
                 for proof in read_path_proofs
             )
             cache_hits = 0
+            cloud_reads = 0
             for proof in read_path_proofs:
                 summary = proof.get("geesefsSummary") or {}
                 cache_hits += int(summary.get("mmapHits") or 0)
                 cache_hits += int(summary.get("readIntoHits") or 0)
                 cache_hits += int(summary.get("bufferHits") or 0)
+                cloud_reads += int(summary.get("cloudReq") or 0)
             if self.config.require_read_path_proof and (
                 cache_hits <= 0 and external_page_hits <= 0
             ):
@@ -2726,6 +2789,14 @@ class Reporter:
             if not hrw_proof.get("ok"):
                 failures.append(
                     f"{row['accessType']}:{row['sizeMiB']}MiB HRW route proof failed: {hrw_proof.get('error') or hrw_proof.get('routes')}"
+                )
+            selected_node_gone = any(
+                bool(route.get("selectedNodeGone"))
+                for route in hrw_proof.get("routes") or []
+            )
+            if cloud_reads > 0 and not selected_node_gone:
+                failures.append(
+                    f"{row['accessType']}:{row['sizeMiB']}MiB cloud read observed while HRW-selected node still exists"
                 )
             remote = row.get("remoteRead")
             if self.config.require_remote_read:

--- a/benchmarks/b9bench/clip_layer_suite.py
+++ b/benchmarks/b9bench/clip_layer_suite.py
@@ -350,6 +350,35 @@ def cache_hosts_snapshot(kube: Kube, pool_name: str, locality: str) -> dict[str,
 
     hosts: list[dict[str, Any]] = []
     for logical_host_id in logical_host_ids:
+        logical_raw = redis_cli(
+            kube.config.namespace,
+            redis_pod,
+            "GET",
+            f"cache:coordinator:host:{logical_host_id}:logical",
+        )
+        logical: dict[str, Any] = {}
+        if logical_raw:
+            try:
+                logical = json.loads(logical_raw)
+            except json.JSONDecodeError:
+                logical = {}
+        logical_host = {
+            "hostId": logical.get("logical_host_id")
+            or logical.get("logicalHostId")
+            or logical_host_id,
+            "registrationId": "",
+            "poolName": logical.get("pool_name") or logical.get("poolName") or pool_name,
+            "nodeId": logical.get("node_id") or logical.get("nodeId") or "",
+            "nodeName": logical.get("node_id") or logical.get("nodeId") or "",
+            "cachePathId": logical.get("cache_path_id")
+            or logical.get("cachePathId")
+            or "",
+            "addr": "",
+            "privateAddr": "",
+            "endpointAvailable": False,
+            "source": "coordinator_logical",
+        }
+        added_registration = False
         for registration_id in registration_ids(kube.config.namespace, redis_pod, logical_host_id):
             raw = redis_cli(
                 kube.config.namespace,
@@ -383,10 +412,14 @@ def cache_hosts_snapshot(kube: Kube, pool_name: str, locality: str) -> dict[str,
                     "privateAddr": registration.get("private_addr")
                     or registration.get("privateAddr")
                     or "",
+                    "endpointAvailable": True,
                     "source": "coordinator",
                 }
             )
+            added_registration = True
             break
+        if not added_registration and logical_host["nodeName"]:
+            hosts.append(logical_host)
     if hosts:
         return {"available": True, "source": "coordinator", "indexKeys": index_keys, "hosts": hosts}
     return cache_hosts_from_worker_logs(kube)
@@ -462,6 +495,7 @@ def cache_hosts_from_worker_logs(kube: Kube) -> dict[str, Any]:
             "addr": addr,
             "privateAddr": addr,
             "pod": pod.get("name", ""),
+            "endpointAvailable": True,
             "source": "worker_logs",
         }
     hosts = list(hosts_by_id.values())
@@ -530,6 +564,7 @@ def hrw_routing_proof(
         for row in worker.get("rows") or []:
             pages_by_hash_node[(row.get("hash") or "", node)] = int(row.get("pages") or 0)
 
+    live_nodes = kube.node_names()
     checked = []
     ok = True
     for route in routes:
@@ -537,14 +572,20 @@ def hrw_routing_proof(
         selected = (route.get("hosts") or [{}])[0]
         node = selected.get("nodeName") or selected.get("nodeId") or ""
         pages = pages_by_hash_node.get((key, node), 0)
+        endpoint_available = bool(
+            selected.get("endpointAvailable", bool(selected.get("privateAddr") or selected.get("addr")))
+        )
+        node_gone = bool(node and live_nodes and node not in live_nodes)
         item = {
             "hash": key,
             "selectedHostId": selected.get("hostId") or "",
             "selectedRegistrationId": selected.get("registrationId") or "",
             "selectedNode": node,
             "selectedPod": selected.get("pod") or "",
+            "selectedEndpointAvailable": endpoint_available,
+            "selectedNodeGone": node_gone,
             "pagesOnSelectedNode": pages,
-            "ok": pages > 0,
+            "ok": pages > 0 or node_gone,
         }
         checked.append(item)
         ok = ok and item["ok"]

--- a/benchmarks/b9bench/runner.py
+++ b/benchmarks/b9bench/runner.py
@@ -458,6 +458,11 @@ class CacheSuiteProbe(ScriptProbeBase):
                     "hrw_selected_registration": hrw_route.get("selectedRegistrationId"),
                     "hrw_selected_node": hrw_route.get("selectedNode"),
                     "hrw_pages_on_selected_node": hrw_route.get("pagesOnSelectedNode"),
+                    "selected_logical_host_id": hrw_route.get("selectedHostId"),
+                    "selected_node": hrw_route.get("selectedNode"),
+                    "selected_endpoint_available": hrw_route.get("selectedEndpointAvailable"),
+                    "node_gone": hrw_route.get("selectedNodeGone"),
+                    "pages_on_selected_host": hrw_route.get("pagesOnSelectedNode"),
                     "remote_target_matches_hrw": hrw_route.get("remoteTargetMatchesHRW"),
                     "remote_target_registration_matches_hrw": hrw_route.get("remoteTargetRegistrationMatchesHRW"),
                 }

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -990,39 +990,20 @@ func (c *Client) ClientLocalPageFileViews(hash string, offset int64, length int6
 	if offset < 0 || length <= 0 {
 		return nil, nil
 	}
-	checked := make(map[string]struct{})
-	for attempt := 0; attempt < c.getContentAttempts(length); attempt++ {
-		host, err := c.getHostForRequest(&ClientRequest{
-			rt:        ClientRequestTypeRetrieval,
-			hash:      hash,
-			key:       opts.RoutingKey,
-			hostIndex: attempt,
-		})
-		if err != nil {
-			if err == ErrHostNotFound {
-				_ = c.refreshRoutableHosts(c.ctx)
-				host, err = c.getHostForRequest(&ClientRequest{
-					rt:        ClientRequestTypeRetrieval,
-					hash:      hash,
-					key:       opts.RoutingKey,
-					hostIndex: attempt,
-				})
-			}
-			if err != nil {
-				continue
-			}
-		}
 
-		checked[host.HostId] = struct{}{}
-		if views, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
-			return views, nil
+	host, err := c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
+	if err != nil {
+		if err == ErrHostNotFound {
+			_ = c.refreshRoutableHosts(c.ctx)
+			host, err = c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
+		}
+		if err != nil {
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
+			return nil, err
 		}
 	}
-
-	for _, host := range c.remainingHostsForRequest(checked) {
-		if views, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
-			return views, nil
-		}
+	if views, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
+		return views, nil
 	}
 
 	atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
@@ -1109,87 +1090,33 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 
 func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
 	length := int64(len(dst))
-	checked := make(map[string]struct{})
-	var primaryErr error
-	var sawMiss bool
-	var sawUnavailable bool
-	var lastErr error
-	for attempt := 0; attempt < c.getContentAttempts(length); attempt++ {
-		host, err := c.getHostForRequest(&ClientRequest{
-			rt:        ClientRequestTypeRetrieval,
-			hash:      hash,
-			key:       opts.RoutingKey,
-			hostIndex: attempt,
-		})
+
+	host, err := c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
+	if err != nil {
+		if err == ErrHostNotFound {
+			_ = c.refreshRoutableHosts(c.ctx)
+			host, err = c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
+		}
 		if err != nil {
-			if err == ErrHostNotFound {
-				_ = c.refreshRoutableHosts(c.ctx)
-				host, err = c.getHostForRequest(&ClientRequest{
-					rt:        ClientRequestTypeRetrieval,
-					hash:      hash,
-					key:       opts.RoutingKey,
-					hostIndex: attempt,
-				})
+			if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
+				return 0, ErrSelectedHostUnavailable
 			}
-			if err != nil {
-				if attempt == 0 {
-					primaryErr = err
-				}
-				lastErr = err
-				continue
-			}
-		}
-
-		checked[host.HostId] = struct{}{}
-		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
-		if err == nil && n == length {
-			return n, nil
-		}
-		if attempt == 0 {
-			primaryErr = err
-		}
-		if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
-			sawUnavailable = true
-		} else if errors.Is(err, ErrContentNotFound) {
-			sawMiss = true
-		}
-		if err != nil {
-			lastErr = err
+			return 0, err
 		}
 	}
 
-	for _, host := range c.remainingHostsForRequest(checked) {
-		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
-		if err == nil && n == length {
-			return n, nil
-		}
-		if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
-			sawUnavailable = true
-		} else if errors.Is(err, ErrContentNotFound) {
-			sawMiss = true
-		}
-		if err != nil {
-			lastErr = err
-		}
+	n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
+	if err == nil && n == length {
+		return n, nil
 	}
-
-	if primaryErr != nil {
-		if errors.Is(primaryErr, ErrSelectedHostUnavailable) || errors.Is(primaryErr, ErrUnableToReachHost) || errors.Is(primaryErr, ErrHostNotFound) {
-			return 0, ErrSelectedHostUnavailable
-		}
-		if errors.Is(primaryErr, ErrContentNotFound) {
-			return 0, ErrContentNotFound
-		}
-		return 0, primaryErr
-	}
-	if sawUnavailable {
+	if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
 		return 0, ErrSelectedHostUnavailable
 	}
-	if sawMiss {
+	if errors.Is(err, ErrContentNotFound) {
 		return 0, ErrContentNotFound
 	}
-	if lastErr != nil {
-		return 0, lastErr
+	if err != nil {
+		return 0, err
 	}
 	return 0, ErrContentNotFound
 }
@@ -1446,6 +1373,37 @@ func (c *Client) getGRPCClient(request *ClientRequest) (proto.CacheClient, *Host
 	return client, host, nil
 }
 
+func (c *Client) getSelectedHostForRequest(rt ClientRequestType, hash string, routingKey string) (*Host, error) {
+	return c.getHostForRequest(&ClientRequest{
+		rt:        rt,
+		hash:      hash,
+		key:       routingKey,
+		hostIndex: 0,
+	})
+}
+
+func (c *Client) getSelectedGRPCClient(ctx context.Context, rt ClientRequestType, hash string, routingKey string) (proto.CacheClient, *Host, error) {
+	client, host, err := c.getGRPCClient(&ClientRequest{
+		rt:        rt,
+		hash:      hash,
+		key:       routingKey,
+		hostIndex: 0,
+	})
+	if err == nil {
+		return client, host, nil
+	}
+	if isStoreHostUnavailable(err) && c.hostDirectory != nil && c.hostMap != nil {
+		_ = c.refreshRoutableHosts(ctx)
+		client, host, err = c.getGRPCClient(&ClientRequest{
+			rt:        rt,
+			hash:      hash,
+			key:       routingKey,
+			hostIndex: 0,
+		})
+	}
+	return client, host, err
+}
+
 func (c *Client) getHostForRequest(request *ClientRequest) (*Host, error) {
 	var host *Host = nil
 
@@ -1648,23 +1606,7 @@ func (c *Client) storeContentFromChunks(chunks chan []byte, hash string, cachePa
 		routingKey = hash
 	}
 
-	var client proto.CacheClient
-	var err error
-	for hostIndex := 0; hostIndex < c.storeHostAttempts(); hostIndex++ {
-		client, _, err = c.getGRPCClient(&ClientRequest{
-			rt:        ClientRequestTypeStorage,
-			hash:      hash,
-			key:       routingKey,
-			hostIndex: hostIndex,
-		})
-		if err == nil {
-			break
-		}
-		if isStoreHostUnavailable(err) {
-			_ = c.refreshRoutableHosts(ctx)
-			continue
-		}
-	}
+	client, _, err := c.getSelectedGRPCClient(ctx, ClientRequestTypeStorage, hash, routingKey)
 	if err != nil {
 		return "", err
 	}
@@ -1711,43 +1653,33 @@ func (c *Client) storeContentFromReaderWithContext(ctx context.Context, reader i
 	seeker, retryable := reader.(io.Seeker)
 	var lastErr error
 	for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
-		for hostIndex := 0; hostIndex < c.storeHostAttempts(); hostIndex++ {
-			if retryable {
-				if _, err := seeker.Seek(0, io.SeekStart); err != nil {
-					return "", err
-				}
-			} else if attempt > 0 || hostIndex > 0 {
-				break
+		if retryable {
+			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				return "", err
 			}
-
-			_, host, err := c.getGRPCClient(&ClientRequest{
-				rt:        ClientRequestTypeStorage,
-				hash:      routingKey,
-				key:       routingKey,
-				hostIndex: hostIndex,
-			})
-			if err != nil {
-				lastErr = err
-				if isStoreHostUnavailable(err) {
-					_ = c.refreshRoutableHosts(ctx)
-				}
-				continue
-			}
-
-			hash, err := c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
-			if err == nil {
-				return hash, nil
-			}
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return "", ctxErr
-			}
-			lastErr = err
-			c.removeHost(host)
-			_ = c.refreshRoutableHosts(ctx)
-			if !retryable {
-				break
-			}
+		} else if attempt > 0 {
+			break
 		}
+
+		_, host, err := c.getSelectedGRPCClient(ctx, ClientRequestTypeStorage, routingKey, routingKey)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		hash, err := c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
+		if err == nil {
+			return hash, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
+		lastErr = err
+		c.removeHost(host)
+		if c.hostDirectory == nil || c.hostMap == nil {
+			break
+		}
+		_ = c.refreshRoutableHosts(ctx)
 		if !retryable {
 			break
 		}
@@ -1967,67 +1899,56 @@ func (c *Client) StoreContentFromS3Source(source S3ContentSource, opts StoreCont
 func (c *Client) storeContentFromSource(ctx context.Context, req *proto.CacheStoreContentFromSourceRequest, hash, routingKey string, lock bool) (string, error) {
 	var lastErr error
 	for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
-		for hostIndex := 0; hostIndex < c.storeHostAttempts(); hostIndex++ {
-			client, host, err := c.getGRPCClient(&ClientRequest{
-				rt:        ClientRequestTypeStorage,
-				hash:      hash,
-				key:       routingKey,
-				hostIndex: hostIndex,
-			})
-			if err != nil {
-				lastErr = err
-				if isStoreHostUnavailable(err) {
-					_ = c.refreshRoutableHosts(ctx)
-				}
-				continue
-			}
+		client, host, err := c.getSelectedGRPCClient(ctx, ClientRequestTypeStorage, hash, routingKey)
+		if err != nil {
+			lastErr = err
+			continue
+		}
 
-			if lock {
-				resp, err := client.StoreContentFromSourceWithLock(ctx, req)
-				if err != nil {
-					lastErr = err
-					c.removeHost(host)
-					_ = c.refreshRoutableHosts(ctx)
-					continue
-				}
-
-				if resp == nil {
-					return "", ErrUnableToPopulateContent
-				}
-				if resp.FailedToAcquireLock {
-					return "", ErrUnableToAcquireLock
-				}
-				if !resp.Ok {
-					return "", ErrUnableToPopulateContent
-				}
-				return resp.Hash, nil
-			}
-
-			resp, err := client.StoreContentFromSource(ctx, req)
+		if lock {
+			resp, err := client.StoreContentFromSourceWithLock(ctx, req)
 			if err != nil {
 				lastErr = err
 				c.removeHost(host)
+				if c.hostDirectory == nil || c.hostMap == nil {
+					break
+				}
 				_ = c.refreshRoutableHosts(ctx)
 				continue
 			}
-			if resp == nil || !resp.Ok {
+
+			if resp == nil {
+				return "", ErrUnableToPopulateContent
+			}
+			if resp.FailedToAcquireLock {
+				return "", ErrUnableToAcquireLock
+			}
+			if !resp.Ok {
 				return "", ErrUnableToPopulateContent
 			}
 			return resp.Hash, nil
 		}
+
+		resp, err := client.StoreContentFromSource(ctx, req)
+		if err != nil {
+			lastErr = err
+			c.removeHost(host)
+			if c.hostDirectory == nil || c.hostMap == nil {
+				break
+			}
+			_ = c.refreshRoutableHosts(ctx)
+			continue
+		}
+		if resp == nil || !resp.Ok {
+			return "", ErrUnableToPopulateContent
+		}
+		return resp.Hash, nil
 	}
 
 	if lastErr != nil {
 		return "", lastErr
 	}
 	return "", ErrHostNotFound
-}
-
-func (c *Client) storeHostAttempts() int {
-	if c == nil || c.clientConfig.NTopHosts <= 0 {
-		return 1
-	}
-	return c.clientConfig.NTopHosts
 }
 
 func isStoreHostUnavailable(err error) bool {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -102,7 +102,7 @@ func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestReadContentIntoFallsBackToReachableReplicaOutsideTopHosts(t *testing.T) {
+func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("local-cache-content")
 	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
@@ -126,17 +126,14 @@ func TestReadContentIntoFallsBackToReachableReplicaOutsideTopHosts(t *testing.T)
 	client.AttachLocalServer(&Server{cas: store})
 
 	dst := make([]byte, len(content))
-	n, err := client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
-	require.NoError(t, err)
-	require.Equal(t, int64(len(content)), n)
-	require.Equal(t, content, dst)
+	_, err = client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 
-	regions, err := client.ClientLocalPageFileViews(hash, 3, 6, ClientOptions{})
-	require.NoError(t, err)
-	require.Len(t, regions, 2)
+	_, err = client.ClientLocalPageFileViews(hash, 3, 6, ClientOptions{})
+	require.ErrorIs(t, err, ErrContentNotFound)
 }
 
-func TestReadContentIntoRefreshesHostsBeforeDeclaringMiss(t *testing.T) {
+func TestReadContentIntoDoesNotMaskSelectedHostMissWithDifferentHost(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -210,10 +207,8 @@ func TestReadContentIntoRefreshesHostsBeforeDeclaringMiss(t *testing.T) {
 	readCtx, readCancel := context.WithTimeout(ctx, 3*time.Second)
 	defer readCancel()
 	dst := make([]byte, len(content))
-	n, err := client.ReadContentInto(readCtx, hash, 0, dst, ClientOptions{RoutingKey: hash})
-	require.NoError(t, err)
-	require.Equal(t, int64(len(content)), n)
-	require.Equal(t, content, dst)
+	_, err = client.ReadContentInto(readCtx, hash, 0, dst, ClientOptions{RoutingKey: hash})
+	require.ErrorIs(t, err, ErrContentNotFound)
 }
 
 func TestReadContentIntoUsesSelectedLocalServer(t *testing.T) {
@@ -713,7 +708,7 @@ func TestStoreContentFromLocalFileRepairsSelectedHostWhenFallbackHasContent(t *t
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestStoreContentFromReaderRetriesSeekableReaderAfterStreamError(t *testing.T) {
+func TestStoreContentFromReaderDoesNotFallbackWhenSelectedHostStreamFails(t *testing.T) {
 	ctx := context.Background()
 	firstHost := &Host{HostId: "first-host", PrivateAddr: "first-host:2049"}
 	secondHost := &Host{HostId: "second-host", PrivateAddr: "second-host:2049"}
@@ -721,7 +716,7 @@ func TestStoreContentFromReaderRetriesSeekableReaderAfterStreamError(t *testing.
 	secondStream := &fakeStoreContentStream{}
 	client := &Client{
 		ctx:                   ctx,
-		clientConfig:          ClientConfig{NTopHosts: 1},
+		clientConfig:          ClientConfig{NTopHosts: 2},
 		grpcClients:           map[string]proto.CacheClient{"first-host": &fakeStoreCacheClient{stream: firstStream}, "second-host": &fakeStoreCacheClient{stream: secondStream}},
 		grpcConns:             make(map[string]*grpc.ClientConn),
 		rawReadPools:          make(map[string]*rawReadConnPool),
@@ -735,13 +730,13 @@ func TestStoreContentFromReaderRetriesSeekableReaderAfterStreamError(t *testing.
 	expectedHash := hex.EncodeToString(sum[:])
 
 	got, err := client.storeContentFromReaderWithContext(ctx, bytes.NewReader(content), expectedHash, "/cache/file.bin", nil)
-	require.NoError(t, err)
-	require.Equal(t, expectedHash, got)
+	require.Error(t, err)
+	require.Empty(t, got)
 	require.NotEmpty(t, firstStream.sent.Bytes())
-	require.Equal(t, content, secondStream.sent.Bytes())
+	require.Empty(t, secondStream.sent.Bytes())
 }
 
-func TestStoreContentFromReaderFallsBackWhenSelectedHostUnavailable(t *testing.T) {
+func TestStoreContentFromReaderDoesNotFallbackWhenSelectedHostUnavailable(t *testing.T) {
 	ctx := context.Background()
 	selectedHost := &Host{HostId: "selected-host"}
 	fallbackHost := &Host{HostId: "fallback-host", PrivateAddr: "fallback-host:2049"}
@@ -762,9 +757,9 @@ func TestStoreContentFromReaderFallsBackWhenSelectedHostUnavailable(t *testing.T
 	expectedHash := hex.EncodeToString(sum[:])
 
 	got, err := client.storeContentFromReaderWithContext(ctx, bytes.NewReader(content), expectedHash, "/cache/file.bin", nil)
-	require.NoError(t, err)
-	require.Equal(t, expectedHash, got)
-	require.Equal(t, content, fallbackStream.sent.Bytes())
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+	require.Empty(t, got)
+	require.Empty(t, fallbackStream.sent.Bytes())
 }
 
 type fakeStoreCacheClient struct {

--- a/pkg/cache/coordinator.go
+++ b/pkg/cache/coordinator.go
@@ -215,5 +215,13 @@ func (c *Coordinator) pruneLogicalHost(ctx context.Context, poolName, locality, 
 		return nil
 	}
 
+	logicalHost, ok, err := c.repository.GetCacheLogicalHost(ctx, logicalHostID)
+	if err != nil {
+		return err
+	}
+	if ok && logicalHost.Locality == locality && (poolName == "" || logicalHost.PoolName == poolName) {
+		return nil
+	}
+
 	return c.repository.RemoveCacheLogicalHost(ctx, poolName, locality, logicalHostID)
 }

--- a/pkg/cache/coordinator_test.go
+++ b/pkg/cache/coordinator_test.go
@@ -251,6 +251,34 @@ func TestCoordinatorListsLogicalHostWhenNoEndpointRegistrationIsActive(t *testin
 	require.Empty(t, hosts[0].PrivateAddr)
 }
 
+func TestCoordinatorUnregisterPreservesLogicalHostForEndpointChurn(t *testing.T) {
+	repo := newMemoryCoordinatorRepository()
+	coordinator := NewCoordinator(repo)
+	ctx := context.Background()
+
+	host := CoordinatorHost{
+		LogicalHostID:  "cache-host-default-node-a-path-0",
+		RegistrationID: "worker-a",
+		PoolName:       "default",
+		Locality:       "default",
+		NodeID:         "node-a",
+		CachePathID:    "path",
+		Addr:           "10.0.0.1:2049",
+		PrivateAddr:    "10.0.0.1:2049",
+	}
+	require.NoError(t, coordinator.RegisterHost(ctx, host, 30*time.Second))
+	require.NoError(t, coordinator.UnregisterHost(ctx, host.PoolName, host.Locality, host.LogicalHostID, host.RegistrationID))
+
+	hosts, err := coordinator.ListHosts(ctx, "default", "default")
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, host.LogicalHostID, hosts[0].LogicalHostID)
+	require.Equal(t, host.NodeID, hosts[0].NodeID)
+	require.Equal(t, host.CachePathID, hosts[0].CachePathID)
+	require.Empty(t, hosts[0].RegistrationID)
+	require.Empty(t, hosts[0].PrivateAddr)
+}
+
 func TestCoordinatorCanListCacheHostsAcrossWorkerPools(t *testing.T) {
 	repo := newMemoryCoordinatorRepository()
 	coordinator := NewCoordinator(repo)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserve logical cache hosts across endpoint churn and enforce strict selected-host routing. The client no longer falls back to other replicas, and benchmarks now reflect endpoint availability and node liveness for clearer diagnostics.

- **Bug Fixes**
  - Coordinator: keep the logical host after unregister if pool/locality still match; return it without registration/addr to avoid host flapping.
  - Client: stop masking misses/unavailability by probing other replicas; return ErrSelectedHostUnavailable or ErrContentNotFound as appropriate and refresh hosts once on ErrHostNotFound.
  - Benchmarks: treat cloud reads as valid only if the selected node is gone; include endpointAvailable and node-gone checks.

- **Refactors**
  - Client: added `getSelectedHostForRequest`/`getSelectedGRPCClient`; removed multi-host attempt loops and `storeHostAttempts`; reads and writes use only the selected host.
  - Benchmarks: added `node_names()` lookup, propagated endpoint/node state through HRW routing proofs and runner metrics.

<sup>Written for commit 17b431b47824a99c4dce3ff59dcf969ffbf414cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

