### PR TITLE
update mapping logic

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -1355,18 +1355,19 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes 2>/dev/null || true
         proof["ok"] = ok
         return proof
 
-    def object_proof(self, content_hash: str) -> dict[str, Any]:
+    def object_proof(self, content_hash: str, expected_size: int = 0) -> dict[str, Any]:
         for pod in self.kube.running_workers():
             candidates = self._candidate_shell_paths(pod, content_hash)
             script = (
-                f"hash={shlex.quote(content_hash)}; "
+                f"hash={shlex.quote(content_hash)}; expected={int(expected_size)}; "
                 "found=''; for candidate in "
                 f'{candidates}; do [ -d "$candidate" ] && found="$candidate" && break; done; '
                 'if [ -z "$found" ]; then printf \'{"exists":false}\\n\'; exit 0; fi; '
-                "i=0; bytes=0; tmp=$(mktemp); "
-                'while [ -f "$found/$hash-$i" ]; do cat "$found/$hash-$i" >> "$tmp"; bytes=$((bytes + $(wc -c < "$found/$hash-$i"))); i=$((i + 1)); done; '
-                'sha=$(sha256sum "$tmp" | awk \'{print $1}\'); rm -f "$tmp"; '
-                'printf \'{"exists":true,"path":"%s","chunks":%s,"bytes":%s,"sha256":"%s"}\\n\' "$found" "$i" "$bytes" "$sha"'
+                "i=0; bytes=0; "
+                'while [ -f "$found/$hash-$i" ]; do bytes=$((bytes + $(stat -c %s "$found/$hash-$i"))); i=$((i + 1)); done; '
+                'marker=false; [ -f "$found/_complete" ] && marker=true; '
+                'matches=false; if [ "$marker" = true ] && { [ "$expected" -eq 0 ] || [ "$bytes" -eq "$expected" ]; }; then matches=true; fi; '
+                'printf \'{"exists":true,"path":"%s","chunks":%s,"bytes":%s,"completeMarker":%s,"matchesHash":%s}\\n\' "$found" "$i" "$bytes" "$marker" "$matches"'
             )
             proc = self.kube.worker_shell(
                 pod["name"],
@@ -1387,7 +1388,6 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes 2>/dev/null || true
                 }
             )
             if proof.get("exists"):
-                proof["matchesHash"] = proof.get("sha256") == content_hash
                 return proof
         return {"hash": content_hash, "exists": False}
 
@@ -3305,7 +3305,7 @@ class CacheBenchmark:
                     entry,
                     geesefs_path,
                 )
-            cas_proof = self.cache.object_proof(entry["sha256"])
+            cas_proof = self.cache.object_proof(entry["sha256"], entry["size"])
             page_proof = self.cache.object_page_proof(entry["sha256"], entry["size"])
             remote_object = self._remote_object_proof(workspace, paths, entry)
             worker_dd = None

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -291,6 +291,7 @@ func (c *Client) addHost(host *Host) error {
 			delete(c.rawReadPools, host.HostId)
 		}
 		c.hasher.Remove(host)
