### PR TITLE
dont admit unreachable hosts

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -545,12 +545,11 @@ func (c *Client) refreshRoutableHosts(ctx context.Context) error {
 		}
 		if logicalHost := group.logicalHost(); logicalHost != nil {
 			c.hostMap.Set(logicalHost)
-			routable = true
 		}
 	}
 	c.removeUndiscoveredLogicalHosts(seenHosts)
 
-	if !routable && len(c.hostMap.GetAll()) == 0 {
+	if !routable {
 		return ErrHostNotFound
 	}
 	return nil

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -259,7 +259,7 @@ func TestRefreshRoutableHostsRemovesUndiscoveredLogicalHost(t *testing.T) {
 	require.NotNil(t, client.hostMap.Get(oldHost.HostId))
 	require.NotNil(t, client.hostMap.Get(stillHost.HostId))
 
-	require.NoError(t, client.refreshRoutableHosts(ctx))
+	require.ErrorIs(t, client.refreshRoutableHosts(ctx), ErrHostNotFound)
 
 	require.Nil(t, client.hostMap.Get(oldHost.HostId))
 	require.NotNil(t, client.hostMap.Get(stillHost.HostId))

--- a/pkg/cache/hostmap.go
+++ b/pkg/cache/hostmap.go
@@ -51,11 +51,14 @@ func (hm *HostMap) Set(host *Host) {
 		return
 	}
 
-	if exists {
+	if !host.HasEndpoint() {
+		Logger.Debugf("Tracked logical cache host @ %s without active endpoint", host.HostId)
+	} else if exists {
 		Logger.Debugf("Updated host @ %s (PrivateAddr=%s, RTT=%s)", host.HostId, host.PrivateAddr, host.RTT)
 	} else {
 		Logger.Infof("Added new host @ %s (PrivateAddr=%s, RTT=%s)", host.HostId, host.PrivateAddr, host.RTT)
 	}
+
 	if err := hm.onHostAdded(host); err != nil {
 		Logger.Warnf("failed to initialize cache host %s: %v", host.HostId, err)
 		hm.mu.Lock()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop admitting logical hosts without a reachable endpoint. If discovery finds no routable hosts, `refreshRoutableHosts` now returns `ErrHostNotFound` instead of falling back to existing entries.

- **Bug Fixes**
  - `refreshRoutableHosts` returns `ErrHostNotFound` when no routable hosts are found, regardless of `hostMap` contents.
  - `HostMap.Set` now logs when a host has no endpoint and does not treat it as routable.
  - Updated test to expect `ErrHostNotFound` in this case.

<sup>Written for commit 632ed030556327586e36640da9beeac9995884c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

