### PR TITLE
remove logical only tweak

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -292,7 +292,6 @@ func (c *Client) addHost(host *Host) error {
 			delete(c.rawReadPools, host.HostId)
 		}
 		c.hasher.Remove(host)
-		c.hasher.Add(host.LogicalOnly())
 		for hash, entry := range c.localHostCache {
 			if entry.host != nil && entry.host.HostId == host.HostId {
 				delete(c.localHostCache, hash)
@@ -452,22 +451,16 @@ func (c *Client) removeHost(host *Host) {
 		return
 	}
 
-	logicalHost := host.LogicalOnly()
 	if c.hostMap != nil {
-		deactivated, ok := c.hostMap.DeactivateEndpoint(host)
-		if !ok {
+		if _, ok := c.hostMap.DeactivateEndpoint(host); !ok {
 			return
 		}
-		logicalHost = deactivated
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.hasher.Remove(host)
-	if logicalHost != nil && logicalHost.HostId != "" {
-		c.hasher.Add(logicalHost)
-	}
 	if conn, ok := c.grpcConns[host.HostId]; ok {
 		_ = conn.Close()
 		delete(c.grpcConns, host.HostId)

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -104,7 +103,7 @@ func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestClientEndpointFailureKeepsLogicalHostInHRW(t *testing.T) {
+func TestClientEndpointFailureRemovesHostFromActiveHRW(t *testing.T) {
 	hostA := &Host{
 		HostId:         "cache-host-default-node-a-path",
 		RegistrationID: "worker-a",
@@ -123,8 +122,6 @@ func TestClientEndpointFailureKeepsLogicalHostInHRW(t *testing.T) {
 	hostMap.Set(hostA)
 	hostMap.Set(hostB)
 
-	hash := rendezvous.New[*Host]()
-	hash.Add(hostMap.GetAll()...)
 	client := &Client{
 		ctx:            context.Background(),
 		clientConfig:   ClientConfig{NTopHosts: 2},
@@ -134,39 +131,24 @@ func TestClientEndpointFailureKeepsLogicalHostInHRW(t *testing.T) {
 		localServers:   make(map[string]*Server),
 		rawReadPools:   make(map[string]*rawReadConnPool),
 		localHostCache: make(map[string]*localClientCache),
-		hasher:         hash,
+		hasher:         &orderedTestHasher{hosts: []*Host{hostA, hostB}},
 	}
-
-	var routingKey string
-	for i := 0; i < 10000; i++ {
-		key := "key-" + strconv.Itoa(i)
-		selected, _ := client.getHostForRequest(&ClientRequest{
-			rt:        ClientRequestTypeRetrieval,
-			hash:      "hash",
-			key:       key,
-			hostIndex: 0,
-		})
-		client.removeLocalHostCache("hash")
-		if selected != nil && selected.HostId == hostA.HostId {
-			routingKey = key
-			break
-		}
-	}
-	require.NotEmpty(t, routingKey)
 
 	client.removeHost(hostA)
 	client.removeLocalHostCache("hash")
+
+	deactivated := hostMap.Get(hostA.HostId)
+	require.NotNil(t, deactivated)
+	require.False(t, deactivated.HasEndpoint())
+
 	selected, err := client.getHostForRequest(&ClientRequest{
 		rt:        ClientRequestTypeRetrieval,
 		hash:      "hash",
-		key:       routingKey,
+		key:       "hash",
 		hostIndex: 0,
 	})
 	require.NoError(t, err)
-	require.Equal(t, hostA.HostId, selected.HostId)
-	require.False(t, selected.HasEndpoint())
-	require.Equal(t, hostA.NodeID, selected.NodeID)
-	require.Equal(t, hostA.CachePathID, selected.CachePathID)
+	require.Equal(t, hostB.HostId, selected.HostId)
 }
 
 func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.T) {
@@ -225,7 +207,7 @@ func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestLogicalOnlyHostRemainsHRWMemberWithoutEndpoint(t *testing.T) {
+func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
 	client := &Client{
 		ctx:                   context.Background(),
 		clientConfig:          ClientConfig{NTopHosts: 1},
@@ -246,15 +228,13 @@ func TestLogicalOnlyHostRemainsHRWMemberWithoutEndpoint(t *testing.T) {
 	}
 	require.NoError(t, client.addHost(logicalHost))
 
-	host, err := client.getHostForRequest(&ClientRequest{
+	_, err := client.getHostForRequest(&ClientRequest{
 		rt:        ClientRequestTypeStorage,
 		hash:      "hash",
 		key:       "hash",
 		hostIndex: 0,
 	})
-	require.NoError(t, err)
-	require.Equal(t, logicalHost.HostId, host.HostId)
-	require.False(t, host.HasEndpoint())
+	require.ErrorIs(t, err, ErrHostNotFound)
 }
 
 func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -256,25 +256,11 @@ func TestRefreshRoutableHostsRemovesUndiscoveredLogicalHost(t *testing.T) {
 	client.hostMap.Set(oldHost)
 	client.hostMap.Set(stillHost)
 
-	selected, err := client.getHostForRequest(&ClientRequest{
-		rt:        ClientRequestTypeRetrieval,
-		hash:      "hash",
-		key:       "hash",
-		hostIndex: 0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, oldHost.HostId, selected.HostId)
+	require.NotNil(t, client.hostMap.Get(oldHost.HostId))
+	require.NotNil(t, client.hostMap.Get(stillHost.HostId))
 
 	require.NoError(t, client.refreshRoutableHosts(ctx))
-	client.removeLocalHostCache("hash")
 
 	require.Nil(t, client.hostMap.Get(oldHost.HostId))
-	selected, err = client.getHostForRequest(&ClientRequest{
-		rt:        ClientRequestTypeRetrieval,
-		hash:      "hash",
-		key:       "hash",
-		hostIndex: 0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, stillHost.HostId, selected.HostId)
+	require.NotNil(t, client.hostMap.Get(stillHost.HostId))
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the “logical-only” host behavior from routing. HRW now only includes hosts with active endpoints, and selection moves to the next active host when one is deactivated.

- **Refactors**
  - Stop adding logical-only hosts to the hasher in `addHost` and `removeHost`.
  - On endpoint deactivation, remove the host from the active HRW set; routing selects the next active host.
  - `getHostForRequest` returns `ErrHostNotFound` when only logical hosts remain.
  - Updated tests to reflect active-only HRW behavior and use `orderedTestHasher` to avoid flakiness.
  - Simplified discovery refresh test to assert host map updates without relying on selection.

<sup>Written for commit 535dca5f531cd6148f58dc7ab98f25378ec848d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

