### PR TITLE
fix coordinator token auth

### DIFF
--- a/pkg/auth/grpc.go
+++ b/pkg/auth/grpc.go
@@ -54,6 +54,12 @@ func NewAuthInterceptor(config types.AppConfig, backendRepo repository.BackendRe
 			pb.WorkerRepositoryService_RemoveCacheFsNode_FullMethodName:                true,
 			pb.WorkerRepositoryService_RemoveCacheFsNodeChild_FullMethodName:           true,
 			pb.WorkerRepositoryService_GetCacheFsNodeChildren_FullMethodName:           true,
+			pb.WorkerRepositoryService_AddRecentCacheStub_FullMethodName:               true,
+			pb.WorkerRepositoryService_ListRecentCacheStubs_FullMethodName:             true,
+			pb.WorkerRepositoryService_MarkCacheStubReported_FullMethodName:            true,
+			pb.WorkerRepositoryService_AcquireCacheReconcileLock_FullMethodName:        true,
+			pb.WorkerRepositoryService_ReleaseCacheReconcileLock_FullMethodName:        true,
+			pb.WorkerRepositoryService_GetCacheOriginCredentials_FullMethodName:        true,
 		},
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow coordinator token to access cache reconciliation RPCs in the auth interceptor, fixing authorization failures during reconcile operations. Adds missing `WorkerRepositoryService` methods to the coordinator-allowed list.

- **Bug Fixes**
  - Added `pb.WorkerRepositoryService_AddRecentCacheStub_FullMethodName`
  - Added `pb.WorkerRepositoryService_ListRecentCacheStubs_FullMethodName`
  - Added `pb.WorkerRepositoryService_MarkCacheStubReported_FullMethodName`
  - Added `pb.WorkerRepositoryService_AcquireCacheReconcileLock_FullMethodName`
  - Added `pb.WorkerRepositoryService_ReleaseCacheReconcileLock_FullMethodName`
  - Added `pb.WorkerRepositoryService_GetCacheOriginCredentials_FullMethodName`

<sup>Written for commit 27b296d6aaff503b62b250add600c9bd1fb03579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

