### PR TITLE
improve cache suite

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -238,6 +238,7 @@ class BenchmarkConfig:
     min_hot_file_read_mbps: float
     min_remote_cache_socket_mbps: float
     min_throughput_size_mb: int
+    hrw_route_top_n: int
     remote_object_full_read_max_mb: int
     workspace_storage_config: str
     workspace_storage_endpoint_url: str
@@ -427,6 +428,12 @@ class BenchmarkConfig:
             "--min-throughput-size-mb",
             type=int,
             default=env_int("BENCH_CACHE_MIN_HOT_FILE_READ_SIZE_MB", 1024),
+        )
+        add(
+            "--hrw-route-top-n",
+            type=int,
+            default=env_int("BENCH_CACHE_HRW_ROUTE_TOP_N", 3),
+            help="number of active HRW-ranked cache hosts accepted as valid fallback targets",
         )
         add(
             "--remote-object-full-read-max-mb",
@@ -1244,7 +1251,12 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
             "routes": [],
         }
         hosts = hosts_snapshot.get("hosts") or []
-        if not hosts:
+        active_hosts = [
+            host
+            for host in hosts
+            if host.get("endpointAvailable") and (host.get("privateAddr") or host.get("addr"))
+        ]
+        if not active_hosts:
             proof["error"] = "no active cache hosts found"
             return proof
 
@@ -1264,11 +1276,11 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                 "run",
                 "./benchmarks/b9bench/cache_tools/hrw_routing.go",
                 "--hosts-json",
-                json.dumps(hosts, sort_keys=True),
+                json.dumps(active_hosts, sort_keys=True),
                 "--keys",
                 content_hash,
                 "--n",
-                "1",
+                str(max(1, self.config.hrw_route_top_n)),
             ],
             cwd=REPO_ROOT,
             stdout=subprocess.PIPE,
@@ -1290,7 +1302,8 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
         checked = []
         ok = True
         for route in routes:
-            selected = (route.get("hosts") or [{}])[0]
+            ranked_hosts = route.get("hosts") or []
+            selected = (ranked_hosts or [{}])[0]
             node = selected.get("nodeName") or selected.get("nodeId") or ""
             pages = pages_by_node.get(node, 0)
             endpoint_available = bool(
@@ -1310,9 +1323,17 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
             }
             if remote_read:
                 target_host = remote_read.get("targetHost") or {}
-                item["remoteTargetHostId"] = target_host.get("hostId") or ""
-                item["remoteTargetRegistrationId"] = target_host.get("registrationId") or ""
-                item["remoteTargetNode"] = remote_read.get("targetNode") or target_host.get("nodeName") or ""
+                target_host_id = target_host.get("hostId") or ""
+                target_registration_id = target_host.get("registrationId") or ""
+                target_node = remote_read.get("targetNode") or target_host.get("nodeName") or ""
+                target_rank = 0
+                for index, ranked in enumerate(ranked_hosts, start=1):
+                    if ranked.get("hostId") == target_host_id:
+                        target_rank = index
+                        break
+                item["remoteTargetHostId"] = target_host_id
+                item["remoteTargetRegistrationId"] = target_registration_id
+                item["remoteTargetNode"] = target_node
                 item["remoteTargetMatchesHRW"] = bool(
                     item["selectedHostId"]
                     and item["selectedHostId"] == item["remoteTargetHostId"]
@@ -1321,6 +1342,15 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                     item["selectedRegistrationId"]
                     and item["selectedRegistrationId"] == item["remoteTargetRegistrationId"]
                 )
+                item["remoteTargetInHRWTopN"] = target_rank > 0
+                item["remoteTargetHRWRank"] = target_rank
+                item["remoteTargetPages"] = pages_by_node.get(target_node, 0)
+                item["fallbackCacheHit"] = bool(
+                    not item["remoteTargetMatchesHRW"]
+                    and item["remoteTargetInHRWTopN"]
+                    and item["remoteTargetPages"] > 0
+                )
+                item["ok"] = bool(item["ok"] or item["fallbackCacheHit"])
             checked.append(item)
             ok = ok and item["ok"]
 
@@ -1973,7 +2003,7 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes /cache/.benchmark-probes 2>/dev/nu
                 )
                 endpoint_ip = self._host_part(private_addr or addr)
                 endpoint_pod = running_workers_by_ip.get(endpoint_ip)
