### PR TITLE
one last host fix

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -278,7 +278,6 @@ func (c *Client) addHost(host *Host) error {
 		return ErrHostNotFound
 	}
 	if !host.HasEndpoint() {
-		logicalHost := host.LogicalOnly()
 		c.mu.Lock()
 		defer c.mu.Unlock()
 
@@ -292,7 +291,6 @@ func (c *Client) addHost(host *Host) error {
 			delete(c.rawReadPools, host.HostId)
 		}
 		c.hasher.Remove(host)
-		c.hasher.Add(logicalHost)
 		for hash, entry := range c.localHostCache {
 			if entry.host != nil && entry.host.HostId == host.HostId {
 				delete(c.localHostCache, hash)
@@ -452,11 +450,8 @@ func (c *Client) removeHost(host *Host) {
 		return
 	}
 
-	logicalHost := host.LogicalOnly()
 	if c.hostMap != nil {
-		var ok bool
-		logicalHost, ok = c.hostMap.DeactivateEndpoint(host)
-		if !ok {
+		if _, ok := c.hostMap.DeactivateEndpoint(host); !ok {
 			return
 		}
 	}
@@ -465,7 +460,6 @@ func (c *Client) removeHost(host *Host) {
 	defer c.mu.Unlock()
 
 	c.hasher.Remove(host)
-	c.hasher.Add(logicalHost)
 	if conn, ok := c.grpcConns[host.HostId]; ok {
 		_ = conn.Close()
 		delete(c.grpcConns, host.HostId)

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	proto "github.com/beam-cloud/beta9/proto"
+	"github.com/beam-cloud/rendezvous"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -100,6 +101,36 @@ func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T
 	_, err := client.ReadContentInto(context.Background(), "hash", 0, dst, ClientOptions{RoutingKey: "hash"})
 
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+}
+
+func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
+	client := &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                rendezvous.New[*Host](),
+		maxGetContentAttempts: 1,
+	}
+
+	logicalHost := &Host{
+		HostId:      "logical-host",
+		PoolName:    "default",
+		Locality:    "test",
+		NodeID:      "node-a",
+		CachePathID: "path",
+	}
+	require.NoError(t, client.addHost(logicalHost))
+
+	_, err := client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeStorage,
+		hash:      "hash",
+		key:       "hash",
+		hostIndex: 0,
+	})
+	require.ErrorIs(t, err, ErrHostNotFound)
 }
 
 func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes host selection by ensuring hosts without endpoints are never members of the Rendezvous (HRW) ring. Prevents accidental selection and stale entries when adding or removing hosts.

- **Bug Fixes**
  - In addHost/removeHost, stop adding LogicalOnly() hosts to the `github.com/beam-cloud/rendezvous` hasher; only remove the real host.
  - Added TestLogicalOnlyHostIsNotActiveHRWMember to assert such hosts are not selectable and return ErrHostNotFound.

<sup>Written for commit 5f3cb205580a96e6a39f41f2200b038ad3876b67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

