### PR TITLE
skip tiny reads

### DIFF
--- a/deploy/charts/beta9/templates/cache-server-daemonset.yaml
+++ b/deploy/charts/beta9/templates/cache-server-daemonset.yaml
@@ -20,6 +20,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 60
+      {{- with .Values.cacheServer.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       {{- if .Values.cacheServer.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -42,8 +45,8 @@ spec:
       {{- end }}
       containers:
       - name: worker
-        image: {{ .Values.images.worker.repository }}:{{ .Values.images.worker.tag | default .Chart.AppVersion }}
-        imagePullPolicy: {{ .Values.images.worker.pullPolicy | default "IfNotPresent" }}
+        image: {{ .Values.cacheServer.image.repository | default .Values.images.worker.repository }}:{{ .Values.cacheServer.image.tag | default .Values.images.worker.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.cacheServer.image.pullPolicy | default .Values.images.worker.pullPolicy | default "IfNotPresent" }}
         command:
         - /usr/bin/tini
         - -g

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -33,6 +33,11 @@ cacheServer:
   hostPath: /var/lib/beta9/cache
   mountPath: /var/lib/beta9/cache
   hostNetwork: true
+  priorityClassName:
+  image:
+    repository: # Defaults to images.worker.repository
+    tag:        # Defaults to images.worker.tag or chart app version
+    pullPolicy: # Defaults to images.worker.pullPolicy or IfNotPresent
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -40,8 +45,8 @@ cacheServer:
     privileged: true
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 250m
+      memory: 512Mi
     limits:
       cpu: "2"
       memory: 2Gi

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823
+	github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42 h1:rvqupNqNax+1v6D
 github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
 github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823 h1:zKZjay2sGry1c4hZrcjXbJQBFglrGTPEeNgiCGKoBz8=
 github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
+github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877 h1:R2G+m4w9VdKpzTEVpYqEI0XxMVCPHXPOdqLOb65dBF0=
+github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877/go.mod h1:+vn8fPGQKaUiDvOy5GLpduzYIQLtMIfnRn08/5fOz+s=
 github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652 h1:lUzupIe/xH4c/WVdWD2kfVQ+RH6DiIPD/Hlaz/PjuYg=
 github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -38,6 +38,7 @@ const (
 	localClientCacheCleanupInterval = 5 * time.Second
 	localClientCacheTTL             = 600 * time.Second
 	defaultRawReadWindowPartBytes   = 4 * 1024 * 1024
+	monitorHostFailureThreshold     = 2
 
 	// NOTE: This value for readAheadKB is separate from the cachefs config since the FUSE library does
 	// weird stuff with the other read_ahead_kb value internally
@@ -492,7 +493,8 @@ func (c *Client) monitorHost(host *Host) {
 		interval = 30 * time.Second
 	}
 
-	if !c.checkHostEndpoint(host) {
+	failures := 0
+	if !c.recordHostMonitorResult(host, &failures) {
 		return
 	}
 
@@ -512,7 +514,7 @@ func (c *Client) monitorHost(host *Host) {
 	for {
 		select {
 		case <-ticker.C:
-			if !c.checkHostEndpoint(host) {
+			if !c.recordHostMonitorResult(host, &failures) {
 				return
 			}
 
@@ -522,43 +524,64 @@ func (c *Client) monitorHost(host *Host) {
 	}
 }
 
-func (c *Client) checkHostEndpoint(host *Host) bool {
-	if !c.isCurrentHostEndpoint(host) {
+func (c *Client) recordHostMonitorResult(host *Host, failures *int) bool {
+	err := c.hostEndpointHealth(host)
+	if err == nil {
+		*failures = 0
+		return true
+	}
+	if errors.Is(err, ErrHostNotFound) {
 		return false
 	}
 
-	err := func() error {
-		c.mu.RLock()
-		client, exists := c.grpcClients[host.HostId]
-		c.mu.RUnlock()
-		if !exists {
-			return ErrHostNotFound
-		}
+	*failures++
+	if *failures < monitorHostFailureThreshold {
+		Logger.Debugf("cache host health check failed @ %s (PrivateAddr=%s, failures=%d/%d): %v", host.HostId, host.PrivateAddr, *failures, monitorHostFailureThreshold, err)
+		return true
+	}
 
-		timeout := time.Duration(c.globalConfig.GRPCDialTimeoutS) * time.Second
-		if timeout <= 0 {
-			timeout = time.Second
-		}
-		ctx, cancel := context.WithTimeout(c.ctx, timeout)
-		defer cancel()
+	c.removeHost(host)
+	return false
+}
 
-		resp, err := client.GetState(ctx, &proto.CacheGetStateRequest{})
-		if err != nil {
-			return ErrInvalidHostVersion
-		}
-
-		if resp.GetVersion() != Version {
-			return ErrInvalidHostVersion
-		}
-
-		return nil
-	}()
-
+func (c *Client) checkHostEndpoint(host *Host) bool {
+	err := c.hostEndpointHealth(host)
 	if err != nil {
 		c.removeHost(host)
 		return false
 	}
 	return true
+}
+
+func (c *Client) hostEndpointHealth(host *Host) error {
+	if !c.isCurrentHostEndpoint(host) {
+		return ErrHostNotFound
+	}
+
+	c.mu.RLock()
+	client, exists := c.grpcClients[host.HostId]
+	c.mu.RUnlock()
+	if !exists {
+		return ErrHostNotFound
+	}
+
+	timeout := time.Duration(c.globalConfig.GRPCDialTimeoutS) * time.Second
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	ctx, cancel := context.WithTimeout(c.ctx, timeout)
+	defer cancel()
+
+	resp, err := client.GetState(ctx, &proto.CacheGetStateRequest{})
+	if err != nil {
+		return err
+	}
+
+	if resp.GetVersion() != Version {
+		return ErrInvalidHostVersion
+	}
+
+	return nil
 }
 
 func (c *Client) removeHost(host *Host) {
@@ -2520,7 +2543,15 @@ func isStoreHostUnavailable(err error) bool {
 }
 
 func (c *Client) HostsAvailable() bool {
-	return c.hostMap.Members().Cardinality() > 0
+	if c.hostMap == nil {
+		return false
+	}
+	for _, host := range c.hostMap.GetAll() {
+		if host.HasEndpoint() {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) WaitForHosts(timeout time.Duration) error {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -39,6 +39,16 @@ func requireTraceAttempt(t *testing.T, trace OperationTrace, source string, resu
 	require.Failf(t, "missing trace attempt", "source=%s result=%s status=%s attempts=%+v", source, result, status, trace.Attempts)
 }
 
+func TestHostsAvailableRequiresActiveEndpoint(t *testing.T) {
+	client := &Client{hostMap: NewHostMap(GlobalConfig{}, nil)}
+
+	client.hostMap.Set((&Host{HostId: "logical-host"}).LogicalOnly())
+	require.False(t, client.HostsAvailable())
+
+	client.hostMap.Set(&Host{HostId: "logical-host", PrivateAddr: "127.0.0.1:2049"})
+	require.True(t, client.HostsAvailable())
+}
+
 func (m *countingCacheMetadataStore) SetStoreFromContentLock(ctx context.Context, locality string, sourcePath string) error {
 	m.setStoreFromContentLockCalls++
 	return m.MockCacheMetadataStore.SetStoreFromContentLock(ctx, locality, sourcePath)
@@ -385,6 +395,39 @@ func TestCheckHostEndpointPrunesUnreachableEndpoint(t *testing.T) {
 
 	_, _, err = client.getGRPCClientForHostIndex(context.Background(), ClientRequestTypeRetrieval, "hash", "hash", 0)
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+}
+
+func TestHostMonitorRequiresConsecutiveFailuresBeforePruningEndpoint(t *testing.T) {
+	host := &Host{
+		HostId:         "cache-host-default-node-a-path",
+		RegistrationID: "worker-a",
+		NodeID:         "node-a",
+		CachePathID:    "path",
+		PrivateAddr:    "10.0.0.1:2049",
+	}
+	hostMap := NewHostMap(GlobalConfig{}, nil)
+	hostMap.Set(host)
+
+	client := &Client{
+		ctx:            context.Background(),
+		clientConfig:   ClientConfig{NTopHosts: 1},
+		hostMap:        hostMap,
+		grpcClients:    map[string]proto.CacheClient{host.HostId: &fakeStoreCacheClient{stateErr: errors.New("connection refused")}},
+		grpcConns:      make(map[string]*grpc.ClientConn),
+		localServers:   make(map[string]*Server),
+		rawReadPools:   make(map[string]*rawReadConnPool),
+		localHostCache: make(map[localHostCacheKey]*localClientCache),
+		hasher:         &orderedTestHasher{hosts: []*Host{host}},
+	}
+
+	failures := 0
+	require.True(t, client.recordHostMonitorResult(host, &failures))
+	require.Equal(t, 1, failures)
+	require.True(t, hostMap.Get(host.HostId).HasEndpoint())
+
+	require.False(t, client.recordHostMonitorResult(host, &failures))
+	require.Equal(t, 2, failures)
+	require.False(t, hostMap.Get(host.HostId).HasEndpoint())
 }
 
 func TestReadContentIntoDoesNotMaskPrimaryUnavailableWithReplicaMiss(t *testing.T) {

--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -124,6 +124,7 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 				return
 			}
 
+			d.hostMap.Set(host)
 			mu.Lock()
 			selectedHosts = append(selectedHosts, host)
 			mu.Unlock()

--- a/pkg/cache/discovery_test.go
+++ b/pkg/cache/discovery_test.go
@@ -3,7 +3,9 @@ package cache
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
+	"time"
 
 	proto "github.com/beam-cloud/beta9/proto"
 	rendezvous "github.com/beam-cloud/rendezvous"
@@ -166,6 +168,77 @@ func TestDiscoveryKeepsKnownRegisteredEndpoint(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, hosts)
+}
+
+func TestDiscoveryPublishesReachableHostBeforeSlowCandidatesFinish(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes:    1024 * 1024,
+			GRPCDialTimeoutS:        1,
+			MaxDiscoveryConcurrency: 2,
+		},
+	}
+	server, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("fast-host"))
+	require.NoError(t, err)
+	addr, err := server.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	slowListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, slowListener.Close()) })
+	go func() {
+		for {
+			conn, err := slowListener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				<-ctx.Done()
+				_ = conn.Close()
+			}()
+		}
+	}()
+
+	hostMap := NewHostMap(GlobalConfig{}, nil)
+	discovery := &DiscoveryClient{
+		cfg:     cfg.Global,
+		hostMap: hostMap,
+		hostDirectory: testHostDirectoryFunc(func(context.Context, string) ([]*Host, error) {
+			return []*Host{
+				{HostId: "fast-host", PrivateAddr: addr},
+				{HostId: "slow-host", PrivateAddr: slowListener.Addr().String()},
+			}, nil
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = discovery.discoverHosts(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		host := hostMap.Get("fast-host")
+		return host != nil && host.HasEndpoint()
+	}, 500*time.Millisecond, 10*time.Millisecond)
+	select {
+	case <-done:
+		require.Fail(t, "discovery finished before slow candidate timed out")
+	default:
+	}
+
+	cancel()
+	<-done
 }
 
 func TestRefreshRoutableHostsReactivatesLogicalOnlyHost(t *testing.T) {

--- a/pkg/cache/raw_transport.go
+++ b/pkg/cache/raw_transport.go
@@ -273,6 +273,10 @@ func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
 		atomic.AddInt64(&cachePathStats.serverRawBytes, responseLength)
 		usedSendfile := false
 		usedCopy := false
+		useSendfile := cs.serverConfig.ReadTransport.Sendfile
+		if threshold := cs.serverConfig.SmallRangeCopyThresholdBytes; threshold > 0 && req.length <= threshold {
+			useSendfile = false
+		}
 		for _, region := range regions {
 			openStarted := time.Now()
 			file, err := os.Open(region.path)
@@ -285,12 +289,14 @@ func (cs *Server) serveRawRead(conn net.Conn, req rawReadRequest) {
 			}
 			copyOffset := region.pageOffset
 			copyLength := int64(region.length)
-			_ = fadviseSequential(file.Fd())
-			_ = fadviseWillneed(file.Fd(), copyOffset, copyLength)
+			if useSendfile {
+				_ = fadviseSequential(file.Fd())
+				_ = fadviseWillneed(file.Fd(), copyOffset, copyLength)
+			}
 			openDuration := time.Since(openStarted)
 			openElapsed += openDuration
 			atomic.AddInt64(&cachePathStats.serverRawOpenNanos, openDuration.Nanoseconds())
-			if cs.serverConfig.ReadTransport.Sendfile {
+			if useSendfile {
 				sendStarted := time.Now()
 				sent, err := sendFileToConn(conn, file, region.pageOffset, int64(region.length))
 				sendDuration := time.Since(sendStarted)

--- a/pkg/cache/raw_transport_test.go
+++ b/pkg/cache/raw_transport_test.go
@@ -77,6 +77,59 @@ func TestSamePortRawReadTransportAndGRPC(t *testing.T) {
 	require.Equal(t, Version, state.GetVersion())
 }
 
+func TestRawReadUsesCopyForSmallPageBackedRange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:                 t.TempDir(),
+			DiskCacheMaxUsagePct:         90,
+			PageSizeBytes:                1024,
+			ObjectTtlS:                   300,
+			SmallRangeCopyThresholdBytes: 128 * 1024,
+			ReadTransport: ServerReadTransportConfig{
+				Enabled:  true,
+				Sendfile: true,
+			},
+		},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+	server, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("raw-host"))
+	require.NoError(t, err)
+	addr, err := server.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	content := []byte("abcdefghijklmnopqrstuvwxyz")
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+	require.NoError(t, server.cas.Add(context.Background(), hash, content))
+
+	before := snapshotCachePathStats()
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte(rawReadMagic))
+	require.NoError(t, err)
+	require.NoError(t, writeRawReadRequest(conn, hash, 3, 8))
+	status, length, err := readRawReadResponseHeader(conn)
+	require.NoError(t, err)
+	require.Equal(t, rawReadStatusOK, status)
+	require.Equal(t, int64(8), length)
+	body := make([]byte, length)
+	_, err = io.ReadFull(conn, body)
+	require.NoError(t, err)
+	require.Equal(t, []byte("defghijk"), body)
+	after := snapshotCachePathStats()
+	diff := diffCachePathStats(after, before)
+	require.Equal(t, int64(1), diff.serverRawCopyHits)
+	require.Equal(t, int64(0), diff.serverRawSendfileHits)
+}
+
 func TestClientLocalPageFileViewsDoesNotPromoteRemotePageRegion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -316,6 +316,7 @@ cache:
     prettyLogs: true
   server:
     pageSizeBytes: 4194304
+    smallRangeCopyThresholdBytes: 131072
     objectTtlS: 0
     s3DownloadConcurrency: 16
     s3DownloadChunkSize: 64000000

--- a/pkg/repository/cache_redis.go
+++ b/pkg/repository/cache_redis.go
@@ -47,6 +47,9 @@ func (r *CacheRedisRepository) SetCacheRegistration(ctx context.Context, host ca
 	if err := r.rdb.SAdd(ctx, cacheCoordinatorIndexKey(host.PoolName, host.Locality), host.LogicalHostID).Err(); err != nil {
 		return err
 	}
+	if err := r.rdb.SAdd(ctx, cacheCoordinatorLocalityIndexKey(host.Locality), host.LogicalHostID).Err(); err != nil {
+		return err
+	}
 	if err := r.rdb.Set(ctx, cacheCoordinatorLogicalHostKey(host.LogicalHostID), logicalPayload, cacheCoordinatorLogicalHostTTL(ttl)).Err(); err != nil {
 		return err
 	}
@@ -73,37 +76,25 @@ func (r *CacheRedisRepository) SetActiveCacheRegistration(ctx context.Context, l
 
 func (r *CacheRedisRepository) ListCacheLogicalHosts(ctx context.Context, poolName, locality string) ([]string, error) {
 	if poolName == "" {
-		return r.listCacheLogicalHostsForLocality(ctx, locality)
+		return r.listCacheLogicalHostsFromIndex(ctx, cacheCoordinatorLocalityIndexKey(locality))
 	}
-	return r.rdb.SMembers(ctx, cacheCoordinatorIndexKey(poolName, locality)).Result()
+	return r.listCacheLogicalHostsFromIndex(ctx, cacheCoordinatorIndexKey(poolName, locality))
 }
 
-func (r *CacheRedisRepository) listCacheLogicalHostsForLocality(ctx context.Context, locality string) ([]string, error) {
-	pattern := cacheCoordinatorIndexKey("*", locality)
-	keys, err := r.rdb.Scan(ctx, pattern)
+func (r *CacheRedisRepository) listCacheLogicalHostsFromIndex(ctx context.Context, key string) ([]string, error) {
+	ids, err := r.rdb.SMembers(ctx, key).Result()
 	if err != nil {
 		return nil, err
 	}
 
-	seen := map[string]struct{}{}
-	for _, key := range keys {
-		ids, err := r.rdb.SMembers(ctx, key).Result()
-		if err != nil {
-			return nil, err
-		}
-		for _, id := range ids {
-			if id != "" {
-				seen[id] = struct{}{}
-			}
+	filtered := ids[:0]
+	for _, id := range ids {
+		if id != "" {
+			filtered = append(filtered, id)
 		}
 	}
-
-	ids := make([]string, 0, len(seen))
-	for id := range seen {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids, nil
+	sort.Strings(filtered)
+	return filtered, nil
 }
 
 func (r *CacheRedisRepository) ListCacheRegistrations(ctx context.Context, logicalHostID string) ([]string, error) {
@@ -164,7 +155,12 @@ func (r *CacheRedisRepository) CountCacheRegistrations(ctx context.Context, logi
 }
 
 func (r *CacheRedisRepository) RemoveCacheLogicalHost(ctx context.Context, poolName, locality, logicalHostID string) error {
-	if err := r.rdb.SRem(ctx, cacheCoordinatorIndexKey(poolName, locality), logicalHostID).Err(); err != nil {
+	if poolName != "" {
+		if err := r.rdb.SRem(ctx, cacheCoordinatorIndexKey(poolName, locality), logicalHostID).Err(); err != nil {
+			return err
+		}
+	}
+	if err := r.rdb.SRem(ctx, cacheCoordinatorLocalityIndexKey(locality), logicalHostID).Err(); err != nil {
 		return err
 	}
 	return r.rdb.Del(ctx, cacheCoordinatorActiveRegistrationKey(logicalHostID), cacheCoordinatorRegistrationSetKey(logicalHostID), cacheCoordinatorLogicalHostKey(logicalHostID)).Err()
@@ -172,6 +168,10 @@ func (r *CacheRedisRepository) RemoveCacheLogicalHost(ctx context.Context, poolN
 
 func cacheCoordinatorIndexKey(poolName, locality string) string {
 	return fmt.Sprintf("%s:host_index:%s:%s", cacheCoordinatorKeyPrefix, poolName, locality)
+}
+
+func cacheCoordinatorLocalityIndexKey(locality string) string {
+	return fmt.Sprintf("%s:host_index_by_locality:%s", cacheCoordinatorKeyPrefix, locality)
 }
 
 func cacheCoordinatorRegistrationSetKey(logicalHostID string) string {

--- a/pkg/repository/cache_redis_test.go
+++ b/pkg/repository/cache_redis_test.go
@@ -44,6 +44,7 @@ func TestCacheRedisRepositoryUsesReadableCoordinatorHostIndexKeys(t *testing.T) 
 
 	keys := server.Keys()
 	require.Contains(t, keys, "cache:coordinator:host_index:default:default")
+	require.Contains(t, keys, "cache:coordinator:host_index_by_locality:default")
 	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:registrations")
 	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:logical")
 	require.Contains(t, keys, "cache:coordinator:host:cache-host-default-node-a-path-0:registration:worker-a")
@@ -58,4 +59,38 @@ func TestCacheRedisRepositoryUsesReadableCoordinatorHostIndexKeys(t *testing.T) 
 	require.Equal(t, host.LogicalHostID, logicalHost.LogicalHostID)
 	require.Empty(t, logicalHost.RegistrationID)
 	require.Empty(t, logicalHost.PrivateAddr)
+}
+
+func TestCacheRedisRepositoryListsLocalityHostsWithoutScanningPoolIndexes(t *testing.T) {
+	ctx := context.Background()
+
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(server.Close)
+
+	rdb, err := common.NewRedisClient(types.RedisConfig{
+		Addrs: []string{server.Addr()},
+		Mode:  types.RedisModeSingle,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	repo := NewCacheRedisRepository(rdb)
+	host := cache.CoordinatorHost{
+		LogicalHostID:  "cache-host-default-node-a-path-0",
+		RegistrationID: "worker-a",
+		PoolName:       "default",
+		Locality:       "default",
+		NodeID:         "node-a",
+		CachePathID:    "path",
+		PrivateAddr:    "10.0.0.1:2049",
+	}
+
+	require.NoError(t, repo.SetCacheRegistration(ctx, host, 30*time.Second))
+	require.NoError(t, rdb.SAdd(ctx, cacheCoordinatorIndexKey("stale-pool", "default"), "stale-logical-host").Err())
+
+	hosts, err := repo.ListCacheLogicalHosts(ctx, "", "default")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{host.LogicalHostID}, hosts)
 }

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -34,6 +34,7 @@ const (
 	cacheDefaultMinRetryBytes           = 0
 	cacheDefaultGetAttempts             = 3
 	cacheDefaultPageFileBuckets         = 1024
+	cacheDefaultSmallRangeCopyBytes     = 128 * 1024
 	cacheDefaultPageFDCacheSize         = 64
 	cacheDefaultRawMaxActiveConns       = 64
 	cacheDefaultRawMaxIdleConns         = 16
@@ -636,6 +637,9 @@ func normalizeCacheConfig(config types.AppConfig, poolConfig types.WorkerPoolCon
 	}
 	if cacheConfig.Server.PageFileBuckets == 0 {
 		cacheConfig.Server.PageFileBuckets = cacheDefaultPageFileBuckets
+	}
+	if cacheConfig.Server.SmallRangeCopyThresholdBytes == 0 {
+		cacheConfig.Server.SmallRangeCopyThresholdBytes = cacheDefaultSmallRangeCopyBytes
 	}
 	cacheConfig.Server.ReadTransport.Enabled = true
 	cacheConfig.Server.ReadTransport.Sendfile = true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip tiny raw reads to reduce overhead: the server now uses a copy path instead of sendfile for small ranges. Also harden cache host health/discovery by pruning endpoints only after consecutive failures and requiring active endpoints to report availability.

- New Features
  - Add server setting smallRangeCopyThresholdBytes (default 128 KiB) to force copy for small raw reads.
  - Skip fadvise when using the copy path in raw transport.
  - Helm: add cache-server priorityClassName and image overrides; increase default requests to 250m CPU / 512Mi.

- Bug Fixes
  - Prune cache endpoints only after 2 consecutive health-check failures; refactor health check for clarity.
  - HostsAvailable now requires at least one host with an active endpoint (no more logical-only true).
  - Discovery publishes reachable hosts to the host map immediately, so fast hosts become usable while slow candidates time out.
  - Redis: add a locality-only host index to list hosts without scanning all pool indexes; update set/remove to keep both indexes in sync.

<sup>Written for commit 4413a385b256e720c4ae6c08a72cd844cb667a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

