### PR TITLE
fix clip v1 reconcile logic

### DIFF
--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -164,10 +164,18 @@ func (r *cacheContentReporter) shouldGenerateRequiredContent(stubID string) bool
 		return true
 	}
 
-	// Cluster-wide one-time claim; on error, fall back to generating.
+	// The Redis marker is advisory. Required-content events are the durable
+	// source of truth, and S2 writes are asynchronous; a marker can outlive a
+	// failed or interrupted write. Re-emit once per worker process when the
+	// marker already exists so reconciliation never gets stuck with an empty
+	// stub cache stream.
 	claimed, err := r.metadata.MarkStubReported(r.ctx, r.locality, stubID, r.recentStubTTL)
 	if err != nil {
 		log.Debug().Err(err).Str("stub_id", stubID).Msg("failed to claim one-time required-content generation")
+		return true
+	}
+	if !claimed {
+		log.Debug().Str("stub_id", stubID).Msg("required-content report already claimed; emitting once locally")
 		return true
 	}
 	return claimed

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -2,11 +2,16 @@ package worker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/beam-cloud/beta9/pkg/cache"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
+	clip "github.com/beam-cloud/clip/pkg/clip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +39,15 @@ func newTestReporter(eventRepo repo.EventRepository) *cacheContentReporter {
 	}
 }
 
+type claimedMetadataStore struct {
+	cache.CacheMetadataStore
+	claimed bool
+}
+
+func (m *claimedMetadataStore) MarkStubReported(context.Context, string, string, time.Duration) (bool, error) {
+	return m.claimed, nil
+}
+
 func TestReporterGeneratesOncePerStub(t *testing.T) {
 	r := newTestReporter(&fakeEventRepo{})
 
@@ -41,6 +55,14 @@ func TestReporterGeneratesOncePerStub(t *testing.T) {
 	require.True(t, r.shouldGenerateRequiredContent("stub-a"))
 	require.False(t, r.shouldGenerateRequiredContent("stub-a"))
 	require.True(t, r.shouldGenerateRequiredContent("stub-b"))
+}
+
+func TestReporterRedisMarkerIsAdvisory(t *testing.T) {
+	r := newTestReporter(&fakeEventRepo{})
+	r.metadata = &claimedMetadataStore{claimed: false}
+
+	require.True(t, r.shouldGenerateRequiredContent("stub-a"))
+	require.False(t, r.shouldGenerateRequiredContent("stub-a"))
 }
 
 func TestReporterCoalescesItemsPerStubKind(t *testing.T) {
@@ -87,8 +109,8 @@ func TestReporterVolumeRespectsSizeThreshold(t *testing.T) {
 	r.volumeMinBytes = 1024
 	r.activeStubs = func(string) []string { return []string{"stub"} }
 
-	r.ReportVolumeContent("ws", "small", "/p/small", 512)  // below threshold -> dropped
-	r.ReportVolumeContent("ws", "big", "/p/big", 4096)     // above threshold -> kept
+	r.ReportVolumeContent("ws", "small", "/p/small", 512) // below threshold -> dropped
+	r.ReportVolumeContent("ws", "big", "/p/big", 4096)    // above threshold -> kept
 
 	r.flush()
 	require.Len(t, fake.pushed, 1)
@@ -106,4 +128,54 @@ func TestReporterVolumeNoActiveStubsIsNoop(t *testing.T) {
 	r.ReportVolumeContent("ws", "big", "/p/big", 4096)
 	r.flush()
 	require.Empty(t, fake.pushed)
+}
+
+func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "usr", "bin"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "usr", "bin", "tool"), []byte("tool-data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "config.json"), []byte(`{"ok":true}`), 0644))
+
+	archivePath := filepath.Join(t.TempDir(), "legacy.rclip")
+	archiver := clip.NewClipArchiver()
+	require.NoError(t, archiver.Create(clip.ClipArchiverOptions{
+		SourcePath:  src,
+		OutputFile:  archivePath,
+		ArchivePath: archivePath,
+	}))
+	meta, err := archiver.ExtractMetadata(archivePath)
+	require.NoError(t, err)
+
+	items, kind := requiredContentItems(meta)
+	require.Equal(t, types.CacheContentKindClipV1, kind)
+	require.Len(t, items, 2)
+	for _, item := range items {
+		require.NotEmpty(t, item.Hash)
+		require.Equal(t, item.Hash, item.RoutingKey)
+		require.Equal(t, item.Hash, item.ExpectedHash)
+		require.Equal(t, types.CacheContentKindClipV1, item.Kind)
+		require.NotEmpty(t, item.Source)
+	}
+}
+
+func TestValidateRestoredImageArchiveAcceptsClipV1WhenDefaultIsV2(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), 0644))
+
+	archivePath := filepath.Join(t.TempDir(), "legacy.rclip")
+	archiver := clip.NewClipArchiver()
+	require.NoError(t, archiver.Create(clip.ClipArchiverOptions{
+		SourcePath:  src,
+		OutputFile:  archivePath,
+		ArchivePath: archivePath,
+	}))
+	info, err := os.Stat(archivePath)
+	require.NoError(t, err)
+
+	client := &ImageClient{
+		config: types.AppConfig{
+			ImageService: types.ImageServiceConfig{ClipVersion: uint32(types.ClipVersion2)},
+		},
+	}
+	require.NoError(t, client.validateRestoredImageArchive(archivePath, "legacy-image", info.Size()))
 }

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -421,6 +421,14 @@ func (c *ImageClient) reportRequiredContent(request *types.ContainerRequest, met
 		return
 	}
 	c.contentReporter.reportItems(request.WorkspaceId, request.StubId, kind, items)
