### PR TITLE
fix client lock bug

### DIFF
--- a/benchmarks/b9bench/cache_tools/hrw_routing.go
+++ b/benchmarks/b9bench/cache_tools/hrw_routing.go
@@ -15,6 +15,7 @@ type host struct {
 	RegistrationID string `json:"registrationId,omitempty"`
 	NodeID         string `json:"nodeId,omitempty"`
 	NodeName       string `json:"nodeName,omitempty"`
+	CachePathID    string `json:"cachePathId,omitempty"`
 	Addr           string `json:"addr,omitempty"`
 	PrivateAddr    string `json:"privateAddr,omitempty"`
 	Pod            string `json:"pod,omitempty"`

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -91,6 +93,9 @@ type Client struct {
 	grpcClients           map[string]proto.CacheClient
 	grpcConns             map[string]*grpc.ClientConn
 	localServers          map[string]*Server
+	localDiskStore        *Store
+	localNodeID           string
+	localCachePathID      string
 	rawReadPools          map[string]*rawReadConnPool
 	hostMap               *HostMap
 	mu                    sync.RWMutex
@@ -160,6 +165,8 @@ func NewClientWithHostDirectory(ctx context.Context, cfg Config, metadataStore C
 		grpcClients:           make(map[string]proto.CacheClient),
 		grpcConns:             make(map[string]*grpc.ClientConn),
 		localServers:          make(map[string]*Server),
+		localNodeID:           os.Getenv("CACHE_NODE_ID"),
+		localCachePathID:      cachePathIDForConfig(cfg),
 		rawReadPools:          make(map[string]*rawReadConnPool),
 		localHostCache:        make(map[localHostCacheKey]*localClientCache),
 		mu:                    sync.RWMutex{},
@@ -172,6 +179,7 @@ func NewClientWithHostDirectory(ctx context.Context, cfg Config, metadataStore C
 
 	bc.hostMap = NewHostMap(cfg.Global, bc.addHost)
 	bc.discoveryClient = NewDiscoveryClient(cfg.Global, bc.hostMap, hostDirectory, locality)
+	bc.initLocalDiskStore(cfg, locality)
 
 	// Start searching for nearby cache hosts
 	go bc.discoveryClient.Start(bc.ctx)
@@ -222,6 +230,10 @@ func (c *Client) Cleanup() error {
 	for hostID, pool := range c.rawReadPools {
 		pool.close()
 		delete(c.rawReadPools, hostID)
+	}
+	if c.localDiskStore != nil {
+		c.localDiskStore.Cleanup()
+		c.localDiskStore = nil
 	}
 	return nil
 }
@@ -274,6 +286,87 @@ func (c *Client) localServersSnapshot() []*Server {
 		}
 	}
 	return servers
+}
+
+func (c *Client) initLocalDiskStore(cfg Config, locality string) {
+	if cfg.Server.DiskCacheDir == "" || cfg.Server.PageSizeBytes <= 0 {
+		return
+	}
+
+	// A worker and the cache-server DaemonSet can share the same node hostPath
+	// while only the DaemonSet owns the active endpoint. Keep a local Store view
+	// so selected same-node content can still use local reads and page views.
+	localHost := &Host{
+		HostId:      "client-local-disk",
+		Locality:    locality,
+		NodeID:      c.localNodeID,
+		CachePathID: c.localCachePathID,
+	}
+	store, err := NewStore(c.ctx, localHost, locality, c.metadataStore, cfg)
+	if err != nil {
+		Logger.Warnf("failed to initialize local cache disk view: %v", err)
+		return
+	}
+	c.localDiskStore = store
+}
+
+func cachePathIDForConfig(config Config) string {
+	identity := canonicalPhysicalCacheIdentityPath(config)
+	if identity == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(identity))
+	return fmt.Sprintf("%x", sum[:6])
+}
+
+func canonicalPhysicalCacheIdentityPath(config Config) string {
+	if config.Server.DiskCacheDir == "" {
+		return ""
+	}
+	diskCacheDir := filepath.Clean(config.Server.DiskCacheDir)
+	if config.Disk.MountPath == "" || config.Disk.HostPath == "" {
+		return diskCacheDir
+	}
+
+	mountPath := filepath.Clean(config.Disk.MountPath)
+	hostPath := filepath.Clean(config.Disk.HostPath)
+	rel, err := filepath.Rel(mountPath, diskCacheDir)
+	if err != nil || relEscapesBase(rel) {
+		return diskCacheDir
+	}
+	return filepath.Clean(filepath.Join(hostPath, rel))
+}
+
+func relEscapesBase(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel)
+}
+
+func (c *Client) localDiskStoreForHost(host *Host) *Store {
+	if c == nil || host == nil || c.localDiskStore == nil {
+		return nil
+	}
+	if c.localNodeID != "" && host.NodeID != "" && host.NodeID != c.localNodeID {
+		return nil
+	}
+	if c.localCachePathID == "" || host.CachePathID == "" || host.CachePathID != c.localCachePathID {
+		return nil
+	}
+	return c.localDiskStore
+}
+
+func (c *Client) selectedLocalDiskStore(ctx context.Context, rt ClientRequestType, hash string, routingKey string) (*Store, *Host, error) {
+	if routingKey == "" {
+		routingKey = hash
+	}
+	host, err := c.getSelectedHostForRequest(rt, hash, routingKey)
+	if err == ErrHostNotFound && c.hostDirectory != nil && c.hostMap != nil {
+		_ = c.refreshRoutableHosts(ctx)
+		host, err = c.getSelectedHostForRequest(rt, hash, routingKey)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.localDiskStoreForHost(host), host, nil
 }
 
 func (c *Client) GetNearbyHosts() ([]*Host, error) {
@@ -714,6 +807,14 @@ func (c *Client) cachedLocalFileHash(ctx context.Context, cachePath string, info
 	return metadata.Hash, true
 }
 
+func (c *Client) cachedContentHash(ctx context.Context, hash string, expectedSize int64) bool {
+	if c == nil || !isContentHash(hash) {
+		return false
+	}
+	exists, err := c.IsCachedOnSelectedHost(hash, hash, expectedSize)
+	return err == nil && exists
+}
+
 func cacheFSMetadataMatchesFileInfo(metadata *FSMetadata, info os.FileInfo) bool {
 	if metadata == nil || metadata.Hash == "" || info == nil || info.IsDir() || info.Size() < 0 {
 		return false
@@ -810,6 +911,18 @@ func (c *Client) IsCachedOnSelectedHost(hash string, routingKey string, expected
 	}
 	if routingKey == "" {
 		routingKey = hash
+	}
+
+	localStore, _, err := c.selectedLocalDiskStore(c.ctx, ClientRequestTypeStorage, hash, routingKey)
+	if err != nil {
+		return false, err
+	}
+	if localStore != nil {
+		exists := localStore.Exists(hash, size)
+		if !exists {
+			c.removeLocalHostCache(hash, routingKey)
+		}
+		return exists, nil
 	}
 
 	client, host, err := c.getGRPCClient(&ClientRequest{
@@ -1080,18 +1193,24 @@ func (c *Client) ClientLocalPageFileView(hash string, offset int64, length int64
 	c.mu.RLock()
 	localServer := c.localServers[host.HostId]
 	c.mu.RUnlock()
-	if localServer == nil || localServer.cas == nil {
-		atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
-		return "", 0, 0, false, nil
+	if localServer != nil && localServer.cas != nil {
+		path, pageOffset, n, ok, err = localServer.cas.PageRegion(hash, offset, length)
+		if err == nil && ok {
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, int64(n))
+			return path, pageOffset, n, ok, err
+		}
 	}
-	path, pageOffset, n, ok, err = localServer.cas.PageRegion(hash, offset, length)
-	if err == nil && ok {
-		atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
-		atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, int64(n))
-	} else {
-		atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
+	if localStore := c.localDiskStoreForHost(host); localStore != nil {
+		path, pageOffset, n, ok, err = localStore.PageRegion(hash, offset, length)
+		if err == nil && ok {
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, int64(n))
+			return path, pageOffset, n, ok, err
+		}
 	}
-	return path, pageOffset, n, ok, err
+	atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
+	return "", 0, 0, false, err
 }
 
 func (c *Client) ClientLocalPageFileViews(hash string, offset int64, length int64, opts ClientOptions) (views []ClientLocalPageFileView, err error) {
@@ -1138,6 +1257,15 @@ func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offse
 	c.mu.RUnlock()
 	if localServer != nil && localServer.cas != nil {
 		if views, ok := clientLocalPageFileViewsFromStore(localServer.cas, hash, offset, length); ok {
+			cacheReadClientLocalPageFileTotal.Inc()
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
+			return views, true
+		}
+	}
+
+	if localStore := c.localDiskStoreForHost(host); localStore != nil {
+		if views, ok := clientLocalPageFileViewsFromStore(localStore, hash, offset, length); ok {
 			cacheReadClientLocalPageFileTotal.Inc()
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
@@ -1326,6 +1454,23 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	c.mu.RUnlock()
 	if localServer != nil && localServer.cas != nil {
 		n, err := localServer.cas.ReadAt(hash, offset, dst)
+		if err == nil && n == length {
+			cacheReadLocalTotal.Inc()
+			atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
+			return n, nil
+		}
+		if err == ErrContentNotFound {
+			atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
+			c.removeLocalHostCache(hash)
+			return 0, err
+		}
+		if err != nil {
+			atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
+		}
+	}
+
+	if localStore := c.localDiskStoreForHost(host); localStore != nil {
+		n, err := localStore.ReadAt(hash, offset, dst)
 		if err == nil && n == length {
 			cacheReadLocalTotal.Inc()
 			atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
@@ -1675,6 +1820,9 @@ func (c *Client) StoreContentFromLocalFile(source LocalContentSource, opts Store
 	if hash, ok := c.cachedLocalFileHash(ctx, source.CachePath, info, opts.RoutingKey); ok {
 		return hash, nil
 	}
+	if c.cachedContentHash(ctx, opts.RoutingKey, info.Size()) {
+		return opts.RoutingKey, nil
+	}
 
 	file, err := os.Open(source.Path)
 	if err != nil {
@@ -1685,6 +1833,9 @@ func (c *Client) StoreContentFromLocalFile(source LocalContentSource, opts Store
 	store := func() (string, error) {
 		if hash, ok := c.cachedLocalFileHash(ctx, source.CachePath, info, opts.RoutingKey); ok {
 			return hash, nil
+		}
+		if c.cachedContentHash(ctx, opts.RoutingKey, info.Size()) {
+			return opts.RoutingKey, nil
 		}
 		if _, err := file.Seek(0, io.SeekStart); err != nil {
 			return "", err

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -24,6 +24,16 @@ type orderedTestHasher struct {
 	hosts []*Host
 }
 
+type countingCacheMetadataStore struct {
+	*MockCacheMetadataStore
+	setStoreFromContentLockCalls int
+}
+
+func (m *countingCacheMetadataStore) SetStoreFromContentLock(ctx context.Context, locality string, sourcePath string) error {
+	m.setStoreFromContentLockCalls++
+	return m.MockCacheMetadataStore.SetStoreFromContentLock(ctx, locality, sourcePath)
+}
+
 func (h *orderedTestHasher) Add(hosts ...*Host) {
 	h.hosts = append(h.hosts, hosts...)
 }
@@ -61,6 +71,51 @@ func (h *keyedTestHasher) GetN(n int, key string) []*Host {
 	return hosts[:n]
 }
 
+func newSharedLocalDiskClient(store *Store, host *Host) *Client {
+	return &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		localDiskStore:        store,
+		localNodeID:           host.NodeID,
+		localCachePathID:      host.CachePathID,
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{host}},
+		maxGetContentAttempts: 1,
+	}
+}
+
+func TestCachePathIDForConfigUsesCanonicalPhysicalPath(t *testing.T) {
+	base := t.TempDir()
+	hostPath := filepath.Join(base, "host-cache")
+	cfgA := Config{
+		Disk: DiskConfig{
+			HostPath:  hostPath,
+			MountPath: "/container-a/cache",
+		},
+		Server: ServerConfig{
+			DiskCacheDir: "/container-a/cache/default/node-a",
+		},
+	}
+	cfgB := Config{
+		Disk: DiskConfig{
+			HostPath:  hostPath,
+			MountPath: "/container-b/cache",
+		},
+		Server: ServerConfig{
+			DiskCacheDir: "/container-b/cache/default/node-a",
+		},
+	}
+	cfgC := cfgA
+	cfgC.Disk.HostPath = filepath.Join(base, "other-host-cache")
+
+	require.Equal(t, cachePathIDForConfig(cfgA), cachePathIDForConfig(cfgB))
+	require.NotEqual(t, cachePathIDForConfig(cfgA), cachePathIDForConfig(cfgC))
+}
+
 func TestReadContentIntoUsesAttachedLocalServerOnlyForSelectedHost(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("local-cache-content")
@@ -92,6 +147,37 @@ func TestReadContentIntoUsesAttachedLocalServerOnlyForSelectedHost(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(content)), n)
 	require.Equal(t, content, dst)
+}
+
+func TestReadContentIntoUsesSelectedSharedLocalDiskStore(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("shared-daemonset-cache-content")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	host := &Host{HostId: "daemon-host", NodeID: "node-a", CachePathID: "cache-path-a"}
+	client := newSharedLocalDiskClient(store, host)
+
+	dst := make([]byte, len(content))
+	n, err := client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+}
+
+func TestReadContentIntoDoesNotUseSharedLocalDiskStoreForDifferentNode(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("shared-daemonset-cache-content")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	host := &Host{HostId: "daemon-host", NodeID: "node-b", CachePathID: "cache-path-a"}
+	client := newSharedLocalDiskClient(store, host)
+	client.localNodeID = "node-a"
+
+	dst := make([]byte, len(content))
+	_, err = client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
 func TestReadContentIntoKeepsLogicalHostUnavailableDistinctFromMiss(t *testing.T) {
@@ -650,6 +736,41 @@ func TestClientLocalPageFileViewsReturnsSelectedClientLocalPageFiles(t *testing.
 	require.FileExists(t, regions[1].Path)
 }
 
+func TestClientLocalPageFileViewsUsesSelectedSharedLocalDiskStore(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("abcdefghijkl")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	host := &Host{HostId: "daemon-host", NodeID: "node-a", CachePathID: "cache-path-a"}
+	client := newSharedLocalDiskClient(store, host)
+
+	regions, err := client.ClientLocalPageFileViews(hash, 3, 6, ClientOptions{})
+	require.NoError(t, err)
+	require.Len(t, regions, 2)
+	require.Equal(t, int64(3), regions[0].Offset)
+	require.Equal(t, 2, regions[0].Length)
+	require.Equal(t, int64(0), regions[1].Offset)
+	require.Equal(t, 4, regions[1].Length)
+	require.FileExists(t, regions[0].Path)
+	require.FileExists(t, regions[1].Path)
+}
+
+func TestClientLocalPageFileViewsDoesNotUseSharedLocalDiskStoreForDifferentCachePath(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("abcdefghijkl")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	host := &Host{HostId: "daemon-host", NodeID: "node-a", CachePathID: "cache-path-b"}
+	client := newSharedLocalDiskClient(store, host)
+	client.localCachePathID = "cache-path-a"
+
+	regions, err := client.ClientLocalPageFileViews(hash, 3, 6, ClientOptions{})
+	require.ErrorIs(t, err, ErrContentNotFound)
+	require.Empty(t, regions)
+}
+
 func TestClientLocalPageFileViewsUsesSelectedLocalServer(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("abcdefghijkl")
@@ -882,6 +1003,76 @@ func TestStoreContentFromLocalFileWaitsForLockedHashAlreadyPublished(t *testing.
 	})
 	require.NoError(t, err)
 	require.Equal(t, hash, got)
+}
+
+func TestStoreContentFromLocalFileWithHashSkipsSelectedHostWhenAlreadyCachedWithoutMetadata(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	content := []byte("already published content")
+	sum := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(sum[:])
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	remoteCfg := cfg
+	remoteCfg.Server.DiskCacheDir = t.TempDir()
+	remoteServer, err := NewServerWithOptions(ctx, remoteCfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	addr, err := remoteServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remoteServer.Close()) })
+
+	remoteHost := remoteServer.Host()
+	require.NotNil(t, remoteHost)
+	remoteHost.Addr = addr
+	remoteHost.PrivateAddr = addr
+
+	hash, _, err := remoteServer.cas.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, hash)
+
+	sourcePath := filepath.Join(t.TempDir(), "source.bin")
+	require.NoError(t, os.WriteFile(sourcePath, content, 0644))
+
+	metadataStore := &countingCacheMetadataStore{MockCacheMetadataStore: NewMockCacheMetadataStore()}
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          ClientConfig{NTopHosts: 1, PreferLocalCacheHost: true},
+		globalConfig:          cfg.Global,
+		metadataStore:         metadataStore,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(remoteHost))
+	defer client.Cleanup()
+
+	got, err := client.StoreContentFromLocalFile(LocalContentSource{
+		Path:      sourcePath,
+		CachePath: sourcePath,
+	}, StoreContentOptions{
+		RoutingKey: expectedHash,
+		Lock:       true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, got)
+	require.Zero(t, metadataStore.setStoreFromContentLockCalls)
 }
 
 func TestStoreContentFromLocalFileWithHashWritesSelectedRemoteHost(t *testing.T) {

--- a/pkg/cache/getcontent_bench_test.go
+++ b/pkg/cache/getcontent_bench_test.go
@@ -203,6 +203,41 @@ func BenchmarkClientLocalReadInto(b *testing.B) {
 	}
 }
 
+func BenchmarkClientSharedLocalDiskReadInto(b *testing.B) {
+	store, hash, _ := benchmarkStoreWithContent(b, 1024*1024, 64*1024*1024)
+	host := &Host{HostId: "daemon-bench-host", NodeID: "node-a", CachePathID: "cache-path-a"}
+	client := newSharedLocalDiskClient(store, host)
+	dst := make([]byte, 1024*1024)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(dst)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		offset := int64(i%64) * int64(len(dst))
+		n, err := client.ReadContentInto(context.Background(), hash, offset, dst, ClientOptions{RoutingKey: hash})
+		if err != nil || n != int64(len(dst)) {
+			b.Fatalf("shared local disk read offset %d: n=%d err=%v", offset, n, err)
+		}
+	}
+}
+
+func BenchmarkClientSharedLocalDiskPageViews(b *testing.B) {
+	store, hash, _ := benchmarkStoreWithContent(b, 1024*1024, 64*1024*1024)
+	host := &Host{HostId: "daemon-bench-host", NodeID: "node-a", CachePathID: "cache-path-a"}
+	client := newSharedLocalDiskClient(store, host)
+
+	b.ReportAllocs()
+	b.SetBytes(1024 * 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		offset := int64(i%64) * 1024 * 1024
+		views, err := client.ClientLocalPageFileViews(hash, offset, 1024*1024, ClientOptions{RoutingKey: hash})
+		if err != nil || len(views) != 1 || views[0].Length != 1024*1024 {
+			b.Fatalf("shared local disk page views offset %d: views=%d err=%v", offset, len(views), err)
+		}
+	}
+}
+
 func BenchmarkClientRawReadInto(b *testing.B) {
 	InitLogger(false, false)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/cache/store_lock.go
+++ b/pkg/cache/store_lock.go
@@ -38,7 +38,10 @@ func refreshStoreFromContentLock(ctx context.Context, metadataStore CacheMetadat
 }
 
 func isStoreFromContentLockNotHeld(err error) bool {
-	return errors.Is(err, redislock.ErrLockNotHeld) || strings.Contains(err.Error(), "redislock: lock not held")
+	return errors.Is(err, redislock.ErrLockNotHeld) ||
+		errors.Is(err, redislock.ErrNotObtained) ||
+		strings.Contains(err.Error(), "redislock: lock not held") ||
+		strings.Contains(err.Error(), "redislock: not obtained")
 }
 
 func storeContentHashLockKey(hash string) string {

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -214,6 +214,9 @@ func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, 
 
 	localViews, err := c.client.ClientLocalPageFileViews(hash, offset, length, cache.ClientOptions{RoutingKey: opts.RoutingKey})
 	if err != nil {
+		if errors.Is(err, cache.ErrContentNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	views = make([]clipStorage.ClientLocalPageFileView, 0, len(localViews))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a client-side locking error when storing by hash and adds support for reading from a shared local disk cache when the selected host is on the same node and cache path. This reduces failed uploads and speeds up local reads and page views.

- **New Features**
  - The client maintains a shared local disk `Store` and uses it for reads/page views when `NodeID` and `CachePathID` match the selected host.
  - Adds a stable `CachePathID` derived from the canonical physical path (using `Disk.HostPath`, `Disk.MountPath`, and `Server.DiskCacheDir`) and surfaces it on hosts.
  - Skips uploads when `RoutingKey` is a content hash and the selected host already has the content.

- **Bug Fixes**
  - Treats `redislock.ErrNotObtained` as “lock not held” to prevent failures when content is already published.
  - Uses the shared local disk for existence checks and reads when eligible, cleans local host cache on misses, and returns no error for local page-view “not found” in the worker.
  - Properly cleans up the local disk `Store` during client shutdown.

<sup>Written for commit 45c7c83c9aeffbd2bdd740f75f6dc102b7e9aae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