-                if endpoint_ip and endpoint_pod is None:
+                if not endpoint_ip or endpoint_pod is None:
                     continue
                 hosts.append(
                     {
@@ -2798,9 +2828,20 @@ class Reporter:
                 row["sizeMiB"] >= self.config.min_throughput_size_mb
                 and read.get("fileReadMBps", 0) < self.config.min_hot_file_read_mbps
             ):
-                failures.append(
-                    f"{row['accessType']}:{row['sizeMiB']}MiB hot file-read {read.get('fileReadMBps', 0):.2f} MB/s below {self.config.min_hot_file_read_mbps:.2f} MB/s"
-                )
+                network = ((row.get("remoteRead") or {}).get("networkProbe") or {})
+                network_mbps = float(network.get("mbps") or 0)
+                required_mbps = self.config.min_hot_file_read_mbps
+                if network.get("ok") and network_mbps > 0:
+                    required_mbps = min(required_mbps, network_mbps * 0.9)
+                if read.get("fileReadMBps", 0) < required_mbps:
+                    suffix = (
+                        f" measured network target {required_mbps:.2f} MB/s (network {network_mbps:.2f} MB/s)"
+                        if network.get("ok") and network_mbps > 0
+                        else f" {self.config.min_hot_file_read_mbps:.2f} MB/s"
+                    )
+                    failures.append(
+                        f"{row['accessType']}:{row['sizeMiB']}MiB hot file-read {read.get('fileReadMBps', 0):.2f} MB/s below{suffix}"
+                    )
             read_path_proofs = [
                 proof
                 for proof in (
@@ -2867,9 +2908,12 @@ class Reporter:
                         )
                 else:
                     route = ((hrw_proof.get("routes") or []) + [{}])[0]
-                    if route and not route.get("remoteTargetMatchesHRW", True):
+                    if route and not (
+                        route.get("remoteTargetMatchesHRW", True)
+                        or route.get("remoteTargetInHRWTopN", False)
+                    ):
                         failures.append(
-                            f"{row['accessType']}:{row['sizeMiB']}MiB remote target {route.get('remoteTargetHostId')} does not match HRW-selected host {route.get('selectedHostId')}"
+                            f"{row['accessType']}:{row['sizeMiB']}MiB remote target {route.get('remoteTargetHostId')} is not in HRW top-{self.config.hrw_route_top_n}"
                         )
             remote_object = row.get("remoteObject")
             if self.config.require_remote_object_proof and (
@@ -3727,6 +3771,7 @@ class CacheBenchmark:
             "remoteCacheProofConcurrency": self.config.remote_cache_proof_concurrency,
             "remoteNetworkProbe": self.config.remote_network_probe,
             "remoteNetworkProbeBytes": self.config.remote_network_probe_bytes,
+            "hrwRouteTopN": self.config.hrw_route_top_n,
             "volumeName": self.config.volume_name,
             "volumeId": volume_id,
             "volumeMountPath": self.config.volume_mount_path,

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -387,6 +387,10 @@ func (c *Client) monitorHost(host *Host) {
 		interval = 30 * time.Second
 	}
 
+	if !c.checkHostEndpoint(host) {
+		return
+	}
+
 	if jitter := time.Duration(time.Now().UnixNano() % int64(interval)); jitter > 0 {
 		timer := time.NewTimer(jitter)
 		select {
@@ -403,40 +407,7 @@ func (c *Client) monitorHost(host *Host) {
 	for {
 		select {
 		case <-ticker.C:
-			if !c.isCurrentHostEndpoint(host) {
-				return
-			}
-
-			err := func() error {
-				c.mu.RLock()
-				client, exists := c.grpcClients[host.HostId]
-				c.mu.RUnlock()
-				if !exists {
-					return ErrHostNotFound
-				}
-
-				timeout := time.Duration(c.globalConfig.GRPCDialTimeoutS) * time.Second
-				if timeout <= 0 {
-					timeout = time.Second
-				}
-				ctx, cancel := context.WithTimeout(c.ctx, timeout)
-				defer cancel()
-
-				resp, err := client.GetState(ctx, &proto.CacheGetStateRequest{})
-				if err != nil {
-					return ErrInvalidHostVersion
-				}
-
-				if resp.GetVersion() != Version {
-					return ErrInvalidHostVersion
-				}
-
-				return nil
-			}()
-
-			// We were unable to reach the host for some reason, remove it as a possible client
-			if err != nil {
-				c.removeHost(host)
+			if !c.checkHostEndpoint(host) {
 				return
 			}
 
@@ -444,6 +415,45 @@ func (c *Client) monitorHost(host *Host) {
 			return
 		}
 	}
+}
+
+func (c *Client) checkHostEndpoint(host *Host) bool {
+	if !c.isCurrentHostEndpoint(host) {
+		return false
+	}
+
+	err := func() error {
+		c.mu.RLock()
+		client, exists := c.grpcClients[host.HostId]
+		c.mu.RUnlock()
+		if !exists {
+			return ErrHostNotFound
+		}
+
+		timeout := time.Duration(c.globalConfig.GRPCDialTimeoutS) * time.Second
+		if timeout <= 0 {
+			timeout = time.Second
+		}
+		ctx, cancel := context.WithTimeout(c.ctx, timeout)
+		defer cancel()
+
+		resp, err := client.GetState(ctx, &proto.CacheGetStateRequest{})
+		if err != nil {
+			return ErrInvalidHostVersion
+		}
+
+		if resp.GetVersion() != Version {
+			return ErrInvalidHostVersion
+		}
+
+		return nil
+	}()
+
+	if err != nil {
+		c.removeHost(host)
+		return false
+	}
+	return true
 }
 
 func (c *Client) removeHost(host *Host) {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -151,6 +151,44 @@ func TestClientEndpointFailureRemovesHostFromActiveHRW(t *testing.T) {
 	require.Equal(t, hostB.HostId, selected.HostId)
 }
 
+func TestCheckHostEndpointPrunesUnreachableEndpoint(t *testing.T) {
+	host := &Host{
+		HostId:         "cache-host-default-node-a-path",
+		RegistrationID: "worker-a",
+		NodeID:         "node-a",
+		CachePathID:    "path",
+		PrivateAddr:    "10.0.0.1:2049",
+	}
+	hostMap := NewHostMap(GlobalConfig{}, nil)
+	hostMap.Set(host)
+
+	client := &Client{
+		ctx:            context.Background(),
+		clientConfig:   ClientConfig{NTopHosts: 1},
+		hostMap:        hostMap,
+		grpcClients:    map[string]proto.CacheClient{host.HostId: &fakeStoreCacheClient{stateErr: errors.New("connection refused")}},
+		grpcConns:      make(map[string]*grpc.ClientConn),
+		localServers:   make(map[string]*Server),
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[string]*localClientCache),
+		hasher:         &orderedTestHasher{hosts: []*Host{host}},
+	}
+
+	require.False(t, client.checkHostEndpoint(host))
+
+	deactivated := hostMap.Get(host.HostId)
+	require.NotNil(t, deactivated)
+	require.False(t, deactivated.HasEndpoint())
+
+	_, err := client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeRetrieval,
+		hash:      "hash",
+		key:       "hash",
+		hostIndex: 0,
+	})
+	require.ErrorIs(t, err, ErrHostNotFound)
+}
+
 func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -967,7 +1005,9 @@ func TestStoreContentFromReaderFallsBackToRankedReplicaWhenSelectedHostUnavailab
 }
 
 type fakeStoreCacheClient struct {
-	stream proto.Cache_StoreContentClient
+	stream   proto.Cache_StoreContentClient
+	state    *proto.CacheGetStateResponse
+	stateErr error
 }
 
 func (f *fakeStoreCacheClient) GetContent(ctx context.Context, in *proto.CacheGetContentRequest, opts ...grpc.CallOption) (*proto.CacheGetContentResponse, error) {
@@ -995,6 +1035,12 @@ func (f *fakeStoreCacheClient) StoreContentFromSourceWithLock(ctx context.Contex
 }
 
 func (f *fakeStoreCacheClient) GetState(ctx context.Context, in *proto.CacheGetStateRequest, opts ...grpc.CallOption) (*proto.CacheGetStateResponse, error) {
+	if f.stateErr != nil {
+		return nil, f.stateErr
+	}
+	if f.state != nil {
+		return f.state, nil
+	}
 	return nil, errors.New("not implemented")
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve cache routing accuracy and harden host monitoring by accepting HRW top‑N fallbacks and pruning unreachable cache hosts earlier. This reduces misroutes and avoids retries against dead endpoints.

- **New Features**
  - Add `--hrw-route-top-n` (env `BENCH_CACHE_HRW_ROUTE_TOP_N`) to accept top‑N HRW‑ranked hosts as valid fallbacks. Proofs include rank, top‑N status, and fallback hits. Validation accepts HRW match or top‑N.
  - HRW proofs now consider only active hosts (endpoint available with `privateAddr`/`addr`). `hrwRouteTopN` is included in the report.
  - Hot file‑read threshold adapts to network probes (uses 90% of measured MB/s when slower than the default).

- **Bug Fixes**
  - `pkg/cache` client: add `checkHostEndpoint` to verify gRPC reachability and version before and during monitoring; unreachable hosts are removed from the active set immediately. New unit test covers pruning behavior.
  - Cache host snapshot now ignores entries without a valid endpoint IP or matching pod, preventing routing to non‑existent endpoints.

<sup>Written for commit 799fd59320ef6021ffb86a3b0fbd71161f84e457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