+	c.contentReporter.flush()
+	log.Debug().
+		Str("workspace_id", request.WorkspaceId).
+		Str("stub_id", request.StubId).
+		Str("image_id", request.ImageId).
+		Str("kind", string(kind)).
+		Int("item_count", len(items)).
+		Msg("reported image required content")
 }
 
 // requiredContentItems enumerates the content a stub's image requires from its
@@ -1187,24 +1195,20 @@ func (c *ImageClient) writeImageArchiveFromContentCache(ctx context.Context, arc
 }
 
 func (c *ImageClient) validateRestoredImageArchive(archivePath, imageId string, size int64) error {
-	if c.config.ImageService.ClipVersion != uint32(types.ClipVersion2) {
+	archiver := clip.NewClipArchiver()
+	meta, err := archiver.ExtractMetadata(archivePath)
+	if err != nil {
+		return fmt.Errorf("restored image archive metadata invalid: image_id=%s: %w", imageId, err)
+	}
+
+	ociInfo, ok := ociStorageInfo(meta)
+	if !ok || strings.ToLower(ociInfo.Type()) != string(clipCommon.StorageModeOCI) {
 		return nil
 	}
 
 	const maxExpectedV2ArchiveSize = int64(128 * 1024 * 1024)
 	if size > maxExpectedV2ArchiveSize {
 		return fmt.Errorf("restored v2 image archive is unexpectedly large: image_id=%s size=%d", imageId, size)
-	}
-
-	archiver := clip.NewClipArchiver()
-	meta, err := archiver.ExtractMetadata(archivePath)
-	if err != nil {
-		return fmt.Errorf("restored v2 image archive metadata invalid: image_id=%s: %w", imageId, err)
-	}
-
-	ociInfo, ok := ociStorageInfo(meta)
-	if !ok || strings.ToLower(ociInfo.Type()) != string(clipCommon.StorageModeOCI) {
-		return fmt.Errorf("restored v2 image archive is not an OCI metadata archive: image_id=%s", imageId)
 	}
 	if ociInfo.ImageMetadata == nil {
 		return fmt.Errorf("restored v2 image archive is missing embedded image metadata: image_id=%s", imageId)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Clip v1 reconciliation and restore flow. We now re-emit required-content when a Redis marker exists and accept v1 archives during validation, preventing stuck cache streams and failed restores.

- **Bug Fixes**
  - Treat Redis marker as advisory; re-emit required-content once per worker when the marker exists to avoid stalled stub cache streams.
  - Flush reported items immediately and add debug logs for visibility.
  - Validate restores by enforcing OCI/v2 checks only when metadata is OCI; accept Clip v1 archives even if the default is v2.

- **Tests**
  - Added coverage for advisory marker behavior and Clip v1 required-content generation.
  - Added validation test ensuring v1 archives pass when v2 is the default.

<sup>Written for commit df5b9e6c0990b8f9e8bac0f27959fb2fe4e9fa0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

