### PR TITLE
fix redis test

### DIFF
--- a/pkg/common/redis_test.go
+++ b/pkg/common/redis_test.go
@@ -71,11 +71,15 @@ func TestRedisLockWithTTLAndRetry(t *testing.T) {
 	// NOTE: I wanted to test this using a TTL, but unfortunately miniredis doesn't support true TTL like redis
 	// TTL'd keys technically still exist. Instead we're relying on manually releasing the lock (which deletes the key)
 	go func() {
-		err := secondLock.Acquire(context.Background(), key, RedisLockOptions{TtlS: 10, Retries: 5})
+		err := secondLock.Acquire(context.Background(), key, RedisLockOptions{
+			TtlS:          10,
+			Retries:       20,
+			RetryInterval: 50 * time.Millisecond,
+		})
 		resultCh <- err
 	}()
 
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(time.Millisecond * 100)
 
 	// Release lock so the secondLock can acquire it
 	err = firstLock.Release(key)

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -51,6 +51,7 @@ const (
 	containerNetworkSlotPoolEnv         string        = "CONTAINER_NETWORK_SLOT_POOL_SIZE"
 	containerNetworkSlotFillInterval    time.Duration = 2 * time.Second
 	containerNetworkCleanupRPCTimeout   time.Duration = 30 * time.Second
+	containerNetworkCleanupLockRetries                = 14
 )
 
 type ContainerNetworkManager struct {
@@ -1889,7 +1890,7 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 	lockResponse, err := handleGRPCResponse(m.workerRepoClient.SetNetworkLock(cleanupCtx, &pb.SetNetworkLockRequest{
 		NetworkPrefix: m.networkPrefix,
 		Ttl:           10,
-		Retries:       10,
+		Retries:       containerNetworkCleanupLockRetries,
 	}))
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a flaky Redis lock test and hardens container network teardown lock acquisition. Adjusts retry behavior and timing to reduce flakes and transient failures.

- **Bug Fixes**
  - Redis test: set RetryInterval to 50ms, increase retries to 20, and shorten wait to 100ms so the second lock can acquire after release.
  - Network teardown: introduce `containerNetworkCleanupLockRetries = 14` and use it for `SetNetworkLock` retries.

<sup>Written for commit ce1209b0b858613c71d266e3c1fbfd278c42daa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

