### PR TITLE
client fallback

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -755,6 +755,15 @@ func (c *Client) readReplicaHostCount() int {
 	return c.clientConfig.NTopHosts
 }
 
+func (c *Client) readContentIntoHostCount(length int64) int {
+	attempts := c.getContentAttempts(length)
+	hostCount := c.readReplicaHostCount()
+	if attempts < hostCount {
+		return attempts
+	}
+	return hostCount
+}
+
 func (c *Client) dataCallOptions() []grpc.CallOption {
 	if !c.globalConfig.GRPCPayloadCodecV2 {
 		return nil
@@ -1460,9 +1469,10 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 	primaryUnavailable := false
 	selectedUnavailable := false
 	contentMissing := false
-	checked := make(map[string]struct{}, c.readReplicaHostCount())
+	hostCount := c.readContentIntoHostCount(length)
+	checked := make(map[string]struct{}, hostCount)
 
-	for hostIndex := 0; hostIndex < c.readReplicaHostCount(); hostIndex++ {
+	for hostIndex := 0; hostIndex < hostCount; hostIndex++ {
 		host, err := c.getHostForRequest(&ClientRequest{
 			rt:        ClientRequestTypeRetrieval,
 			hash:      hash,

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1455,12 +1455,16 @@ func (c *Client) ReadContentIntoWithTrace(ctx context.Context, hash string, offs
 
 	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts, &trace); err == nil {
 		return n, trace, nil
-	} else if c.hostDirectory == nil || c.hostMap == nil {
+	} else if !shouldRefreshReadContentIntoHosts(err) || c.hostDirectory == nil || c.hostMap == nil {
 		return 0, trace, err
 	}
 
 	read, err = c.readContentIntoAfterHostRefresh(ctx, hash, offset, dst, opts, &trace)
 	return read, trace, err
+}
+
+func shouldRefreshReadContentIntoHosts(err error) bool {
+	return errors.Is(err, ErrSelectedHostUnavailable) || errors.Is(err, ErrUnableToReachHost) || errors.Is(err, ErrHostNotFound) || errors.Is(err, ErrClientNotFound)
 }
 
 func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, offset int64, dst []byte, opts ClientOptions, trace *OperationTrace) (int64, error) {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -643,7 +643,7 @@ func TestReadContentIntoFallsBackToRankedReplicaHost(t *testing.T) {
 		rawReadPools:          make(map[string]*rawReadConnPool),
 		localHostCache:        make(map[localHostCacheKey]*localClientCache),
 		hasher:                &orderedTestHasher{hosts: []*Host{primaryHost, replicaHost}},
-		maxGetContentAttempts: 1,
+		maxGetContentAttempts: 2,
 	}
 	require.NoError(t, client.addHost(primaryHost))
 	require.NoError(t, client.addHost(replicaHost))
@@ -654,6 +654,78 @@ func TestReadContentIntoFallsBackToRankedReplicaHost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(content)), n)
 	require.Equal(t, content, dst)
+}
+
+func TestReadContentIntoDoesNotRetrySmallReadsBelowMinRetryLength(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Client: ClientConfig{NTopHosts: 2},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+
+	primaryServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("primary-host"))
+	require.NoError(t, err)
+	primaryAddr, err := primaryServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, primaryServer.Close()) }()
+
+	replicaCfg := cfg
+	replicaCfg.Server.DiskCacheDir = t.TempDir()
+	replicaServer, err := NewServerWithOptions(ctx, replicaCfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("replica-host"))
+	require.NoError(t, err)
+	replicaAddr, err := replicaServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, replicaServer.Close()) }()
+
+	content := []byte("content-on-ranked-replica")
+	hash, _, err := replicaServer.cas.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	primaryHost := primaryServer.Host()
+	require.NotNil(t, primaryHost)
+	primaryHost.Addr = primaryAddr
+	primaryHost.PrivateAddr = primaryAddr
+	replicaHost := replicaServer.Host()
+	require.NotNil(t, replicaHost)
+	replicaHost.Addr = replicaAddr
+	replicaHost.PrivateAddr = replicaAddr
+
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          cfg.Client,
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{primaryHost, replicaHost}},
+		minRetryLengthBytes:   int64(len(content) + 1),
+		maxGetContentAttempts: 2,
+	}
+	require.NoError(t, client.addHost(primaryHost))
+	require.NoError(t, client.addHost(replicaHost))
+	defer client.Cleanup()
+
+	dst := make([]byte, len(content))
+	_, trace, err := client.ReadContentIntoWithTrace(ctx, hash, 0, dst, ClientOptions{RoutingKey: hash})
+	require.ErrorIs(t, err, ErrContentNotFound)
+	require.NotEmpty(t, trace.Attempts)
+	for _, attempt := range trace.Attempts {
+		require.Equal(t, 0, attempt.HostIndex)
+	}
 }
 
 func TestReadContentIntoUsesSelectedLocalServer(t *testing.T) {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -728,6 +728,66 @@ func TestReadContentIntoDoesNotRetrySmallReadsBelowMinRetryLength(t *testing.T) 
 	}
 }
 
+func TestReadContentIntoDoesNotRefreshHostsOnContentMiss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Client: ClientConfig{NTopHosts: 1},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+
+	server, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("primary-host"))
+	require.NoError(t, err)
+	addr, err := server.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, server.Close()) }()
+
+	host := server.Host()
+	require.NotNil(t, host)
+	host.Addr = addr
+	host.PrivateAddr = addr
+
+	refreshCalls := 0
+	hostMap := NewHostMap(GlobalConfig{}, nil)
+	client := &Client{
+		ctx:          ctx,
+		locality:     "test",
+		clientConfig: cfg.Client,
+		globalConfig: cfg.Global,
+		hostMap:      hostMap,
+		hostDirectory: testHostDirectoryFunc(func(context.Context, string) ([]*Host, error) {
+			refreshCalls++
+			return []*Host{host}, nil
+		}),
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{host}},
+		maxGetContentAttempts: 1,
+	}
+	require.NoError(t, client.addHost(host))
+	defer client.Cleanup()
+
+	dst := make([]byte, 16)
+	_, trace, err := client.ReadContentIntoWithTrace(ctx, strings.Repeat("a", sha256.Size*2), 0, dst, ClientOptions{})
+	require.ErrorIs(t, err, ErrContentNotFound)
+	require.Equal(t, 0, refreshCalls)
+	require.Equal(t, 0, trace.HostRefreshes)
+	require.Equal(t, "miss", trace.Result)
+}
+
 func TestReadContentIntoUsesSelectedLocalServer(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("local-cache-content")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve read fallback behavior to reduce unnecessary retries and host refreshes during ReadContentInto. Small reads no longer retry, and host refresh happens only on host errors, not content misses.

- **Bug Fixes**
  - Limit host probing to the allowed attempt count for the read size, preventing extra fan-out; honor `minRetryLengthBytes` so small reads don’t retry.
  - Refresh hosts only on host availability errors (selected host unavailable, unreachable, not found, or client not found); don’t refresh on content misses.
  - Ensure fallback to the ranked replica when attempts allow; updated tests accordingly.
  - Added tests for no-retry on small reads and no host refresh on content miss, with trace assertions.

<sup>Written for commit 634b1955ea7e0fb2716787499a1b29ebf5751987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

