### PR TITLE
fix: bound reconciliation

### DIFF
--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -20,6 +20,11 @@ import (
 const (
 	defaultS2EventStreamPrefix = "events"
 	defaultS2EventReadLimit    = 10000
+	// maxStubCacheReadRecords bounds how many records ReadStubCacheRequiredContent
+	// will page through. Required content is coalesced to a small number of events
+	// per stub, so this is far above realistic sizes; it exists only to guarantee
+	// the read terminates even if the stream is continuously appended.
+	maxStubCacheReadRecords = 200000
 	s2EventHistoryReadLimit    = uint64(1000)
 	s2EventQueueSize           = 16384
 	s2EventBatchSize           = 256
@@ -996,11 +1001,14 @@ func (r *S2EventRepository) ReadStubCacheRequiredContent(ctx context.Context, wo
 		return nil, nil
 	}
 
-	// Read the full stream (paginating past the per-read limit) so the coalesced
-	// required-content set is never truncated for stubs with many events.
+	// Read the stream (paginating past the per-read limit) so the coalesced
+	// required-content set is not truncated. Required content is coalesced to a
+	// small number of events per stub, so this is short in practice; the read is
+	// bounded so a continuously-appended stream can never stall reconciliation.
 	merged := map[string]types.CacheRequiredContentItem{}
 	seqNum := uint64(0)
-	for {
+	recordsRead := 0
+	for recordsRead < maxStubCacheReadRecords {
 		count := uint64(defaultS2EventReadLimit)
 		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
 			SeqNum: &seqNum,
@@ -1015,6 +1023,7 @@ func (r *S2EventRepository) ReadStubCacheRequiredContent(ctx context.Context, wo
 		if len(batch.Records) == 0 {
 			break
 		}
+		recordsRead += len(batch.Records)
 
 		for _, record := range batch.Records {
 			var envelope struct {
@@ -1046,6 +1055,9 @@ func (r *S2EventRepository) ReadStubCacheRequiredContent(ctx context.Context, wo
 		if uint64(len(batch.Records)) < count {
 			break
 		}
+	}
+	if recordsRead >= maxStubCacheReadRecords {
+		log.Warn().Str("stream", string(streamName)).Int("records_read", recordsRead).Msg("stub cache required-content read hit record cap; result may be partial")
 	}
 
 	items := make([]types.CacheRequiredContentItem, 0, len(merged))

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -355,6 +355,8 @@ func (m *WorkerCacheManager) reconcileOnce() {
 		return
 	}
 
+	m.pruneReconcileFailures()
+
 	maxStubs := m.config.Cache.Reconciliation.MaxStubsPerCycle
 	if maxStubs <= 0 {
 		maxStubs = cacheDefaultReconcileMaxStubsCycle
@@ -442,30 +444,50 @@ func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHos
 	ctx, cancel := context.WithTimeout(m.ctx, reconcileItemTimeout)
 	defer cancel()
 
-	m.reconcileLogFields(log.Info(), localHostID, stub, item).
+	m.reconcileLogFields(log.Debug(), localHostID, stub, item).
 		Str("source", item.Source).
 		Int64("size_bytes", item.SizeBytes).
 		Msg("reconciling missing cache content")
 
 	startedAt := time.Now()
 	status := m.materialize(ctx, server, stub, item, routingKey)
+	elapsed := time.Since(startedAt)
 
-	result := log.Info()
-	if status != types.CacheAuditStatusMaterialized {
-		result = log.Warn()
-	}
-	m.reconcileLogFields(result, localHostID, stub, item).
-		Str("status", status).
-		Dur("duration", time.Since(startedAt)).
-		Msg("cache content reconciled")
-
-	if status == types.CacheAuditStatusMaterialized {
+	switch {
+	case status == types.CacheAuditStatusMaterialized:
 		m.clearReconcileFailure(item.Hash, routingKey)
-	} else {
+		m.reconcileLogFields(log.Info(), localHostID, stub, item).
+			Str("status", status).Dur("duration", elapsed).
+			Msg("cache content reconciled")
+	case reconcileStatusIsFailure(status):
+		// Genuine fetch failure (e.g. an unresolvable origin source) - back off
+		// so it is not retried and re-logged every cycle.
 		m.recordReconcileFailure(item.Hash, routingKey)
+		m.reconcileLogFields(log.Warn(), localHostID, stub, item).
+			Str("status", status).Dur("duration", elapsed).
+			Msg("cache content reconciliation failed")
+	default:
+		// A miss (no replica and no usable origin) is expected/transient and is
+		// resolved by the normal read path, so it is not backed off.
+		m.reconcileLogFields(log.Debug(), localHostID, stub, item).
+			Str("status", status).Dur("duration", elapsed).
+			Msg("cache content not reconciled")
 	}
 
 	m.auditCacheEvent(localHostID, stub, item, routingKey, status)
+}
+
+// reconcileStatusIsFailure reports whether a materialization outcome is a genuine
+// failure that should be backed off, as opposed to an expected miss.
+func reconcileStatusIsFailure(status string) bool {
+	switch status {
+	case types.CacheAuditStatusOriginFailure,
+		types.CacheAuditStatusReplicaFailure,
+		types.CacheAuditStatusHostUnavailable:
+		return true
+	default:
+		return false
+	}
 }
 
 // reconcileBackingOff reports whether an item failed to materialize recently and
@@ -499,6 +521,19 @@ func (m *WorkerCacheManager) clearReconcileFailure(hash, routingKey string) {
 	m.reconcileFailuresMu.Lock()
 	delete(m.reconcileFailures, key)
 	m.reconcileFailuresMu.Unlock()
+}
+
+// pruneReconcileFailures drops expired backoff entries so the map stays bounded
+// to items that are currently failing, even if they are never retried (e.g. the
+// stub ages out or ownership moves).
+func (m *WorkerCacheManager) pruneReconcileFailures() {
+	m.reconcileFailuresMu.Lock()
+	defer m.reconcileFailuresMu.Unlock()
+	for key, failedAt := range m.reconcileFailures {
+		if time.Since(failedAt) >= reconcileFailureBackoff {
+			delete(m.reconcileFailures, key)
+		}
+	}
 }
 
 // reconcileLogFields adds the fields common to per-item reconciliation logs.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bound cache reconciliation so it can’t stall on a growing event stream, and reduced noisy retries by backing off only on real failures and pruning expired backoffs.

- Bug Fixes
  - `pkg/repository/events_s2.go`: Capped total S2 records read when coalescing required content; paginate until the cap and warn if hit to ensure reconciliation completes.
  - `pkg/worker/cache_reconciler.go`: Classified outcomes so only real failures are backed off; pruned expired backoffs each cycle and cleared on success to bound memory; refined logs (debug for attempts/misses, info on success, warn on failure) with durations.

<sup>Written for commit 2bc05e302f425ec7a8412401e202a9dc70239e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

