### PR TITLE
fix embedded cache port if serverport is enabled

### DIFF
--- a/deploy/charts/beta9/templates/cache-server-daemonset.yaml
+++ b/deploy/charts/beta9/templates/cache-server-daemonset.yaml
@@ -79,8 +79,16 @@ spec:
               fieldPath: status.podIP
         - name: CACHE_HOST_NETWORK
           value: {{ .Values.cacheServer.hostNetwork | quote }}
+        - name: CACHE_SERVER_PORT
+          value: {{ .Values.cacheServer.serverPort | quote }}
         - name: WORKER_ID
           value: cache-server-$(CACHE_NODE_ID)
+        ports:
+        - name: cache
+          containerPort: {{ .Values.cacheServer.serverPort }}
+          {{- if .Values.cacheServer.hostNetwork }}
+          hostPort: {{ .Values.cacheServer.serverPort }}
+          {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/beta9/config.yaml

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -30,6 +30,7 @@ cacheServer:
   configSecretName: beta9-config-helm
   poolName: default
   locality: default
+  serverPort: 2050
   hostPath: /var/lib/beta9/cache
   mountPath: /var/lib/beta9/cache
   hostNetwork: true

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -23,7 +23,7 @@ import (
 const (
 	cacheDefaultLocality                = "default"
 	cacheDefaultDiskPath                = "/var/lib/beta9/cache"
-	cacheDefaultServerPort              = 2049
+	cacheDefaultServerPort              = 2050
 	cacheDefaultDiscoveryS              = 5
 	cacheDefaultDiscoveryJitterS        = 3
 	cacheDefaultMaxDiscoveryConcurrency = 8
@@ -636,11 +636,23 @@ func (m *WorkerCacheManager) bindAddr(cacheConfig cache.Config) string {
 		port = cacheDefaultServerPort
 	}
 
-	if cacheHostNetwork(m.config) {
+	// Host-network embedded workers default to an ephemeral port to avoid
+	// collisions when many share a node (the advertised address carries the real
+	// port). The one-per-node cache-server daemonset always binds the fixed port,
+	// as does any worker with an explicitly configured fixed port.
+	if cacheHostNetwork(m.config) && !cacheServerOnlyMode() && !m.fixedCacheServerPortConfigured() {
 		return ":0"
 	}
 
 	return fmt.Sprintf(":%d", port)
+}
+
+// fixedCacheServerPortConfigured reports whether a cache server port was
+// explicitly set (via the config or the CACHE_SERVER_PORT env), as opposed to
+// falling back to the default. When set, it is honored even for embedded
+// host-network workers.
+func (m *WorkerCacheManager) fixedCacheServerPortConfigured() bool {
+	return m.config.Cache.Global.ServerPort > 0 || cacheServerPortFromEnv() > 0
 }
 
 func normalizeCacheConfig(config types.AppConfig, poolConfig types.WorkerPoolConfig, nodeID, locality string) cache.Config {
@@ -651,6 +663,12 @@ func normalizeCacheConfig(config types.AppConfig, poolConfig types.WorkerPoolCon
 	}
 	if cacheConfig.Global.ServerPort == 0 {
 		cacheConfig.Global.ServerPort = cacheDefaultServerPort
+	}
+	// CACHE_SERVER_PORT lets the deployment (e.g. the cache-server daemonset) pin
+	// the listen port without editing the shared config secret. It takes
+	// precedence over the configured/default port.
+	if port := cacheServerPortFromEnv(); port > 0 {
+		cacheConfig.Global.ServerPort = port
 	}
 	if cacheConfig.Global.DiscoveryIntervalS == 0 {
 		cacheConfig.Global.DiscoveryIntervalS = cacheDefaultDiscoveryS
@@ -838,6 +856,21 @@ func cacheHostNetwork(config types.AppConfig) bool {
 func cacheServerOnlyMode() bool {
 	enabled, err := strconv.ParseBool(os.Getenv("CACHE_SERVER_ONLY"))
 	return err == nil && enabled
+}
+
+// cacheServerPortFromEnv returns the cache server listen port set via
+// CACHE_SERVER_PORT, or 0 when unset/invalid. It lets the deployment pin the
+// port without editing the shared config secret.
+func cacheServerPortFromEnv() uint {
+	value := os.Getenv("CACHE_SERVER_PORT")
+	if value == "" {
+		return 0
+	}
+	port, err := strconv.ParseUint(value, 10, 16)
+	if err != nil {
+		return 0
+	}
+	return uint(port)
 }
 
 func cacheWorkerInstanceID(workerID string) string {

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -533,3 +533,80 @@ func (s *testCacheCoordinator) unregisterCalled(registrationID string) bool {
 
 	return s.unregisters[registrationID]
 }
+
+func TestBindAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		// env
+		hostNetwork    string // CACHE_HOST_NETWORK
+		cacheServer    string // CACHE_SERVER_ONLY
+		envPort        string // CACHE_SERVER_PORT
+		configPort     uint   // raw config (m.config.Cache.Global.ServerPort)
+		normalizedPort uint   // resolved port passed to bindAddr
+		expected       string
+	}{
+		{
+			name:           "daemonset host-network binds fixed port",
+			hostNetwork:    "true",
+			cacheServer:    "true",
+			normalizedPort: 2050,
+			expected:       ":2050",
+		},
+		{
+			name:           "embedded host-network without explicit port is ephemeral",
+			hostNetwork:    "true",
+			cacheServer:    "false",
+			normalizedPort: 2050,
+			expected:       ":0",
+		},
+		{
+			name:           "embedded host-network honors explicit config port",
+			hostNetwork:    "true",
+			cacheServer:    "false",
+			configPort:     9000,
+			normalizedPort: 9000,
+			expected:       ":9000",
+		},
+		{
+			name:           "embedded host-network honors CACHE_SERVER_PORT env",
+			hostNetwork:    "true",
+			cacheServer:    "false",
+			envPort:        "9001",
+			normalizedPort: 9001,
+			expected:       ":9001",
+		},
+		{
+			name:           "non-host-network binds fixed port",
+			hostNetwork:    "false",
+			cacheServer:    "false",
+			normalizedPort: 2050,
+			expected:       ":2050",
+		},
+		{
+			name:           "zero port falls back to default",
+			hostNetwork:    "true",
+			cacheServer:    "true",
+			normalizedPort: 0,
+			expected:       ":2050",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CACHE_HOST_NETWORK", tc.hostNetwork)
+			t.Setenv("CACHE_SERVER_ONLY", tc.cacheServer)
+			t.Setenv("CACHE_SERVER_PORT", tc.envPort)
+
+			m := &WorkerCacheManager{
+				config: types.AppConfig{
+					Cache: cache.Config{
+						Global: cache.GlobalConfig{ServerPort: tc.configPort},
+					},
+				},
+			}
+			cacheConfig := cache.Config{Global: cache.GlobalConfig{ServerPort: tc.normalizedPort}}
+
+			require.Equal(t, tc.expected, m.bindAddr(cacheConfig))
+		})
+	}
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -43,6 +43,11 @@ const (
 	shutdownForceWait              time.Duration = 5 * time.Second
 	shutdownCleanupReserve         time.Duration = 5 * time.Second
 	defaultContainerStartupTimeout time.Duration = 5 * time.Minute
+	// maxContainerStartupTimeout bounds the configurable startup timeout so a
+	// large/sentinel maxSchedulingLatencyMs cannot overflow time.Duration (int64
+	// nanoseconds) and wrap negative, which would fire the startup timer
+	// immediately and fail every container.
+	maxContainerStartupTimeout time.Duration = 1 * time.Hour
 )
 
 type Worker struct {
@@ -598,8 +603,15 @@ func (s *Worker) runContainerRequest(request *types.ContainerRequest) {
 		err = run()
 	} else {
 		timeout := defaultContainerStartupTimeout
-		if s.config.Worker.Failover.MaxSchedulingLatencyMs > 0 {
-			timeout = time.Duration(s.config.Worker.Failover.MaxSchedulingLatencyMs) * time.Millisecond
+		if ms := s.config.Worker.Failover.MaxSchedulingLatencyMs; ms > 0 {
+			// Clamp before converting to a nanosecond duration: ms is an int64 of
+			// milliseconds, so large/sentinel values (e.g. a misconfigured
+			// maxSchedulingLatencyMs) would overflow and wrap negative, making the
+			// timer fire immediately and fail every container startup.
+			if ms > maxContainerStartupTimeout.Milliseconds() {
+				ms = maxContainerStartupTimeout.Milliseconds()
+			}
+			timeout = time.Duration(ms) * time.Millisecond
 		}
 
 		errCh := make(chan error, 1)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix cache server port handling so fixed ports are honored and exposed, while embedded host-network workers use an ephemeral port unless a fixed port is set. Also clamps container startup timeout to 1h to prevent overflow and immediate failures.

- **Bug Fixes**
  - Helm chart: set `cacheServer.serverPort` default to 2050; add `CACHE_SERVER_PORT` env; expose `containerPort` and `hostPort` when `hostNetwork` is true.
  - Worker cache manager: default port is 2050; honors `CACHE_SERVER_PORT`; host-network embedded workers bind `:0` unless a fixed port is configured; server-only daemonset always binds the fixed port.
  - Worker: cap `MaxSchedulingLatencyMs` at 1h to avoid duration overflow causing instant startup timeouts.
  - Tests: add unit tests for bind address and port selection (daemonset, host-network, env/config overrides).

<sup>Written for commit f4e1e8f651ddbf4f3674525a79e3e595e7d40c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

