### PR TITLE
top n cache hosts

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -36,6 +36,7 @@ const (
 	localClientCacheCleanupInterval = 5 * time.Second
 	localClientCacheTTL             = 600 * time.Second
 	defaultRawReadWindowPartBytes   = 4 * 1024 * 1024
+	defaultStoreReplicaHosts        = 2
 
 	// NOTE: This value for readAheadKB is separate from the cachefs config since the FUSE library does
 	// weird stuff with the other read_ahead_kb value internally
@@ -579,6 +580,26 @@ func (c *Client) getContentAttempts(length int64) int {
 	return attempts
 }
 
+func (c *Client) readReplicaHostCount() int {
+	if c.clientConfig.NTopHosts < 1 {
+		return 1
+	}
+	return c.clientConfig.NTopHosts
+}
+
+func (c *Client) storeReplicaHostCount(replayable bool) int {
+	if !replayable {
+		return 1
+	}
+	if c.clientConfig.NTopHosts < 1 {
+		return 1
+	}
+	if c.clientConfig.NTopHosts < defaultStoreReplicaHosts {
+		return c.clientConfig.NTopHosts
+	}
+	return defaultStoreReplicaHosts
+}
+
 func (c *Client) dataCallOptions() []grpc.CallOption {
 	if !c.globalConfig.GRPCPayloadCodecV2 {
 		return nil
@@ -1084,35 +1105,94 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 
 func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
 	length := int64(len(dst))
+	var lastErr error
+	primaryUnavailable := false
+	selectedUnavailable := false
+	contentMissing := false
+	checked := make(map[string]struct{}, c.readReplicaHostCount())
 
-	host, err := c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
-	if err != nil {
+	for hostIndex := 0; hostIndex < c.readReplicaHostCount(); hostIndex++ {
+		host, err := c.getHostForRequest(&ClientRequest{
+			rt:        ClientRequestTypeRetrieval,
+			hash:      hash,
+			key:       opts.RoutingKey,
+			hostIndex: hostIndex,
+		})
+		if err != nil {
+			if err == ErrHostNotFound {
+				_ = c.refreshRoutableHosts(c.ctx)
+				host, err = c.getHostForRequest(&ClientRequest{
+					rt:        ClientRequestTypeRetrieval,
+					hash:      hash,
+					key:       opts.RoutingKey,
+					hostIndex: hostIndex,
+				})
+			}
+			if err != nil {
+				if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
+					if hostIndex == 0 {
+						primaryUnavailable = true
+					}
+					selectedUnavailable = true
+					lastErr = ErrSelectedHostUnavailable
+					continue
+				}
+				lastErr = err
+				continue
+			}
+		}
+		if host == nil || host.HostId == "" {
+			lastErr = ErrHostNotFound
+			continue
+		}
+		if _, ok := checked[host.HostId]; ok {
+			continue
+		}
+		checked[host.HostId] = struct{}{}
+
+		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
+		if err == nil && n == length {
+			return n, nil
+		}
+		if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
+			if hostIndex == 0 {
+				primaryUnavailable = true
+			}
+			selectedUnavailable = true
+			lastErr = ErrSelectedHostUnavailable
+			continue
+		}
+		if errors.Is(err, ErrContentNotFound) {
+			contentMissing = true
+			lastErr = ErrContentNotFound
+			continue
+		}
 		if err == ErrHostNotFound {
-			_ = c.refreshRoutableHosts(c.ctx)
-			host, err = c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
+			if hostIndex == 0 {
+				primaryUnavailable = true
+			}
+			selectedUnavailable = true
+			lastErr = ErrSelectedHostUnavailable
+			continue
 		}
 		if err != nil {
-			if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
-				return 0, ErrSelectedHostUnavailable
-			}
-			return 0, err
+			lastErr = err
+			continue
 		}
+		contentMissing = true
+		lastErr = ErrContentNotFound
 	}
 
-	n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
-	if err == nil && n == length {
-		return n, nil
-	}
-	if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
+	if primaryUnavailable || (selectedUnavailable && !contentMissing) {
 		return 0, ErrSelectedHostUnavailable
 	}
-	if errors.Is(err, ErrContentNotFound) {
+	if contentMissing {
 		return 0, ErrContentNotFound
 	}
-	if err != nil {
-		return 0, err
+	if lastErr != nil {
+		return 0, lastErr
 	}
-	return 0, ErrContentNotFound
+	return 0, ErrHostNotFound
 }
 
 func (c *Client) readContentIntoAfterHostRefresh(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
@@ -1377,11 +1457,15 @@ func (c *Client) getSelectedHostForRequest(rt ClientRequestType, hash string, ro
 }
 
 func (c *Client) getSelectedGRPCClient(ctx context.Context, rt ClientRequestType, hash string, routingKey string) (proto.CacheClient, *Host, error) {
+	return c.getGRPCClientForHostIndex(ctx, rt, hash, routingKey, 0)
+}
+
+func (c *Client) getGRPCClientForHostIndex(ctx context.Context, rt ClientRequestType, hash string, routingKey string, hostIndex int) (proto.CacheClient, *Host, error) {
 	client, host, err := c.getGRPCClient(&ClientRequest{
 		rt:        rt,
 		hash:      hash,
 		key:       routingKey,
-		hostIndex: 0,
+		hostIndex: hostIndex,
 	})
 	if err == nil {
 		return client, host, nil
@@ -1392,7 +1476,7 @@ func (c *Client) getSelectedGRPCClient(ctx context.Context, rt ClientRequestType
 			rt:        rt,
 			hash:      hash,
 			key:       routingKey,
-			hostIndex: 0,
+			hostIndex: hostIndex,
 		})
 	}
 	return client, host, err
@@ -1646,37 +1730,61 @@ func (c *Client) storeContentFromChunks(chunks chan []byte, hash string, cachePa
 func (c *Client) storeContentFromReaderWithContext(ctx context.Context, reader io.Reader, routingKey string, cachePath string, fileMetadata *proto.CacheFSMetadata) (string, error) {
 	seeker, retryable := reader.(io.Seeker)
 	var lastErr error
-	for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
-		if retryable {
-			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
-				return "", err
+	var storedHash string
+	successes := 0
+	replicaHosts := c.storeReplicaHostCount(retryable)
+
+	for hostIndex := 0; hostIndex < replicaHosts; hostIndex++ {
+		hostStored := false
+		for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
+			if retryable {
+				if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+					return "", err
+				}
+			} else if attempt > 0 || hostIndex > 0 {
+				break
 			}
-		} else if attempt > 0 {
-			break
-		}
 
-		_, host, err := c.getSelectedGRPCClient(ctx, ClientRequestTypeStorage, routingKey, routingKey)
-		if err != nil {
+			_, host, err := c.getGRPCClientForHostIndex(ctx, ClientRequestTypeStorage, routingKey, routingKey, hostIndex)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			hash, err := c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
+			if err == nil {
+				if storedHash == "" {
+					storedHash = hash
+				} else if hash != storedHash {
+					return storedHash, fmt.Errorf("stored content hash mismatch across replicas: expected %s, got %s", storedHash, hash)
+				}
+				successes++
+				hostStored = true
+				break
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
 			lastErr = err
-			continue
+			if c.hostDirectory == nil || c.hostMap == nil {
+				break
+			}
+			c.removeHost(host)
+			_ = c.refreshRoutableHosts(ctx)
+			if !retryable {
+				break
+			}
 		}
+		if !retryable || (!hostStored && hostIndex == 0 && replicaHosts == 1) {
+			break
+		}
+	}
 
-		hash, err := c.storeContentFromReaderToHostWithContext(ctx, host, reader, cachePath, fileMetadata)
-		if err == nil {
-			return hash, nil
+	if successes > 0 {
+		if lastErr != nil && successes < replicaHosts {
+			Logger.Debugf("StoreContent replica population partially succeeded: hash=%s routing_key=%s successes=%d/%d last_err=%v", storedHash, routingKey, successes, replicaHosts, lastErr)
 		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", ctxErr
-		}
-		lastErr = err
-		c.removeHost(host)
-		if c.hostDirectory == nil || c.hostMap == nil {
-			break
-		}
-		_ = c.refreshRoutableHosts(ctx)
-		if !retryable {
-			break
-		}
+		return storedHash, nil
 	}
 
 	if lastErr != nil {
@@ -1892,51 +2000,85 @@ func (c *Client) StoreContentFromS3Source(source S3ContentSource, opts StoreCont
 
 func (c *Client) storeContentFromSource(ctx context.Context, req *proto.CacheStoreContentFromSourceRequest, hash, routingKey string, lock bool) (string, error) {
 	var lastErr error
-	for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
-		client, host, err := c.getSelectedGRPCClient(ctx, ClientRequestTypeStorage, hash, routingKey)
-		if err != nil {
-			lastErr = err
-			continue
-		}
+	var storedHash string
+	successes := 0
+	replicaHosts := c.storeReplicaHostCount(true)
 
-		if lock {
-			resp, err := client.StoreContentFromSourceWithLock(ctx, req)
+	for hostIndex := 0; hostIndex < replicaHosts; hostIndex++ {
+		hostStored := false
+		for attempt := 0; attempt < c.getContentAttempts(0); attempt++ {
+			client, host, err := c.getGRPCClientForHostIndex(ctx, ClientRequestTypeStorage, hash, routingKey, hostIndex)
 			if err != nil {
 				lastErr = err
-				c.removeHost(host)
-				if c.hostDirectory == nil || c.hostMap == nil {
-					break
-				}
-				_ = c.refreshRoutableHosts(ctx)
 				continue
 			}
 
-			if resp == nil {
-				return "", ErrUnableToPopulateContent
-			}
-			if resp.FailedToAcquireLock {
-				return "", ErrUnableToAcquireLock
-			}
-			if !resp.Ok {
-				return "", ErrUnableToPopulateContent
-			}
-			return resp.Hash, nil
-		}
+			if lock {
+				resp, err := client.StoreContentFromSourceWithLock(ctx, req)
+				if err != nil {
+					lastErr = err
+					if c.hostDirectory == nil || c.hostMap == nil {
+						break
+					}
+					c.removeHost(host)
+					_ = c.refreshRoutableHosts(ctx)
+					continue
+				}
 
-		resp, err := client.StoreContentFromSource(ctx, req)
-		if err != nil {
-			lastErr = err
-			c.removeHost(host)
-			if c.hostDirectory == nil || c.hostMap == nil {
+				if resp == nil {
+					lastErr = ErrUnableToPopulateContent
+					break
+				}
+				if resp.FailedToAcquireLock {
+					return "", ErrUnableToAcquireLock
+				}
+				if !resp.Ok {
+					lastErr = ErrUnableToPopulateContent
+					break
+				}
+				if storedHash == "" {
+					storedHash = resp.Hash
+				} else if resp.Hash != storedHash {
+					return storedHash, fmt.Errorf("stored content hash mismatch across replicas: expected %s, got %s", storedHash, resp.Hash)
+				}
+				successes++
+				hostStored = true
 				break
 			}
-			_ = c.refreshRoutableHosts(ctx)
-			continue
+
+			resp, err := client.StoreContentFromSource(ctx, req)
+			if err != nil {
+				lastErr = err
+				if c.hostDirectory == nil || c.hostMap == nil {
+					break
+				}
+				c.removeHost(host)
+				_ = c.refreshRoutableHosts(ctx)
+				continue
+			}
+			if resp == nil || !resp.Ok {
+				lastErr = ErrUnableToPopulateContent
+				break
+			}
+			if storedHash == "" {
+				storedHash = resp.Hash
+			} else if resp.Hash != storedHash {
+				return storedHash, fmt.Errorf("stored content hash mismatch across replicas: expected %s, got %s", storedHash, resp.Hash)
+			}
+			successes++
+			hostStored = true
+			break
 		}
-		if resp == nil || !resp.Ok {
-			return "", ErrUnableToPopulateContent
+		if !hostStored && hostIndex == 0 && replicaHosts == 1 {
+			break
 		}
-		return resp.Hash, nil
+	}
+
+	if successes > 0 {
+		if lastErr != nil && successes < replicaHosts {
+			Logger.Debugf("StoreFromContent replica population partially succeeded: hash=%s routing_key=%s successes=%d/%d last_err=%v", storedHash, routingKey, successes, replicaHosts, lastErr)
+		}
+		return storedHash, nil
 	}
 
 	if lastErr != nil {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -103,6 +103,62 @@ func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
+func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Client: ClientConfig{NTopHosts: 2},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+
+	replicaServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("replica-host"))
+	require.NoError(t, err)
+	replicaAddr, err := replicaServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, replicaServer.Close()) }()
+
+	primaryHost := &Host{
+		HostId:      "primary-host",
+		PoolName:    "default",
+		Locality:    "test",
+		NodeID:      "node-a",
+		CachePathID: "path",
+	}
+	replicaHost := replicaServer.Host()
+	require.NotNil(t, replicaHost)
+	replicaHost.Addr = replicaAddr
+	replicaHost.PrivateAddr = replicaAddr
+
+	client := &Client{
+		ctx:                   ctx,
+		clientConfig:          cfg.Client,
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{primaryHost, replicaHost}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(replicaHost))
+	defer client.Cleanup()
+
+	dst := make([]byte, 8)
+	_, err = client.ReadContentInto(ctx, "missing-hash", 0, dst, ClientOptions{RoutingKey: "missing-hash"})
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+}
+
 func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
 	client := &Client{
 		ctx:                   context.Background(),
@@ -240,6 +296,75 @@ func TestReadContentIntoDoesNotMaskSelectedHostMissWithDifferentHost(t *testing.
 	dst := make([]byte, len(content))
 	_, err = client.ReadContentInto(readCtx, hash, 0, dst, ClientOptions{RoutingKey: hash})
 	require.ErrorIs(t, err, ErrContentNotFound)
+}
+
+func TestReadContentIntoFallsBackToRankedReplicaHost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Client: ClientConfig{NTopHosts: 2},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+
+	primaryServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("primary-host"))
+	require.NoError(t, err)
+	primaryAddr, err := primaryServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, primaryServer.Close()) }()
+
+	replicaCfg := cfg
+	replicaCfg.Server.DiskCacheDir = t.TempDir()
+	replicaServer, err := NewServerWithOptions(ctx, replicaCfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("replica-host"))
+	require.NoError(t, err)
+	replicaAddr, err := replicaServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, replicaServer.Close()) }()
+
+	content := []byte("content-on-ranked-replica")
+	hash, _, err := replicaServer.cas.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	primaryHost := primaryServer.Host()
+	require.NotNil(t, primaryHost)
+	primaryHost.Addr = primaryAddr
+	primaryHost.PrivateAddr = primaryAddr
+	replicaHost := replicaServer.Host()
+	require.NotNil(t, replicaHost)
+	replicaHost.Addr = replicaAddr
+	replicaHost.PrivateAddr = replicaAddr
+
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          cfg.Client,
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[string]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{primaryHost, replicaHost}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(primaryHost))
+	require.NoError(t, client.addHost(replicaHost))
+	defer client.Cleanup()
+
+	dst := make([]byte, len(content))
+	n, err := client.ReadContentInto(ctx, hash, 0, dst, ClientOptions{RoutingKey: hash})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
 }
 
 func TestReadContentIntoUsesSelectedLocalServer(t *testing.T) {
@@ -739,7 +864,7 @@ func TestStoreContentFromLocalFileRepairsSelectedHostWhenFallbackHasContent(t *t
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestStoreContentFromReaderDoesNotFallbackWhenSelectedHostStreamFails(t *testing.T) {
+func TestStoreContentFromReaderFallsBackToRankedReplicaWhenSelectedHostStreamFails(t *testing.T) {
 	ctx := context.Background()
 	firstHost := &Host{HostId: "first-host", PrivateAddr: "first-host:2049"}
 	secondHost := &Host{HostId: "second-host", PrivateAddr: "second-host:2049"}
@@ -761,13 +886,13 @@ func TestStoreContentFromReaderDoesNotFallbackWhenSelectedHostStreamFails(t *tes
 	expectedHash := hex.EncodeToString(sum[:])
 
 	got, err := client.storeContentFromReaderWithContext(ctx, bytes.NewReader(content), expectedHash, "/cache/file.bin", nil)
-	require.Error(t, err)
-	require.Empty(t, got)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
 	require.NotEmpty(t, firstStream.sent.Bytes())
-	require.Empty(t, secondStream.sent.Bytes())
+	require.Equal(t, content, secondStream.sent.Bytes())
 }
 
-func TestStoreContentFromReaderDoesNotFallbackWhenSelectedHostUnavailable(t *testing.T) {
+func TestStoreContentFromReaderFallsBackToRankedReplicaWhenSelectedHostUnavailable(t *testing.T) {
 	ctx := context.Background()
 	selectedHost := &Host{HostId: "selected-host"}
 	fallbackHost := &Host{HostId: "fallback-host", PrivateAddr: "fallback-host:2049"}
@@ -788,9 +913,9 @@ func TestStoreContentFromReaderDoesNotFallbackWhenSelectedHostUnavailable(t *tes
 	expectedHash := hex.EncodeToString(sum[:])
 
 	got, err := client.storeContentFromReaderWithContext(ctx, bytes.NewReader(content), expectedHash, "/cache/file.bin", nil)
-	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
-	require.Empty(t, got)
-	require.Empty(t, fallbackStream.sent.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
+	require.Equal(t, content, fallbackStream.sent.Bytes())
 }
 
 type fakeStoreCacheClient struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds top-N host routing for cache reads and writes to improve availability and clarity of failures. Reads can fall back to ranked replicas, and stores can replicate to up to two hosts when the input is replayable.

- New Features
  - Introduced `NTopHosts` in client routing: reads try the top N ranked hosts instead of only the primary.
  - Stores replicate to up to 2 hosts when the reader is replayable; uses min(`NTopHosts`, 2) and verifies identical content hashes across replicas.
  - Added host-indexed gRPC client selection to target specific ranked replicas.

- Bug Fixes
  - Do not mask a primary-unavailable error with a replica miss; returns `ErrSelectedHostUnavailable` correctly.
  - Read and store paths now fall back to ranked replicas when the selected host is unavailable or streaming fails.
  - More precise error signaling between `ErrSelectedHostUnavailable` and `ErrContentNotFound`; removes and refreshes unhealthy hosts on failure.

<sup>Written for commit b391417a04bc5c6ff23e4e6b02dd79cd004b5f3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

