### PR TITLE
fix v1 reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260604002849-11525095d3f5
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260604002849-11525095d3f5
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260604123946-2905639b64b3
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -128,14 +128,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42 h1:rvqupNqNax+1v6DPE8N4yRysQpD4tKU+W4G8aKKg41U=
-github.com/beam-cloud/clip v0.0.0-20260601215454-8a155c0f9d42/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
-github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823 h1:zKZjay2sGry1c4hZrcjXbJQBFglrGTPEeNgiCGKoBz8=
-github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
 github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877 h1:R2G+m4w9VdKpzTEVpYqEI0XxMVCPHXPOdqLOb65dBF0=
 github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877/go.mod h1:+vn8fPGQKaUiDvOy5GLpduzYIQLtMIfnRn08/5fOz+s=
-github.com/beam-cloud/geesefs v0.0.0-20260604002849-11525095d3f5 h1:ve/k/XLUb08MHn6MhTm4xAMTvPKbYNvuu3KyyncYwyw=
-github.com/beam-cloud/geesefs v0.0.0-20260604002849-11525095d3f5/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260604123946-2905639b64b3 h1:lqVS6G9Qq5w34KamD6/GqgbhNrG/AHLuYGVrxJ3UD/A=
+github.com/beam-cloud/geesefs v0.0.0-20260604123946-2905639b64b3/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823 h1:zKZjay2sGry1c4h
 github.com/beam-cloud/clip v0.0.0-20260603162509-c9d1ed562823/go.mod h1:Tt5HW/Mp3twQHzal5RE3FYACcxaMaT+QyTBo8aGbsyI=
 github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877 h1:R2G+m4w9VdKpzTEVpYqEI0XxMVCPHXPOdqLOb65dBF0=
 github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877/go.mod h1:+vn8fPGQKaUiDvOy5GLpduzYIQLtMIfnRn08/5fOz+s=
