### PR TITLE
fix trace bug

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1536,6 +1536,8 @@ func (c *Client) ReadContentIntoWithTrace(ctx context.Context, hash string, offs
 
 	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts, &trace); err == nil {
 		return n, trace, nil
+	} else if errors.Is(err, ErrContentNotFound) {
+		return 0, trace, err
 	} else if c.hostDirectory == nil || c.hostMap == nil {
 		return 0, trace, err
 	}

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -630,6 +630,40 @@ func TestReadContentIntoDoesNotMaskSelectedHostMissWithDifferentHost(t *testing.
 	require.ErrorIs(t, err, ErrContentNotFound)
 }
 
+func TestReadContentIntoDoesNotRefreshHostsOnConfirmedMiss(t *testing.T) {
+	store := newTestStore(t, 4)
+	host := &Host{HostId: "selected-host", Locality: "test"}
+	refreshes := 0
+	client := &Client{
+		ctx:          context.Background(),
+		locality:     "test",
+		clientConfig: ClientConfig{NTopHosts: 1},
+		grpcClients:  make(map[string]proto.CacheClient),
+		grpcConns:    make(map[string]*grpc.ClientConn),
+		localServers: map[string]*Server{
+			host.HostId: {cas: store},
+		},
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[localHostCacheKey]*localClientCache),
+		hostMap:        NewHostMap(GlobalConfig{}, nil),
+		hostDirectory: testHostDirectoryFunc(func(context.Context, string) ([]*Host, error) {
+			refreshes++
+			return []*Host{host}, nil
+		}),
+		hasher:                &orderedTestHasher{hosts: []*Host{host}},
+		maxGetContentAttempts: 1,
+	}
+
+	dst := make([]byte, 4)
+	_, trace, err := client.ReadContentIntoWithTrace(context.Background(), "missing-hash", 0, dst, ClientOptions{RoutingKey: "missing-hash"})
+
+	require.ErrorIs(t, err, ErrContentNotFound)
+	require.Zero(t, refreshes)
+	require.Zero(t, trace.HostRefreshes)
+	require.Len(t, trace.Attempts, 1)
+	require.Equal(t, CacheResultMiss, trace.Attempts[0].Result)
+}
+
 func TestReadContentIntoFallsBackToRankedReplicaHost(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes inaccurate trace data by returning early on confirmed content misses in `ReadContentIntoWithTrace`, avoiding host refreshes and extra attempts.

- **Bug Fixes**
  - Return immediately when `tryReadContentIntoKnownHosts` yields `ErrContentNotFound`, preventing host directory refresh and additional reads.
  - Added `TestReadContentIntoDoesNotRefreshHostsOnConfirmedMiss` to assert zero host refreshes, a single miss attempt, and correct error.

<sup>Written for commit 527e1ffa3634c475e6bd2951aaae72289e598b92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

