### PR TITLE
add ds marker

### DIFF
--- a/pkg/worker/cache_coordinator.go
+++ b/pkg/worker/cache_coordinator.go
@@ -130,10 +130,12 @@ func (r *gatewayCacheRegistration) registerOnce(ctx context.Context) error {
 		TtlSeconds: int32(cacheRegistrationTTL(r.cacheConfig) / time.Second),
 	}))
 	if err == nil {
-		logger := log.Debug()
+		logger := log.Trace()
+		message := "refreshed cache host registration"
 		if !r.loggedSuccess {
 			logger = log.Info()
 			r.loggedSuccess = true
+			message = "registered cache host"
 		}
 		logger.
 			Str("logical_host_id", host.LogicalHostId).
@@ -143,7 +145,9 @@ func (r *gatewayCacheRegistration) registerOnce(ctx context.Context) error {
 			Str("node_id", host.NodeId).
 			Str("cache_path_id", host.CachePathId).
 			Str("addr", host.PrivateAddr).
-			Msg("Registered cache host")
+			Int32("ttl_seconds", int32(cacheRegistrationTTL(r.cacheConfig)/time.Second)).
+			Float32("capacity_usage_pct", host.CapacityUsagePct).
+			Msg(message)
 	}
 	return err
 }

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -47,32 +47,35 @@ const (
 	cacheDefaultRegistrationTTL         = 30 * time.Second
 	cacheDefaultRegistrationHeartbeat   = 10 * time.Second
 	cacheDefaultHostWatchInterval       = 5 * time.Second
+	cacheServerDaemonSetMarkerName      = ".beta9-cache-server-daemonset"
 )
 
 type WorkerCacheManager struct {
-	ctx                context.Context
-	cancel             context.CancelFunc
-	config             types.AppConfig
-	poolConfig         types.WorkerPoolConfig
-	workerRepo         pb.WorkerRepositoryServiceClient
-	workerID           string
-	instanceID         string
-	poolName           string
-	podAddr            string
-	nodeID             string
-	locality           string
-	cacheIdentityPath  string
-	metadataStore      cache.CacheMetadataStore
-	client             *cache.Client
-	server             *cache.Server
-	serverLock         *os.File
-	registration       *gatewayCacheRegistration
-	registrationCancel context.CancelFunc
-	draining           bool
-	mu                 sync.Mutex
-	wg                 sync.WaitGroup
-	drainOnce          sync.Once
-	drainErr           error
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	config                types.AppConfig
+	poolConfig            types.WorkerPoolConfig
+	workerRepo            pb.WorkerRepositoryServiceClient
+	workerID              string
+	instanceID            string
+	poolName              string
+	podAddr               string
+	nodeID                string
+	locality              string
+	cacheIdentityPath     string
+	metadataStore         cache.CacheMetadataStore
+	client                *cache.Client
+	server                *cache.Server
+	serverLock            *os.File
+	registration          *gatewayCacheRegistration
+	registrationCancel    context.CancelFunc
+	registrationDone      <-chan struct{}
+	daemonSetPresenceDone <-chan struct{}
+	draining              bool
+	mu                    sync.Mutex
+	wg                    sync.WaitGroup
+	drainOnce             sync.Once
+	drainErr              error
 }
 
 func NewWorkerCacheManager(ctx context.Context, config types.AppConfig, poolConfig types.WorkerPoolConfig, workerRepo pb.WorkerRepositoryServiceClient, workerID, poolName, podAddr string) *WorkerCacheManager {
@@ -120,13 +123,14 @@ func (m *WorkerCacheManager) Start() (*cache.Client, error) {
 	m.client = client
 	hostID := cacheLogicalHostID(m.locality, m.nodeID, m.cacheIdentityPath)
 	nodeCacheServer := m.nodeCacheServer(cacheConfig, hostID)
+	nodeCacheServer.StartDaemonSetPresence()
 	startedCacheServer, err := nodeCacheServer.Start()
 	if err != nil {
 		_ = client.Cleanup()
 		m.cancel()
 		return nil, err
 	}
-	if !startedCacheServer {
+	if !startedCacheServer || !cacheServerOnlyMode() {
 		nodeCacheServer.Watch()
 	}
 
@@ -150,7 +154,13 @@ func (m *WorkerCacheManager) Close() error {
 	server := m.server
 	client := m.client
 	lock := m.serverLock
+	daemonSetPresenceDone := m.daemonSetPresenceDone
+	m.server = nil
 	m.serverLock = nil
+	m.registration = nil
+	m.registrationCancel = nil
+	m.registrationDone = nil
+	m.daemonSetPresenceDone = nil
 	m.mu.Unlock()
 
 	if client != nil {
@@ -161,6 +171,13 @@ func (m *WorkerCacheManager) Close() error {
 	}
 	if lock != nil {
 		errs = errors.Join(errs, releaseCacheServerLock(lock))
+	}
+	if daemonSetPresenceDone != nil {
+		select {
+		case <-daemonSetPresenceDone:
+		case <-time.After(cacheCoordinatorRPCTimeout):
+			errs = errors.Join(errs, errors.New("timed out waiting for cache server daemonset marker loop to stop"))
+		}
 	}
 
 	m.wg.Wait()
@@ -186,6 +203,7 @@ func (m *WorkerCacheManager) Drain() error {
 		m.draining = true
 		cancel := m.registrationCancel
 		registration := m.registration
+		registrationDone := m.registrationDone
 		server := m.server
 		m.mu.Unlock()
 
@@ -195,10 +213,16 @@ func (m *WorkerCacheManager) Drain() error {
 		if cancel != nil {
 			cancel()
 		}
-		m.wg.Wait()
+		if registrationDone != nil {
+			select {
+			case <-registrationDone:
+			case <-time.After(cacheCoordinatorRPCTimeout):
+				m.drainErr = errors.Join(m.drainErr, errors.New("timed out waiting for cache registration loop to stop"))
+			}
+		}
 
 		if registration != nil {
-			m.drainErr = registration.unregister(context.Background())
+			m.drainErr = errors.Join(m.drainErr, registration.unregister(context.Background()))
 		}
 	})
 
@@ -262,6 +286,10 @@ func (s nodeCacheServer) Start() (bool, error) {
 	}
 	m.mu.Unlock()
 
+	if !cacheServerOnlyMode() && cacheServerDaemonSetMarkerFresh(s.config.Server.DiskCacheDir, cacheRegistrationTTL(s.config)) {
+		return false, nil
+	}
+
 	lock, acquired, err := acquireCacheServerLock(s.config.Server.DiskCacheDir)
 	if err != nil || !acquired {
 		return false, err
@@ -294,6 +322,8 @@ func (s nodeCacheServer) Start() (bool, error) {
 	m.serverLock = lock
 	m.registration = registration
 	m.registrationCancel = registrationCancel
+	registrationDone := make(chan struct{})
+	m.registrationDone = registrationDone
 	m.wg.Add(1)
 	m.mu.Unlock()
 
@@ -303,6 +333,7 @@ func (s nodeCacheServer) Start() (bool, error) {
 
 	go func() {
 		defer m.wg.Done()
+		defer close(registrationDone)
 		runGatewayCacheRegistration(registrationCtx, registration)
 	}()
 
@@ -312,6 +343,44 @@ func (s nodeCacheServer) Start() (bool, error) {
 		Msg("acquired node-local cache server lock")
 
 	return true, nil
+}
+
+func (s nodeCacheServer) StartDaemonSetPresence() {
+	if !cacheServerOnlyMode() {
+		return
+	}
+
+	m := s.manager
+	interval := cacheRegistrationHeartbeat(s.config)
+	if interval <= 0 {
+		interval = cacheDefaultRegistrationHeartbeat
+	}
+
+	done := make(chan struct{})
+	m.mu.Lock()
+	m.daemonSetPresenceDone = done
+	m.mu.Unlock()
+
+	if err := writeCacheServerDaemonSetMarker(s.config.Server.DiskCacheDir, m.workerID, m.instanceID); err != nil {
+		log.Warn().Err(err).Msg("failed to write cache server daemonset marker")
+	}
+
+	go func() {
+		defer close(done)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-ticker.C:
+				if err := writeCacheServerDaemonSetMarker(s.config.Server.DiskCacheDir, m.workerID, m.instanceID); err != nil {
+					log.Warn().Err(err).Msg("failed to refresh cache server daemonset marker")
+				}
+			}
+		}
+	}()
 }
 
 func (s nodeCacheServer) Watch() {
@@ -333,22 +402,87 @@ func (s nodeCacheServer) Watch() {
 				return
 			case <-ticker.C:
 				m.mu.Lock()
-				done := m.draining || m.server != nil
+				draining := m.draining
+				running := m.server != nil
 				m.mu.Unlock()
-				if done {
+				if draining {
 					return
+				}
+				if !cacheServerOnlyMode() && cacheServerDaemonSetMarkerFresh(s.config.Server.DiskCacheDir, cacheRegistrationTTL(s.config)) {
+					if running {
+						if err := m.stopNodeCacheServer("cache server daemonset marker is fresh"); err != nil {
+							log.Warn().Err(err).Msg("failed to stop embedded cache server")
+						}
+					}
+					continue
+				}
+				if running {
+					if cacheServerOnlyMode() {
+						return
+					}
+					continue
 				}
 				startedCacheServer, err := s.Start()
 				if err != nil {
 					log.Warn().Err(err).Msg("failed to start standby cache server")
 					continue
 				}
-				if startedCacheServer {
+				if startedCacheServer && cacheServerOnlyMode() {
 					return
 				}
 			}
 		}
 	}()
+}
+
+func (m *WorkerCacheManager) stopNodeCacheServer(reason string) error {
+	m.mu.Lock()
+	server := m.server
+	lock := m.serverLock
+	registration := m.registration
+	cancel := m.registrationCancel
+	done := m.registrationDone
+	if server == nil && lock == nil && registration == nil {
+		m.mu.Unlock()
+		return nil
+	}
+	m.server = nil
+	m.serverLock = nil
+	m.registration = nil
+	m.registrationCancel = nil
+	m.registrationDone = nil
+	m.mu.Unlock()
+
+	var errs error
+	if registration != nil && m.client != nil {
+		m.client.DetachLocalServer(registration.logicalHostID)
+	}
+	if server != nil {
+		server.Drain()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(cacheCoordinatorRPCTimeout):
+			errs = errors.Join(errs, errors.New("timed out waiting for cache registration loop to stop"))
+		}
+	}
+	if registration != nil {
+		errs = errors.Join(errs, registration.unregister(context.Background()))
+	}
+	if server != nil {
+		errs = errors.Join(errs, server.Close())
+	}
+	if lock != nil {
+		errs = errors.Join(errs, releaseCacheServerLock(lock))
+	}
+	if errs == nil {
+		log.Info().Str("reason", reason).Msg("stopped embedded cache server")
+	}
+	return errs
 }
 
 func acquireCacheServerLock(cacheDir string) (*os.File, bool, error) {
@@ -368,6 +502,46 @@ func acquireCacheServerLock(cacheDir string) (*os.File, bool, error) {
 		return nil, false, err
 	}
 	return lock, true, nil
+}
+
+func writeCacheServerDaemonSetMarker(cacheDir, workerID, instanceID string) error {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return err
+	}
+	markerPath := cacheServerDaemonSetMarkerPath(cacheDir)
+	tmp, err := os.CreateTemp(cacheDir, cacheServerDaemonSetMarkerName+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	body := fmt.Sprintf("worker_id=%s\ninstance_id=%s\nupdated_unix_nano=%d\n", workerID, instanceID, time.Now().UnixNano())
+	if _, err := tmp.WriteString(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, markerPath)
+}
+
+func cacheServerDaemonSetMarkerFresh(cacheDir string, ttl time.Duration) bool {
+	if ttl <= 0 {
+		ttl = cacheDefaultRegistrationTTL
+	}
+	info, err := os.Stat(cacheServerDaemonSetMarkerPath(cacheDir))
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) <= ttl
+}
+
+func cacheServerDaemonSetMarkerPath(cacheDir string) string {
+	return filepath.Join(cacheDir, cacheServerDaemonSetMarkerName)
 }
 
 func releaseCacheServerLock(lock *os.File) error {
@@ -574,6 +748,11 @@ func cacheHostNetwork(config types.AppConfig) bool {
 	}
 
 	return config.Worker.HostNetwork
+}
+
+func cacheServerOnlyMode() bool {
+	enabled, err := strconv.ParseBool(os.Getenv("CACHE_SERVER_ONLY"))
+	return err == nil && enabled
 }
 
 func cacheWorkerInstanceID(workerID string) string {

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -127,6 +128,96 @@ func TestCacheServerLockAllowsSingleNodeLocalOwner(t *testing.T) {
 	require.NoError(t, releaseCacheServerLock(second))
 }
 
+func TestEmbeddedWorkerSkipsCacheServerWhenDaemonSetMarkerFresh(t *testing.T) {
+	t.Setenv("CACHE_SERVER_ONLY", "false")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cacheDir := t.TempDir()
+	require.NoError(t, writeCacheServerDaemonSetMarker(cacheDir, "cache-server-node", "pod-a"))
+
+	config := testCacheManagerConfig(cacheDir)
+	manager := NewWorkerCacheManager(ctx, config, types.WorkerPoolConfig{}, nil, "worker-a", "default", "127.0.0.1")
+	cacheConfig := normalizeCacheConfig(config, types.WorkerPoolConfig{}, "single-node", "test")
+	started, err := manager.nodeCacheServer(cacheConfig, "cache-host").Start()
+
+	require.NoError(t, err)
+	require.False(t, started)
+	require.False(t, manager.runningCacheServer())
+}
+
+func TestEmbeddedWorkerYieldsCacheServerToDaemonSetMarker(t *testing.T) {
+	t.Setenv("CACHE_SERVER_ONLY", "false")
+	t.Setenv("CACHE_NODE_ID", "single-node")
+	t.Setenv("CACHE_LOCALITY", "test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	repoClient, repo, cleanup := startTestCacheCoordinator(t)
+	defer cleanup()
+
+	cacheDir := t.TempDir()
+	config := testCacheManagerConfig(cacheDir)
+	manager := NewWorkerCacheManager(ctx, config, types.WorkerPoolConfig{}, repoClient, "worker-a", "default", "127.0.0.1")
+	client, err := manager.Start()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer func() { _ = manager.Close() }()
+
+	require.Eventually(t, func() bool {
+		return manager.runningCacheServer() && len(repo.activeHosts()) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	require.NoError(t, writeCacheServerDaemonSetMarker(cacheDir, "cache-server-single-node", "pod-a"))
+
+	require.Eventually(t, func() bool {
+		return !manager.runningCacheServer() && len(repo.activeHosts()) == 0
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestCacheServerDaemonSetMarkerFreshUsesTTL(t *testing.T) {
+	cacheDir := t.TempDir()
+	require.False(t, cacheServerDaemonSetMarkerFresh(cacheDir, time.Second))
+
+	require.NoError(t, writeCacheServerDaemonSetMarker(cacheDir, "cache-server-node", "pod-a"))
+	require.True(t, cacheServerDaemonSetMarkerFresh(cacheDir, time.Second))
+
+	stale := time.Now().Add(-2 * time.Second)
+	require.NoError(t, os.Chtimes(cacheServerDaemonSetMarkerPath(cacheDir), stale, stale))
+	require.False(t, cacheServerDaemonSetMarkerFresh(cacheDir, time.Second))
+}
+
+func TestCacheServerDaemonSetMarkerLoopStopsOnClose(t *testing.T) {
+	t.Setenv("CACHE_SERVER_ONLY", "true")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cacheDir := t.TempDir()
+	config := testCacheManagerConfig(cacheDir)
+	manager := NewWorkerCacheManager(ctx, config, types.WorkerPoolConfig{}, nil, "cache-server-single-node", "default", "127.0.0.1")
+	cacheConfig := normalizeCacheConfig(config, types.WorkerPoolConfig{}, "single-node", "test")
+	manager.nodeCacheServer(cacheConfig, "cache-host").StartDaemonSetPresence()
+
+	require.Eventually(t, func() bool {
+		return cacheServerDaemonSetMarkerFresh(cacheDir, time.Second)
+	}, time.Second, 10*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("cache server daemonset marker loop did not stop on close")
+	}
+}
+
 func TestWorkerCacheManagersUseSingleNodeLocalServerAndStandbyTakeover(t *testing.T) {
 	t.Setenv("CACHE_NODE_ID", "single-node")
 	t.Setenv("CACHE_LOCALITY", "test")
@@ -163,6 +254,7 @@ func TestWorkerCacheManagersUseSingleNodeLocalServerAndStandbyTakeover(t *testin
 	active := runningCacheServers(managers)[0]
 	require.Equal(t, "worker-a", active.workerID)
 	logicalHostID := active.registration.logicalHostID
+	activeRegistrationID := active.registration.registrationID
 
 	content := []byte("node-local-cache-content-survives-worker-churn")
 	sum := sha256.Sum256(content)
@@ -183,7 +275,7 @@ func TestWorkerCacheManagersUseSingleNodeLocalServerAndStandbyTakeover(t *testin
 			return false
 		}
 		for _, host := range activeHosts {
-			return host.GetLogicalHostId() == logicalHostID && host.GetRegistrationId() != active.registration.registrationID
+			return host.GetLogicalHostId() == logicalHostID && host.GetRegistrationId() != activeRegistrationID
 		}
 		return false
 	}, 5*time.Second, 50*time.Millisecond)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a DaemonSet marker to coordinate cache server ownership so workers yield to a DaemonSet-managed cache server when present. Also adds `CACHE_SERVER_ONLY` mode to write and refresh the marker from DaemonSet pods.

- **New Features**
  - Writes `.beta9-cache-server-daemonset` in the cache dir and refreshes it on heartbeat when `CACHE_SERVER_ONLY=true`.
  - Embedded workers check marker freshness (using registration TTL) and skip starting or stop an existing embedded cache server to yield to the DaemonSet.
  - Adds graceful stop for the embedded server (detach, drain, unregister, release lock) and waits for registration/marker loops to end with timeouts.
  - Improves cache host registration logs: now trace-level refresh, info on first register, includes TTL and capacity usage.

- **Migration**
  - Run DaemonSet cache pods with `CACHE_SERVER_ONLY=true`; ensure DaemonSet and workers share the same disk cache directory.
  - No config changes for workers; they auto-detect the marker and yield based on its freshness.

<sup>Written for commit 4c143acdd4f95ec39db0a54230d0e17da8a55f4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

