### PR TITLE
add more cache traces

### DIFF
--- a/benchmarks/b9bench/cache_suite.py
+++ b/benchmarks/b9bench/cache_suite.py
@@ -319,7 +319,7 @@ class BenchmarkConfig:
         add("--volume-subdir", default=os.getenv("BENCH_CACHE_VOLUME_SUBDIR", ""))
         add(
             "--worker-workspace-root",
-            default=os.getenv("BENCH_WORKER_WORKSPACE_ROOT", "/workspace/data"),
+            default=os.getenv("BENCH_WORKER_WORKSPACE_ROOT", "/storage"),
         )
         add(
             "--cache-mount-path",
@@ -1830,9 +1830,12 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes 2>/dev/null || true
                 "targetHost": target_host,
                 "differentWorkerPod": bool(target_pod)
                 and source_pod["name"] != target_pod["name"],
-                "differentNode": bool(target_pod)
+                "differentNode": bool(source_pod.get("nodeName", ""))
                 and source_pod.get("nodeName", "")
-                != target_pod.get("nodeName", ""),
+                != (
+                    (target_pod or {}).get("nodeName", "")
+                    or target_host.get("nodeName", "")
+                ),
             }
         )
         if self.config.remote_network_probe and target_pod:
@@ -2127,7 +2130,7 @@ rm -rf /var/lib/beta9/cache/.benchmark-probes 2>/dev/null || true
 
     def cache_hosts_from_worker_logs(self) -> dict[str, Any]:
         hosts: list[dict[str, Any]] = []
