### PR TITLE
fix routing bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42
+	github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42 h1:rvqupNqNax+1v6DPE8N4yRysQpD4tKU+W4G8aKKg41U=
 github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
+github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823 h1:zKZjay2sGry1c4hZrcjXbJQBFglrGTPEeNgiCGKoBz8=
+github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
 github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652 h1:lUzupIe/xH4c/WVdWD2kfVQ+RH6DiIPD/Hlaz/PjuYg=
 github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -849,6 +849,13 @@ func cacheFSMetadataMatchesFileInfo(metadata *FSMetadata, info os.FileInfo) bool
 // a recovery path for placement drift or host churn. Do not use it to decide
 // whether a cache-through write can be skipped.
 func (c *Client) IsCachedReachable(hash string, routingKey string) (bool, error) {
+	return c.IsCachedReachableContext(c.ctx, hash, routingKey)
+}
+
+func (c *Client) IsCachedReachableContext(ctx context.Context, hash string, routingKey string) (bool, error) {
+	if ctx == nil {
+		ctx = c.ctx
+	}
 	if routingKey == "" {
 		routingKey = hash
 	}
@@ -870,7 +877,7 @@ func (c *Client) IsCachedReachable(hash string, routingKey string) (bool, error)
 			return false, nil
 		}
 
-		resp, err := client.HasContent(c.ctx, &proto.CacheHasContentRequest{Hash: hash})
+		resp, err := client.HasContent(ctx, &proto.CacheHasContentRequest{Hash: hash})
 		if err != nil {
 			c.removeHost(host)
 			return false, err
@@ -895,7 +902,7 @@ func (c *Client) IsCachedReachable(hash string, routingKey string) (bool, error)
 		}
 
 		checked[host.HostId] = struct{}{}
-		resp, err := client.HasContent(c.ctx, &proto.CacheHasContentRequest{Hash: hash})
+		resp, err := client.HasContent(ctx, &proto.CacheHasContentRequest{Hash: hash})
 		if err != nil {
 			c.removeHost(host)
 			continue

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -986,6 +986,14 @@ func (c *ImageClient) copyImageArchiveFromContentCacheMetadata(ctx context.Conte
 		return false, fmt.Errorf("image archive too large for local restore: %d bytes", metadata.Size)
 	}
 
+	exists, err := c.cacheClient.IsCachedReachableContext(ctx, metadata.Hash, cachePath)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+
 	if err := c.writeImageArchiveFromContentCache(ctx, archivePath, imageId, metadata.Hash, int64(metadata.Size), cachePath); err != nil {
 		if isEmbeddedImageCacheMiss(err) {
 			return false, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes cache routing by passing the request context through cache reachability checks and the image restore path. Prevents wrong-route cache lookups and unnecessary restore attempts.

- **Bug Fixes**
  - Added `IsCachedReachableContext(ctx, hash, routingKey)` and use `ctx` for `HasContent` calls to honor per-request routing.
  - Updated image restore to check `IsCachedReachableContext` before reading from cache, returning early if unreachable.

- **Dependencies**
  - Bumped `github.com/beam-cloud/clip` to `v0.0.0-20260603162509-c9d1ed562823`.

<sup>Written for commit 8626f3725e55f2d06993b2552f963d27fa05db80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