+		c.hasher.Add(host.LogicalOnly())
 		for hash, entry := range c.localHostCache {
 			if entry.host != nil && entry.host.HostId == host.HostId {
 				delete(c.localHostCache, hash)
@@ -460,16 +461,23 @@ func (c *Client) removeHost(host *Host) {
 		return
 	}
 
+	var logicalHost *Host
 	if c.hostMap != nil {
-		if _, ok := c.hostMap.DeactivateEndpoint(host); !ok {
+		var ok bool
+		logicalHost, ok = c.hostMap.DeactivateEndpoint(host)
+		if !ok {
 			return
 		}
+	}
+	if logicalHost == nil {
+		logicalHost = host.LogicalOnly()
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.hasher.Remove(host)
+	c.hasher.Add(logicalHost)
 	if conn, ok := c.grpcConns[host.HostId]; ok {
 		_ = conn.Close()
 		delete(c.grpcConns, host.HostId)
@@ -1585,9 +1593,11 @@ func (c *Client) getHostForRequest(request *ClientRequest) (*Host, error) {
 				host = nil
 			} else {
 				host = hosts[request.hostIndex]
-				c.localHostCache[request.hash] = &localClientCache{
-					host:      host,
-					timestamp: time.Now(),
+				if request.hostIndex == 0 {
+					c.localHostCache[request.hash] = &localClientCache{
+						host:      host,
+						timestamp: time.Now(),
+					}
 				}
 			}
 

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -103,7 +104,37 @@ func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestClientEndpointFailureRemovesHostFromActiveHRW(t *testing.T) {
+func TestFallbackHostSelectionDoesNotPoisonPrimaryCache(t *testing.T) {
+	primaryHost := &Host{HostId: "primary-host"}
+	fallbackHost := &Host{HostId: "fallback-host", PrivateAddr: "fallback-host:2049"}
+	client := &Client{
+		ctx:            context.Background(),
+		clientConfig:   ClientConfig{NTopHosts: 2},
+		localHostCache: make(map[string]*localClientCache),
+		hasher:         &orderedTestHasher{hosts: []*Host{primaryHost, fallbackHost}},
+	}
+
+	selected, err := client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeRetrieval,
+		hash:      "hash",
+		key:       "hash",
+		hostIndex: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, fallbackHost.HostId, selected.HostId)
+	require.Empty(t, client.localHostCache)
+
+	selected, err = client.getHostForRequest(&ClientRequest{
+		rt:        ClientRequestTypeRetrieval,
+		hash:      "hash",
+		key:       "hash",
+		hostIndex: 0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, primaryHost.HostId, selected.HostId)
+}
+
+func TestClientEndpointFailureKeepsLogicalHostInHRW(t *testing.T) {
 	hostA := &Host{
 		HostId:         "cache-host-default-node-a-path",
 		RegistrationID: "worker-a",
@@ -121,6 +152,18 @@ func TestClientEndpointFailureRemovesHostFromActiveHRW(t *testing.T) {
 	hostMap := NewHostMap(GlobalConfig{}, nil)
 	hostMap.Set(hostA)
 	hostMap.Set(hostB)
+	hasher := rendezvous.New[*Host]()
+	hasher.Add(hostA, hostB)
+	keyForHostA := ""
+	for i := 0; i < 10000; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		host, _ := hasher.Get(key)
+		if host != nil && host.HostId == hostA.HostId {
+			keyForHostA = key
+			break
+		}
+	}
+	require.NotEmpty(t, keyForHostA)
 
 	client := &Client{
 		ctx:            context.Background(),
@@ -131,11 +174,11 @@ func TestClientEndpointFailureRemovesHostFromActiveHRW(t *testing.T) {
 		localServers:   make(map[string]*Server),
 		rawReadPools:   make(map[string]*rawReadConnPool),
 		localHostCache: make(map[string]*localClientCache),
-		hasher:         &orderedTestHasher{hosts: []*Host{hostA, hostB}},
+		hasher:         hasher,
 	}
 
 	client.removeHost(hostA)
-	client.removeLocalHostCache("hash")
+	client.removeLocalHostCache(keyForHostA)
 
 	deactivated := hostMap.Get(hostA.HostId)
 	require.NotNil(t, deactivated)
@@ -143,12 +186,16 @@ func TestClientEndpointFailureRemovesHostFromActiveHRW(t *testing.T) {
 
 	selected, err := client.getHostForRequest(&ClientRequest{
 		rt:        ClientRequestTypeRetrieval,
-		hash:      "hash",
-		key:       "hash",
+		hash:      keyForHostA,
+		key:       keyForHostA,
 		hostIndex: 0,
 	})
 	require.NoError(t, err)
-	require.Equal(t, hostB.HostId, selected.HostId)
+	require.Equal(t, hostA.HostId, selected.HostId)
+	require.False(t, selected.HasEndpoint())
+
+	_, _, err = client.getGRPCClientForHostIndex(context.Background(), ClientRequestTypeRetrieval, keyForHostA, keyForHostA, 0)
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
 func TestCheckHostEndpointPrunesUnreachableEndpoint(t *testing.T) {
@@ -180,13 +227,18 @@ func TestCheckHostEndpointPrunesUnreachableEndpoint(t *testing.T) {
 	require.NotNil(t, deactivated)
 	require.False(t, deactivated.HasEndpoint())
 
-	_, err := client.getHostForRequest(&ClientRequest{
+	selected, err := client.getHostForRequest(&ClientRequest{
 		rt:        ClientRequestTypeRetrieval,
 		hash:      "hash",
 		key:       "hash",
 		hostIndex: 0,
 	})
-	require.ErrorIs(t, err, ErrHostNotFound)
+	require.NoError(t, err)
+	require.Equal(t, host.HostId, selected.HostId)
+	require.False(t, selected.HasEndpoint())
+
+	_, _, err = client.getGRPCClientForHostIndex(context.Background(), ClientRequestTypeRetrieval, "hash", "hash", 0)
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
 func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.T) {
@@ -245,7 +297,7 @@ func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
+func TestLogicalOnlyHostStaysInHRWButHasNoEndpoint(t *testing.T) {
 	client := &Client{
 		ctx:                   context.Background(),
 		clientConfig:          ClientConfig{NTopHosts: 1},
@@ -266,13 +318,18 @@ func TestLogicalOnlyHostIsNotActiveHRWMember(t *testing.T) {
 	}
 	require.NoError(t, client.addHost(logicalHost))
 
-	_, err := client.getHostForRequest(&ClientRequest{
+	selected, err := client.getHostForRequest(&ClientRequest{
 		rt:        ClientRequestTypeStorage,
 		hash:      "hash",
 		key:       "hash",
 		hostIndex: 0,
 	})
-	require.ErrorIs(t, err, ErrHostNotFound)
+	require.NoError(t, err)
+	require.Equal(t, logicalHost.HostId, selected.HostId)
+	require.False(t, selected.HasEndpoint())
+
+	_, _, err = client.getGRPCClientForHostIndex(context.Background(), ClientRequestTypeStorage, "hash", "hash", 0)
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
 func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keeps logical hosts in HRW after endpoint deactivation and avoids caching fallback selections, improving request routing and error signaling in `pkg/cache`. Also speeds up `benchmarks/b9bench` CAS object checks by using size + completion marker instead of hashing.

- **Bug Fixes**
  - Preserve logical-only hosts in the HRW ring when endpoints are deactivated; add/remove logical hosts in the hasher to keep selection deterministic and surface `ErrSelectedHostUnavailable`.
  - Cache only the primary (index 0) host selection so fallbacks don’t poison `localHostCache`.
  - Updated tests to reflect logical host retention and correct error paths.

- **Performance**
  - `benchmarks/b9bench`: `object_proof` now takes expected size and checks `_complete` marker, counting bytes via `stat`; removes temp file and `sha256` work. Returns `completeMarker` and `matchesHash`; `_run_workload` passes object size.

<sup>Written for commit 68b52916d8a142e14d8bf0b839ebface9c86f4cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