-github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652 h1:lUzupIe/xH4c/WVdWD2kfVQ+RH6DiIPD/Hlaz/PjuYg=
-github.com/beam-cloud/geesefs v0.0.0-20260531020909-5bc55ffc1652/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260604002849-11525095d3f5 h1:ve/k/XLUb08MHn6MhTm4xAMTvPKbYNvuu3KyyncYwyw=
+github.com/beam-cloud/geesefs v0.0.0-20260604002849-11525095d3f5/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/raw_transport_test.go
+++ b/pkg/cache/raw_transport_test.go
@@ -126,8 +126,13 @@ func TestRawReadUsesCopyForSmallPageBackedRange(t *testing.T) {
 	require.Equal(t, []byte("defghijk"), body)
 	after := snapshotCachePathStats()
 	diff := diffCachePathStats(after, before)
-	require.Equal(t, int64(1), diff.serverRawCopyHits)
+	// The guarantee for a small (sub-threshold) range is that it is never served
+	// via sendfile. It is served from the local page file through the copy path,
+	// or the readAt fallback if the page region isn't resolvable on this read;
+	// asserting on copy alone is flaky across filesystems, so require that it was
+	// served by one of the non-sendfile local paths.
 	require.Equal(t, int64(0), diff.serverRawSendfileHits)
+	require.Equal(t, int64(1), diff.serverRawCopyHits+diff.serverRawReadAtHits)
 }
 
 func TestClientLocalPageFileViewsDoesNotPromoteRemotePageRegion(t *testing.T) {

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -33,12 +33,13 @@ type Config struct {
 // It is disabled by default; when off, workers do not report required content
 // and cache servers do not run the loop, preserving prior startup behavior.
 type ReconciliationConfig struct {
-	Enabled               bool `key:"enabled" json:"enabled"`
-	IntervalSeconds       int  `key:"intervalSeconds" json:"interval_seconds"`
-	RecentStubTTLSeconds  int  `key:"recentStubTTLSeconds" json:"recent_stub_ttl_seconds"`
-	LockTTLSeconds        int  `key:"lockTTLSeconds" json:"lock_ttl_seconds"`
-	MaxStubsPerCycle      int  `key:"maxStubsPerCycle" json:"max_stubs_per_cycle"`
-	OriginFallbackEnabled bool `key:"originFallbackEnabled" json:"origin_fallback_enabled"`
+	Enabled               bool  `key:"enabled" json:"enabled"`
+	IntervalSeconds       int   `key:"intervalSeconds" json:"interval_seconds"`
+	RecentStubTTLSeconds  int   `key:"recentStubTTLSeconds" json:"recent_stub_ttl_seconds"`
+	LockTTLSeconds        int   `key:"lockTTLSeconds" json:"lock_ttl_seconds"`
+	MaxStubsPerCycle      int   `key:"maxStubsPerCycle" json:"max_stubs_per_cycle"`
+	VolumeMinBytes        int64 `key:"volumeMinBytes" json:"volume_min_bytes"`
+	OriginFallbackEnabled bool  `key:"originFallbackEnabled" json:"origin_fallback_enabled"`
 }
 
 type DiskConfig struct {

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -343,6 +343,7 @@ cache:
     recentStubTTLSeconds: 604800 # keep required content warm for 7 days after a stub's last container
     lockTTLSeconds: 300
     maxStubsPerCycle: 256
+    volumeMinBytes: 134217728 # 128MiB; only large geesefs volume objects are reconciled
     originFallbackEnabled: false
 
 providers:

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -278,7 +278,7 @@ type EventRepository interface {
 	PushWorkerPoolDegradedEvent(poolName string, reasons []string, poolState *types.WorkerPoolState)
 	PushWorkerPoolHealthyEvent(poolName string, poolState *types.WorkerPoolState)
 	PushGatewayEndpointCalledEvent(method, path, workspaceID string, statusCode int, userAgent, remoteIP, requestID, contentType, accept, errorMessage string)
-	PushStubCacheRequiredContent(schema types.EventStubCacheRequiredContentSchema)
+	PushStubCacheRequiredContent(schema types.EventStubCacheRequiredContentSchema) error
 	PushPlatformCacheEvent(schema types.EventPlatformCacheSchema)
 	ReadStubCacheRequiredContent(ctx context.Context, workspaceID, stubID string) ([]types.CacheRequiredContentItem, error)
 }

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -940,7 +940,11 @@ func (r *EventClientRepo) PushGatewayEndpointCalledEvent(method, path, workspace
 	)
 }
 
-func (r *EventClientRepo) PushStubCacheRequiredContent(schema types.EventStubCacheRequiredContentSchema) {
+type syncEventSink interface {
+	PushEventSync(event cloudevents.Event) error
+}
+
+func (r *EventClientRepo) PushStubCacheRequiredContent(schema types.EventStubCacheRequiredContentSchema) error {
 	if schema.Timestamp.IsZero() {
 		schema.Timestamp = time.Now().UTC()
 	}
@@ -952,7 +956,32 @@ func (r *EventClientRepo) PushStubCacheRequiredContent(schema types.EventStubCac
 		}
 		schema.TotalBytes = total
 	}
-	r.pushEvent(types.EventStubCacheRequiredContent, types.EventStubCacheRequiredContentSchemaVersion, schema)
+	if len(r.storageSinks) == 0 && len(r.callbackSinks) == 0 {
+		return nil
+	}
+
+	event, err := r.createEventObject(types.EventStubCacheRequiredContent, types.EventStubCacheRequiredContentSchemaVersion, schema)
+	if err != nil {
+		return err
+	}
+
+	for _, sink := range r.storageSinks {
+		if syncSink, ok := sink.(syncEventSink); ok {
+			if err := syncSink.PushEventSync(event); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := sink.PushEvent(event); err != nil {
+			return err
+		}
+	}
+	for _, sink := range r.callbackSinks {
+		if err := sink.PushEvent(event); err != nil {
+			log.Debug().Err(err).Str("event_type", event.Type()).Msg("failed to push required-content event callback")
+		}
+	}
+	return nil
 }
 
 func (r *EventClientRepo) PushPlatformCacheEvent(schema types.EventPlatformCacheSchema) {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -25,13 +25,13 @@ const (
 	// per stub, so this is far above realistic sizes; it exists only to guarantee
 	// the read terminates even if the stream is continuously appended.
 	maxStubCacheReadRecords = 200000
-	s2EventHistoryReadLimit    = uint64(1000)
-	s2EventQueueSize           = 16384
-	s2EventBatchSize           = 256
-	s2EventRetentionSeconds    = int64(30 * 24 * 60 * 60)
-	s2EventWriteTimeout        = 5 * time.Second
-	s2EventEnqueueTimeout      = 250 * time.Millisecond
-	s2EventFlushInterval       = 100 * time.Millisecond
+	s2EventHistoryReadLimit = uint64(1000)
+	s2EventQueueSize        = 16384
+	s2EventBatchSize        = 256
+	s2EventRetentionSeconds = int64(30 * 24 * 60 * 60)
+	s2EventWriteTimeout     = 5 * time.Second
+	s2EventEnqueueTimeout   = 250 * time.Millisecond
+	s2EventFlushInterval    = 100 * time.Millisecond
 )
 
 type S2EventRepository struct {
@@ -97,6 +97,10 @@ func (r *S2EventRepository) PushEvent(event cloudevents.Event) error {
 	case <-timer.C:
 		return fmt.Errorf("s2 event queue is full")
 	}
+}
+
+func (r *S2EventRepository) PushEventSync(event cloudevents.Event) error {
+	return r.appendEvent(event)
 }
 
 func (r *S2EventRepository) runWriter() {

--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -90,7 +90,7 @@ func (s *GeeseStorage) handleGeeseContentEvent(data map[string]interface{}) {
 	if hash == "" {
 		return
 	}
-	path := firstStringValue(data, "path", "key", "object")
+	path := firstStringValue(data, "path", "key", "object", "inode")
 	size := firstInt64Value(data, "size_bytes", "size", "content_length")
 	s.reportVolumeContent(hash, path, size)
 }

--- a/pkg/storage/geese_test.go
+++ b/pkg/storage/geese_test.go
@@ -2,6 +2,20 @@ package storage
 
 import "testing"
 
+type testVolumeReporter struct {
+	workspaceID string
+	hash        string
+	sourcePath  string
+	sizeBytes   int64
+}
+
+func (r *testVolumeReporter) ReportVolumeContent(workspaceID, hash, sourcePath string, sizeBytes int64) {
+	r.workspaceID = workspaceID
+	r.hash = hash
+	r.sourcePath = sourcePath
+	r.sizeBytes = sizeBytes
+}
+
 func TestEffectiveGeeseMemoryLimitMB(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -25,5 +39,30 @@ func TestEffectiveGeeseMemoryLimitMB(t *testing.T) {
 				t.Fatalf("effectiveGeeseMemoryLimitMB(%d, %q) = %d, want %d", tt.configured, tt.worker, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestHandleGeeseContentEventReportsStoredContent(t *testing.T) {
+	reporter := &testVolumeReporter{}
+	storage := &GeeseStorage{}
+	storage.SetVolumeContentReporter("workspace-id", reporter)
+
+	storage.handleGeeseContentEvent(map[string]interface{}{
+		"content_hash": "hash",
+		"inode":        "/volumes/workspace/files/data.bin",
+		"size_bytes":   uint64(32 << 20),
+	})
+
+	if reporter.workspaceID != "workspace-id" {
+		t.Fatalf("workspaceID = %q", reporter.workspaceID)
+	}
+	if reporter.hash != "hash" {
+		t.Fatalf("hash = %q", reporter.hash)
+	}
+	if reporter.sourcePath != "/volumes/workspace/files/data.bin" {
+		t.Fatalf("sourcePath = %q", reporter.sourcePath)
+	}
+	if reporter.sizeBytes != 32<<20 {
+		t.Fatalf("sizeBytes = %d", reporter.sizeBytes)
 	}
 }

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -54,10 +54,9 @@ var (
 type CacheContentKind string
 
 const (
-	CacheContentKindClipV1        CacheContentKind = "clip_v1"
-	CacheContentKindClipV1Archive CacheContentKind = "clip_v1_archive"
-	CacheContentKindClipV2        CacheContentKind = "clip_v2"
-	CacheContentKindVolume        CacheContentKind = "volume"
+	CacheContentKindClipV1 CacheContentKind = "clip_v1"
+	CacheContentKindClipV2 CacheContentKind = "clip_v2"
+	CacheContentKindVolume CacheContentKind = "volume"
 )
 
 // Platform cache audit statuses for EventPlatformCacheSchema.Status.

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -54,19 +54,20 @@ var (
 type CacheContentKind string
 
 const (
-	CacheContentKindClipV1 CacheContentKind = "clip_v1"
-	CacheContentKindClipV2 CacheContentKind = "clip_v2"
-	CacheContentKindVolume CacheContentKind = "volume"
+	CacheContentKindClipV1        CacheContentKind = "clip_v1"
+	CacheContentKindClipV1Archive CacheContentKind = "clip_v1_archive"
+	CacheContentKindClipV2        CacheContentKind = "clip_v2"
+	CacheContentKindVolume        CacheContentKind = "volume"
 )
 
 // Platform cache audit statuses for EventPlatformCacheSchema.Status.
 const (
-	CacheAuditStatusMaterialized   = "materialized"
-	CacheAuditStatusMiss           = "miss"
+	CacheAuditStatusMaterialized    = "materialized"
+	CacheAuditStatusMiss            = "miss"
 	CacheAuditStatusHostUnavailable = "host_unavailable"
-	CacheAuditStatusOriginFailure  = "origin_failure"
-	CacheAuditStatusReplicaFailure = "replica_failure"
-	CacheAuditStatusSkipped        = "skipped"
+	CacheAuditStatusOriginFailure   = "origin_failure"
+	CacheAuditStatusReplicaFailure  = "replica_failure"
+	CacheAuditStatusSkipped         = "skipped"
 )
 
 var EventStubCacheRequiredContentSchemaVersion = "1.0"

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -56,7 +56,7 @@ const (
 	cacheDefaultReconcileRecentStubTTLS = 7 * 24 * 60 * 60 // 7 days after a stub's last container
 	cacheDefaultReconcileLockTTLS       = 300
 	cacheDefaultReconcileMaxStubsCycle  = 256
-	cacheDefaultVolumeReportMinKB       = 1024
+	cacheDefaultVolumeReportMinBytes    = 128 * 1024 * 1024
 )
 
 type WorkerCacheManager struct {
@@ -199,7 +199,7 @@ func (m *WorkerCacheManager) startReconciliation(cacheConfig cache.Config) {
 		m.metadataStore,
 		m.locality,
 		m.recentStubTTL(),
-		cacheVolumeReportMinBytes(),
+		m.cacheVolumeReportMinBytes(),
 		m.activeStubsForWorkspace,
 	)
 
@@ -214,10 +214,13 @@ func (m *WorkerCacheManager) startReconciliation(cacheConfig cache.Config) {
 		Msg("cache required-content reconciliation enabled")
 }
 
-// cacheVolumeReportMinBytes is the geesefs object size threshold (in bytes)
-// above which volume content is reported, matching the geesefs hash threshold.
-func cacheVolumeReportMinBytes() int64 {
-	return int64(cacheDefaultVolumeReportMinKB) * 1024
+// cacheVolumeReportMinBytes is the geesefs object size threshold above which
+// volume content is reported as required content for reconciliation.
+func (m *WorkerCacheManager) cacheVolumeReportMinBytes() int64 {
+	if m != nil && m.config.Cache.Reconciliation.VolumeMinBytes > 0 {
+		return m.config.Cache.Reconciliation.VolumeMinBytes
+	}
+	return cacheDefaultVolumeReportMinBytes
 }
 
 func (m *WorkerCacheManager) Close() error {

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -173,7 +173,7 @@ func TestEmbeddedWorkerYieldsCacheServerToDaemonSetMarker(t *testing.T) {
 	require.NoError(t, writeCacheServerDaemonSetMarker(cacheDir, "cache-server-single-node", "pod-a"))
 
 	require.Eventually(t, func() bool {
-		return !manager.runningCacheServer() && len(repo.activeHosts()) == 0
+		return !manager.runningCacheServer() && repo.unregisterCalled("worker-a")
 	}, 5*time.Second, 50*time.Millisecond)
 }
 
@@ -442,8 +442,9 @@ func runningCacheServers(managers []*WorkerCacheManager) []*WorkerCacheManager {
 
 type testCacheCoordinator struct {
 	pb.UnimplementedWorkerRepositoryServiceServer
-	mu    sync.Mutex
-	hosts map[string]*pb.CacheCoordinatorHost
+	mu          sync.Mutex
+	hosts       map[string]*pb.CacheCoordinatorHost
+	unregisters map[string]bool
 }
 
 func startTestCacheCoordinator(t *testing.T) (pb.WorkerRepositoryServiceClient, *testCacheCoordinator, func()) {
@@ -453,7 +454,10 @@ func startTestCacheCoordinator(t *testing.T) (pb.WorkerRepositoryServiceClient, 
 	require.NoError(t, err)
 
 	server := grpc.NewServer()
-	coordinator := &testCacheCoordinator{hosts: make(map[string]*pb.CacheCoordinatorHost)}
+	coordinator := &testCacheCoordinator{
+		hosts:       make(map[string]*pb.CacheCoordinatorHost),
+		unregisters: make(map[string]bool),
+	}
 	pb.RegisterWorkerRepositoryServiceServer(server, coordinator)
 	go func() {
 		_ = server.Serve(listener)
@@ -488,6 +492,7 @@ func (s *testCacheCoordinator) UnregisterCacheHost(ctx context.Context, req *pb.
 	}
 
 	s.mu.Lock()
+	s.unregisters[req.GetRegistrationId()] = true
 	if host := s.hosts[req.GetLogicalHostId()]; host != nil && host.GetRegistrationId() == req.GetRegistrationId() {
 		delete(s.hosts, req.GetLogicalHostId())
 	}
@@ -520,4 +525,11 @@ func (s *testCacheCoordinator) activeHosts() map[string]*pb.CacheCoordinatorHost
 		hosts[id] = &copyHost
 	}
 	return hosts
+}
+
+func (s *testCacheCoordinator) unregisterCalled(registrationID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.unregisters[registrationID]
 }

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -641,35 +641,38 @@ func (m *WorkerCacheManager) materialize(ctx context.Context, server *cache.Serv
 
 // materializeArchiveObject re-fetches the whole CLIP v1 archive from the image
 // registry and stores it as a single content object, mirroring the embedded
-// image-archive cache that the image-load path populates. It uses the worker's
-// configured image registry (the same source/credentials the load path uses);
-// no credentials are persisted to Redis or S2.
+// image-archive cache that the image-load path populates. It pulls from the same
+// source the load path uses: the S3 image registry for the S3 store, or the
+// mounted image volume for the local store. No credentials are persisted.
 func (m *WorkerCacheManager) materializeArchiveObject(ctx context.Context, server *cache.Server, item types.CacheRequiredContentItem, routingKey string) string {
-	s3 := m.config.ImageService.Registries.S3
-	if m.config.ImageService.RegistryStore != reg.S3ImageRegistryStore || s3.BucketName == "" || item.Source == "" {
-		// Non-S3 stores keep the archive on local disk only, so there is no
-		// cross-host origin to re-fetch from; rely on replica copy / next load.
-		return types.CacheAuditStatusMiss
+	source := &pb.CacheSource{
+		CachePath:    routingKey,
+		ExpectedHash: item.Hash,
 	}
 
-	req := &pb.CacheStoreContentFromSourceRequest{
-		Source: &pb.CacheSource{
-			Path:           item.Source,
-			CachePath:      routingKey,
-			ExpectedHash:   item.Hash,
-			BucketName:     s3.BucketName,
-			Region:         s3.Region,
-			EndpointUrl:    s3.Endpoint,
-			AccessKey:      s3.AccessKey,
-			SecretKey:      s3.SecretKey,
-			ForcePathStyle: s3.ForcePathStyle,
-		},
+	if m.config.ImageService.RegistryStore == reg.S3ImageRegistryStore {
+		s3 := m.config.ImageService.Registries.S3
+		if s3.BucketName == "" || item.Source == "" {
+			return types.CacheAuditStatusMiss
+		}
+		source.Path = item.Source
+		source.BucketName = s3.BucketName
+		source.Region = s3.Region
+		source.EndpointUrl = s3.Endpoint
+		source.AccessKey = s3.AccessKey
+		source.SecretKey = s3.SecretKey
+		source.ForcePathStyle = s3.ForcePathStyle
+	} else {
+		// Local registry store: the durable archive lives on the mounted image
+		// volume at the cachefs path; read it directly (no bucket/credentials).
+		source.Path = routingKey
 	}
-	resp, err := server.StoreContentFromSource(ctx, req)
+
+	resp, err := server.StoreContentFromSource(ctx, &pb.CacheStoreContentFromSourceRequest{Source: source})
 	if err == nil && resp != nil && resp.Ok {
 		return types.CacheAuditStatusMaterialized
 	}
-	log.Debug().Err(err).Str("hash", item.Hash).Str("source", item.Source).Msg("cache reconciliation image archive fetch failed")
+	log.Debug().Err(err).Str("hash", item.Hash).Str("routing_key", routingKey).Msg("cache reconciliation image archive fetch failed")
 	return types.CacheAuditStatusOriginFailure
 }
 

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -629,11 +629,48 @@ func (m *WorkerCacheManager) materialize(ctx context.Context, server *cache.Serv
 		return m.materializeOCILayer(ctx, server, stub, item)
 	case types.CacheContentKindVolume:
 		return m.materializeVolumeObject(ctx, server, stub, item)
+	case types.CacheContentKindClipV1:
+		// The v1 archive is one content-addressed object; re-fetch the whole
+		// archive from the image registry (the same source the image-load path
+		// pulls it from) and store it under its hash + cachefs path.
+		return m.materializeArchiveObject(ctx, server, item, routingKey)
 	default:
-		// CLIP v1 content is content-addressed archive data with no standalone
-		// origin source; it is materialized from a replica when available.
 		return types.CacheAuditStatusMiss
 	}
+}
+
+// materializeArchiveObject re-fetches the whole CLIP v1 archive from the image
+// registry and stores it as a single content object, mirroring the embedded
+// image-archive cache that the image-load path populates. It uses the worker's
+// configured image registry (the same source/credentials the load path uses);
+// no credentials are persisted to Redis or S2.
+func (m *WorkerCacheManager) materializeArchiveObject(ctx context.Context, server *cache.Server, item types.CacheRequiredContentItem, routingKey string) string {
+	s3 := m.config.ImageService.Registries.S3
+	if m.config.ImageService.RegistryStore != reg.S3ImageRegistryStore || s3.BucketName == "" || item.Source == "" {
+		// Non-S3 stores keep the archive on local disk only, so there is no
+		// cross-host origin to re-fetch from; rely on replica copy / next load.
+		return types.CacheAuditStatusMiss
+	}
+
+	req := &pb.CacheStoreContentFromSourceRequest{
+		Source: &pb.CacheSource{
+			Path:           item.Source,
+			CachePath:      routingKey,
+			ExpectedHash:   item.Hash,
+			BucketName:     s3.BucketName,
+			Region:         s3.Region,
+			EndpointUrl:    s3.Endpoint,
+			AccessKey:      s3.AccessKey,
+			SecretKey:      s3.SecretKey,
+			ForcePathStyle: s3.ForcePathStyle,
+		},
+	}
+	resp, err := server.StoreContentFromSource(ctx, req)
+	if err == nil && resp != nil && resp.Ok {
+		return types.CacheAuditStatusMaterialized
+	}
+	log.Debug().Err(err).Str("hash", item.Hash).Str("source", item.Source).Msg("cache reconciliation image archive fetch failed")
+	return types.CacheAuditStatusOriginFailure
 }
 
 func (m *WorkerCacheManager) requiredContentComplete(server *cache.Server, item types.CacheRequiredContentItem, routingKey string) bool {

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -18,7 +18,6 @@ package worker
 import (
 	"compress/gzip"
 	"context"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -612,10 +611,6 @@ func (m *WorkerCacheManager) reconcileLogFields(event *zerolog.Event, localHostI
 // prefers a reachable replica and otherwise fetches from the item's origin in
 // the same way the read path does. It never persists credentials in Redis or S2.
 func (m *WorkerCacheManager) materialize(ctx context.Context, server *cache.Server, stub cache.RecentStub, item types.CacheRequiredContentItem, routingKey string) string {
-	if item.Kind == types.CacheContentKindClipV1Archive {
-		return m.materializeClipV1Archive(ctx, server, item, routingKey)
-	}
-
 	if ok, err := m.client.MaterializeFromReplica(ctx, server, item.Hash, routingKey, item.SizeBytes); err != nil {
 		log.Debug().Err(err).Str("hash", item.Hash).Msg("cache reconciliation replica copy failed")
 	} else if ok {
@@ -642,56 +637,7 @@ func (m *WorkerCacheManager) materialize(ctx context.Context, server *cache.Serv
 }
 
 func (m *WorkerCacheManager) requiredContentComplete(server *cache.Server, item types.CacheRequiredContentItem, routingKey string) bool {
-	if item.Kind != types.CacheContentKindClipV1Archive {
-		return server.HasCompleteContent(item.Hash, item.SizeBytes)
-	}
-
-	metadata, err := m.client.CacheFSMetadata(m.ctx, routingKey)
-	if err != nil || metadata == nil || metadata.Hash == "" {
-		return false
-	}
-	return server.HasCompleteContent(metadata.Hash, int64(metadata.Size))
-}
-
-func (m *WorkerCacheManager) materializeClipV1Archive(ctx context.Context, server *cache.Server, item types.CacheRequiredContentItem, routingKey string) string {
-	if metadata, err := m.client.CacheFSMetadata(ctx, routingKey); err == nil && metadata != nil && metadata.Hash != "" {
-		if server.HasCompleteContent(metadata.Hash, int64(metadata.Size)) {
-			return types.CacheAuditStatusMaterialized
-		}
-		if ok, err := m.client.MaterializeFromReplica(ctx, server, metadata.Hash, routingKey, int64(metadata.Size)); err != nil {
-			log.Debug().Err(err).Str("hash", metadata.Hash).Str("routing_key", routingKey).Msg("cache reconciliation v1 archive replica copy failed")
-		} else if ok {
-			return types.CacheAuditStatusMaterialized
-		}
-	}
-
-	if !m.config.Cache.Reconciliation.OriginFallbackEnabled || item.Source == "" {
-		return types.CacheAuditStatusMiss
-	}
-
-	req := &pb.CacheStoreContentFromSourceRequest{Source: &pb.CacheSource{
-		Path:      item.Source,
-		CachePath: routingKey,
-	}}
-	switch m.config.ImageService.RegistryStore {
-	case reg.S3ImageRegistryStore:
-		sourceRegistry := m.config.ImageService.Registries.S3
-		req.Source.BucketName = sourceRegistry.BucketName
-		req.Source.Region = sourceRegistry.Region
-		req.Source.EndpointUrl = sourceRegistry.Endpoint
-		req.Source.AccessKey = sourceRegistry.AccessKey
-		req.Source.SecretKey = sourceRegistry.SecretKey
-		req.Source.ForcePathStyle = sourceRegistry.ForcePathStyle
-	default:
-		req.Source.Path = filepath.Join("/images", item.Source)
-	}
-
-	resp, err := server.StoreContentFromSource(ctx, req)
-	if err == nil && resp != nil && resp.Ok {
-		return types.CacheAuditStatusMaterialized
-	}
-	log.Debug().Err(err).Str("source", item.Source).Str("routing_key", routingKey).Msg("cache reconciliation v1 archive fetch failed")
-	return types.CacheAuditStatusOriginFailure
+	return server.HasCompleteContent(item.Hash, item.SizeBytes)
 }
 
 // materializeVolumeObject fetches a workspace object from object storage using

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -164,10 +164,18 @@ func (r *cacheContentReporter) shouldGenerateRequiredContent(stubID string) bool
 		return true
 	}
 
-	// Cluster-wide one-time claim; on error, fall back to generating.
+	// The Redis marker is advisory. Required-content events are the durable
+	// source of truth, and S2 writes are asynchronous; a marker can outlive a
+	// failed or interrupted write. Re-emit once per worker process when the
+	// marker already exists so reconciliation never gets stuck with an empty
+	// stub cache stream.
 	claimed, err := r.metadata.MarkStubReported(r.ctx, r.locality, stubID, r.recentStubTTL)
 	if err != nil {
 		log.Debug().Err(err).Str("stub_id", stubID).Msg("failed to claim one-time required-content generation")
+		return true
+	}
+	if !claimed {
+		log.Debug().Str("stub_id", stubID).Msg("required-content report already claimed; emitting once locally")
 		return true
 	}
 	return claimed

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -18,6 +18,7 @@ package worker
 import (
 	"compress/gzip"
 	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -107,6 +108,16 @@ type reporterKey struct {
 	kind        types.CacheContentKind
 }
 
+type reporterStubKey struct {
+	workspaceID string
+	stubID      string
+}
+
+type requiredContentReport struct {
+	kind  types.CacheContentKind
+	items []types.CacheRequiredContentItem
+}
+
 func newCacheContentReporter(
 	ctx context.Context,
 	eventRepo repo.EventRepository,
@@ -143,10 +154,9 @@ func (r *cacheContentReporter) touchRecentStub(workspaceID, stubID string) {
 	}
 }
 
-// shouldGenerateRequiredContent reports whether this is the first load of a stub
-// (cluster-wide) and therefore the one time its required content should be
-// enumerated and written to S2. Subsequent container starts only refresh the
-// recent-stub window via touchRecentStub.
+// shouldGenerateRequiredContent reports whether this worker process has already
+// enumerated a stub's required content. The durable S2 stream is the source of
+// truth, so Redis is marked only after a successful event write.
 func (r *cacheContentReporter) shouldGenerateRequiredContent(stubID string) bool {
 	if r == nil || stubID == "" {
 		return false
@@ -160,25 +170,7 @@ func (r *cacheContentReporter) shouldGenerateRequiredContent(stubID string) bool
 	r.reported[stubID] = struct{}{}
 	r.mu.Unlock()
 
-	if r.metadata == nil {
-		return true
-	}
-
-	// The Redis marker is advisory. Required-content events are the durable
-	// source of truth, and S2 writes are asynchronous; a marker can outlive a
-	// failed or interrupted write. Re-emit once per worker process when the
-	// marker already exists so reconciliation never gets stuck with an empty
-	// stub cache stream.
-	claimed, err := r.metadata.MarkStubReported(r.ctx, r.locality, stubID, r.recentStubTTL)
-	if err != nil {
-		log.Debug().Err(err).Str("stub_id", stubID).Msg("failed to claim one-time required-content generation")
-		return true
-	}
-	if !claimed {
-		log.Debug().Str("stub_id", stubID).Msg("required-content report already claimed; emitting once locally")
-		return true
-	}
-	return claimed
+	return true
 }
 
 func (r *cacheContentReporter) run() {
@@ -198,7 +190,14 @@ func (r *cacheContentReporter) run() {
 // reportItems merges a coalesced set of items for a stub and records the stub in
 // the recent index so the reconciliation loop can discover it.
 func (r *cacheContentReporter) reportItems(workspaceID, stubID string, kind types.CacheContentKind, items []types.CacheRequiredContentItem) {
-	if r == nil || workspaceID == "" || stubID == "" || len(items) == 0 {
+	r.reportBatches(workspaceID, stubID, []requiredContentReport{{kind: kind, items: items}})
+}
+
+// reportBatches records all required-content kinds for a stub under one lock.
+// This prevents the periodic flush from publishing one image kind, marking the
+// stub as reported, and missing another kind from the same image load.
+func (r *cacheContentReporter) reportBatches(workspaceID, stubID string, reports []requiredContentReport) {
+	if r == nil || workspaceID == "" || stubID == "" || len(reports) == 0 {
 		return
 	}
 
@@ -208,28 +207,27 @@ func (r *cacheContentReporter) reportItems(workspaceID, stubID string, kind type
 		}
 	}
 
-	key := reporterKey{workspaceID: workspaceID, stubID: stubID, kind: kind}
-
 	r.mu.Lock()
-	bucket := r.pending[key]
-	if bucket == nil {
-		bucket = make(map[string]types.CacheRequiredContentItem)
-		r.pending[key] = bucket
-	}
-	for _, item := range items {
-		if item.Hash == "" {
+	defer r.mu.Unlock()
+	for _, report := range reports {
+		if len(report.items) == 0 {
 			continue
 		}
-		if item.RoutingKey == "" {
-			item.RoutingKey = item.Hash
+		key := reporterKey{workspaceID: workspaceID, stubID: stubID, kind: report.kind}
+		bucket := r.pending[key]
+		if bucket == nil {
+			bucket = make(map[string]types.CacheRequiredContentItem)
+			r.pending[key] = bucket
 		}
-		bucket[item.Hash+"\x00"+item.RoutingKey] = item
-	}
-	total := len(bucket)
-	r.mu.Unlock()
-
-	if total >= reporterMaxItemsPerEvent {
-		r.flush()
+		for _, item := range report.items {
+			if item.Hash == "" {
+				continue
+			}
+			if item.RoutingKey == "" {
+				item.RoutingKey = item.Hash
+			}
+			bucket[item.Hash+"\x00"+item.RoutingKey] = item
+		}
 	}
 }
 
@@ -247,23 +245,77 @@ func (r *cacheContentReporter) flush() {
 		return
 	}
 
+	failed := make(map[reporterKey]map[string]types.CacheRequiredContentItem)
+	stubOK := make(map[reporterStubKey]bool)
 	for key, bucket := range pending {
 		if len(bucket) == 0 {
 			continue
 		}
+		stubKey := reporterStubKey{workspaceID: key.workspaceID, stubID: key.stubID}
+		if _, ok := stubOK[stubKey]; !ok {
+			stubOK[stubKey] = true
+		}
+
 		items := make([]types.CacheRequiredContentItem, 0, len(bucket))
 		for _, item := range bucket {
 			items = append(items, item)
 		}
+		ok := true
 		for start := 0; start < len(items); start += reporterMaxItemsPerEvent {
 			end := min(start+reporterMaxItemsPerEvent, len(items))
-			r.eventRepo.PushStubCacheRequiredContent(types.EventStubCacheRequiredContentSchema{
+			if err := r.eventRepo.PushStubCacheRequiredContent(types.EventStubCacheRequiredContentSchema{
 				WorkspaceID: key.workspaceID,
 				StubID:      key.stubID,
 				Locality:    r.locality,
 				Kind:        key.kind,
 				Items:       items[start:end],
-			})
+			}); err != nil {
+				log.Debug().Err(err).Str("workspace_id", key.workspaceID).Str("stub_id", key.stubID).Str("kind", string(key.kind)).Msg("failed to publish required-content event")
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			stubOK[stubKey] = false
+			failed[key] = bucket
+			continue
+		}
+	}
+
+	for stubKey, ok := range stubOK {
+		if ok {
+			r.markStubReported(stubKey.stubID)
+		}
+	}
+
+	if len(failed) > 0 {
+		r.requeue(failed)
+	}
+}
+
+func (r *cacheContentReporter) markStubReported(stubID string) {
+	if r == nil || r.metadata == nil || stubID == "" {
+		return
+	}
+	if _, err := r.metadata.MarkStubReported(r.ctx, r.locality, stubID, r.recentStubTTL); err != nil {
+		log.Debug().Err(err).Str("stub_id", stubID).Msg("failed to mark required-content report complete")
+	}
+}
+
+func (r *cacheContentReporter) requeue(items map[reporterKey]map[string]types.CacheRequiredContentItem) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key, bucket := range items {
+		if len(bucket) == 0 {
+			continue
+		}
+		current := r.pending[key]
+		if current == nil {
+			current = make(map[string]types.CacheRequiredContentItem, len(bucket))
+			r.pending[key] = current
+		}
+		for itemKey, item := range bucket {
+			current[itemKey] = item
 		}
 	}
 }
@@ -312,14 +364,15 @@ func (m *WorkerCacheManager) activeStubsForWorkspace(workspaceID string) []strin
 		if instance == nil || instance.Request == nil {
 			return true
 		}
-		if instance.Request.WorkspaceId != workspaceID || instance.StubId == "" {
+		stubID := cacheRequestStubID(instance.Request)
+		if cacheRequestWorkspaceID(instance.Request) != workspaceID || stubID == "" {
 			return true
 		}
-		if _, ok := seen[instance.StubId]; ok {
+		if _, ok := seen[stubID]; ok {
 			return true
 		}
-		seen[instance.StubId] = struct{}{}
-		stubs = append(stubs, instance.StubId)
+		seen[stubID] = struct{}{}
+		stubs = append(stubs, stubID)
 		return true
 	})
 	return stubs
@@ -416,7 +469,7 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 			continue
 		}
 
-		if server.HasCompleteContent(item.Hash, item.SizeBytes) {
+		if m.requiredContentComplete(server, item, routingKey) {
 			continue
 		}
 
@@ -445,7 +498,7 @@ func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHos
 	}()
 
 	// Re-check after acquiring the lock; another process may have just completed it.
-	if server.HasCompleteContent(item.Hash, item.SizeBytes) {
+	if m.requiredContentComplete(server, item, routingKey) {
 		return
 	}
 
@@ -559,6 +612,10 @@ func (m *WorkerCacheManager) reconcileLogFields(event *zerolog.Event, localHostI
 // prefers a reachable replica and otherwise fetches from the item's origin in
 // the same way the read path does. It never persists credentials in Redis or S2.
 func (m *WorkerCacheManager) materialize(ctx context.Context, server *cache.Server, stub cache.RecentStub, item types.CacheRequiredContentItem, routingKey string) string {
+	if item.Kind == types.CacheContentKindClipV1Archive {
+		return m.materializeClipV1Archive(ctx, server, item, routingKey)
+	}
+
 	if ok, err := m.client.MaterializeFromReplica(ctx, server, item.Hash, routingKey, item.SizeBytes); err != nil {
 		log.Debug().Err(err).Str("hash", item.Hash).Msg("cache reconciliation replica copy failed")
 	} else if ok {
@@ -582,6 +639,59 @@ func (m *WorkerCacheManager) materialize(ctx context.Context, server *cache.Serv
 		// origin source; it is materialized from a replica when available.
 		return types.CacheAuditStatusMiss
 	}
+}
+
+func (m *WorkerCacheManager) requiredContentComplete(server *cache.Server, item types.CacheRequiredContentItem, routingKey string) bool {
+	if item.Kind != types.CacheContentKindClipV1Archive {
+		return server.HasCompleteContent(item.Hash, item.SizeBytes)
+	}
+
+	metadata, err := m.client.CacheFSMetadata(m.ctx, routingKey)
+	if err != nil || metadata == nil || metadata.Hash == "" {
+		return false
+	}
+	return server.HasCompleteContent(metadata.Hash, int64(metadata.Size))
+}
+
+func (m *WorkerCacheManager) materializeClipV1Archive(ctx context.Context, server *cache.Server, item types.CacheRequiredContentItem, routingKey string) string {
+	if metadata, err := m.client.CacheFSMetadata(ctx, routingKey); err == nil && metadata != nil && metadata.Hash != "" {
+		if server.HasCompleteContent(metadata.Hash, int64(metadata.Size)) {
+			return types.CacheAuditStatusMaterialized
+		}
+		if ok, err := m.client.MaterializeFromReplica(ctx, server, metadata.Hash, routingKey, int64(metadata.Size)); err != nil {
+			log.Debug().Err(err).Str("hash", metadata.Hash).Str("routing_key", routingKey).Msg("cache reconciliation v1 archive replica copy failed")
+		} else if ok {
+			return types.CacheAuditStatusMaterialized
+		}
+	}
+
+	if !m.config.Cache.Reconciliation.OriginFallbackEnabled || item.Source == "" {
+		return types.CacheAuditStatusMiss
+	}
+
+	req := &pb.CacheStoreContentFromSourceRequest{Source: &pb.CacheSource{
+		Path:      item.Source,
+		CachePath: routingKey,
+	}}
+	switch m.config.ImageService.RegistryStore {
+	case reg.S3ImageRegistryStore:
+		sourceRegistry := m.config.ImageService.Registries.S3
+		req.Source.BucketName = sourceRegistry.BucketName
+		req.Source.Region = sourceRegistry.Region
+		req.Source.EndpointUrl = sourceRegistry.Endpoint
+		req.Source.AccessKey = sourceRegistry.AccessKey
+		req.Source.SecretKey = sourceRegistry.SecretKey
+		req.Source.ForcePathStyle = sourceRegistry.ForcePathStyle
+	default:
+		req.Source.Path = filepath.Join("/images", item.Source)
+	}
+
+	resp, err := server.StoreContentFromSource(ctx, req)
+	if err == nil && resp != nil && resp.Ok {
+		return types.CacheAuditStatusMaterialized
+	}
+	log.Debug().Err(err).Str("source", item.Source).Str("routing_key", routingKey).Msg("cache reconciliation v1 archive fetch failed")
+	return types.CacheAuditStatusOriginFailure
 }
 
 // materializeVolumeObject fetches a workspace object from object storage using
@@ -739,6 +849,7 @@ func (m *WorkerCacheManager) auditCacheEvent(localHostID string, stub cache.Rece
 		StubID:      stub.StubID,
 		Hash:        item.Hash,
 		RoutingKey:  routingKey,
+		Kind:        item.Kind,
 		Status:      status,
 		Source:      item.Source,
 		SizeBytes:   item.SizeBytes,

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -241,6 +241,9 @@ func TestClipV1ArchiveRequiredContentIsSingleArchiveObject(t *testing.T) {
 	require.Equal(t, "archive-hash", item.ExpectedHash)
 	require.Equal(t, "/images/image.clip", item.RoutingKey)
 	require.Equal(t, int64(4096), item.SizeBytes)
+	// Origin source is the registry object key so a host that lost the archive
+	// can re-fetch it from the same place the image-load path pulls it.
+	require.Equal(t, "image.clip", item.Source)
 	require.Equal(t, types.CacheContentKindClipV1, item.Kind)
 }
 
@@ -312,6 +315,7 @@ func TestReportRequiredContentClipV1EmitsSingleArchiveObject(t *testing.T) {
 	require.Equal(t, "archive-hash", item.ExpectedHash)
 	require.Equal(t, "/images/image.clip", item.RoutingKey)
 	require.Equal(t, int64(4096), item.SizeBytes)
+	require.Equal(t, "image.clip", item.Source)
 }
 
 func TestReportRequiredContentClipV1SkipsWhenArchiveUncached(t *testing.T) {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -2,11 +2,16 @@ package worker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/beam-cloud/beta9/pkg/cache"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
+	clip "github.com/beam-cloud/clip/pkg/clip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +39,15 @@ func newTestReporter(eventRepo repo.EventRepository) *cacheContentReporter {
 	}
 }
 
+type claimedMetadataStore struct {
+	cache.CacheMetadataStore
+	claimed bool
+}
+
+func (m *claimedMetadataStore) MarkStubReported(context.Context, string, string, time.Duration) (bool, error) {
+	return m.claimed, nil
+}
+
 func TestReporterGeneratesOncePerStub(t *testing.T) {
 	r := newTestReporter(&fakeEventRepo{})
 
@@ -41,6 +55,14 @@ func TestReporterGeneratesOncePerStub(t *testing.T) {
 	require.True(t, r.shouldGenerateRequiredContent("stub-a"))
 	require.False(t, r.shouldGenerateRequiredContent("stub-a"))
 	require.True(t, r.shouldGenerateRequiredContent("stub-b"))
+}
+
+func TestReporterRedisMarkerIsAdvisory(t *testing.T) {
+	r := newTestReporter(&fakeEventRepo{})
+	r.metadata = &claimedMetadataStore{claimed: false}
+
+	require.True(t, r.shouldGenerateRequiredContent("stub-a"))
+	require.False(t, r.shouldGenerateRequiredContent("stub-a"))
 }
 
 func TestReporterCoalescesItemsPerStubKind(t *testing.T) {
@@ -87,8 +109,8 @@ func TestReporterVolumeRespectsSizeThreshold(t *testing.T) {
 	r.volumeMinBytes = 1024
 	r.activeStubs = func(string) []string { return []string{"stub"} }
 
-	r.ReportVolumeContent("ws", "small", "/p/small", 512)  // below threshold -> dropped
-	r.ReportVolumeContent("ws", "big", "/p/big", 4096)     // above threshold -> kept
+	r.ReportVolumeContent("ws", "small", "/p/small", 512) // below threshold -> dropped
+	r.ReportVolumeContent("ws", "big", "/p/big", 4096)    // above threshold -> kept
 
 	r.flush()
 	require.Len(t, fake.pushed, 1)
@@ -106,4 +128,54 @@ func TestReporterVolumeNoActiveStubsIsNoop(t *testing.T) {
 	r.ReportVolumeContent("ws", "big", "/p/big", 4096)
 	r.flush()
 	require.Empty(t, fake.pushed)
+}
+
+func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "usr", "bin"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "usr", "bin", "tool"), []byte("tool-data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "config.json"), []byte(`{"ok":true}`), 0644))
+
+	archivePath := filepath.Join(t.TempDir(), "legacy.rclip")
+	archiver := clip.NewClipArchiver()
+	require.NoError(t, archiver.Create(clip.ClipArchiverOptions{
+		SourcePath:  src,
+		OutputFile:  archivePath,
+		ArchivePath: archivePath,
+	}))
+	meta, err := archiver.ExtractMetadata(archivePath)
+	require.NoError(t, err)
+
+	items, kind := requiredContentItems(meta)
+	require.Equal(t, types.CacheContentKindClipV1, kind)
+	require.Len(t, items, 2)
+	for _, item := range items {
+		require.NotEmpty(t, item.Hash)
+		require.Equal(t, item.Hash, item.RoutingKey)
+		require.Equal(t, item.Hash, item.ExpectedHash)
+		require.Equal(t, types.CacheContentKindClipV1, item.Kind)
+		require.NotEmpty(t, item.Source)
+	}
+}
+
+func TestValidateRestoredImageArchiveAcceptsClipV1WhenDefaultIsV2(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), 0644))
+
+	archivePath := filepath.Join(t.TempDir(), "legacy.rclip")
+	archiver := clip.NewClipArchiver()
+	require.NoError(t, archiver.Create(clip.ClipArchiverOptions{
+		SourcePath:  src,
+		OutputFile:  archivePath,
+		ArchivePath: archivePath,
+	}))
+	info, err := os.Stat(archivePath)
+	require.NoError(t, err)
+
+	client := &ImageClient{
+		config: types.AppConfig{
+			ImageService: types.ImageServiceConfig{ClipVersion: uint32(types.ClipVersion2)},
+		},
+	}
+	require.NoError(t, client.validateRestoredImageArchive(archivePath, "legacy-image", info.Size()))
 }

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -9,9 +10,12 @@ import (
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/registry"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	clip "github.com/beam-cloud/clip/pkg/clip"
+	clipCommon "github.com/beam-cloud/clip/pkg/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,12 +25,17 @@ type fakeEventRepo struct {
 	repo.EventRepository
 	mu     sync.Mutex
 	pushed []types.EventStubCacheRequiredContentSchema
+	err    error
 }
 
-func (f *fakeEventRepo) PushStubCacheRequiredContent(schema types.EventStubCacheRequiredContentSchema) {
+func (f *fakeEventRepo) PushStubCacheRequiredContent(schema types.EventStubCacheRequiredContentSchema) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
 	f.pushed = append(f.pushed, schema)
+	return nil
 }
 
 func newTestReporter(eventRepo repo.EventRepository) *cacheContentReporter {
@@ -42,10 +51,16 @@ func newTestReporter(eventRepo repo.EventRepository) *cacheContentReporter {
 type claimedMetadataStore struct {
 	cache.CacheMetadataStore
 	claimed bool
+	marked  int
 }
 
 func (m *claimedMetadataStore) MarkStubReported(context.Context, string, string, time.Duration) (bool, error) {
+	m.marked++
 	return m.claimed, nil
+}
+
+func (m *claimedMetadataStore) AddRecentStub(context.Context, string, string, string, time.Duration) error {
+	return nil
 }
 
 func TestReporterGeneratesOncePerStub(t *testing.T) {
@@ -103,6 +118,37 @@ func TestReporterSeparatesByKind(t *testing.T) {
 	require.Len(t, fake.pushed, 2)
 }
 
+func TestReporterMarksRedisAfterSuccessfulRequiredContentWrite(t *testing.T) {
+	fake := &fakeEventRepo{}
+	metadata := &claimedMetadataStore{claimed: true}
+	r := newTestReporter(fake)
+	r.metadata = metadata
+
+	r.reportItems("ws", "stub", types.CacheContentKindClipV1Archive, []types.CacheRequiredContentItem{{Hash: "archive", RoutingKey: "/images/archive.clip"}})
+	require.Zero(t, metadata.marked)
+
+	r.flush()
+	require.Len(t, fake.pushed, 1)
+	require.Equal(t, 1, metadata.marked)
+}
+
+func TestReporterRetriesRequiredContentWhenEventWriteFails(t *testing.T) {
+	fake := &fakeEventRepo{err: errors.New("s2 unavailable")}
+	metadata := &claimedMetadataStore{claimed: true}
+	r := newTestReporter(fake)
+	r.metadata = metadata
+
+	r.reportItems("ws", "stub", types.CacheContentKindClipV1Archive, []types.CacheRequiredContentItem{{Hash: "archive", RoutingKey: "/images/archive.clip"}})
+	r.flush()
+	require.Empty(t, fake.pushed)
+	require.Zero(t, metadata.marked)
+
+	fake.err = nil
+	r.flush()
+	require.Len(t, fake.pushed, 1)
+	require.Equal(t, 1, metadata.marked)
+}
+
 func TestReporterVolumeRespectsSizeThreshold(t *testing.T) {
 	fake := &fakeEventRepo{}
 	r := newTestReporter(fake)
@@ -118,6 +164,23 @@ func TestReporterVolumeRespectsSizeThreshold(t *testing.T) {
 	require.Equal(t, types.CacheContentKindVolume, event.Kind)
 	require.Len(t, event.Items, 1)
 	require.Equal(t, "big", event.Items[0].Hash)
+	require.Equal(t, "/p/big", event.Items[0].Source)
+	require.Equal(t, int64(4096), event.Items[0].SizeBytes)
+}
+
+func TestReporterVolumeDefaultThresholdKeepsOnlyLargeObjects(t *testing.T) {
+	fake := &fakeEventRepo{}
+	r := newTestReporter(fake)
+	r.volumeMinBytes = cacheDefaultVolumeReportMinBytes
+	r.activeStubs = func(string) []string { return []string{"stub"} }
+
+	r.ReportVolumeContent("ws", "small", "/p/32mb", 32<<20)
+	r.ReportVolumeContent("ws", "large", "/p/128mb", 128<<20)
+
+	r.flush()
+	require.Len(t, fake.pushed, 1)
+	require.Len(t, fake.pushed[0].Items, 1)
+	require.Equal(t, "large", fake.pushed[0].Items[0].Hash)
 }
 
 func TestReporterVolumeNoActiveStubsIsNoop(t *testing.T) {
@@ -130,13 +193,23 @@ func TestReporterVolumeNoActiveStubsIsNoop(t *testing.T) {
 	require.Empty(t, fake.pushed)
 }
 
-func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
+func TestCacheVolumeReportMinBytesDefaultAndOverride(t *testing.T) {
+	manager := &WorkerCacheManager{}
+	require.Equal(t, int64(128<<20), manager.cacheVolumeReportMinBytes())
+
+	manager.config.Cache.Reconciliation.VolumeMinBytes = 64 << 20
+	require.Equal(t, int64(64<<20), manager.cacheVolumeReportMinBytes())
+}
+
+func testClipV1Metadata(t *testing.T) *clipCommon.ClipArchiveMetadata {
+	t.Helper()
+
 	src := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "usr", "bin"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "usr", "bin", "tool"), []byte("tool-data"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "config.json"), []byte(`{"ok":true}`), 0644))
 
-	archivePath := filepath.Join(t.TempDir(), "legacy.rclip")
+	archivePath := filepath.Join(t.TempDir(), "legacy.clip")
 	archiver := clip.NewClipArchiver()
 	require.NoError(t, archiver.Create(clip.ClipArchiverOptions{
 		SourcePath:  src,
@@ -145,7 +218,11 @@ func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
 	}))
 	meta, err := archiver.ExtractMetadata(archivePath)
 	require.NoError(t, err)
+	return meta
+}
 
+func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
+	meta := testClipV1Metadata(t)
 	items, kind := requiredContentItems(meta)
 	require.Equal(t, types.CacheContentKindClipV1, kind)
 	require.Len(t, items, 2)
@@ -156,6 +233,135 @@ func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
 		require.Equal(t, types.CacheContentKindClipV1, item.Kind)
 		require.NotEmpty(t, item.Source)
 	}
+}
+
+func TestRequiredContentItemsClipV2FromOCILayers(t *testing.T) {
+	meta := testClipV2Metadata()
+
+	items, kind := requiredContentItems(meta)
+	require.Equal(t, types.CacheContentKindClipV2, kind)
+	require.Len(t, items, 2)
+
+	byHash := map[string]types.CacheRequiredContentItem{}
+	for _, item := range items {
+		byHash[item.Hash] = item
+		require.Equal(t, item.Hash, item.RoutingKey)
+		require.Equal(t, item.Hash, item.ExpectedHash)
+		require.Equal(t, types.CacheContentKindClipV2, item.Kind)
+		require.NotEmpty(t, item.Source)
+	}
+	require.Equal(t, "registry.example.com/team/image@sha256:layer-a", byHash["hash-a"].Source)
+	require.Equal(t, "registry.example.com/team/image@sha256:layer-b", byHash["hash-b"].Source)
+}
+
+func testClipV2Metadata() *clipCommon.ClipArchiveMetadata {
+	return &clipCommon.ClipArchiveMetadata{
+		StorageInfo: clipCommon.OCIStorageInfo{
+			RegistryURL: "https://registry.example.com",
+			Repository:  "team/image",
+			DecompressedHashByLayer: map[string]string{
+				"sha256:layer-a": "hash-a",
+				"sha256:layer-b": "hash-b",
+			},
+		},
+	}
+}
+
+func TestReportRequiredContentClipV1IncludesArchiveItem(t *testing.T) {
+	fake := &fakeEventRepo{}
+	client := &ImageClient{contentReporter: newTestReporter(fake)}
+	request := &types.ContainerRequest{
+		WorkspaceId: "workspace",
+		StubId:      "stub",
+		ImageId:     "image",
+	}
+
+	client.reportRequiredContent(request, testClipV1Metadata(t))
+	client.contentReporter.flush()
+
+	require.Len(t, fake.pushed, 1)
+	event := fake.pushed[0]
+	require.Equal(t, types.CacheContentKindClipV1Archive, event.Kind)
+	require.Equal(t, "workspace", event.WorkspaceID)
+	require.Equal(t, "stub", event.StubID)
+	require.Len(t, event.Items, 1)
+
+	archiveItem := event.Items[0]
+	require.Equal(t, types.CacheContentKindClipV1Archive, archiveItem.Kind)
+	require.Equal(t, "clip-v1-archive:image", archiveItem.Hash)
+	require.Equal(t, "/images/image.clip", archiveItem.RoutingKey)
+	require.Equal(t, "image.clip", archiveItem.Source)
+}
+
+func TestReportRequiredContentClipV1DoesNotEmitIndexEntries(t *testing.T) {
+	fake := &fakeEventRepo{}
+	client := &ImageClient{contentReporter: newTestReporter(fake)}
+	request := &types.ContainerRequest{
+		WorkspaceId: "workspace",
+		StubId:      "stub",
+		ImageId:     "image",
+	}
+
+	client.reportRequiredContent(request, testClipV1Metadata(t))
+	client.contentReporter.flush()
+
+	require.Len(t, fake.pushed, 1)
+	require.Equal(t, types.CacheContentKindClipV1Archive, fake.pushed[0].Kind)
+	require.Len(t, fake.pushed[0].Items, 1)
+}
+
+func TestReportRequiredContentUsesNestedRequestIDs(t *testing.T) {
+	fake := &fakeEventRepo{}
+	client := &ImageClient{contentReporter: newTestReporter(fake)}
+	request := &types.ContainerRequest{
+		ImageId: "image",
+		Workspace: types.Workspace{
+			ExternalId: "workspace-nested",
+		},
+		Stub: types.StubWithRelated{
+			Stub: types.Stub{ExternalId: "stub-nested"},
+		},
+	}
+
+	client.reportRequiredContent(request, testClipV2Metadata())
+	client.contentReporter.flush()
+
+	require.Len(t, fake.pushed, 1)
+	require.Equal(t, "workspace-nested", fake.pushed[0].WorkspaceID)
+	require.Equal(t, "stub-nested", fake.pushed[0].StubID)
+	require.Equal(t, types.CacheContentKindClipV2, fake.pushed[0].Kind)
+	require.Len(t, fake.pushed[0].Items, 2)
+}
+
+func TestActiveStubsForWorkspaceUsesNestedRequestIDs(t *testing.T) {
+	manager := &WorkerCacheManager{containerInstances: common.NewSafeMap[*ContainerInstance]()}
+	manager.containerInstances.Set("container", &ContainerInstance{
+		Request: &types.ContainerRequest{
+			Workspace: types.Workspace{ExternalId: "workspace-nested"},
+			Stub: types.StubWithRelated{
+				Stub: types.Stub{ExternalId: "stub-nested"},
+			},
+		},
+	})
+
+	require.Equal(t, []string{"stub-nested"}, manager.activeStubsForWorkspace("workspace-nested"))
+	require.Empty(t, manager.activeStubsForWorkspace("other-workspace"))
+}
+
+func TestContentCachePathUsesFullClipArchiveForS3V1(t *testing.T) {
+	client := &ImageClient{
+		imageCachePath: "/images/cache",
+		config: types.AppConfig{
+			ImageService: types.ImageServiceConfig{RegistryStore: registry.S3ImageRegistryStore},
+		},
+	}
+	request := &types.ContainerRequest{ImageId: "image", ContainerId: "endpoint-container"}
+
+	require.Equal(t, "/images/cache/image.clip", client.contentCachePath(request, lazyImageArchive{}))
+
+	client.config.ImageService.RegistryStore = registry.LocalImageRegistryStore
+	client.config.ImageService.LocalCacheEnabled = true
+	require.Equal(t, "/images/cache/image.cache", client.contentCachePath(request, lazyImageArchive{}))
 }
 
 func TestValidateRestoredImageArchiveAcceptsClipV1WhenDefaultIsV2(t *testing.T) {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -124,7 +124,7 @@ func TestReporterMarksRedisAfterSuccessfulRequiredContentWrite(t *testing.T) {
 	r := newTestReporter(fake)
 	r.metadata = metadata
 
-	r.reportItems("ws", "stub", types.CacheContentKindClipV1Archive, []types.CacheRequiredContentItem{{Hash: "archive", RoutingKey: "/images/archive.clip"}})
+	r.reportItems("ws", "stub", types.CacheContentKindClipV1, []types.CacheRequiredContentItem{{Hash: "h1"}})
 	require.Zero(t, metadata.marked)
 
 	r.flush()
@@ -138,7 +138,7 @@ func TestReporterRetriesRequiredContentWhenEventWriteFails(t *testing.T) {
 	r := newTestReporter(fake)
 	r.metadata = metadata
 
-	r.reportItems("ws", "stub", types.CacheContentKindClipV1Archive, []types.CacheRequiredContentItem{{Hash: "archive", RoutingKey: "/images/archive.clip"}})
+	r.reportItems("ws", "stub", types.CacheContentKindClipV1, []types.CacheRequiredContentItem{{Hash: "h1"}})
 	r.flush()
 	require.Empty(t, fake.pushed)
 	require.Zero(t, metadata.marked)
@@ -221,25 +221,43 @@ func testClipV1Metadata(t *testing.T) *clipCommon.ClipArchiveMetadata {
 	return meta
 }
 
-func TestRequiredContentItemsClipV1FromArchive(t *testing.T) {
-	meta := testClipV1Metadata(t)
-	items, kind := requiredContentItems(meta)
-	require.Equal(t, types.CacheContentKindClipV1, kind)
-	require.Len(t, items, 2)
-	for _, item := range items {
-		require.NotEmpty(t, item.Hash)
-		require.Equal(t, item.Hash, item.RoutingKey)
-		require.Equal(t, item.Hash, item.ExpectedHash)
-		require.Equal(t, types.CacheContentKindClipV1, item.Kind)
-		require.NotEmpty(t, item.Source)
+func newTestV1ImageClient(reporter *cacheContentReporter, metadata *cache.FSMetadata) *ImageClient {
+	return &ImageClient{
+		contentReporter: reporter,
+		registry:        &registry.ImageRegistry{ImageFileExtension: registry.LocalImageFileExtension},
+		archiveContentMetadata: func(_ context.Context, _ string) (*cache.FSMetadata, error) {
+			return metadata, nil
+		},
 	}
 }
 
-func TestRequiredContentItemsClipV2FromOCILayers(t *testing.T) {
-	meta := testClipV2Metadata()
+func TestClipV1ArchiveRequiredContentIsSingleArchiveObject(t *testing.T) {
+	client := newTestV1ImageClient(nil, &cache.FSMetadata{Hash: "archive-hash", Size: 4096})
+	request := &types.ContainerRequest{WorkspaceId: "workspace", StubId: "stub", ImageId: "image"}
 
-	items, kind := requiredContentItems(meta)
-	require.Equal(t, types.CacheContentKindClipV2, kind)
+	item, ok := client.clipV1ArchiveRequiredContent(context.Background(), request)
+	require.True(t, ok)
+	require.Equal(t, "archive-hash", item.Hash)
+	require.Equal(t, "archive-hash", item.ExpectedHash)
+	require.Equal(t, "/images/image.clip", item.RoutingKey)
+	require.Equal(t, int64(4096), item.SizeBytes)
+	require.Equal(t, types.CacheContentKindClipV1, item.Kind)
+}
+
+func TestClipV1ArchiveRequiredContentSkipsWhenUncached(t *testing.T) {
+	client := newTestV1ImageClient(nil, nil)
+	request := &types.ContainerRequest{WorkspaceId: "workspace", StubId: "stub", ImageId: "image"}
+
+	_, ok := client.clipV1ArchiveRequiredContent(context.Background(), request)
+	require.False(t, ok)
+}
+
+func TestOCIRequiredContentItemsFromLayers(t *testing.T) {
+	meta := testClipV2Metadata()
+	ociInfo, ok := ociStorageInfo(meta)
+	require.True(t, ok)
+
+	items := ociRequiredContentItems(ociInfo)
 	require.Len(t, items, 2)
 
 	byHash := map[string]types.CacheRequiredContentItem{}
@@ -267,47 +285,48 @@ func testClipV2Metadata() *clipCommon.ClipArchiveMetadata {
 	}
 }
 
-func TestReportRequiredContentClipV1IncludesArchiveItem(t *testing.T) {
+func TestReportRequiredContentClipV1EmitsSingleArchiveObject(t *testing.T) {
 	fake := &fakeEventRepo{}
-	client := &ImageClient{contentReporter: newTestReporter(fake)}
+	client := newTestV1ImageClient(newTestReporter(fake), &cache.FSMetadata{Hash: "archive-hash", Size: 4096})
 	request := &types.ContainerRequest{
 		WorkspaceId: "workspace",
 		StubId:      "stub",
 		ImageId:     "image",
 	}
 
-	client.reportRequiredContent(request, testClipV1Metadata(t))
+	client.reportRequiredContent(context.Background(), request, testClipV1Metadata(t))
 	client.contentReporter.flush()
 
 	require.Len(t, fake.pushed, 1)
 	event := fake.pushed[0]
-	require.Equal(t, types.CacheContentKindClipV1Archive, event.Kind)
+	require.Equal(t, types.CacheContentKindClipV1, event.Kind)
 	require.Equal(t, "workspace", event.WorkspaceID)
 	require.Equal(t, "stub", event.StubID)
-	require.Len(t, event.Items, 1)
 
-	archiveItem := event.Items[0]
-	require.Equal(t, types.CacheContentKindClipV1Archive, archiveItem.Kind)
-	require.Equal(t, "clip-v1-archive:image", archiveItem.Hash)
-	require.Equal(t, "/images/image.clip", archiveItem.RoutingKey)
-	require.Equal(t, "image.clip", archiveItem.Source)
+	// The whole v1 archive is reconciled as a single content object routed by
+	// its cachefs path, not as thousands of per-file index entries.
+	require.Len(t, event.Items, 1)
+	item := event.Items[0]
+	require.Equal(t, types.CacheContentKindClipV1, item.Kind)
+	require.Equal(t, "archive-hash", item.Hash)
+	require.Equal(t, "archive-hash", item.ExpectedHash)
+	require.Equal(t, "/images/image.clip", item.RoutingKey)
+	require.Equal(t, int64(4096), item.SizeBytes)
 }
 
-func TestReportRequiredContentClipV1DoesNotEmitIndexEntries(t *testing.T) {
+func TestReportRequiredContentClipV1SkipsWhenArchiveUncached(t *testing.T) {
 	fake := &fakeEventRepo{}
-	client := &ImageClient{contentReporter: newTestReporter(fake)}
+	client := newTestV1ImageClient(newTestReporter(fake), nil)
 	request := &types.ContainerRequest{
 		WorkspaceId: "workspace",
 		StubId:      "stub",
 		ImageId:     "image",
 	}
 
-	client.reportRequiredContent(request, testClipV1Metadata(t))
+	client.reportRequiredContent(context.Background(), request, testClipV1Metadata(t))
 	client.contentReporter.flush()
 
-	require.Len(t, fake.pushed, 1)
-	require.Equal(t, types.CacheContentKindClipV1Archive, fake.pushed[0].Kind)
-	require.Len(t, fake.pushed[0].Items, 1)
+	require.Empty(t, fake.pushed)
 }
 
 func TestReportRequiredContentUsesNestedRequestIDs(t *testing.T) {
@@ -323,7 +342,7 @@ func TestReportRequiredContentUsesNestedRequestIDs(t *testing.T) {
 		},
 	}
 
-	client.reportRequiredContent(request, testClipV2Metadata())
+	client.reportRequiredContent(context.Background(), request, testClipV2Metadata())
 	client.contentReporter.flush()
 
 	require.Len(t, fake.pushed, 1)

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -421,6 +421,14 @@ func (c *ImageClient) reportRequiredContent(request *types.ContainerRequest, met
 		return
 	}
 	c.contentReporter.reportItems(request.WorkspaceId, request.StubId, kind, items)
+	c.contentReporter.flush()
+	log.Debug().
+		Str("workspace_id", request.WorkspaceId).
+		Str("stub_id", request.StubId).
+		Str("image_id", request.ImageId).
+		Str("kind", string(kind)).
+		Int("item_count", len(items)).
+		Msg("reported image required content")
 }
 
 // requiredContentItems enumerates the content a stub's image requires from its
@@ -1187,24 +1195,20 @@ func (c *ImageClient) writeImageArchiveFromContentCache(ctx context.Context, arc
 }
 
 func (c *ImageClient) validateRestoredImageArchive(archivePath, imageId string, size int64) error {
-	if c.config.ImageService.ClipVersion != uint32(types.ClipVersion2) {
+	archiver := clip.NewClipArchiver()
+	meta, err := archiver.ExtractMetadata(archivePath)
+	if err != nil {
+		return fmt.Errorf("restored image archive metadata invalid: image_id=%s: %w", imageId, err)
+	}
+
+	ociInfo, ok := ociStorageInfo(meta)
+	if !ok || strings.ToLower(ociInfo.Type()) != string(clipCommon.StorageModeOCI) {
 		return nil
 	}
 
 	const maxExpectedV2ArchiveSize = int64(128 * 1024 * 1024)
 	if size > maxExpectedV2ArchiveSize {
 		return fmt.Errorf("restored v2 image archive is unexpectedly large: image_id=%s size=%d", imageId, size)
-	}
-
-	archiver := clip.NewClipArchiver()
-	meta, err := archiver.ExtractMetadata(archivePath)
-	if err != nil {
-		return fmt.Errorf("restored v2 image archive metadata invalid: image_id=%s: %w", imageId, err)
-	}
-
-	ociInfo, ok := ociStorageInfo(meta)
-	if !ok || strings.ToLower(ociInfo.Type()) != string(clipCommon.StorageModeOCI) {
-		return fmt.Errorf("restored v2 image archive is not an OCI metadata archive: image_id=%s", imageId)
 	}
 	if ociInfo.ImageMetadata == nil {
 		return fmt.Errorf("restored v2 image archive is missing embedded image metadata: image_id=%s", imageId)

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -269,7 +269,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	// keeps this stub's content warm for the configured TTL after its last
 	// container. This is cheap and independent of one-time content generation.
 	if c.contentReporter != nil && request != nil {
-		c.contentReporter.touchRecentStub(request.WorkspaceId, request.StubId)
+		c.contentReporter.touchRecentStub(cacheRequestWorkspaceID(request), cacheRequestStubID(request))
 	}
 
 	if elapsed, ok := c.mountedImageHit(startTime, request, "clip_mounted_fuse_hit"); ok {
@@ -393,6 +393,8 @@ func (c *ImageClient) prepareLazyImageArchive(ctx context.Context, request *type
 	}
 	if archive.usesOCIStorage() {
 		log.Info().Str("image_id", request.ImageId).Str("storage_type", archive.storageMode).Msg("detected CLIP OCI image")
+	} else {
+		c.restoreV1ArchiveDataCache(ctx, request)
 	}
 
 	c.reportRequiredContent(request, meta)
@@ -409,7 +411,18 @@ func (c *ImageClient) reportRequiredContent(request *types.ContainerRequest, met
 	}
 
 	items, kind := requiredContentItems(meta)
-	if len(items) == 0 {
+	archiveItem, hasArchiveItem := c.clipV1ArchiveRequiredContentItem(request, meta)
+
+	reports := make([]requiredContentReport, 0, 2)
+	if hasArchiveItem {
+		reports = append(reports, requiredContentReport{
+			kind:  types.CacheContentKindClipV1Archive,
+			items: []types.CacheRequiredContentItem{archiveItem},
+		})
+	} else if len(items) > 0 {
+		reports = append(reports, requiredContentReport{kind: kind, items: items})
+	}
+	if len(reports) == 0 {
 		// Nothing to report; do not claim the one-time generation so a later
 		// load that does yield items can still publish them.
 		return
@@ -417,18 +430,42 @@ func (c *ImageClient) reportRequiredContent(request *types.ContainerRequest, met
 
 	// Required content is immutable per stub, so publish it only the first time
 	// the stub loads, not on every container start.
-	if !c.contentReporter.shouldGenerateRequiredContent(request.StubId) {
+	stubID := cacheRequestStubID(request)
+	if !c.contentReporter.shouldGenerateRequiredContent(stubID) {
 		return
 	}
-	c.contentReporter.reportItems(request.WorkspaceId, request.StubId, kind, items)
-	c.contentReporter.flush()
+
+	workspaceID := cacheRequestWorkspaceID(request)
+	c.contentReporter.reportBatches(workspaceID, stubID, reports)
+
 	log.Debug().
-		Str("workspace_id", request.WorkspaceId).
-		Str("stub_id", request.StubId).
+		Str("workspace_id", workspaceID).
+		Str("stub_id", stubID).
 		Str("image_id", request.ImageId).
 		Str("kind", string(kind)).
 		Int("item_count", len(items)).
+		Bool("archive_item", hasArchiveItem).
 		Msg("reported image required content")
+}
+
+func cacheRequestWorkspaceID(request *types.ContainerRequest) string {
+	if request == nil {
+		return ""
+	}
+	if request.WorkspaceId != "" {
+		return request.WorkspaceId
+	}
+	return request.Workspace.ExternalId
+}
+
+func cacheRequestStubID(request *types.ContainerRequest) string {
+	if request == nil {
+		return ""
+	}
+	if request.StubId != "" {
+		return request.StubId
+	}
+	return request.Stub.ExternalId
 }
 
 // requiredContentItems enumerates the content a stub's image requires from its
@@ -507,6 +544,31 @@ func (c *ImageClient) localArchivePath(imageId string) string {
 	return fmt.Sprintf("%s/%s.%s", c.imageCachePath, imageId, c.registry.ImageFileExtension)
 }
 
+func (c *ImageClient) clipV1ArchiveCachePath(imageId string) string {
+	return fmt.Sprintf("/images/%s.%s", imageId, reg.LocalImageFileExtension)
+}
+
+func (c *ImageClient) clipV1ArchiveDataCachePath(imageId string) string {
+	return fmt.Sprintf("%s/%s.%s", c.imageCachePath, imageId, reg.LocalImageFileExtension)
+}
+
+func (c *ImageClient) clipV1ArchiveRequiredContentItem(request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) (types.CacheRequiredContentItem, bool) {
+	if request == nil || request.ImageId == "" || meta == nil || meta.Index == nil {
+		return types.CacheRequiredContentItem{}, false
+	}
+	if ociInfo, ok := ociStorageInfo(meta); ok && len(ociInfo.DecompressedHashByLayer) > 0 {
+		return types.CacheRequiredContentItem{}, false
+	}
+
+	cachePath := c.clipV1ArchiveCachePath(request.ImageId)
+	return types.CacheRequiredContentItem{
+		Hash:       "clip-v1-archive:" + request.ImageId,
+		RoutingKey: cachePath,
+		Source:     fmt.Sprintf("%s.%s", request.ImageId, reg.LocalImageFileExtension),
+		Kind:       types.CacheContentKindClipV1Archive,
+	}, true
+}
+
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
@@ -573,11 +635,37 @@ func (c *ImageClient) contentCachePath(request *types.ContainerRequest, archive 
 		return c.imageCachePath
 	}
 
+	if c.config.ImageService.RegistryStore == registry.S3ImageRegistryStore {
+		return c.clipV1ArchiveDataCachePath(request.ImageId)
+	}
+
 	if c.config.ImageService.LocalCacheEnabled || strings.HasPrefix(request.ContainerId, types.BuildContainerPrefix) {
 		return fmt.Sprintf("%s/%s.cache", c.imageCachePath, request.ImageId)
 	}
 
 	return ""
+}
+
+func (c *ImageClient) restoreV1ArchiveDataCache(ctx context.Context, request *types.ContainerRequest) {
+	if c.cacheClient == nil || request == nil || c.config.ImageService.RegistryStore != registry.S3ImageRegistryStore {
+		return
+	}
+
+	cachePath := c.clipV1ArchiveCachePath(request.ImageId)
+	metadata, err := c.cacheClient.CacheFSMetadata(ctx, cachePath)
+	if err != nil || metadata == nil || metadata.Hash == "" || metadata.Size == 0 {
+		return
+	}
+
+	exists, err := c.cacheClient.IsCachedReachableContext(ctx, metadata.Hash, cachePath)
+	if err != nil || !exists {
+		return
+	}
+
+	targetPath := c.clipV1ArchiveDataCachePath(request.ImageId)
+	if err := c.writeImageArchiveFromContentCache(ctx, targetPath, request.ImageId, metadata.Hash, int64(metadata.Size), cachePath); err != nil {
+		log.Debug().Err(err).Str("image_id", request.ImageId).Str("cache_path", cachePath).Msg("failed to restore v1 archive data cache")
+	}
 }
 
 func (c *ImageClient) acquireRemoteImageMountLock(imageId string) (func(), error) {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -524,8 +524,20 @@ func (c *ImageClient) clipV1ArchiveRequiredContent(ctx context.Context, request 
 		RoutingKey:   cachePath,
 		ExpectedHash: metadata.Hash,
 		SizeBytes:    int64(metadata.Size),
-		Kind:         types.CacheContentKindClipV1,
+		// Origin source descriptor: the archive's key in the image registry,
+		// so a cache host that owns the archive but lost it can re-fetch it from
+		// the same place the image-load path pulls it. Non-secret (object key
+		// only); credentials are resolved at fetch time.
+		Source: c.imageArchiveSourceKey(request.ImageId),
+		Kind:   types.CacheContentKindClipV1,
 	}, true
+}
+
+// imageArchiveSourceKey returns the image registry object key for a stub's
+// archive (e.g. "{imageId}.rclip"), matching the key used by the embedded-cache
+// pull that originally stored it.
+func (c *ImageClient) imageArchiveSourceKey(imageId string) string {
+	return fmt.Sprintf("%s.%s", imageId, c.registry.ImageFileExtension)
 }
 
 // ociLayerReference builds a fully-qualified, non-secret OCI layer digest

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -1804,11 +1804,15 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 	// Local OCI-layout reference name. Digest-pinned source images
 	// (registry/repo@sha256:...) have no tag, which would yield an empty,
 	// invalid reference for both the skopeo destination and the umoci unpack
-	// ("refusing to resolve invalid reference"). The source is still pulled by
-	// its full (digest) reference; this name only labels it in the local layout.
+	// ("refusing to resolve invalid reference"). Derive a unique, tag-safe ref
+	// from the digest rather than a shared "latest": the OCI layout is shared
+	// per-repo, so distinct digests of the same repo must not collide on one ref
+	// (which would unpack the wrong image when builds overlap). The image is
+	// still pulled by its full (digest) reference; this name only labels it
+	// locally.
 	ociRef := baseImage.Tag
 	if ociRef == "" {
-		ociRef = "latest"
+		ociRef = localOCILayoutRef(baseImage.Digest)
 	}
 	dest := fmt.Sprintf("oci:%s:%s", baseImage.Repo, ociRef)
 
@@ -1860,6 +1864,24 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 	}
 
 	return nil
+}
+
+// localOCILayoutRef converts an image digest (e.g. "sha256:abc...") into a
+// tag-safe, content-unique reference for the local OCI layout. Because the
+// layout is shared per repository, using the digest keeps distinct images
+// distinct (and identical content idempotent), avoiding a shared "latest" ref
+// that could unpack the wrong image when same-repo builds overlap. Falls back to
+// "latest" only when no digest is available.
+func localOCILayoutRef(digest string) string {
+	if digest == "" {
+		return "latest"
+	}
+	// OCI tags must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}.
+	ref := strings.NewReplacer(":", "-", "/", "-", "+", "-", "@", "-").Replace(digest)
+	if len(ref) > 128 {
+		ref = ref[:128]
+	}
+	return ref
 }
 
 func (c *ImageClient) unpack(ctx context.Context, baseImageName string, baseImageTag string, bundlePath *PathInfo) error {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -141,6 +141,10 @@ type ImageClient struct {
 	logger             *ContainerLogger
 	eventRepo          repo.EventRepository
 	contentReporter    *cacheContentReporter
+	// archiveContentMetadata resolves the cached image archive object (hash/size)
+	// for a cachefs path. It is a field so tests can inject a fake; in production
+	// it delegates to the cache client.
+	archiveContentMetadata func(ctx context.Context, cachePath string) (*cache.FSMetadata, error)
 	// Cache source image references for v2 images (imageId -> sourceImageRef)
 	v2ImageRefs       *common.SafeMap[string]
 	v2ArchiveMetadata *common.SafeMap[*clipCommon.ClipArchiveMetadata]
@@ -189,6 +193,9 @@ func NewImageClient(config types.AppConfig, workerId string, workerRepoClient pb
 		logger: &ContainerLogger{
 			logLinesPerHour: config.Worker.ContainerLogLinesPerHour,
 		},
+	}
+	if c.cacheClient != nil {
+		c.archiveContentMetadata = c.cacheClient.CacheFSMetadata
 	}
 	go c.runClipReadEventReporter()
 
@@ -397,7 +404,7 @@ func (c *ImageClient) prepareLazyImageArchive(ctx context.Context, request *type
 		c.restoreV1ArchiveDataCache(ctx, request)
 	}
 
-	c.reportRequiredContent(request, meta)
+	c.reportRequiredContent(ctx, request, meta)
 
 	return archive, nil
 }
@@ -405,26 +412,15 @@ func (c *ImageClient) prepareLazyImageArchive(ctx context.Context, request *type
 // reportRequiredContent enumerates the content a stub's image requires and feeds
 // it to the cache reconciliation reporter. It runs at image-load time (off the
 // read hot path) and is a no-op when reconciliation is disabled.
-func (c *ImageClient) reportRequiredContent(request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) {
+func (c *ImageClient) reportRequiredContent(ctx context.Context, request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) {
 	if c.contentReporter == nil || request == nil || meta == nil {
 		return
 	}
 
-	items, kind := requiredContentItems(meta)
-	archiveItem, hasArchiveItem := c.clipV1ArchiveRequiredContentItem(request, meta)
-
-	reports := make([]requiredContentReport, 0, 2)
-	if hasArchiveItem {
-		reports = append(reports, requiredContentReport{
-			kind:  types.CacheContentKindClipV1Archive,
-			items: []types.CacheRequiredContentItem{archiveItem},
-		})
-	} else if len(items) > 0 {
-		reports = append(reports, requiredContentReport{kind: kind, items: items})
-	}
-	if len(reports) == 0 {
+	report, ok := c.imageRequiredContent(ctx, request, meta)
+	if !ok {
 		// Nothing to report; do not claim the one-time generation so a later
-		// load that does yield items can still publish them.
+		// load that does yield content can still publish it.
 		return
 	}
 
@@ -436,15 +432,14 @@ func (c *ImageClient) reportRequiredContent(request *types.ContainerRequest, met
 	}
 
 	workspaceID := cacheRequestWorkspaceID(request)
-	c.contentReporter.reportBatches(workspaceID, stubID, reports)
+	c.contentReporter.reportBatches(workspaceID, stubID, []requiredContentReport{report})
 
 	log.Debug().
 		Str("workspace_id", workspaceID).
 		Str("stub_id", stubID).
 		Str("image_id", request.ImageId).
-		Str("kind", string(kind)).
-		Int("item_count", len(items)).
-		Bool("archive_item", hasArchiveItem).
+		Str("kind", string(report.kind)).
+		Int("item_count", len(report.items)).
 		Msg("reported image required content")
 }
 
@@ -468,59 +463,69 @@ func cacheRequestStubID(request *types.ContainerRequest) string {
 	return request.Stub.ExternalId
 }
 
-// requiredContentItems enumerates the content a stub's image requires from its
-// CLIP metadata, returning the items and their content kind.
-func requiredContentItems(meta *clipCommon.ClipArchiveMetadata) ([]types.CacheRequiredContentItem, types.CacheContentKind) {
-	// CLIP v2 (OCI): decompressed layer hashes are available directly from
-	// image metadata, keyed by layer digest. The non-secret source descriptor
-	// is the full OCI layer reference so the HRW owner can fetch and decompress
-	// the layer from the source registry exactly as the read path does.
+// imageRequiredContent returns the required-content batch for a stub's image:
+// per-layer decompressed hashes for CLIP v2, or the whole archive as a single
+// content object for CLIP v1 (reconciling the archive as one file avoids
+// re-materializing the thousands of per-file entries in the v1 index).
+func (c *ImageClient) imageRequiredContent(ctx context.Context, request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) (requiredContentReport, bool) {
 	if ociInfo, ok := ociStorageInfo(meta); ok && len(ociInfo.DecompressedHashByLayer) > 0 {
-		items := make([]types.CacheRequiredContentItem, 0, len(ociInfo.DecompressedHashByLayer))
-		for layerDigest, hash := range ociInfo.DecompressedHashByLayer {
-			if hash == "" {
-				continue
-			}
-			items = append(items, types.CacheRequiredContentItem{
-				Hash:         hash,
-				RoutingKey:   hash,
-				ExpectedHash: hash,
-				Source:       ociLayerReference(ociInfo, layerDigest),
-				Kind:         types.CacheContentKindClipV2,
-			})
+		items := ociRequiredContentItems(ociInfo)
+		if len(items) == 0 {
+			return requiredContentReport{}, false
 		}
-		return items, types.CacheContentKindClipV2
+		return requiredContentReport{kind: types.CacheContentKindClipV2, items: items}, true
 	}
 
-	// CLIP v1: deduplicated content hashes from the archive index.
-	if meta.Index == nil {
-		return nil, types.CacheContentKindClipV1
+	item, ok := c.clipV1ArchiveRequiredContent(ctx, request)
+	if !ok {
+		return requiredContentReport{}, false
 	}
-	seen := map[string]struct{}{}
-	items := make([]types.CacheRequiredContentItem, 0)
-	meta.Index.Ascend(nil, func(a interface{}) bool {
-		node, ok := a.(*clipCommon.ClipNode)
-		if !ok || node == nil || node.ContentHash == "" {
-			return true
+	return requiredContentReport{kind: types.CacheContentKindClipV1, items: []types.CacheRequiredContentItem{item}}, true
+}
+
+// ociRequiredContentItems enumerates CLIP v2 decompressed layer hashes. The
+// non-secret source descriptor is the full OCI layer reference so the HRW owner
+// can fetch and decompress the layer from the source registry like the read path.
+func ociRequiredContentItems(ociInfo *clipCommon.OCIStorageInfo) []types.CacheRequiredContentItem {
+	items := make([]types.CacheRequiredContentItem, 0, len(ociInfo.DecompressedHashByLayer))
+	for layerDigest, hash := range ociInfo.DecompressedHashByLayer {
+		if hash == "" {
+			continue
 		}
-		if node.NodeType != clipCommon.FileNode {
-			return true
-		}
-		if _, exists := seen[node.ContentHash]; exists {
-			return true
-		}
-		seen[node.ContentHash] = struct{}{}
 		items = append(items, types.CacheRequiredContentItem{
-			Hash:         node.ContentHash,
-			RoutingKey:   node.ContentHash,
-			ExpectedHash: node.ContentHash,
-			SizeBytes:    int64(node.Attr.Size),
-			Source:       node.Path,
-			Kind:         types.CacheContentKindClipV1,
+			Hash:         hash,
+			RoutingKey:   hash,
+			ExpectedHash: hash,
+			Source:       ociLayerReference(ociInfo, layerDigest),
+			Kind:         types.CacheContentKindClipV2,
 		})
-		return true
-	})
-	return items, types.CacheContentKindClipV1
+	}
+	return items
+}
+
+// clipV1ArchiveRequiredContent describes the cached CLIP v1 archive as a single
+// content object, routed the same way the read/restore path routes it (by the
+// archive cachefs path). The archive is already populated in the content cache
+// by the embedded-cache pull that runs before this, so its hash/size are
+// available without an extra fetch.
+func (c *ImageClient) clipV1ArchiveRequiredContent(ctx context.Context, request *types.ContainerRequest) (types.CacheRequiredContentItem, bool) {
+	if c.archiveContentMetadata == nil || request == nil {
+		return types.CacheRequiredContentItem{}, false
+	}
+
+	cachePath := c.imageArchiveCachePath(request.ImageId)
+	metadata, err := c.archiveContentMetadata(ctx, cachePath)
+	if err != nil || metadata == nil || metadata.Hash == "" || metadata.Size == 0 {
+		return types.CacheRequiredContentItem{}, false
+	}
+
+	return types.CacheRequiredContentItem{
+		Hash:         metadata.Hash,
+		RoutingKey:   cachePath,
+		ExpectedHash: metadata.Hash,
+		SizeBytes:    int64(metadata.Size),
+		Kind:         types.CacheContentKindClipV1,
+	}, true
 }
 
 // ociLayerReference builds a fully-qualified, non-secret OCI layer digest
@@ -550,23 +555,6 @@ func (c *ImageClient) clipV1ArchiveCachePath(imageId string) string {
 
 func (c *ImageClient) clipV1ArchiveDataCachePath(imageId string) string {
 	return fmt.Sprintf("%s/%s.%s", c.imageCachePath, imageId, reg.LocalImageFileExtension)
-}
-
-func (c *ImageClient) clipV1ArchiveRequiredContentItem(request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) (types.CacheRequiredContentItem, bool) {
-	if request == nil || request.ImageId == "" || meta == nil || meta.Index == nil {
-		return types.CacheRequiredContentItem{}, false
-	}
-	if ociInfo, ok := ociStorageInfo(meta); ok && len(ociInfo.DecompressedHashByLayer) > 0 {
-		return types.CacheRequiredContentItem{}, false
-	}
-
-	cachePath := c.clipV1ArchiveCachePath(request.ImageId)
-	return types.CacheRequiredContentItem{
-		Hash:       "clip-v1-archive:" + request.ImageId,
-		RoutingKey: cachePath,
-		Source:     fmt.Sprintf("%s.%s", request.ImageId, reg.LocalImageFileExtension),
-		Kind:       types.CacheContentKindClipV1Archive,
-	}, true
 }
 
 func fileExists(path string) bool {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -1801,7 +1801,16 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 	copyDir := filepath.Join(imageTmpDir, baseImage.Repo)
 	os.MkdirAll(copyDir, 0755)
 
-	dest := fmt.Sprintf("oci:%s:%s", baseImage.Repo, baseImage.Tag)
+	// Local OCI-layout reference name. Digest-pinned source images
+	// (registry/repo@sha256:...) have no tag, which would yield an empty,
+	// invalid reference for both the skopeo destination and the umoci unpack
+	// ("refusing to resolve invalid reference"). The source is still pulled by
+	// its full (digest) reference; this name only labels it in the local layout.
+	ociRef := baseImage.Tag
+	if ociRef == "" {
+		ociRef = "latest"
+	}
+	dest := fmt.Sprintf("oci:%s:%s", baseImage.Repo, ociRef)
 
 	imageBytes, err := c.skopeoClient.InspectSizeInBytes(ctx, *request.BuildOptions.SourceImage, request.BuildOptions.SourceImageCreds)
 	if err != nil {
@@ -1837,7 +1846,7 @@ func (c *ImageClient) PullAndArchiveImage(ctx context.Context, outputLogger *slo
 
 	outputLogger.Info("Unpacking image...\n")
 	tmpBundlePath := NewPathInfo(filepath.Join(baseTmpBundlePath, request.ImageId))
-	err = c.unpack(ctx, baseImage.Repo, baseImage.Tag, tmpBundlePath)
+	err = c.unpack(ctx, baseImage.Repo, ociRef, tmpBundlePath)
 	if err != nil {
 		return fmt.Errorf("unable to unpack image: %v", err)
 	}
@@ -1910,7 +1919,9 @@ func (c *ImageClient) Archive(ctx context.Context, bundlePath *PathInfo, imageId
 				},
 			},
 			ProgressChan: progressChan,
-			ContentCache: newImageContentCache(c.cacheClient, imageId, "legacy-file-build"),
+			// v1 content is cached and reconciled as a single archive object on
+			// first load (the embedded image-archive cache), so we intentionally
+			// do not warm every individual file into the distributed cache here.
 		}, &clipCommon.S3StorageInfo{
 			Bucket:         c.config.ImageService.Registries.S3.BucketName,
 			Region:         c.config.ImageService.Registries.S3.Region,
@@ -1919,10 +1930,11 @@ func (c *ImageClient) Archive(ctx context.Context, bundlePath *PathInfo, imageId
 			ForcePathStyle: c.config.ImageService.Registries.S3.ForcePathStyle,
 		})
 	case registry.LocalImageRegistryStore:
+		// No per-file ContentCache: v1 is cached/reconciled as a single archive
+		// object on first load, not file-by-file during the build.
 		err = clip.CreateArchive(clip.CreateOptions{
-			InputPath:    bundlePath.Path,
-			OutputPath:   archivePath,
-			ContentCache: newImageContentCache(c.cacheClient, imageId, "legacy-file-build"),
+			InputPath:  bundlePath.Path,
+			OutputPath: archivePath,
 		})
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CLIP v1 cache reconciliation by treating the archive as a single content‑addressed object routed by its `.clip` path, and materializing it from the S3 registry or the mounted image volume. Makes required‑content publishing reliable and idempotent, and raises the default volume reporting threshold to 128MiB.

- **Bug Fixes**
  - CLIP v1: reconcile as a single archive object using CacheFS metadata; materialize by re‑fetching from the S3 image registry or the mounted image volume for local store.
  - Required‑content publishing: synchronous S2 writes, `PushStubCacheRequiredContent` returns errors, batch all kinds per stub under one lock, requeue on failure, and set the Redis “reported” marker only after a successful write.
  - S3 v1 images: restore the data cache from the content cache and use the full `.clip` path for the v1 data cache.
  - Use nested request IDs when top‑level `WorkspaceId`/`StubId` are empty.
  - Accept `inode` in `geesefs` content events; include content kind in cache audit events.
  - OCI pulls: handle digest‑pinned source images by using a default local OCI ref tag to avoid invalid references.
  - CLIP v1 builds: skip per‑file distributed cache warming; v1 is cached/reconciled as a single archive object.

- **New Features**
  - Add `cache.reconciliation.volumeMinBytes` (default 128MiB). Only larger `geesefs` volume objects are reconciled by default.
  - Bump `github.com/beam-cloud/geesefs` pin.

<sup>Written for commit a451b4689c67c8cf0909f42930a69fad707a5b59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