-        workers = {pod["name"]: pod for pod in self.kube.cache_endpoint_pods()}
+        workers = {pod["name"]: pod for pod in self.kube.cache_probe_pods()}
         for pod_name, pod in workers.items():
             proc = run(
                 [

--- a/benchmarks/b9bench/clip_layer_suite.py
+++ b/benchmarks/b9bench/clip_layer_suite.py
@@ -460,7 +460,7 @@ def registration_ids(namespace: str, redis_pod: str, logical_host_id: str) -> li
 
 def cache_hosts_from_worker_logs(kube: Kube) -> dict[str, Any]:
     hosts_by_id: dict[str, dict[str, Any]] = {}
-    for pod in kube.cache_endpoint_pods():
+    for pod in kube.cache_probe_pods():
         proc = run(
             [
                 "kubectl",

--- a/benchmarks/b9bench/validators.py
+++ b/benchmarks/b9bench/validators.py
@@ -29,9 +29,13 @@ class Validator:
             failures.append(
                 f"{measurement.suite}/{measurement.scenario}/{measurement.measurement}: missing embedded-cache hit proof"
             )
-        if tags.get("requires_remote_worker") and evidence.get("remote_worker") is not True:
+        if (
+            tags.get("requires_remote_worker")
+            and evidence.get("remote_worker") is not True
+            and evidence.get("remote_node") is not True
+        ):
             failures.append(
-                f"{measurement.suite}/{measurement.scenario}/{measurement.measurement}: missing different-worker remote proof"
+                f"{measurement.suite}/{measurement.scenario}/{measurement.measurement}: missing different-worker or different-node remote proof"
             )
         if tags.get("reject_cloud_read") and evidence.get("cloud_read"):
             failures.append(

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1214,8 +1214,22 @@ func (c *Client) ClientLocalPageFileView(hash string, offset int64, length int64
 }
 
 func (c *Client) ClientLocalPageFileViews(hash string, offset int64, length int64, opts ClientOptions) (views []ClientLocalPageFileView, err error) {
+	views, _, err = c.ClientLocalPageFileViewsWithTrace(hash, offset, length, opts)
+	return views, err
+}
+
+func (c *Client) ClientLocalPageFileViewsWithTrace(hash string, offset int64, length int64, opts ClientOptions) (views []ClientLocalPageFileView, trace OperationTrace, err error) {
 	started := time.Now()
 	defer func() {
+		elapsed := time.Since(started)
+		trace.Operation = "client_local_page_file_views"
+		trace.Result = operationTracePageViewResult(err, len(views))
+		trace.Hash = hash
+		trace.RoutingKey = opts.RoutingKey
+		trace.Offset = offset
+		trace.Length = length
+		trace.Views = len(views)
+		trace.DurationUs = elapsed.Microseconds()
 		if elapsed := time.Since(started); elapsed > 100*time.Millisecond || err != nil {
 			Logger.Debugf("cache client-local page-file views result: hash=%s offset=%d length=%d views=%d err=%v elapsed=%s", hash, offset, length, len(views), err, elapsed.Truncate(time.Millisecond))
 		}
@@ -1225,31 +1239,35 @@ func (c *Client) ClientLocalPageFileViews(hash string, offset int64, length int6
 		opts.RoutingKey = hash
 	}
 	if offset < 0 || length <= 0 {
-		return nil, nil
+		return nil, trace, nil
 	}
 
 	host, err := c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
 	if err != nil {
 		if err == ErrHostNotFound {
 			_ = c.refreshRoutableHosts(c.ctx)
+			trace.HostRefreshes++
 			host, err = c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
 		}
 		if err != nil {
+			trace.addAttempt(0, host, "host_select", operationTraceReadResult(err, 0, length), 0, time.Since(started), err)
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
-			return nil, err
+			return nil, trace, err
 		}
 	}
-	if views, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
-		return views, nil
+	if views, source, ok := c.clientLocalPageFileViewsFromHost(host, hash, offset, length); ok {
+		trace.addAttempt(0, host, source, "hit", int64(len(views)), time.Since(started), nil)
+		return views, trace, nil
 	}
 
+	trace.addAttempt(0, host, "client_local_page_file", "miss", 0, time.Since(started), ErrContentNotFound)
 	atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
-	return nil, ErrContentNotFound
+	return nil, trace, ErrContentNotFound
 }
 
-func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offset int64, length int64) ([]ClientLocalPageFileView, bool) {
+func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offset int64, length int64) ([]ClientLocalPageFileView, string, bool) {
 	if host == nil {
-		return nil, false
+		return nil, "", false
 	}
 
 	c.mu.RLock()
@@ -1260,7 +1278,7 @@ func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offse
 			cacheReadClientLocalPageFileTotal.Inc()
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
-			return views, true
+			return views, "local_server_page_file", true
 		}
 	}
 
@@ -1269,11 +1287,11 @@ func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offse
 			cacheReadClientLocalPageFileTotal.Inc()
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
 			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
-			return views, true
+			return views, "local_disk_page_file", true
 		}
 	}
 
-	return nil, false
+	return nil, "", false
 }
 
 func clientLocalPageFileViewsFromStore(store *Store, hash string, offset int64, length int64) ([]ClientLocalPageFileView, bool) {
@@ -1300,6 +1318,11 @@ func clientLocalPageFileViewsFromStore(store *Store, hash string, offset int64, 
 }
 
 func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (read int64, err error) {
+	read, _, err = c.ReadContentIntoWithTrace(ctx, hash, offset, dst, opts)
+	return read, err
+}
+
+func (c *Client) ReadContentIntoWithTrace(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (read int64, trace OperationTrace, err error) {
 	if ctx == nil {
 		ctx = c.ctx
 	}
@@ -1309,7 +1332,7 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 		defer cancel()
 	}
 	if len(dst) == 0 {
-		return 0, nil
+		return 0, trace, nil
 	}
 	if opts.RoutingKey == "" {
 		opts.RoutingKey = hash
@@ -1318,6 +1341,15 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 	length := int64(len(dst))
 	started := time.Now()
 	defer func() {
+		elapsed := time.Since(started)
+		trace.Operation = "read_into"
+		trace.Result = operationTraceReadResult(err, read, length)
+		trace.Hash = hash
+		trace.RoutingKey = opts.RoutingKey
+		trace.Offset = offset
+		trace.Length = length
+		trace.Read = read
+		trace.DurationUs = elapsed.Microseconds()
 		if elapsed := time.Since(started); elapsed > time.Second || err != nil {
 			Logger.Debugf("cache read-into result: hash=%s routing_key=%s offset=%d length=%d read=%d err=%v elapsed=%s", hash, opts.RoutingKey, offset, length, read, err, elapsed.Truncate(time.Millisecond))
 		}
@@ -1325,16 +1357,17 @@ func (c *Client) ReadContentInto(ctx context.Context, hash string, offset int64,
 	atomic.AddInt64(&cachePathStats.clientReadIntoRequests, 1)
 	atomic.AddInt64(&cachePathStats.clientReadIntoBytes, length)
 
-	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts); err == nil {
-		return n, nil
+	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts, &trace); err == nil {
+		return n, trace, nil
 	} else if c.hostDirectory == nil || c.hostMap == nil {
-		return 0, err
+		return 0, trace, err
 	}
 
-	return c.readContentIntoAfterHostRefresh(ctx, hash, offset, dst, opts)
+	read, err = c.readContentIntoAfterHostRefresh(ctx, hash, offset, dst, opts, &trace)
+	return read, trace, err
 }
 
-func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
+func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions, trace *OperationTrace) (int64, error) {
 	length := int64(len(dst))
 	var lastErr error
 	primaryUnavailable := false
@@ -1352,6 +1385,7 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 		if err != nil {
 			if err == ErrHostNotFound {
 				_ = c.refreshRoutableHosts(c.ctx)
+				trace.HostRefreshes++
 				host, err = c.getHostForRequest(&ClientRequest{
 					rt:        ClientRequestTypeRetrieval,
 					hash:      hash,
@@ -1360,6 +1394,7 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 				})
 			}
 			if err != nil {
+				trace.addAttempt(hostIndex, host, "host_select", operationTraceReadResult(err, 0, length), 0, 0, err)
 				if errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) {
 					if hostIndex == 0 {
 						primaryUnavailable = true
@@ -1381,7 +1416,7 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 		}
 		checked[host.HostId] = struct{}{}
 
-		n, err := c.readContentIntoFromHost(ctx, host, hash, offset, dst)
+		n, err := c.readContentIntoFromHost(ctx, host, hostIndex, hash, offset, dst, trace)
 		if err == nil && n == length {
 			return n, nil
 		}
@@ -1426,7 +1461,7 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 	return 0, ErrHostNotFound
 }
 
-func (c *Client) readContentIntoAfterHostRefresh(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions) (int64, error) {
+func (c *Client) readContentIntoAfterHostRefresh(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions, trace *OperationTrace) (int64, error) {
 	if c.hostDirectory == nil || c.hostMap == nil {
 		return 0, ErrHostNotFound
 	}
@@ -1435,7 +1470,8 @@ func (c *Client) readContentIntoAfterHostRefresh(ctx context.Context, hash strin
 	if err := c.refreshRoutableHosts(ctx); err != nil && ctx.Err() != nil {
 		return 0, err
 	}
-	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts); err == nil {
+	trace.HostRefreshes++
+	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts, trace); err == nil {
 		Logger.Debugf("cache read-into recovered after host refresh: hash=%s routing_key=%s offset=%d length=%d", hash, opts.RoutingKey, offset, len(dst))
 		return n, nil
 	} else {
@@ -1443,8 +1479,9 @@ func (c *Client) readContentIntoAfterHostRefresh(ctx context.Context, hash strin
 	}
 }
 
-func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash string, offset int64, dst []byte) (int64, error) {
+func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hostIndex int, hash string, offset int64, dst []byte, trace *OperationTrace) (int64, error) {
 	if host == nil {
+		trace.addAttempt(hostIndex, host, "host_select", "unavailable", 0, 0, ErrHostNotFound)
 		return 0, ErrHostNotFound
 	}
 
@@ -1453,7 +1490,9 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	localServer := c.localServers[host.HostId]
 	c.mu.RUnlock()
 	if localServer != nil && localServer.cas != nil {
+		attemptStarted := time.Now()
 		n, err := localServer.cas.ReadAt(hash, offset, dst)
+		trace.addAttempt(hostIndex, host, "local_server", operationTraceReadResult(err, n, length), n, time.Since(attemptStarted), err)
 		if err == nil && n == length {
 			cacheReadLocalTotal.Inc()
 			atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
@@ -1470,7 +1509,9 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	}
 
 	if localStore := c.localDiskStoreForHost(host); localStore != nil {
+		attemptStarted := time.Now()
 		n, err := localStore.ReadAt(hash, offset, dst)
+		trace.addAttempt(hostIndex, host, "local_disk", operationTraceReadResult(err, n, length), n, time.Since(attemptStarted), err)
 		if err == nil && n == length {
 			cacheReadLocalTotal.Inc()
 			atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
@@ -1487,12 +1528,15 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	}
 
 	if !host.HasEndpoint() {
+		trace.addAttempt(hostIndex, host, "endpoint", "unavailable", 0, 0, ErrSelectedHostUnavailable)
 		c.removeLocalHostCache(hash)
 		return 0, ErrSelectedHostUnavailable
 	}
 
 	if c.clientConfig.ReadTransport.Enabled {
+		attemptStarted := time.Now()
 		n, err := c.rawReadIntoWindowed(ctx, host, hash, offset, dst)
+		trace.addAttempt(hostIndex, host, "raw", operationTraceReadResult(err, n, length), n, time.Since(attemptStarted), err)
 		if err == nil && n == length {
 			return n, nil
 		}
@@ -1509,6 +1553,7 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	client, exists := c.grpcClients[host.HostId]
 	c.mu.RUnlock()
 	if !exists {
+		trace.addAttempt(hostIndex, host, "grpc_client", "unavailable", 0, 0, ErrSelectedHostUnavailable)
 		c.removeLocalHostCache(hash)
 		return 0, ErrSelectedHostUnavailable
 	}
@@ -1516,6 +1561,7 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 	start := time.Now()
 	getContentResponse, err := client.GetContent(ctx, &proto.CacheGetContentRequest{Hash: hash, Offset: offset, Length: length}, c.dataCallOptions()...)
 	if err != nil {
+		trace.addAttempt(hostIndex, host, "grpc", "unavailable", 0, time.Since(start), err)
 		atomic.AddInt64(&cachePathStats.clientGRPCErrors, 1)
 		if c.globalConfig.GRPCPayloadCodecV2 {
 			cacheReadGRPCCodecV2FallbackTotal.Inc()
@@ -1523,13 +1569,19 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hash s
 		c.removeHost(host)
 		return 0, ErrSelectedHostUnavailable
 	}
-	if !getContentResponse.Ok || int64(len(getContentResponse.Content)) != length {
+	responseLength := int64(0)
+	if getContentResponse != nil {
+		responseLength = int64(len(getContentResponse.Content))
+	}
+	if getContentResponse == nil || !getContentResponse.Ok || responseLength != length {
+		trace.addAttempt(hostIndex, host, "grpc", "miss", responseLength, time.Since(start), ErrContentNotFound)
 		atomic.AddInt64(&cachePathStats.clientGRPCMisses, 1)
 		c.removeLocalHostCache(hash)
 		return 0, ErrContentNotFound
 	}
 
 	copy(dst, getContentResponse.Content)
+	trace.addAttempt(hostIndex, host, "grpc", "hit", length, time.Since(start), nil)
 	atomic.AddInt64(&cachePathStats.clientGRPCHits, 1)
 	if c.globalConfig.GRPCPayloadCodecV2 {
 		cacheReadGRPCCodecV2Total.Inc()

--- a/pkg/cache/trace.go
+++ b/pkg/cache/trace.go
@@ -1,0 +1,98 @@
+package cache
+
+import (
+	"errors"
+	"time"
+)
+
+type OperationTraceAttempt struct {
+	HostIndex      int    `json:"host_index"`
+	HostID         string `json:"host_id,omitempty"`
+	RegistrationID string `json:"registration_id,omitempty"`
+	PoolName       string `json:"pool_name,omitempty"`
+	Locality       string `json:"locality,omitempty"`
+	NodeID         string `json:"node_id,omitempty"`
+	CachePathID    string `json:"cache_path_id,omitempty"`
+	Addr           string `json:"addr,omitempty"`
+	PrivateAddr    string `json:"private_addr,omitempty"`
+	HasEndpoint    bool   `json:"has_endpoint"`
+	Source         string `json:"source"`
+	Result         string `json:"result"`
+	Read           int64  `json:"read,omitempty"`
+	ElapsedUs      int64  `json:"elapsed_us,omitempty"`
+	Error          string `json:"error,omitempty"`
+}
+
+type OperationTrace struct {
+	Operation     string                  `json:"operation,omitempty"`
+	Result        string                  `json:"result,omitempty"`
+	Hash          string                  `json:"hash,omitempty"`
+	RoutingKey    string                  `json:"routing_key,omitempty"`
+	Offset        int64                   `json:"offset,omitempty"`
+	Length        int64                   `json:"length,omitempty"`
+	Read          int64                   `json:"read,omitempty"`
+	Views         int                     `json:"views,omitempty"`
+	DurationUs    int64                   `json:"duration_us,omitempty"`
+	HostRefreshes int                     `json:"host_refreshes,omitempty"`
+	Attempts      []OperationTraceAttempt `json:"attempts,omitempty"`
+}
+
+func (t *OperationTrace) addAttempt(hostIndex int, host *Host, source string, result string, read int64, elapsed time.Duration, err error) {
+	if t == nil {
+		return
+	}
+
+	attempt := OperationTraceAttempt{
+		HostIndex:   hostIndex,
+		Source:      source,
+		Result:      result,
+		Read:        read,
+		ElapsedUs:   elapsed.Microseconds(),
+		HasEndpoint: host.HasEndpoint(),
+	}
+	if err != nil {
+		attempt.Error = err.Error()
+	}
+	if host != nil {
+		attempt.HostID = host.HostId
+		attempt.RegistrationID = host.RegistrationID
+		attempt.PoolName = host.PoolName
+		attempt.Locality = host.Locality
+		attempt.NodeID = host.NodeID
+		attempt.CachePathID = host.CachePathID
+		attempt.Addr = host.Addr
+		attempt.PrivateAddr = host.PrivateAddr
+	}
+
+	t.Attempts = append(t.Attempts, attempt)
+}
+
+func operationTraceReadResult(err error, read int64, length int64) string {
+	switch {
+	case err == nil && read == length:
+		return "hit"
+	case errors.Is(err, ErrContentNotFound):
+		return "miss"
+	case errors.Is(err, ErrSelectedHostUnavailable), errors.Is(err, ErrUnableToReachHost), errors.Is(err, ErrHostNotFound), errors.Is(err, ErrClientNotFound):
+		return "unavailable"
+	case err == nil && read != length:
+		return "short_read"
+	default:
+		return "error"
+	}
+}
+
+func operationTracePageViewResult(err error, viewCount int) string {
+	switch {
+	case err == nil && viewCount > 0:
+		return "hit"
+	case err == nil:
+		return "miss"
+	case errors.Is(err, ErrContentNotFound):
+		return "miss"
+	case errors.Is(err, ErrSelectedHostUnavailable), errors.Is(err, ErrUnableToReachHost), errors.Is(err, ErrHostNotFound), errors.Is(err, ErrClientNotFound):
+		return "unavailable"
+	default:
+		return "error"
+	}
+}

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -420,7 +420,7 @@ func (c *ImageClient) lazyMountOptions(ctx context.Context, request *types.Conta
 	if archive.usesOCIStorage() {
 		cacheKind = "oci-layer-runtime"
 	}
-	contentCache := newImageContentCache(c.cacheClient, request.ImageId, cacheKind)
+	contentCache := newImageContentCache(c.cacheClient, request.ImageId, cacheKind, c.imageContentCacheObserver(request))
 	mountOptions := clip.MountOptions{
 		ArchivePath:           archive.path,
 		MountPoint:            c.imageMountPoint(request.ImageId),

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -24,16 +24,26 @@ type imageContentCache struct {
 	imageID string
 	kind    string
 
-	readRequests   atomic.Int64
-	readBytes      atomic.Int64
-	readErrors     atomic.Int64
-	existsRequests atomic.Int64
-	existsHits     atomic.Int64
-	existsErrors   atomic.Int64
-	storeRequests  atomic.Int64
-	storeBytes     atomic.Int64
-	storeErrors    atomic.Int64
-	lastSummaryNS  atomic.Int64
+	readRequests     atomic.Int64
+	readBytes        atomic.Int64
+	readHits         atomic.Int64
+	readMisses       atomic.Int64
+	readUnavailable  atomic.Int64
+	readShortReads   atomic.Int64
+	readErrors       atomic.Int64
+	existsRequests   atomic.Int64
+	existsHits       atomic.Int64
+	existsErrors     atomic.Int64
+	pageViewRequests atomic.Int64
+	pageViewHits     atomic.Int64
+	pageViewMisses   atomic.Int64
+	pageViewErrors   atomic.Int64
+	pageViewBytes    atomic.Int64
+	storeRequests    atomic.Int64
+	storeBytes       atomic.Int64
+	storeSuccesses   atomic.Int64
+	storeErrors      atomic.Int64
+	lastSummaryNS    atomic.Int64
 }
 
 func newImageContentCache(client *cache.Client, imageID string, kind ...string) *imageContentCache {
@@ -78,10 +88,22 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 	c.readBytes.Add(length)
 	defer func() {
 		elapsed := time.Since(started)
+		result := imageContentCacheReadResult(err, read, length)
+		switch result {
+		case "hit":
+			c.readHits.Add(1)
+		case "miss":
+			c.readMisses.Add(1)
+		case "unavailable":
+			c.readUnavailable.Add(1)
+		case "short_read":
+			c.readShortReads.Add(1)
+		}
 		if err != nil || read != length {
 			c.readErrors.Add(1)
 			log.Warn().
 				Err(err).
+				Str("cache_result", result).
 				Str("image_id", c.imageID).
 				Str("kind", c.kind).
 				Str("hash", shortHash(hash)).
@@ -93,6 +115,7 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 				Msg("clip image content cache read result")
 		} else if elapsed > imageContentCacheSlowRead {
 			log.Debug().
+				Str("cache_result", result).
 				Str("image_id", c.imageID).
 				Str("kind", c.kind).
 				Str("hash", shortHash(hash)).
@@ -183,11 +206,23 @@ func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, 
 	}
 
 	started := time.Now()
+	c.pageViewRequests.Add(1)
 	defer func() {
 		elapsed := time.Since(started)
+		result := imageContentCachePageViewResult(err, len(views))
+		switch result {
+		case "hit":
+			c.pageViewHits.Add(1)
+			c.pageViewBytes.Add(length)
+		case "miss":
+			c.pageViewMisses.Add(1)
+		case "unavailable", "error":
+			c.pageViewErrors.Add(1)
+		}
 		if err != nil {
 			log.Warn().
 				Err(err).
+				Str("cache_result", result).
 				Str("image_id", c.imageID).
 				Str("kind", c.kind).
 				Str("hash", shortHash(hash)).
@@ -199,6 +234,7 @@ func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, 
 				Msg("clip image content cache client-local page-file views result")
 		} else if len(views) == 0 || elapsed > imageContentCacheSlowRead {
 			log.Debug().
+				Str("cache_result", result).
 				Str("image_id", c.imageID).
 				Str("kind", c.kind).
 				Str("hash", shortHash(hash)).
@@ -217,7 +253,7 @@ func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, 
 		if errors.Is(err, cache.ErrContentNotFound) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, imageContentCacheError(err)
 	}
 	views = make([]clipStorage.ClientLocalPageFileView, 0, len(localViews))
 	for _, view := range localViews {
@@ -266,6 +302,7 @@ func (c *imageContentCache) StoreContent(chunks chan []byte, hash string, opts s
 		c.storeErrors.Add(1)
 		log.Warn().
 			Err(err).
+			Str("cache_result", "error").
 			Str("image_id", c.imageID).
 			Str("kind", c.kind).
 			Str("hash", shortHash(hash)).
@@ -273,8 +310,12 @@ func (c *imageContentCache) StoreContent(chunks chan []byte, hash string, opts s
 			Int64("bytes", storeBytes.Load()).
 			Dur("elapsed", elapsed).
 			Msg("clip image content cache store result")
-	} else if elapsed > imageContentCacheSlowStore {
+	} else {
+		c.storeSuccesses.Add(1)
+	}
+	if err == nil && elapsed > imageContentCacheSlowStore {
 		log.Debug().
+			Str("cache_result", "stored_or_present").
 			Str("image_id", c.imageID).
 			Str("kind", c.kind).
 			Str("hash", shortHash(hash)).
@@ -305,6 +346,7 @@ func (c *imageContentCache) StoreContentFromLocalPath(path string, hash string, 
 			c.storeErrors.Add(1)
 			log.Warn().
 				Err(err).
+				Str("cache_result", "error").
 				Str("image_id", c.imageID).
 				Str("kind", c.kind).
 				Str("hash", shortHash(hash)).
@@ -312,8 +354,12 @@ func (c *imageContentCache) StoreContentFromLocalPath(path string, hash string, 
 				Str("path", path).
 				Dur("elapsed", elapsed).
 				Msg("clip image content cache local-path store result")
-		} else if elapsed > imageContentCacheSlowStore {
+		} else {
+			c.storeSuccesses.Add(1)
+		}
+		if err == nil && elapsed > imageContentCacheSlowStore {
 			log.Debug().
+				Str("cache_result", "stored_or_present").
 				Str("image_id", c.imageID).
 				Str("kind", c.kind).
 				Str("hash", shortHash(hash)).
@@ -355,14 +401,54 @@ func (c *imageContentCache) maybeLogSummary() {
 		Str("kind", c.kind).
 		Int64("read_requests", c.readRequests.Load()).
 		Int64("read_bytes", c.readBytes.Load()).
+		Int64("read_hits", c.readHits.Load()).
+		Int64("read_misses", c.readMisses.Load()).
+		Int64("read_unavailable", c.readUnavailable.Load()).
+		Int64("read_short_reads", c.readShortReads.Load()).
 		Int64("read_errors", c.readErrors.Load()).
 		Int64("exists_requests", c.existsRequests.Load()).
 		Int64("exists_hits", c.existsHits.Load()).
 		Int64("exists_errors", c.existsErrors.Load()).
+		Int64("page_view_requests", c.pageViewRequests.Load()).
+		Int64("page_view_hits", c.pageViewHits.Load()).
+		Int64("page_view_misses", c.pageViewMisses.Load()).
+		Int64("page_view_errors", c.pageViewErrors.Load()).
+		Int64("page_view_bytes", c.pageViewBytes.Load()).
 		Int64("store_requests", c.storeRequests.Load()).
 		Int64("store_bytes", c.storeBytes.Load()).
+		Int64("store_successes", c.storeSuccesses.Load()).
 		Int64("store_errors", c.storeErrors.Load()).
 		Msg("clip image content cache summary")
+}
+
+func imageContentCacheReadResult(err error, read int64, length int64) string {
+	switch {
+	case err == nil && read == length:
+		return "hit"
+	case errors.Is(err, clipStorage.ErrContentCacheMiss):
+		return "miss"
+	case errors.Is(err, clipStorage.ErrContentCacheUnavailable):
+		return "unavailable"
+	case err == nil && read != length:
+		return "short_read"
+	default:
+		return "error"
+	}
+}
+
+func imageContentCachePageViewResult(err error, viewCount int) string {
+	switch {
+	case err == nil && viewCount > 0:
+		return "hit"
+	case err == nil:
+		return "miss"
+	case errors.Is(err, clipStorage.ErrContentCacheMiss):
+		return "miss"
+	case errors.Is(err, clipStorage.ErrContentCacheUnavailable):
+		return "unavailable"
+	default:
+		return "error"
+	}
 }
 
 func shortHash(hash string) string {

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -23,6 +24,7 @@ type imageContentCache struct {
 	client  *cache.Client
 	imageID string
 	kind    string
+	observe imageContentCacheObserver
 
 	readRequests     atomic.Int64
 	readBytes        atomic.Int64
@@ -46,15 +48,39 @@ type imageContentCache struct {
 	lastSummaryNS    atomic.Int64
 }
 
-func newImageContentCache(client *cache.Client, imageID string, kind ...string) *imageContentCache {
+type imageContentCacheObserver func(imageContentCacheTrace)
+
+type imageContentCacheTrace struct {
+	Operation  string
+	Result     string
+	ImageID    string
+	Kind       string
+	Hash       string
+	RoutingKey string
+	Offset     int64
+	Length     int64
+	Read       int64
+	Views      int
+	Bytes      int64
+	StartedAt  time.Time
+	Duration   time.Duration
+	Error      string
+	Trace      cache.OperationTrace
+}
+
+func newImageContentCache(client *cache.Client, imageID string, kind string, observers ...imageContentCacheObserver) *imageContentCache {
 	if client == nil {
 		return nil
 	}
 	cacheKind := "content"
-	if len(kind) > 0 && kind[0] != "" {
-		cacheKind = kind[0]
+	if kind != "" {
+		cacheKind = kind
 	}
-	return &imageContentCache{client: client, imageID: imageID, kind: cacheKind}
+	var observer imageContentCacheObserver
+	if len(observers) > 0 {
+		observer = observers[0]
+	}
+	return &imageContentCache{client: client, imageID: imageID, kind: cacheKind, observe: observer}
 }
 
 func (c *imageContentCache) GetContent(hash string, offset int64, length int64, opts struct{ RoutingKey string }) ([]byte, error) {
@@ -84,6 +110,7 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 
 	started := time.Now()
 	length := int64(len(dest))
+	var cacheTrace cache.OperationTrace
 	c.readRequests.Add(1)
 	c.readBytes.Add(length)
 	defer func() {
@@ -126,12 +153,28 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 				Msg("clip image content cache slow read")
 		}
 		c.maybeLogSummary()
+		c.observeContentCacheTrace(imageContentCacheTrace{
+			Operation:  "read_into",
+			Result:     result,
+			ImageID:    c.imageID,
+			Kind:       c.kind,
+			Hash:       hash,
+			RoutingKey: opts.RoutingKey,
+			Offset:     offset,
+			Length:     length,
+			Read:       read,
+			Bytes:      read,
+			StartedAt:  started,
+			Duration:   elapsed,
+			Error:      imageContentCacheErrorString(err),
+			Trace:      cacheTrace,
+		})
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), imageContentCacheReadTimeout)
 	defer cancel()
 
-	read, err = c.client.ReadContentInto(ctx, hash, offset, dest, cache.ClientOptions{RoutingKey: opts.RoutingKey})
+	read, cacheTrace, err = c.client.ReadContentIntoWithTrace(ctx, hash, offset, dest, cache.ClientOptions{RoutingKey: opts.RoutingKey})
 	if err != nil {
 		return read, imageContentCacheError(err)
 	}
@@ -206,6 +249,7 @@ func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, 
 	}
 
 	started := time.Now()
+	var cacheTrace cache.OperationTrace
 	c.pageViewRequests.Add(1)
 	defer func() {
 		elapsed := time.Since(started)
@@ -246,9 +290,25 @@ func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, 
 				Msg("clip image content cache client-local page-file views result")
 		}
 		c.maybeLogSummary()
+		c.observeContentCacheTrace(imageContentCacheTrace{
+			Operation:  "page_file_views",
+			Result:     result,
+			ImageID:    c.imageID,
+			Kind:       c.kind,
+			Hash:       hash,
+			RoutingKey: opts.RoutingKey,
+			Offset:     offset,
+			Length:     length,
+			Views:      len(views),
+			Bytes:      length,
+			StartedAt:  started,
+			Duration:   elapsed,
+			Error:      imageContentCacheErrorString(err),
+			Trace:      cacheTrace,
+		})
 	}()
 
-	localViews, err := c.client.ClientLocalPageFileViews(hash, offset, length, cache.ClientOptions{RoutingKey: opts.RoutingKey})
+	localViews, cacheTrace, err := c.client.ClientLocalPageFileViewsWithTrace(hash, offset, length, cache.ClientOptions{RoutingKey: opts.RoutingKey})
 	if err != nil {
 		if errors.Is(err, cache.ErrContentNotFound) {
 			return nil, nil
@@ -298,7 +358,9 @@ func (c *imageContentCache) StoreContent(chunks chan []byte, hash string, opts s
 	actualHash, err := c.client.StoreContent(countingChunks, hash, struct{ RoutingKey string }{RoutingKey: opts.RoutingKey})
 	close(done)
 	elapsed := time.Since(started)
+	result := "stored_or_present"
 	if err != nil {
+		result = "error"
 		c.storeErrors.Add(1)
 		log.Warn().
 			Err(err).
@@ -326,6 +388,18 @@ func (c *imageContentCache) StoreContent(chunks chan []byte, hash string, opts s
 			Msg("clip image content cache store result")
 	}
 	c.maybeLogSummary()
+	c.observeContentCacheTrace(imageContentCacheTrace{
+		Operation:  "store_stream",
+		Result:     result,
+		ImageID:    c.imageID,
+		Kind:       c.kind,
+		Hash:       hash,
+		RoutingKey: opts.RoutingKey,
+		Bytes:      storeBytes.Load(),
+		StartedAt:  started,
+		Duration:   elapsed,
+		Error:      imageContentCacheErrorString(err),
+	})
 
 	return actualHash, err
 }
@@ -370,6 +444,22 @@ func (c *imageContentCache) StoreContentFromLocalPath(path string, hash string, 
 				Msg("clip image content cache local-path store result")
 		}
 		c.maybeLogSummary()
+		result := "stored_or_present"
+		if err != nil {
+			result = "error"
+		}
+		c.observeContentCacheTrace(imageContentCacheTrace{
+			Operation:  "store_local_path",
+			Result:     result,
+			ImageID:    c.imageID,
+			Kind:       c.kind,
+			Hash:       hash,
+			RoutingKey: opts.RoutingKey,
+			Bytes:      fileSize(path),
+			StartedAt:  started,
+			Duration:   elapsed,
+			Error:      imageContentCacheErrorString(err),
+		})
 	}()
 
 	return c.client.StoreContentFromLocalFile(cache.LocalContentSource{
@@ -384,6 +474,13 @@ func (c *imageContentCache) StoreContentFromLocalPath(path string, hash string, 
 func drainImageContentChunks(chunks <-chan []byte) {
 	for range chunks {
 	}
+}
+
+func (c *imageContentCache) observeContentCacheTrace(event imageContentCacheTrace) {
+	if c == nil || c.observe == nil {
+		return
+	}
+	c.observe(event)
 }
 
 func (c *imageContentCache) maybeLogSummary() {
@@ -419,6 +516,21 @@ func (c *imageContentCache) maybeLogSummary() {
 		Int64("store_successes", c.storeSuccesses.Load()).
 		Int64("store_errors", c.storeErrors.Load()).
 		Msg("clip image content cache summary")
+}
+
+func imageContentCacheErrorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func fileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }
 
 func imageContentCacheReadResult(err error, read int64, length int64) string {

--- a/pkg/worker/image_events.go
+++ b/pkg/worker/image_events.go
@@ -32,6 +32,7 @@ type clipReadAggregate struct {
 	byAccess    map[string]*clipReadRollup
 	byOperation map[string]*clipReadRollup
 	bySource    map[string]*clipReadRollup
+	byResult    map[string]*clipReadRollup
 	byLayer     map[string]*clipReadRollup
 	byContent   map[string]*clipReadRollup
 	firstError  string
@@ -45,6 +46,8 @@ type clipReadRollup struct {
 	LayerDigest      string `json:"layer_digest,omitempty"`
 	DecompressedHash string `json:"decompressed_hash,omitempty"`
 	ContentHash      string `json:"content_hash,omitempty"`
+	CacheResult      string `json:"cache_result,omitempty"`
+	CacheTier        string `json:"cache_tier,omitempty"`
 	Count            int64  `json:"count"`
 	ErrorCount       int64  `json:"error_count,omitempty"`
 	TotalUs          int64  `json:"total_us"`
@@ -112,6 +115,7 @@ func newClipReadAggregate(request *types.ContainerRequest) *clipReadAggregate {
 		byAccess:    map[string]*clipReadRollup{},
 		byOperation: map[string]*clipReadRollup{},
 		bySource:    map[string]*clipReadRollup{},
+		byResult:    map[string]*clipReadRollup{},
 		byLayer:     map[string]*clipReadRollup{},
 		byContent:   map[string]*clipReadRollup{},
 		sampleAttrs: map[string]string{},
@@ -136,13 +140,17 @@ func (a *clipReadAggregate) add(event clipCommon.ReadTraceEvent) {
 			continue
 		}
 		switch key {
-		case "cached_locally", "content_cache_available", "storage_mode":
+		case "cache_result", "cache_tier", "cached_locally", "content_cache_available", "content_cache_result", "content_cache_warm", "fallback", "storage_mode":
 			a.sampleAttrs[key] = value
 		}
 	}
 
 	contentHash := event.Attrs["content_hash"]
+	cacheResult := clipReadCacheResult(event)
 	a.addRollup(a.byOperation, event.Operation, event)
+	if cacheResult != "" {
+		a.addRollup(a.byResult, clipReadRollupKey(event.Operation, event.Source, cacheResult), event)
+	}
 
 	if isCanonicalClipRead(event.Operation) {
 		if a.startedAt.IsZero() || event.StartedAt.Before(a.startedAt) {
@@ -154,7 +162,7 @@ func (a *clipReadAggregate) add(event clipCommon.ReadTraceEvent) {
 		a.readCount++
 		a.bytesRead += event.BytesRead
 		a.total += event.Duration
-		a.addRollup(a.byAccess, clipReadRollupKey(event.Operation, event.Path, event.Source, event.LayerDigest, event.DecompressedHash, contentHash), event)
+		a.addRollup(a.byAccess, clipReadRollupKey(event.Operation, event.Path, event.Source, event.LayerDigest, event.DecompressedHash, contentHash, cacheResult), event)
 		a.addRollup(a.bySource, event.Source, event)
 		if event.LayerDigest != "" {
 			a.addRollup(a.byLayer, event.LayerDigest, event)
@@ -178,6 +186,8 @@ func (a *clipReadAggregate) addRollup(target map[string]*clipReadRollup, key str
 			LayerDigest:      event.LayerDigest,
 			DecompressedHash: event.DecompressedHash,
 			ContentHash:      event.Attrs["content_hash"],
+			CacheResult:      clipReadCacheResult(event),
+			CacheTier:        event.Attrs["cache_tier"],
 		}
 		target[key] = rollup
 	}
@@ -223,6 +233,7 @@ func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushR
 		"top_layers_json":     clipReadRollupsJSON(aggregate.byLayer, clipReadAggregateTopN),
 		"top_operations_json": clipReadRollupsJSON(aggregate.byOperation, clipReadAggregateTopN),
 		"top_paths_json":      clipReadRollupsJSON(aggregate.byAccess, clipReadAggregateTopN),
+		"top_results_json":    clipReadRollupsJSON(aggregate.byResult, clipReadAggregateTopN),
 		"top_sources_json":    clipReadRollupsJSON(aggregate.bySource, clipReadAggregateTopN),
 		"total_duration_us":   strconv.FormatInt(aggregate.total.Microseconds(), 10),
 		"wall_duration_us":    strconv.FormatInt(wallDuration.Microseconds(), 10),
@@ -249,6 +260,7 @@ func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushR
 		Str("top_sources_json", attrs["top_sources_json"]).
 		Str("top_paths_json", attrs["top_paths_json"]).
 		Str("top_operations_json", attrs["top_operations_json"]).
+		Str("top_results_json", attrs["top_results_json"]).
 		Str("top_content_json", attrs["top_content_json"]).
 		Str("first_error", aggregate.firstError).
 		Msg("clip read path summary")
@@ -274,6 +286,13 @@ func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushR
 
 func isCanonicalClipRead(operation string) bool {
 	return operation == string(types.ContainerLifecycleClipRead) || operation == string(types.ContainerLifecycleClipOCIRead)
+}
+
+func clipReadCacheResult(event clipCommon.ReadTraceEvent) string {
+	return firstNonEmptyImageValue(
+		event.Attrs["cache_result"],
+		event.Attrs["content_cache_result"],
+	)
 }
 
 func clipReadRollupKey(parts ...string) string {

--- a/pkg/worker/image_events.go
+++ b/pkg/worker/image_events.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/beam-cloud/beta9/pkg/cache"
 	"github.com/beam-cloud/beta9/pkg/types"
 	clipCommon "github.com/beam-cloud/clip/pkg/common"
 	"github.com/prometheus/procfs"
@@ -21,22 +22,33 @@ const (
 )
 
 type clipReadAggregate struct {
-	request     *types.ContainerRequest
-	startedAt   time.Time
-	lastAt      time.Time
-	success     bool
-	readCount   int64
-	errorCount  int64
-	bytesRead   int64
-	total       time.Duration
-	byAccess    map[string]*clipReadRollup
-	byOperation map[string]*clipReadRollup
-	bySource    map[string]*clipReadRollup
-	byResult    map[string]*clipReadRollup
-	byLayer     map[string]*clipReadRollup
-	byContent   map[string]*clipReadRollup
-	firstError  string
-	sampleAttrs map[string]string
+	request               *types.ContainerRequest
+	startedAt             time.Time
+	lastAt                time.Time
+	success               bool
+	readCount             int64
+	errorCount            int64
+	bytesRead             int64
+	total                 time.Duration
+	cacheCount            int64
+	cacheErrorCount       int64
+	cacheHitCount         int64
+	cacheMissCount        int64
+	cacheUnavailableCount int64
+	cacheBytes            int64
+	cacheTotal            time.Duration
+	byAccess              map[string]*clipReadRollup
+	byOperation           map[string]*clipReadRollup
+	bySource              map[string]*clipReadRollup
+	byResult              map[string]*clipReadRollup
+	byLayer               map[string]*clipReadRollup
+	byContent             map[string]*clipReadRollup
+	byCacheOperation      map[string]*clipCacheRollup
+	byCacheResult         map[string]*clipCacheRollup
+	byCacheSource         map[string]*clipCacheRollup
+	byCacheHost           map[string]*clipCacheRollup
+	firstError            string
+	sampleAttrs           map[string]string
 }
 
 type clipReadRollup struct {
@@ -55,6 +67,28 @@ type clipReadRollup struct {
 	TotalMs          int64  `json:"total_ms"`
 	MaxMs            int64  `json:"max_ms"`
 	BytesRead        int64  `json:"bytes_read"`
+}
+
+type clipCacheRollup struct {
+	Operation      string `json:"operation,omitempty"`
+	Result         string `json:"result,omitempty"`
+	Source         string `json:"source,omitempty"`
+	HostIndex      int    `json:"host_index,omitempty"`
+	HostID         string `json:"host_id,omitempty"`
+	RegistrationID string `json:"registration_id,omitempty"`
+	PoolName       string `json:"pool_name,omitempty"`
+	Locality       string `json:"locality,omitempty"`
+	NodeID         string `json:"node_id,omitempty"`
+	CachePathID    string `json:"cache_path_id,omitempty"`
+	HasEndpoint    bool   `json:"has_endpoint,omitempty"`
+	Count          int64  `json:"count"`
+	ErrorCount     int64  `json:"error_count,omitempty"`
+	TotalUs        int64  `json:"total_us"`
+	MaxUs          int64  `json:"max_us"`
+	TotalMs        int64  `json:"total_ms"`
+	MaxMs          int64  `json:"max_ms"`
+	Bytes          int64  `json:"bytes,omitempty"`
+	Read           int64  `json:"read,omitempty"`
 }
 
 type clipPIDReference struct {
@@ -108,17 +142,42 @@ func (c *ImageClient) recordClipReadEvent(event clipCommon.ReadTraceEvent) {
 	c.clipRuntimeMu.Unlock()
 }
 
+func (c *ImageClient) imageContentCacheObserver(request *types.ContainerRequest) imageContentCacheObserver {
+	return func(event imageContentCacheTrace) {
+		c.recordImageContentCacheEvent(request, event)
+	}
+}
+
+func (c *ImageClient) recordImageContentCacheEvent(request *types.ContainerRequest, event imageContentCacheTrace) {
+	if c == nil || request == nil {
+		return
+	}
+
+	c.clipRuntimeMu.Lock()
+	aggregate := c.clipAggregates[request.ContainerId]
+	if aggregate == nil {
+		aggregate = newClipReadAggregate(request)
+		c.clipAggregates[request.ContainerId] = aggregate
+	}
+	aggregate.addContentCache(event)
+	c.clipRuntimeMu.Unlock()
+}
+
 func newClipReadAggregate(request *types.ContainerRequest) *clipReadAggregate {
 	return &clipReadAggregate{
-		request:     request,
-		success:     true,
-		byAccess:    map[string]*clipReadRollup{},
-		byOperation: map[string]*clipReadRollup{},
-		bySource:    map[string]*clipReadRollup{},
-		byResult:    map[string]*clipReadRollup{},
-		byLayer:     map[string]*clipReadRollup{},
-		byContent:   map[string]*clipReadRollup{},
-		sampleAttrs: map[string]string{},
+		request:          request,
+		success:          true,
+		byAccess:         map[string]*clipReadRollup{},
+		byOperation:      map[string]*clipReadRollup{},
+		bySource:         map[string]*clipReadRollup{},
+		byResult:         map[string]*clipReadRollup{},
+		byLayer:          map[string]*clipReadRollup{},
+		byContent:        map[string]*clipReadRollup{},
+		byCacheOperation: map[string]*clipCacheRollup{},
+		byCacheResult:    map[string]*clipCacheRollup{},
+		byCacheSource:    map[string]*clipCacheRollup{},
+		byCacheHost:      map[string]*clipCacheRollup{},
+		sampleAttrs:      map[string]string{},
 	}
 }
 
@@ -173,6 +232,74 @@ func (a *clipReadAggregate) add(event clipCommon.ReadTraceEvent) {
 	}
 }
 
+func (a *clipReadAggregate) addContentCache(event imageContentCacheTrace) {
+	if a == nil {
+		return
+	}
+
+	durationUs := event.Duration.Microseconds()
+	if event.StartedAt.IsZero() {
+		event.StartedAt = time.Now().Add(-event.Duration)
+	}
+	endedAt := event.StartedAt.Add(event.Duration)
+	if a.startedAt.IsZero() || event.StartedAt.Before(a.startedAt) {
+		a.startedAt = event.StartedAt
+	}
+	if endedAt.After(a.lastAt) {
+		a.lastAt = endedAt
+	}
+
+	a.cacheCount++
+	a.cacheBytes += event.Bytes
+	a.cacheTotal += event.Duration
+	switch event.Result {
+	case "hit", "stored_or_present":
+		a.cacheHitCount++
+	case "miss":
+		a.cacheMissCount++
+	case "unavailable":
+		a.cacheUnavailableCount++
+	case "error":
+		a.cacheErrorCount++
+	}
+	if event.Error != "" && event.Result != "error" {
+		a.cacheErrorCount++
+		if a.firstError == "" && event.Error != "" {
+			a.firstError = event.Error
+		}
+	}
+	if a.firstError == "" && event.Error != "" {
+		a.firstError = event.Error
+	}
+
+	a.addCacheRollup(a.byCacheOperation, clipReadRollupKey(event.Operation, event.Result), event.Operation, event.Result, "", nil, durationUs, event.Bytes, event.Read, event.Error)
+	a.addCacheRollup(a.byCacheResult, clipReadRollupKey(event.Result, event.Operation), event.Operation, event.Result, "", nil, durationUs, event.Bytes, event.Read, event.Error)
+
+	if len(event.Trace.Attempts) == 0 {
+		a.addCacheRollup(a.byCacheSource, clipReadRollupKey(event.Operation, "content_cache", event.Result), event.Operation, event.Result, "content_cache", nil, durationUs, event.Bytes, event.Read, event.Error)
+		return
+	}
+
+	for _, attempt := range event.Trace.Attempts {
+		attemptDurationUs := attempt.ElapsedUs
+		if attemptDurationUs <= 0 {
+			attemptDurationUs = durationUs
+		}
+		source := attempt.Source
+		if source == "" {
+			source = "unknown"
+		}
+		result := attempt.Result
+		if result == "" {
+			result = event.Result
+		}
+		a.addCacheRollup(a.byCacheSource, clipReadRollupKey(event.Operation, source, result), event.Operation, result, source, &attempt, attemptDurationUs, 0, attempt.Read, attempt.Error)
+		if attempt.HostID != "" {
+			a.addCacheRollup(a.byCacheHost, clipReadRollupKey(attempt.HostID, source, result), event.Operation, result, source, &attempt, attemptDurationUs, 0, attempt.Read, attempt.Error)
+		}
+	}
+}
+
 func (a *clipReadAggregate) addRollup(target map[string]*clipReadRollup, key string, event clipCommon.ReadTraceEvent) {
 	if key == "" {
 		key = "unknown"
@@ -206,8 +333,46 @@ func (a *clipReadAggregate) addRollup(target map[string]*clipReadRollup, key str
 	}
 }
 
+func (a *clipReadAggregate) addCacheRollup(target map[string]*clipCacheRollup, key string, operation string, result string, source string, attempt *cache.OperationTraceAttempt, durationUs int64, bytes int64, read int64, err string) {
+	if key == "" {
+		key = "unknown"
+	}
+	rollup := target[key]
+	if rollup == nil {
+		rollup = &clipCacheRollup{
+			Operation: operation,
+			Result:    result,
+			Source:    source,
+		}
+		if attempt != nil {
+			rollup.HostIndex = attempt.HostIndex
+			rollup.HostID = attempt.HostID
+			rollup.RegistrationID = attempt.RegistrationID
+			rollup.PoolName = attempt.PoolName
+			rollup.Locality = attempt.Locality
+			rollup.NodeID = attempt.NodeID
+			rollup.CachePathID = attempt.CachePathID
+			rollup.HasEndpoint = attempt.HasEndpoint
+		}
+		target[key] = rollup
+	}
+
+	rollup.Count++
+	if err != "" || result == "miss" || result == "unavailable" || result == "error" {
+		rollup.ErrorCount++
+	}
+	rollup.TotalUs += durationUs
+	rollup.TotalMs = durationUsToMilliseconds(rollup.TotalUs)
+	if durationUs > rollup.MaxUs {
+		rollup.MaxUs = durationUs
+		rollup.MaxMs = durationUsToMilliseconds(durationUs)
+	}
+	rollup.Bytes += bytes
+	rollup.Read += read
+}
+
 func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushReason string) {
-	if c == nil || c.eventRepo == nil || aggregate == nil || aggregate.request == nil || aggregate.readCount == 0 {
+	if c == nil || c.eventRepo == nil || aggregate == nil || aggregate.request == nil || (aggregate.readCount == 0 && aggregate.cacheCount == 0) {
 		return
 	}
 
@@ -219,24 +384,35 @@ func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushR
 	phaseEnd := aggregate.startedAt.Add(aggregate.total)
 
 	attrs := map[string]string{
-		"aggregate":           "true",
-		"bytes_read":          strconv.FormatInt(aggregate.bytesRead, 10),
-		"duration_ns":         strconv.FormatInt(aggregate.total.Nanoseconds(), 10),
-		"duration_us":         strconv.FormatInt(aggregate.total.Microseconds(), 10),
-		"error_count":         strconv.FormatInt(aggregate.errorCount, 10),
-		"first_access_at":     aggregate.startedAt.UTC().Format(time.RFC3339Nano),
-		"flush_reason":        flushReason,
-		"image_id":            request.ImageId,
-		"last_access_at":      aggregate.lastAt.UTC().Format(time.RFC3339Nano),
-		"read_count":          strconv.FormatInt(aggregate.readCount, 10),
-		"top_content_json":    clipReadRollupsJSON(aggregate.byContent, clipReadAggregateTopN),
-		"top_layers_json":     clipReadRollupsJSON(aggregate.byLayer, clipReadAggregateTopN),
-		"top_operations_json": clipReadRollupsJSON(aggregate.byOperation, clipReadAggregateTopN),
-		"top_paths_json":      clipReadRollupsJSON(aggregate.byAccess, clipReadAggregateTopN),
-		"top_results_json":    clipReadRollupsJSON(aggregate.byResult, clipReadAggregateTopN),
-		"top_sources_json":    clipReadRollupsJSON(aggregate.bySource, clipReadAggregateTopN),
-		"total_duration_us":   strconv.FormatInt(aggregate.total.Microseconds(), 10),
-		"wall_duration_us":    strconv.FormatInt(wallDuration.Microseconds(), 10),
+		"aggregate":                 "true",
+		"bytes_read":                strconv.FormatInt(aggregate.bytesRead, 10),
+		"cache_bytes":               strconv.FormatInt(aggregate.cacheBytes, 10),
+		"cache_duration_us":         strconv.FormatInt(aggregate.cacheTotal.Microseconds(), 10),
+		"cache_error_count":         strconv.FormatInt(aggregate.cacheErrorCount, 10),
+		"cache_hit_count":           strconv.FormatInt(aggregate.cacheHitCount, 10),
+		"cache_miss_count":          strconv.FormatInt(aggregate.cacheMissCount, 10),
+		"cache_operation_count":     strconv.FormatInt(aggregate.cacheCount, 10),
+		"cache_unavailable_count":   strconv.FormatInt(aggregate.cacheUnavailableCount, 10),
+		"duration_ns":               strconv.FormatInt(aggregate.total.Nanoseconds(), 10),
+		"duration_us":               strconv.FormatInt(aggregate.total.Microseconds(), 10),
+		"error_count":               strconv.FormatInt(aggregate.errorCount, 10),
+		"first_access_at":           aggregate.startedAt.UTC().Format(time.RFC3339Nano),
+		"flush_reason":              flushReason,
+		"image_id":                  request.ImageId,
+		"last_access_at":            aggregate.lastAt.UTC().Format(time.RFC3339Nano),
+		"read_count":                strconv.FormatInt(aggregate.readCount, 10),
+		"top_cache_hosts_json":      clipCacheRollupsJSON(aggregate.byCacheHost, clipReadAggregateTopN),
+		"top_cache_operations_json": clipCacheRollupsJSON(aggregate.byCacheOperation, clipReadAggregateTopN),
+		"top_cache_results_json":    clipCacheRollupsJSON(aggregate.byCacheResult, clipReadAggregateTopN),
+		"top_cache_sources_json":    clipCacheRollupsJSON(aggregate.byCacheSource, clipReadAggregateTopN),
+		"top_content_json":          clipReadRollupsJSON(aggregate.byContent, clipReadAggregateTopN),
+		"top_layers_json":           clipReadRollupsJSON(aggregate.byLayer, clipReadAggregateTopN),
+		"top_operations_json":       clipReadRollupsJSON(aggregate.byOperation, clipReadAggregateTopN),
+		"top_paths_json":            clipReadRollupsJSON(aggregate.byAccess, clipReadAggregateTopN),
+		"top_results_json":          clipReadRollupsJSON(aggregate.byResult, clipReadAggregateTopN),
+		"top_sources_json":          clipReadRollupsJSON(aggregate.bySource, clipReadAggregateTopN),
+		"total_duration_us":         strconv.FormatInt(aggregate.total.Microseconds(), 10),
+		"wall_duration_us":          strconv.FormatInt(wallDuration.Microseconds(), 10),
 	}
 	if aggregate.firstError != "" {
 		attrs["first_error"] = aggregate.firstError
@@ -257,10 +433,18 @@ func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushR
 		Int64("total_us", aggregate.total.Microseconds()).
 		Int64("wall_us", wallDuration.Microseconds()).
 		Int64("error_count", aggregate.errorCount).
+		Int64("cache_operation_count", aggregate.cacheCount).
+		Int64("cache_total_us", aggregate.cacheTotal.Microseconds()).
+		Int64("cache_error_count", aggregate.cacheErrorCount).
+		Int64("cache_hit_count", aggregate.cacheHitCount).
+		Int64("cache_miss_count", aggregate.cacheMissCount).
+		Int64("cache_unavailable_count", aggregate.cacheUnavailableCount).
 		Str("top_sources_json", attrs["top_sources_json"]).
 		Str("top_paths_json", attrs["top_paths_json"]).
 		Str("top_operations_json", attrs["top_operations_json"]).
 		Str("top_results_json", attrs["top_results_json"]).
+		Str("top_cache_sources_json", attrs["top_cache_sources_json"]).
+		Str("top_cache_hosts_json", attrs["top_cache_hosts_json"]).
 		Str("top_content_json", attrs["top_content_json"]).
 		Str("first_error", aggregate.firstError).
 		Msg("clip read path summary")
@@ -310,6 +494,35 @@ func clipReadRollupsJSON(rollups map[string]*clipReadRollup, limit int) string {
 	}
 
 	items := make([]clipReadRollup, 0, len(rollups))
+	for _, rollup := range rollups {
+		if rollup == nil {
+			continue
+		}
+		items = append(items, *rollup)
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].TotalUs != items[j].TotalUs {
+			return items[i].TotalUs > items[j].TotalUs
+		}
+		return items[i].MaxUs > items[j].MaxUs
+	})
+	if len(items) > limit {
+		items = items[:limit]
+	}
+
+	data, err := json.Marshal(items)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
+}
+
+func clipCacheRollupsJSON(rollups map[string]*clipCacheRollup, limit int) string {
+	if len(rollups) == 0 || limit <= 0 {
+		return "[]"
+	}
+
+	items := make([]clipCacheRollup, 0, len(rollups))
 	for _, rollup := range rollups {
 		if rollup == nil {
 			continue


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add detailed cache operation tracing for read and page-file view paths, and pipe those traces into image read aggregates for clearer metrics and easier debugging.

- **New Features**
  - Added `OperationTrace` in `pkg/cache` with per-attempt host details (source, result, bytes/read, timing) and summary fields.
  - New client APIs: `ReadContentIntoWithTrace` and `ClientLocalPageFileViewsWithTrace`; existing methods now delegate to traced versions.
  - Traces are observed in `pkg/worker` via an image content cache observer, aggregating cache stats (hits/misses/unavailable/errors, bytes, duration) and emitting top cache sources/hosts/results.
  - Expanded counters and logs for reads, page-file views, and stores with `cache_result`, bytes, and latency; added rollups for cache operations in image read summaries.

- **Bug Fixes**
  - Validator accepts `remote_node` as valid proof when `requires_remote_worker`.
  - Benchmarks: switch to `cache_probe_pods`, improve node detection fallback, and set `BENCH_WORKER_WORKSPACE_ROOT` default to `/storage`.

<sup>Written for commit 61c56977c8f695000c9e4b66e174bbc3f4487682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

