### PR TITLE
small fix to keep things on the cache path

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -69,7 +69,7 @@ VOLUME_CONTAINER_PREFIX = "/volumes"
 GEESEFS_SUMMARY_RE = re.compile(
     r"geesefs read path summary: .*?"
     r"mmap_page\(attempt=(\d+) hit=(\d+) miss=(\d+) mmap_fail=(\d+) ([0-9.]+)MiB[^)]*\).*?"
-    r"read_into\(attempt=(\d+) hit=(\d+) miss=(\d+) ([0-9.]+)MiB\).*?"
+    r"read_into\(attempt=(\d+) hit=(\d+) miss=(\d+) ([0-9.]+)MiB[^)]*\).*?"
     r"stream\(attempt=(\d+) hit=(\d+) miss=(\d+) ([0-9.]+)MiB\).*?"
     r"unary\(attempt=(\d+) hit=(\d+) miss=(\d+) ([0-9.]+)MiB\).*?"
     r"cloud\(req=(\d+) ([0-9.]+)MiB\)"
@@ -80,12 +80,14 @@ GEESEFS_BUFFER_RE = re.compile(
 CACHE_SUMMARY_RE = re.compile(
     r"cache read path summary: .*?"
     r"client\(read_into=(\d+) ([0-9.]+)MiB local_hit=(\d+) local_miss=(\d+) "
-    r"raw_hit=(\d+) raw_miss=(\d+) raw_err=(\d+) "
+    r"raw_req=(\d+) raw_hit=(\d+) raw_miss=(\d+) raw_err=(\d+) "
+    r"raw_wait_avg=[^ ]+ raw_header_avg=[^ ]+ raw_body_avg=[^ ]+ "
     r"grpc_hit=(\d+) grpc_miss=(\d+) grpc_err=(\d+)\).*?"
     r"client_local_page_file\(req=(\d+) hit=(\d+) miss=(\d+) ([0-9.]+)MiB\).*?"
     r"server\(grpc_req=(\d+) grpc_hit=(\d+) grpc_miss=(\d+) ([0-9.]+)MiB "
     r"stream_req=(\d+) stream_chunks=(\d+) ([0-9.]+)MiB stream_err=(\d+) "
-    r"raw_req=(\d+) raw_sendfile=(\d+) raw_copy=(\d+) raw_readat=(\d+) raw_miss=(\d+) raw_err=(\d+)\)"
+    r"(?:raw_conn=(\d+) )?raw_req=(\d+) raw_sendfile=(\d+) raw_copy=(\d+) raw_readat=(\d+) raw_miss=(\d+) raw_err=(\d+) "
+    r"[0-9.]+MiB raw_region_avg=[^ ]+ raw_open_avg=[^ ]+ raw_send_avg=[^ )]+\)"
 )
 FUSE_RESPONSE_RE = re.compile(
     r"geesefs fuse read response complete: .*?"
@@ -985,6 +987,7 @@ class ReadPathParser:
         cache_summary: dict[str, Any] = {
             "summaryLines": 0,
             "clientLocalHits": 0,
+            "clientRawRequests": 0,
             "clientRawHits": 0,
             "clientRawMisses": 0,
             "clientRawErrors": 0,
@@ -1007,20 +1010,21 @@ class ReadPathParser:
             if m:
                 cache_summary["summaryLines"] += 1
                 cache_summary["clientLocalHits"] += int(m.group(3))
-                cache_summary["clientRawHits"] += int(m.group(5))
-                cache_summary["clientRawMisses"] += int(m.group(6))
-                cache_summary["clientRawErrors"] += int(m.group(7))
-                cache_summary["clientGRPCHits"] += int(m.group(8))
-                cache_summary["clientGRPCMisses"] += int(m.group(9))
-                cache_summary["clientGRPCErrors"] += int(m.group(10))
-                cache_summary["clientLocalPageFileHits"] += int(m.group(12))
-                cache_summary["serverGRPCHits"] += int(m.group(16))
-                cache_summary["serverStreamChunks"] += int(m.group(20))
-                cache_summary["serverRawRequests"] += int(m.group(22))
-                cache_summary["serverRawSendfile"] += int(m.group(23))
-                cache_summary["serverRawCopy"] += int(m.group(24))
-                cache_summary["serverRawReadAt"] += int(m.group(25))
-                cache_summary["serverRawErrors"] += int(m.group(28))
+                cache_summary["clientRawRequests"] += int(m.group(5))
+                cache_summary["clientRawHits"] += int(m.group(6))
+                cache_summary["clientRawMisses"] += int(m.group(7))
+                cache_summary["clientRawErrors"] += int(m.group(8))
+                cache_summary["clientGRPCHits"] += int(m.group(9))
+                cache_summary["clientGRPCMisses"] += int(m.group(10))
+                cache_summary["clientGRPCErrors"] += int(m.group(11))
+                cache_summary["clientLocalPageFileHits"] += int(m.group(13))
+                cache_summary["serverGRPCHits"] += int(m.group(17))
+                cache_summary["serverStreamChunks"] += int(m.group(21))
+                cache_summary["serverRawRequests"] += int(m.group(25))
+                cache_summary["serverRawSendfile"] += int(m.group(26))
+                cache_summary["serverRawCopy"] += int(m.group(27))
+                cache_summary["serverRawReadAt"] += int(m.group(28))
+                cache_summary["serverRawErrors"] += int(m.group(30))
             if "geesefs external page hit" in line and geesefs_path in line:
                 external_hit_lines += 1
             m = FUSE_RESPONSE_RE.search(line)
@@ -1618,6 +1622,22 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
     def remote_read(
         self, entry: dict[str, Any], cas_proof: dict[str, Any]
     ) -> dict[str, Any]:
+        last_payload: dict[str, Any] = {}
+        for attempt in range(3):
+            payload = self._remote_read_once(entry, cas_proof)
+            payload["attempt"] = attempt + 1
+            last_payload = payload
+            if payload.get("ok"):
+                return payload
+            error = str(payload.get("error") or "")
+            if not self._retry_worker_probe(error):
+                return payload
+            time.sleep(2)
+        return last_payload
+
+    def _remote_read_once(
+        self, entry: dict[str, Any], cas_proof: dict[str, Any]
+    ) -> dict[str, Any]:
         hosts = self.cache_hosts_snapshot()
         target_host = self._choose_cache_host(hosts, cas_proof)
         if target_host is None:
@@ -1883,6 +1903,11 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
             index_keys = [
                 f"cache:coordinator:host_index:{self.config.cache_pool_name}:{self.config.cache_locality}"
             ]
+        running_workers_by_ip = {
+            pod.get("podIP", ""): pod
+            for pod in self.kube.running_workers()
+            if pod.get("podIP", "")
+        }
         logical_host_ids = []
         seen_logical_hosts = set()
         for index_key in index_keys:
@@ -1940,6 +1965,16 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                     registration = json.loads(raw)
                 except json.JSONDecodeError:
                     continue
+                addr = registration.get("addr") or ""
+                private_addr = (
+                    registration.get("private_addr")
+                    or registration.get("privateAddr")
+                    or ""
+                )
+                endpoint_ip = self._host_part(private_addr or addr)
+                endpoint_pod = running_workers_by_ip.get(endpoint_ip)
+                if endpoint_ip and endpoint_pod is None:
+                    continue
                 hosts.append(
                     {
                         "hostId": registration.get("logical_host_id")
@@ -1954,16 +1989,16 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                         "nodeId": registration.get("node_id")
                         or registration.get("nodeId")
                         or "",
-                        "nodeName": registration.get("node_id")
+                        "nodeName": (endpoint_pod or {}).get("nodeName", "")
+                        or registration.get("node_id")
                         or registration.get("nodeId")
                         or "",
                         "cachePathId": registration.get("cache_path_id")
                         or registration.get("cachePathId")
                         or "",
-                        "addr": registration.get("addr") or "",
-                        "privateAddr": registration.get("private_addr")
-                        or registration.get("privateAddr")
-                        or "",
+                        "addr": addr,
+                        "privateAddr": private_addr,
+                        "pod": (endpoint_pod or {}).get("name", ""),
                         "endpointAvailable": True,
                         "source": "coordinator",
                     }
@@ -2125,8 +2160,15 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
     ) -> Tuple[Optional[dict[str, str]], Optional[dict[str, str]]]:
         target_ip = self._host_part(self._cache_host_addr(target_host))
         workers = self.kube.running_workers()
+        target_pod_name = target_host.get("pod") or ""
         target_pod = next(
-            (pod for pod in workers if pod.get("podIP") == target_ip), None
+            (
+                pod
+                for pod in workers
+                if (target_pod_name and pod["name"] == target_pod_name)
+                or (target_ip and pod.get("podIP") == target_ip)
+            ),
+            None,
         )
         target_node = (target_pod or {}).get("nodeName") or target_host.get("nodeName", "")
         source_pod = None

--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260530205416-d45959c45f88
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349 h1:HIBhVld58bETqMM/XcSQ7Q+qRBoe4v4XqB6lS7W6KOM=
 github.com/beam-cloud/clip v0.0.0-20260530193418-6c040c276349/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/geesefs v0.0.0-20260530205416-d45959c45f88 h1:EgqeucLJURXFX63Pew9z95uJR7enl6YI7o/OlS2mcBg=
-github.com/beam-cloud/geesefs v0.0.0-20260530205416-d45959c45f88/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652 h1:lUzupIe/xH4c/WVdWD2kfVQ+RH6DiIPD/Hlaz/PjuYg=
+github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -292,6 +292,7 @@ func (c *Client) addHost(host *Host) error {
 			delete(c.rawReadPools, host.HostId)
 		}
 		c.hasher.Remove(host)
+		c.hasher.Add(host.LogicalOnly())
 		for hash, entry := range c.localHostCache {
 			if entry.host != nil && entry.host.HostId == host.HostId {
 				delete(c.localHostCache, hash)
@@ -451,16 +452,22 @@ func (c *Client) removeHost(host *Host) {
 		return
 	}
 
+	logicalHost := host.LogicalOnly()
 	if c.hostMap != nil {
-		if _, ok := c.hostMap.DeactivateEndpoint(host); !ok {
+		deactivated, ok := c.hostMap.DeactivateEndpoint(host)
+		if !ok {
 			return
 		}
+		logicalHost = deactivated
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.hasher.Remove(host)
+	if logicalHost != nil && logicalHost.HostId != "" {
+		c.hasher.Add(logicalHost)
+	}
 	if conn, ok := c.grpcConns[host.HostId]; ok {
 		_ = conn.Close()
 		delete(c.grpcConns, host.HostId)
@@ -517,10 +524,12 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 	}
 
 	routable := false
+	seenHosts := map[string]struct{}{}
 	for _, group := range cacheHostCandidateGroups(hosts) {
 		if group.hostID == "" {
 			continue
 		}
+		seenHosts[group.hostID] = struct{}{}
 
 		if c.keepExistingCacheHost(group) {
 			routable = true
@@ -537,11 +546,48 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 			routable = true
 		}
 	}
+	c.removeUndiscoveredLogicalHosts(seenHosts)
 
 	if !routable && len(c.hostMap.GetAll()) == 0 {
 		return ErrHostNotFound
 	}
 	return nil
+}
+
+func (c *Client) removeUndiscoveredLogicalHosts(seenHosts map[string]struct{}) {
+	if c.hostMap == nil {
+		return
+	}
+	for _, known := range c.hostMap.GetAll() {
+		if known == nil || known.HostId == "" {
+			continue
+		}
+		if _, ok := seenHosts[known.HostId]; ok {
+			continue
+		}
+		removed, ok := c.hostMap.RemoveLogicalHost(known.HostId)
+		if !ok {
+			continue
+		}
+
+		c.mu.Lock()
+		c.hasher.Remove(removed)
+		if conn, ok := c.grpcConns[removed.HostId]; ok {
+			_ = conn.Close()
+			delete(c.grpcConns, removed.HostId)
+		}
+		delete(c.grpcClients, removed.HostId)
+		if pool, ok := c.rawReadPools[removed.HostId]; ok {
+			pool.close()
+			delete(c.rawReadPools, removed.HostId)
+		}
+		for hash, entry := range c.localHostCache {
+			if entry.host != nil && entry.host.HostId == removed.HostId {
+				delete(c.localHostCache, hash)
+			}
+		}
+		c.mu.Unlock()
+	}
 }
 
 func (c *Client) keepExistingCacheHost(group cacheHostCandidateGroup) bool {
@@ -772,29 +818,46 @@ func (c *Client) IsCachedOnSelectedHost(hash string, routingKey string) (bool, e
 
 func (c *Client) rawReadInto(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (read int64, err error) {
 	started := time.Now()
+	reqCount := atomic.AddInt64(&cachePathStats.clientRawRequests, 1)
+	status := "unknown"
+	hostID := ""
+	addr := ""
+	var waitElapsed time.Duration
+	var headerElapsed time.Duration
+	var bodyElapsed time.Duration
 	defer func() {
-		if elapsed := time.Since(started); elapsed > time.Second || err != nil {
-			hostID := ""
-			addr := ""
-			if host != nil {
-				hostID = host.HostId
-				addr = host.PrivateAddr
-				if addr == "" {
-					addr = host.Addr
-				}
-			}
-			Logger.Debugf("cache remote page-region raw read result: host=%s addr=%s hash=%s offset=%d length=%d read=%d err=%v elapsed=%s", hostID, addr, hash, offset, len(dst), read, err, elapsed.Truncate(time.Millisecond))
+		elapsed := time.Since(started)
+		if shouldTraceCachePath(reqCount, elapsed, err != nil || status != "ok") {
+			Logger.Debugf(
+				"cache raw client read trace: seq=%d status=%s host=%s addr=%s hash=%s offset=%d length=%d read=%d err=%v elapsed=%s wait=%s header=%s body=%s",
+				reqCount,
+				status,
+				hostID,
+				addr,
+				hash,
+				offset,
+				len(dst),
+				read,
+				err,
+				elapsed.Truncate(time.Millisecond),
+				waitElapsed.Truncate(time.Microsecond),
+				headerElapsed.Truncate(time.Microsecond),
+				bodyElapsed.Truncate(time.Microsecond),
+			)
 		}
 	}()
 	if host == nil || !c.clientConfig.ReadTransport.Enabled {
+		status = "disabled_or_missing_host"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, ErrUnableToReachHost
 	}
-	addr := host.Addr
+	hostID = host.HostId
+	addr = host.Addr
 	if host.PrivateAddr != "" {
 		addr = host.PrivateAddr
 	}
 	if addr == "" {
+		status = "missing_addr"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, ErrUnableToReachHost
 	}
@@ -807,8 +870,12 @@ func (c *Client) rawReadInto(ctx context.Context, host *Host, hash string, offse
 	}
 	c.mu.Unlock()
 
+	waitStarted := time.Now()
 	conn, err := pool.get(ctx.Done())
+	waitElapsed = time.Since(waitStarted)
+	atomic.AddInt64(&cachePathStats.clientRawWaitNanos, waitElapsed.Nanoseconds())
 	if err != nil {
+		status = "conn_wait_error"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, err
 	}
@@ -828,32 +895,48 @@ func (c *Client) rawReadInto(ctx context.Context, host *Host, hash string, offse
 	}
 
 	length := int64(len(dst))
+	headerStarted := time.Now()
 	if err := writeRawReadRequest(conn, hash, offset, length); err != nil {
+		headerElapsed = time.Since(headerStarted)
+		atomic.AddInt64(&cachePathStats.clientRawHeaderNanos, headerElapsed.Nanoseconds())
+		status = "write_request_error"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, err
 	}
-	status, responseLength, err := readRawReadResponseHeader(conn)
+	respStatus, responseLength, err := readRawReadResponseHeader(conn)
+	headerElapsed = time.Since(headerStarted)
+	atomic.AddInt64(&cachePathStats.clientRawHeaderNanos, headerElapsed.Nanoseconds())
 	if err != nil {
+		status = "read_header_error"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, err
 	}
-	if status == rawReadStatusMiss {
+	if respStatus == rawReadStatusMiss {
+		status = "miss"
 		cacheReadRawFallbackTotal.Inc()
 		atomic.AddInt64(&cachePathStats.clientRawMisses, 1)
 		reusable = true
 		return 0, ErrContentNotFound
 	}
-	if status != rawReadStatusOK || responseLength != length {
+	if respStatus != rawReadStatusOK || responseLength != length {
+		status = "bad_response"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, ErrUnableToReachHost
 	}
+	bodyStarted := time.Now()
 	if _, err := io.ReadFull(conn, dst); err != nil {
+		bodyElapsed = time.Since(bodyStarted)
+		atomic.AddInt64(&cachePathStats.clientRawBodyNanos, bodyElapsed.Nanoseconds())
+		status = "body_error"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)
 		return 0, err
 	}
+	bodyElapsed = time.Since(bodyStarted)
+	atomic.AddInt64(&cachePathStats.clientRawBodyNanos, bodyElapsed.Nanoseconds())
 	cacheReadRawTransportTotal.Inc()
 	atomic.AddInt64(&cachePathStats.clientRawHits, 1)
 	reusable = true
+	status = "ok"
 	return length, nil
 }
 

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -103,6 +104,71 @@ func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
+func TestClientEndpointFailureKeepsLogicalHostInHRW(t *testing.T) {
+	hostA := &Host{
+		HostId:         "cache-host-default-node-a-path",
+		RegistrationID: "worker-a",
+		NodeID:         "node-a",
+		CachePathID:    "path",
+		PrivateAddr:    "10.0.0.1:2049",
+	}
+	hostB := &Host{
+		HostId:         "cache-host-default-node-b-path",
+		RegistrationID: "worker-b",
+		NodeID:         "node-b",
+		CachePathID:    "path",
+		PrivateAddr:    "10.0.0.2:2049",
+	}
+	hostMap := NewHostMap(GlobalConfig{}, nil)
+	hostMap.Set(hostA)
+	hostMap.Set(hostB)
+
+	hash := rendezvous.New[*Host]()
+	hash.Add(hostMap.GetAll()...)
+	client := &Client{
+		ctx:            context.Background(),
+		clientConfig:   ClientConfig{NTopHosts: 2},
+		hostMap:        hostMap,
+		grpcClients:    make(map[string]proto.CacheClient),
+		grpcConns:      make(map[string]*grpc.ClientConn),
+		localServers:   make(map[string]*Server),
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[string]*localClientCache),
+		hasher:         hash,
+	}
+
+	var routingKey string
+	for i := 0; i < 10000; i++ {
+		key := "key-" + strconv.Itoa(i)
+		selected, _ := client.getHostForRequest(&ClientRequest{
+			rt:        ClientRequestTypeRetrieval,
+			hash:      "hash",
+			key:       key,
+			hostIndex: 0,
+		})
+		client.removeLocalHostCache("hash")
+		if selected != nil && selected.HostId == hostA.HostId {
+			routingKey = key
+			break
+		}
+	}
+	require.NotEmpty(t, routingKey)
+
+	client.removeHost(hostA)
+	client.removeLocalHostCache("hash")
+	selected, err := client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeRetrieval,
+		hash:      "hash",
+		key:       routingKey,
+		hostIndex: 0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, hostA.HostId, selected.HostId)
+	require.False(t, selected.HasEndpoint())
+	require.Equal(t, hostA.NodeID, selected.NodeID)
+	require.Equal(t, hostA.CachePathID, selected.CachePathID)
+}
+
 func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -159,7 +225,7 @@ func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
+func TestLogicalOnlyHostRemainsHRWMemberWithoutEndpoint(t *testing.T) {
 	client := &Client{
 		ctx:                   context.Background(),
 		clientConfig:          ClientConfig{NTopHosts: 1},
@@ -180,13 +246,15 @@ func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
 	}
 	require.NoError(t, client.addHost(logicalHost))
 
-	_, err := client.getHostForRequest(&ClientRequest{
+	host, err := client.getHostForRequest(&ClientRequest{
 		rt:        ClientRequestTypeStorage,
 		hash:      "hash",
 		key:       "hash",
 		hostIndex: 0,
 	})
-	require.ErrorIs(t, err, ErrHostNotFound)
+	require.NoError(t, err)
+	require.Equal(t, logicalHost.HostId, host.HostId)
+	require.False(t, host.HasEndpoint())
 }
 
 func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -223,3 +223,58 @@ func TestRefreshRoutableHostsReactivatesLogicalOnlyHost(t *testing.T) {
 	require.Equal(t, addr, refreshed.PrivateAddr)
 	require.True(t, client.hasCacheClient("logical-host"))
 }
+
+func TestRefreshRoutableHostsRemovesUndiscoveredLogicalHost(t *testing.T) {
+	ctx := context.Background()
+	oldHost := (&Host{
+		HostId:      "cache-host-default-node-old-path",
+		Locality:    "default",
+		NodeID:      "node-old",
+		CachePathID: "path",
+	}).LogicalOnly()
+	stillHost := (&Host{
+		HostId:      "cache-host-default-node-live-path",
+		Locality:    "default",
+		NodeID:      "node-live",
+		CachePathID: "path",
+	}).LogicalOnly()
+	client := &Client{
+		ctx:            ctx,
+		clientConfig:   ClientConfig{NTopHosts: 1},
+		grpcClients:    make(map[string]proto.CacheClient),
+		grpcConns:      make(map[string]*grpc.ClientConn),
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[string]*localClientCache),
+		hasher:         &orderedTestHasher{},
+		hostMap:        NewHostMap(GlobalConfig{}, nil),
+		hostDirectory: testHostDirectoryFunc(func(context.Context, string) ([]*Host, error) {
+			return []*Host{stillHost}, nil
+		}),
+		maxGetContentAttempts: 1,
+	}
+	client.hostMap.onHostAdded = client.addHost
+	client.hostMap.Set(oldHost)
+	client.hostMap.Set(stillHost)
+
+	selected, err := client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeRetrieval,
+		hash:      "hash",
+		key:       "hash",
+		hostIndex: 0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, oldHost.HostId, selected.HostId)
+
+	require.NoError(t, client.refreshRoutableHosts(ctx))
+	client.removeLocalHostCache("hash")
+
+	require.Nil(t, client.hostMap.Get(oldHost.HostId))
+	selected, err = client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeRetrieval,
+		hash:      "hash",
+		key:       "hash",
+		hostIndex: 0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, stillHost.HostId, selected.HostId)
+}

--- a/pkg/cache/hostmap.go
+++ b/pkg/cache/hostmap.go
@@ -90,6 +90,24 @@ func (hm *HostMap) Remove(host *Host) bool {
 	return true
 }
 
+func (hm *HostMap) RemoveLogicalHost(hostID string) (*Host, bool) {
+	if hostID == "" {
+		return nil, false
+	}
+
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	existing, exists := hm.hosts[hostID]
+	if !exists {
+		return nil, false
+	}
+
+	Logger.Infof("Removed logical cache host @ %s", hostID)
+	delete(hm.hosts, hostID)
+	return existing, true
+}
+
 func (hm *HostMap) DeactivateEndpoint(host *Host) (*Host, bool) {
 	if host == nil || host.HostId == "" {
 		return nil, false

--- a/pkg/cache/path_stats.go
+++ b/pkg/cache/path_stats.go
@@ -6,7 +6,12 @@ import (
 	"time"
 )
 
-const cachePathStatsLogInterval = 10 * time.Second
+const (
+	cachePathStatsLogInterval = 10 * time.Second
+	cachePathTraceInitial     = 4
+	cachePathTraceEvery       = 1024
+	cachePathTraceSlow        = 100 * time.Millisecond
+)
 
 var (
 	cachePathStats     cachePathStatsCounters
@@ -18,9 +23,13 @@ type cachePathStatsCounters struct {
 	clientReadIntoBytes    int64
 	clientLocalHits        int64
 	clientLocalMisses      int64
+	clientRawRequests      int64
 	clientRawHits          int64
 	clientRawMisses        int64
 	clientRawErrors        int64
+	clientRawWaitNanos     int64
+	clientRawHeaderNanos   int64
+	clientRawBodyNanos     int64
 	clientGRPCHits         int64
 	clientGRPCMisses       int64
 	clientGRPCErrors       int64
@@ -46,24 +55,34 @@ type cachePathStatsCounters struct {
 	serverStreamChunks    int64
 	serverStreamBytes     int64
 	serverStreamErrors    int64
+	serverRawConns        int64
 	serverRawRequests     int64
 	serverRawSendfileHits int64
 	serverRawCopyHits     int64
 	serverRawReadAtHits   int64
 	serverRawMisses       int64
 	serverRawErrors       int64
+	serverRawBytes        int64
+	serverRawRegionNanos  int64
+	serverRawOpenNanos    int64
+	serverRawSendNanos    int64
 
-	storeReadAtRequests  int64
-	storeReadAtBytes     int64
-	storeMemoryPages     int64
-	storeMemoryBytes     int64
-	storeDiskPages       int64
-	storeDiskBytes       int64
-	storeMisses          int64
-	storePageRegions     int64
-	storePageRegionHits  int64
-	storePageRegionMiss  int64
-	storePageRegionBytes int64
+	storeReadAtRequests      int64
+	storeReadAtBytes         int64
+	storeMemoryPages         int64
+	storeMemoryBytes         int64
+	storeDiskPages           int64
+	storeDiskBytes           int64
+	storeMisses              int64
+	storePageRegions         int64
+	storePageRegionHits      int64
+	storePageRegionMiss      int64
+	storePageRegionBytes     int64
+	storePageRegionLockNanos int64
+	storePageRegionPathNanos int64
+	storeDiskLockNanos       int64
+	storeDiskOpenNanos       int64
+	storeDiskReadNanos       int64
 }
 
 type cachePathStatsSnapshot = cachePathStatsCounters
@@ -73,6 +92,7 @@ func startCachePathStatsLogger() {
 		return
 	}
 	cachePathStatsOnce.Do(func() {
+		Logger.Debugf("cache read path stats logger started: interval=%s", cachePathStatsLogInterval)
 		go func() {
 			ticker := time.NewTicker(cachePathStatsLogInterval)
 			defer ticker.Stop()
@@ -87,14 +107,18 @@ func startCachePathStatsLogger() {
 						continue
 					}
 					Logger.Debugf(
-						"cache read path summary: client(read_into=%d %.2fMiB local_hit=%d local_miss=%d raw_hit=%d raw_miss=%d raw_err=%d grpc_hit=%d grpc_miss=%d grpc_err=%d) client_local_page_file(req=%d hit=%d miss=%d %.2fMiB) cachefs(read=%d %.2fMiB fd_hit=%d data=%d miss_retry=%d store_retry_err=%d read_err=%d) server(grpc_req=%d grpc_hit=%d grpc_miss=%d %.2fMiB stream_req=%d stream_chunks=%d %.2fMiB stream_err=%d raw_req=%d raw_sendfile=%d raw_copy=%d raw_readat=%d raw_miss=%d raw_err=%d) store(readat=%d %.2fMiB mem_pages=%d %.2fMiB disk_pages=%d %.2fMiB miss=%d page_region=%d hit=%d miss=%d %.2fMiB)",
+						"cache read path summary: client(read_into=%d %.2fMiB local_hit=%d local_miss=%d raw_req=%d raw_hit=%d raw_miss=%d raw_err=%d raw_wait_avg=%s raw_header_avg=%s raw_body_avg=%s grpc_hit=%d grpc_miss=%d grpc_err=%d) client_local_page_file(req=%d hit=%d miss=%d %.2fMiB) cachefs(read=%d %.2fMiB fd_hit=%d data=%d miss_retry=%d store_retry_err=%d read_err=%d) server(grpc_req=%d grpc_hit=%d grpc_miss=%d %.2fMiB stream_req=%d stream_chunks=%d %.2fMiB stream_err=%d raw_conn=%d raw_req=%d raw_sendfile=%d raw_copy=%d raw_readat=%d raw_miss=%d raw_err=%d %.2fMiB raw_region_avg=%s raw_open_avg=%s raw_send_avg=%s) store(readat=%d %.2fMiB mem_pages=%d %.2fMiB disk_pages=%d %.2fMiB miss=%d page_region=%d hit=%d miss=%d %.2fMiB page_lock_avg=%s page_path_avg=%s disk_lock_avg=%s disk_open_avg=%s disk_read_avg=%s)",
 						d.clientReadIntoRequests,
 						bytesToMiB(d.clientReadIntoBytes),
 						d.clientLocalHits,
 						d.clientLocalMisses,
+						d.clientRawRequests,
 						d.clientRawHits,
 						d.clientRawMisses,
 						d.clientRawErrors,
+						avgDurationNanos(d.clientRawWaitNanos, d.clientRawHits+d.clientRawMisses+d.clientRawErrors),
+						avgDurationNanos(d.clientRawHeaderNanos, d.clientRawHits+d.clientRawMisses+d.clientRawErrors),
+						avgDurationNanos(d.clientRawBodyNanos, d.clientRawHits),
 						d.clientGRPCHits,
 						d.clientGRPCMisses,
 						d.clientGRPCErrors,
@@ -117,12 +141,17 @@ func startCachePathStatsLogger() {
 						d.serverStreamChunks,
 						bytesToMiB(d.serverStreamBytes),
 						d.serverStreamErrors,
+						d.serverRawConns,
 						d.serverRawRequests,
 						d.serverRawSendfileHits,
 						d.serverRawCopyHits,
 						d.serverRawReadAtHits,
 						d.serverRawMisses,
 						d.serverRawErrors,
+						bytesToMiB(d.serverRawBytes),
+						avgDurationNanos(d.serverRawRegionNanos, d.serverRawRequests),
+						avgDurationNanos(d.serverRawOpenNanos, d.serverRawSendfileHits+d.serverRawCopyHits),
+						avgDurationNanos(d.serverRawSendNanos, d.serverRawSendfileHits+d.serverRawCopyHits+d.serverRawReadAtHits),
 						d.storeReadAtRequests,
 						bytesToMiB(d.storeReadAtBytes),
 						d.storeMemoryPages,
@@ -134,6 +163,11 @@ func startCachePathStatsLogger() {
 						d.storePageRegionHits,
 						d.storePageRegionMiss,
 						bytesToMiB(d.storePageRegionBytes),
+						avgDurationNanos(d.storePageRegionLockNanos, d.storePageRegions),
+						avgDurationNanos(d.storePageRegionPathNanos, d.storePageRegions),
+						avgDurationNanos(d.storeDiskLockNanos, d.storeDiskPages+d.storeMisses),
+						avgDurationNanos(d.storeDiskOpenNanos, d.storeDiskPages),
+						avgDurationNanos(d.storeDiskReadNanos, d.storeDiskPages),
 					)
 				}
 			}
@@ -147,9 +181,13 @@ func snapshotCachePathStats() cachePathStatsSnapshot {
 		clientReadIntoBytes:    atomic.LoadInt64(&cachePathStats.clientReadIntoBytes),
 		clientLocalHits:        atomic.LoadInt64(&cachePathStats.clientLocalHits),
 		clientLocalMisses:      atomic.LoadInt64(&cachePathStats.clientLocalMisses),
+		clientRawRequests:      atomic.LoadInt64(&cachePathStats.clientRawRequests),
 		clientRawHits:          atomic.LoadInt64(&cachePathStats.clientRawHits),
 		clientRawMisses:        atomic.LoadInt64(&cachePathStats.clientRawMisses),
 		clientRawErrors:        atomic.LoadInt64(&cachePathStats.clientRawErrors),
+		clientRawWaitNanos:     atomic.LoadInt64(&cachePathStats.clientRawWaitNanos),
+		clientRawHeaderNanos:   atomic.LoadInt64(&cachePathStats.clientRawHeaderNanos),
+		clientRawBodyNanos:     atomic.LoadInt64(&cachePathStats.clientRawBodyNanos),
 		clientGRPCHits:         atomic.LoadInt64(&cachePathStats.clientGRPCHits),
 		clientGRPCMisses:       atomic.LoadInt64(&cachePathStats.clientGRPCMisses),
 		clientGRPCErrors:       atomic.LoadInt64(&cachePathStats.clientGRPCErrors),
@@ -175,24 +213,34 @@ func snapshotCachePathStats() cachePathStatsSnapshot {
 		serverStreamChunks:    atomic.LoadInt64(&cachePathStats.serverStreamChunks),
 		serverStreamBytes:     atomic.LoadInt64(&cachePathStats.serverStreamBytes),
 		serverStreamErrors:    atomic.LoadInt64(&cachePathStats.serverStreamErrors),
+		serverRawConns:        atomic.LoadInt64(&cachePathStats.serverRawConns),
 		serverRawRequests:     atomic.LoadInt64(&cachePathStats.serverRawRequests),
 		serverRawSendfileHits: atomic.LoadInt64(&cachePathStats.serverRawSendfileHits),
 		serverRawCopyHits:     atomic.LoadInt64(&cachePathStats.serverRawCopyHits),
 		serverRawReadAtHits:   atomic.LoadInt64(&cachePathStats.serverRawReadAtHits),
 		serverRawMisses:       atomic.LoadInt64(&cachePathStats.serverRawMisses),
 		serverRawErrors:       atomic.LoadInt64(&cachePathStats.serverRawErrors),
+		serverRawBytes:        atomic.LoadInt64(&cachePathStats.serverRawBytes),
+		serverRawRegionNanos:  atomic.LoadInt64(&cachePathStats.serverRawRegionNanos),
+		serverRawOpenNanos:    atomic.LoadInt64(&cachePathStats.serverRawOpenNanos),
+		serverRawSendNanos:    atomic.LoadInt64(&cachePathStats.serverRawSendNanos),
 
-		storeReadAtRequests:  atomic.LoadInt64(&cachePathStats.storeReadAtRequests),
-		storeReadAtBytes:     atomic.LoadInt64(&cachePathStats.storeReadAtBytes),
-		storeMemoryPages:     atomic.LoadInt64(&cachePathStats.storeMemoryPages),
-		storeMemoryBytes:     atomic.LoadInt64(&cachePathStats.storeMemoryBytes),
-		storeDiskPages:       atomic.LoadInt64(&cachePathStats.storeDiskPages),
-		storeDiskBytes:       atomic.LoadInt64(&cachePathStats.storeDiskBytes),
-		storeMisses:          atomic.LoadInt64(&cachePathStats.storeMisses),
-		storePageRegions:     atomic.LoadInt64(&cachePathStats.storePageRegions),
-		storePageRegionHits:  atomic.LoadInt64(&cachePathStats.storePageRegionHits),
-		storePageRegionMiss:  atomic.LoadInt64(&cachePathStats.storePageRegionMiss),
-		storePageRegionBytes: atomic.LoadInt64(&cachePathStats.storePageRegionBytes),
+		storeReadAtRequests:      atomic.LoadInt64(&cachePathStats.storeReadAtRequests),
+		storeReadAtBytes:         atomic.LoadInt64(&cachePathStats.storeReadAtBytes),
+		storeMemoryPages:         atomic.LoadInt64(&cachePathStats.storeMemoryPages),
+		storeMemoryBytes:         atomic.LoadInt64(&cachePathStats.storeMemoryBytes),
+		storeDiskPages:           atomic.LoadInt64(&cachePathStats.storeDiskPages),
+		storeDiskBytes:           atomic.LoadInt64(&cachePathStats.storeDiskBytes),
+		storeMisses:              atomic.LoadInt64(&cachePathStats.storeMisses),
+		storePageRegions:         atomic.LoadInt64(&cachePathStats.storePageRegions),
+		storePageRegionHits:      atomic.LoadInt64(&cachePathStats.storePageRegionHits),
+		storePageRegionMiss:      atomic.LoadInt64(&cachePathStats.storePageRegionMiss),
+		storePageRegionBytes:     atomic.LoadInt64(&cachePathStats.storePageRegionBytes),
+		storePageRegionLockNanos: atomic.LoadInt64(&cachePathStats.storePageRegionLockNanos),
+		storePageRegionPathNanos: atomic.LoadInt64(&cachePathStats.storePageRegionPathNanos),
+		storeDiskLockNanos:       atomic.LoadInt64(&cachePathStats.storeDiskLockNanos),
+		storeDiskOpenNanos:       atomic.LoadInt64(&cachePathStats.storeDiskOpenNanos),
+		storeDiskReadNanos:       atomic.LoadInt64(&cachePathStats.storeDiskReadNanos),
 	}
 }
 
@@ -202,9 +250,13 @@ func diffCachePathStats(cur, prev cachePathStatsSnapshot) cachePathStatsSnapshot
 		clientReadIntoBytes:    cur.clientReadIntoBytes - prev.clientReadIntoBytes,
 		clientLocalHits:        cur.clientLocalHits - prev.clientLocalHits,
 		clientLocalMisses:      cur.clientLocalMisses - prev.clientLocalMisses,
+		clientRawRequests:      cur.clientRawRequests - prev.clientRawRequests,
 		clientRawHits:          cur.clientRawHits - prev.clientRawHits,
 		clientRawMisses:        cur.clientRawMisses - prev.clientRawMisses,
 		clientRawErrors:        cur.clientRawErrors - prev.clientRawErrors,
+		clientRawWaitNanos:     cur.clientRawWaitNanos - prev.clientRawWaitNanos,
+		clientRawHeaderNanos:   cur.clientRawHeaderNanos - prev.clientRawHeaderNanos,
+		clientRawBodyNanos:     cur.clientRawBodyNanos - prev.clientRawBodyNanos,
 		clientGRPCHits:         cur.clientGRPCHits - prev.clientGRPCHits,
 		clientGRPCMisses:       cur.clientGRPCMisses - prev.clientGRPCMisses,
 		clientGRPCErrors:       cur.clientGRPCErrors - prev.clientGRPCErrors,
@@ -230,24 +282,34 @@ func diffCachePathStats(cur, prev cachePathStatsSnapshot) cachePathStatsSnapshot
 		serverStreamChunks:    cur.serverStreamChunks - prev.serverStreamChunks,
 		serverStreamBytes:     cur.serverStreamBytes - prev.serverStreamBytes,
 		serverStreamErrors:    cur.serverStreamErrors - prev.serverStreamErrors,
+		serverRawConns:        cur.serverRawConns - prev.serverRawConns,
 		serverRawRequests:     cur.serverRawRequests - prev.serverRawRequests,
 		serverRawSendfileHits: cur.serverRawSendfileHits - prev.serverRawSendfileHits,
 		serverRawCopyHits:     cur.serverRawCopyHits - prev.serverRawCopyHits,
 		serverRawReadAtHits:   cur.serverRawReadAtHits - prev.serverRawReadAtHits,
 		serverRawMisses:       cur.serverRawMisses - prev.serverRawMisses,
 		serverRawErrors:       cur.serverRawErrors - prev.serverRawErrors,
+		serverRawBytes:        cur.serverRawBytes - prev.serverRawBytes,
+		serverRawRegionNanos:  cur.serverRawRegionNanos - prev.serverRawRegionNanos,
+		serverRawOpenNanos:    cur.serverRawOpenNanos - prev.serverRawOpenNanos,
+		serverRawSendNanos:    cur.serverRawSendNanos - prev.serverRawSendNanos,
 
-		storeReadAtRequests:  cur.storeReadAtRequests - prev.storeReadAtRequests,
-		storeReadAtBytes:     cur.storeReadAtBytes - prev.storeReadAtBytes,
-		storeMemoryPages:     cur.storeMemoryPages - prev.storeMemoryPages,
-		storeMemoryBytes:     cur.storeMemoryBytes - prev.storeMemoryBytes,
-		storeDiskPages:       cur.storeDiskPages - prev.storeDiskPages,
-		storeDiskBytes:       cur.storeDiskBytes - prev.storeDiskBytes,
-		storeMisses:          cur.storeMisses - prev.storeMisses,
-		storePageRegions:     cur.storePageRegions - prev.storePageRegions,
-		storePageRegionHits:  cur.storePageRegionHits - prev.storePageRegionHits,
-		storePageRegionMiss:  cur.storePageRegionMiss - prev.storePageRegionMiss,
-		storePageRegionBytes: cur.storePageRegionBytes - prev.storePageRegionBytes,
+		storeReadAtRequests:      cur.storeReadAtRequests - prev.storeReadAtRequests,
+		storeReadAtBytes:         cur.storeReadAtBytes - prev.storeReadAtBytes,
+		storeMemoryPages:         cur.storeMemoryPages - prev.storeMemoryPages,
+		storeMemoryBytes:         cur.storeMemoryBytes - prev.storeMemoryBytes,
+		storeDiskPages:           cur.storeDiskPages - prev.storeDiskPages,
+		storeDiskBytes:           cur.storeDiskBytes - prev.storeDiskBytes,
+		storeMisses:              cur.storeMisses - prev.storeMisses,
+		storePageRegions:         cur.storePageRegions - prev.storePageRegions,
+		storePageRegionHits:      cur.storePageRegionHits - prev.storePageRegionHits,
+		storePageRegionMiss:      cur.storePageRegionMiss - prev.storePageRegionMiss,
+		storePageRegionBytes:     cur.storePageRegionBytes - prev.storePageRegionBytes,
+		storePageRegionLockNanos: cur.storePageRegionLockNanos - prev.storePageRegionLockNanos,
+		storePageRegionPathNanos: cur.storePageRegionPathNanos - prev.storePageRegionPathNanos,
+		storeDiskLockNanos:       cur.storeDiskLockNanos - prev.storeDiskLockNanos,
+		storeDiskOpenNanos:       cur.storeDiskOpenNanos - prev.storeDiskOpenNanos,
+		storeDiskReadNanos:       cur.storeDiskReadNanos - prev.storeDiskReadNanos,
 	}
 }
 
@@ -257,11 +319,26 @@ func (s cachePathStatsSnapshot) isZero() bool {
 		s.cacheFSReads == 0 &&
 		s.serverGRPCGetRequests == 0 &&
 		s.serverStreamRequests == 0 &&
+		s.serverRawConns == 0 &&
 		s.serverRawRequests == 0 &&
 		s.storeReadAtRequests == 0 &&
 		s.storePageRegions == 0
 }
 
+func shouldTraceCachePath(count int64, elapsed time.Duration, failed bool) bool {
+	if Logger == nil || !Logger.debug {
+		return false
+	}
+	return failed || elapsed >= cachePathTraceSlow || count <= cachePathTraceInitial || count%cachePathTraceEvery == 0
+}
+
 func bytesToMiB(bytes int64) float64 {
 	return float64(bytes) / (1024 * 1024)
+}
+
+func avgDurationNanos(totalNanos int64, count int64) time.Duration {
+	if count <= 0 {
+		return 0
+	}
+	return time.Duration(totalNanos / count)
 }

--- a/pkg/cache/raw_transport.go
+++ b/pkg/cache/raw_transport.go
@@ -99,6 +99,10 @@ func (l *cacheMuxListener) dispatch(conn net.Conn) {
 	_ = conn.SetReadDeadline(time.Time{})
 
 	if n == len(rawReadMagic) && string(prefix) == rawReadMagic {
+		connCount := atomic.AddInt64(&cachePathStats.serverRawConns, 1)
+		if shouldTraceCachePath(connCount, 0, false) {
+			Logger.Debugf("cache raw server connection accepted: seq=%d remote=%s local=%s", connCount, conn.RemoteAddr(), conn.LocalAddr())
+		}
 		l.rawHandler(conn)
 		return
 	}
@@ -212,27 +216,68 @@ func (cs *Server) handleRawReadConn(conn net.Conn) {
 }
 
 func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
-	atomic.AddInt64(&cachePathStats.serverRawRequests, 1)
+	started := time.Now()
+	reqCount := atomic.AddInt64(&cachePathStats.serverRawRequests, 1)
+	if shouldTraceCachePath(reqCount, 0, false) {
+		Logger.Debugf("cache raw server request received: seq=%d hash=%s offset=%d length=%d", reqCount, req.hash, req.offset, req.length)
+	}
+	status := "unknown"
+	method := "none"
+	var responseBytes int64
+	var regionElapsed time.Duration
+	var openElapsed time.Duration
+	var sendElapsed time.Duration
+	var regionCount int
+	defer func() {
+		elapsed := time.Since(started)
+		if shouldTraceCachePath(reqCount, elapsed, status != "ok") {
+			Logger.Debugf(
+				"cache raw server read trace: seq=%d status=%s method=%s hash=%s offset=%d length=%d bytes=%d regions=%d elapsed=%s region=%s open=%s send=%s",
+				reqCount,
+				status,
+				method,
+				req.hash,
+				req.offset,
+				req.length,
+				responseBytes,
+				regionCount,
+				elapsed.Truncate(time.Millisecond),
+				regionElapsed.Truncate(time.Microsecond),
+				openElapsed.Truncate(time.Microsecond),
+				sendElapsed.Truncate(time.Microsecond),
+			)
+		}
+	}()
 	maxLength := int64(defaultRawReadChunkBytes)
 	if cs.globalConfig.GRPCMessageSizeBytes > 0 {
 		maxLength = int64(cs.globalConfig.GRPCMessageSizeBytes)
 	}
 	if req.length < 0 || req.length > maxLength {
+		status = "invalid_length"
 		atomic.AddInt64(&cachePathStats.serverRawErrors, 1)
 		_ = writeRawReadResponseHeader(conn, rawReadStatusError, 0)
 		return
 	}
 
+	regionStarted := time.Now()
 	regions, responseLength, ok, err := cs.rawReadPageRegions(req)
+	regionElapsed = time.Since(regionStarted)
+	regionCount = len(regions)
+	atomic.AddInt64(&cachePathStats.serverRawRegionNanos, regionElapsed.Nanoseconds())
 	if err == nil && ok {
 		if err := writeRawReadResponseHeader(conn, rawReadStatusOK, responseLength); err != nil {
+			status = "write_header_error"
 			return
 		}
+		responseBytes = responseLength
+		atomic.AddInt64(&cachePathStats.serverRawBytes, responseLength)
 		usedSendfile := false
 		usedCopy := false
 		for _, region := range regions {
+			openStarted := time.Now()
 			file, err := os.Open(region.path)
 			if err != nil {
+				status = "open_error"
 				Logger.Warnf("raw cache read open failed: hash=%s offset=%d length=%d path=%s err=%v", req.hash, req.offset, req.length, region.path, err)
 				atomic.AddInt64(&cachePathStats.serverRawErrors, 1)
 				_ = conn.Close()
@@ -242,10 +287,18 @@ func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
 			copyLength := int64(region.length)
 			_ = fadviseSequential(file.Fd())
 			_ = fadviseWillneed(file.Fd(), copyOffset, copyLength)
+			openDuration := time.Since(openStarted)
+			openElapsed += openDuration
+			atomic.AddInt64(&cachePathStats.serverRawOpenNanos, openDuration.Nanoseconds())
 			if cs.serverConfig.ReadTransport.Sendfile {
+				sendStarted := time.Now()
 				sent, err := sendFileToConn(conn, file, region.pageOffset, int64(region.length))
+				sendDuration := time.Since(sendStarted)
+				sendElapsed += sendDuration
+				atomic.AddInt64(&cachePathStats.serverRawSendNanos, sendDuration.Nanoseconds())
 				if sent > 0 {
 					usedSendfile = true
+					method = "sendfile"
 					copyOffset += sent
 					copyLength -= sent
 				}
@@ -258,27 +311,42 @@ func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
 				}
 			}
 			if _, err := file.Seek(copyOffset, io.SeekStart); err != nil {
+				status = "seek_error"
 				Logger.Warnf("raw cache read seek failed: hash=%s offset=%d length=%d path=%s page_offset=%d remaining=%d err=%v", req.hash, req.offset, req.length, region.path, copyOffset, copyLength, err)
 				_ = file.Close()
 				atomic.AddInt64(&cachePathStats.serverRawErrors, 1)
 				_ = conn.Close()
 				return
 			}
+			copyStarted := time.Now()
 			if _, err := io.CopyN(conn, file, copyLength); err != nil {
+				copyDuration := time.Since(copyStarted)
+				sendElapsed += copyDuration
+				atomic.AddInt64(&cachePathStats.serverRawSendNanos, copyDuration.Nanoseconds())
 				if isRawReadClientAbort(err) {
+					status = "client_abort"
 					Logger.Debugf("raw cache read client aborted: hash=%s offset=%d length=%d path=%s page_offset=%d remaining=%d err=%v", req.hash, req.offset, req.length, region.path, copyOffset, copyLength, err)
 					_ = file.Close()
 					_ = conn.Close()
 					return
 				}
+				status = "copy_error"
 				Logger.Warnf("raw cache read copy failed: hash=%s offset=%d length=%d path=%s page_offset=%d remaining=%d err=%v", req.hash, req.offset, req.length, region.path, copyOffset, copyLength, err)
 				_ = file.Close()
 				atomic.AddInt64(&cachePathStats.serverRawErrors, 1)
 				_ = conn.Close()
 				return
 			}
+			copyDuration := time.Since(copyStarted)
+			sendElapsed += copyDuration
+			atomic.AddInt64(&cachePathStats.serverRawSendNanos, copyDuration.Nanoseconds())
 			_ = file.Close()
 			usedCopy = true
+			if method == "none" {
+				method = "copy"
+			} else if method != "copy" {
+				method = "sendfile+copy"
+			}
 		}
 		if usedSendfile {
 			cacheReadRawSendfileTotal.Inc()
@@ -287,25 +355,38 @@ func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
 		if usedCopy {
 			atomic.AddInt64(&cachePathStats.serverRawCopyHits, 1)
 		}
+		status = "ok"
 		return
 	}
 
 	buf := make([]byte, req.length)
 	n64, err := cs.cas.ReadAt(req.hash, req.offset, buf)
 	if err != nil || n64 != req.length {
+		status = "miss"
 		atomic.AddInt64(&cachePathStats.serverRawMisses, 1)
 		_ = writeRawReadResponseHeader(conn, rawReadStatusMiss, 0)
 		return
 	}
 	if err := writeRawReadResponseHeader(conn, rawReadStatusOK, n64); err != nil {
+		status = "write_header_error"
 		atomic.AddInt64(&cachePathStats.serverRawErrors, 1)
 		return
 	}
+	sendStarted := time.Now()
 	if _, err := conn.Write(buf[:n64]); err != nil {
+		sendElapsed = time.Since(sendStarted)
+		atomic.AddInt64(&cachePathStats.serverRawSendNanos, sendElapsed.Nanoseconds())
+		status = "write_body_error"
 		atomic.AddInt64(&cachePathStats.serverRawErrors, 1)
 		return
 	}
+	sendElapsed = time.Since(sendStarted)
+	atomic.AddInt64(&cachePathStats.serverRawSendNanos, sendElapsed.Nanoseconds())
+	responseBytes = n64
+	atomic.AddInt64(&cachePathStats.serverRawBytes, n64)
 	atomic.AddInt64(&cachePathStats.serverRawReadAtHits, 1)
+	method = "readat"
+	status = "ok"
 }
 
 func isRawReadClientAbort(err error) bool {

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -1017,7 +1017,9 @@ func (cas *Store) readPageFromDisk(hash string, chunkIdx int64, pageOffset int64
 	pageLock := cas.pageLock(hash, chunkIdx)
 	lockStart := time.Now()
 	pageLock.RLock()
-	cachePageLockWaitMs.Update(float64(time.Since(lockStart).Milliseconds()))
+	lockElapsed := time.Since(lockStart)
+	cachePageLockWaitMs.Update(float64(lockElapsed.Milliseconds()))
+	atomic.AddInt64(&cachePathStats.storeDiskLockNanos, lockElapsed.Nanoseconds())
 	defer pageLock.RUnlock()
 
 	if cas.memoryCacheEnabled {
@@ -1049,7 +1051,9 @@ func (cas *Store) readPageFromDisk(hash string, chunkIdx int64, pageOffset int64
 	readLength := min(maxLength, min(info.Size()-pageOffset, int64(len(dst))))
 
 	// Use fadvise to hint sequential/random access patterns
+	openStarted := time.Now()
 	file, err := os.Open(chunkPath)
+	atomic.AddInt64(&cachePathStats.storeDiskOpenNanos, time.Since(openStarted).Nanoseconds())
 	if err != nil {
 		return 0, ErrContentNotFound
 	}
@@ -1067,7 +1071,9 @@ func (cas *Store) readPageFromDisk(hash string, chunkIdx int64, pageOffset int64
 
 	readStart := time.Now()
 	n, err := file.ReadAt(dst[:readLength], pageOffset)
-	cachePageReadLatencyMs.Update(float64(time.Since(readStart).Milliseconds()))
+	readElapsed := time.Since(readStart)
+	cachePageReadLatencyMs.Update(float64(readElapsed.Milliseconds()))
+	atomic.AddInt64(&cachePathStats.storeDiskReadNanos, readElapsed.Nanoseconds())
 	if err != nil && !errors.Is(err, io.EOF) {
 		atomic.AddInt64(&cachePathStats.storeMisses, 1)
 		return int64(n), ErrContentNotFound
@@ -1137,10 +1143,14 @@ func (cas *Store) PageRegion(hash string, offset int64, length int64) (path stri
 	}
 
 	pageLock := cas.pageLock(hash, pageIdx)
+	lockStarted := time.Now()
 	pageLock.RLock()
+	atomic.AddInt64(&cachePathStats.storePageRegionLockNanos, time.Since(lockStarted).Nanoseconds())
 	defer pageLock.RUnlock()
 
+	pathStarted := time.Now()
 	pagePath, info, err := cas.existingPagePath(hash, pageIdx)
+	atomic.AddInt64(&cachePathStats.storePageRegionPathNanos, time.Since(pathStarted).Nanoseconds())
 	if err != nil {
 		atomic.AddInt64(&cachePathStats.storePageRegionMiss, 1)
 		return "", 0, 0, false, err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keeps cache requests on the cache path during endpoint flaps by keeping logical hosts in the HRW ring and pruning only undiscovered hosts. Adds detailed raw transport and store timings to the cache path summary to diagnose latency and misses.

- **Bug Fixes**
  - Keep logical hosts in HRW even when their endpoint goes away; only the endpoint is deactivated.
  - Remove logical hosts not seen during discovery to avoid routing to dead nodes.
  - Improve remote source selection by matching pod name or IP; only use registrations with a running worker.

- **New Features**
  - Add client raw read metrics: request count, wait/header/body timings, and per-request trace logging with throttling.
  - Add server raw metrics: connection count, bytes sent, region/open/send timings, and detailed per-request traces.
  - Track store timings: page-region lock/path and disk lock/open/read durations.
  - Extend periodic “cache read path summary” with new fields; update `benchmarks/b9bench/cache_suite.py` regex/parsing to match.
  - Update `github.com/yandex-cloud/geesefs` replace to `github.com/beam-cloud/geesefs` at the latest commit.

<sup>Written for commit 789712da8ab03fd0c0cea702d44f019fea4c65bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

