### PR TITLE
cache discovery fix

### DIFF
--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -332,7 +333,7 @@ func (m *WorkerCacheManager) createEmbeddedServer(cacheConfig cache.Config, host
 		return nil, "", err
 	}
 
-	advertisedAddr, err := server.Serve(m.bindAddr(cacheConfig), m.podAddr)
+	advertisedAddr, err := server.Serve(m.bindAddr(cacheConfig), m.cacheAdvertiseHost())
 	if err != nil {
 		_ = server.Close()
 		return nil, "", err
@@ -645,6 +646,22 @@ func (m *WorkerCacheManager) bindAddr(cacheConfig cache.Config) string {
 	}
 
 	return fmt.Sprintf(":%d", port)
+}
+
+// cacheAdvertiseHost returns the address other cache clients should use to reach
+// this node's cache server. It must be an IP (the node's private IP), never a
+// hostname: cache clients resolve via cluster DNS, not tailscale MagicDNS, so a
+// tailscale POD_HOSTNAME would be unresolvable and the host would look down.
+// It prefers an explicit pod IP and otherwise returns "" so the cache server
+// falls back to its own discovered private IP.
+func (m *WorkerCacheManager) cacheAdvertiseHost() string {
+	if net.ParseIP(m.podAddr) != nil {
+		return m.podAddr
+	}
+	if ip, err := getIPFromEnv("POD_IP"); err == nil {
+		return ip
+	}
+	return ""
 }
 
 // fixedCacheServerPortConfigured reports whether a cache server port was

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -534,6 +534,40 @@ func (s *testCacheCoordinator) unregisterCalled(registrationID string) bool {
 	return s.unregisters[registrationID]
 }
 
+func TestCacheAdvertiseHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		podAddr  string
+		podIP    string
+		expected string
+	}{
+		{
+			name:     "pod addr is an ip",
+			podAddr:  "10.0.0.5",
+			expected: "10.0.0.5",
+		},
+		{
+			name:     "tailscale hostname falls back to pod ip",
+			podAddr:  "machine-6a392694.tailc480d.ts.net",
+			podIP:    "10.0.0.6",
+			expected: "10.0.0.6",
+		},
+		{
+			name:     "hostname without pod ip yields empty (server discovers private ip)",
+			podAddr:  "machine-6a392694.tailc480d.ts.net",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("POD_IP", tc.podIP)
+			m := &WorkerCacheManager{podAddr: tc.podAddr}
+			require.Equal(t, tc.expected, m.cacheAdvertiseHost())
+		})
+	}
+}
+
 func TestBindAddr(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the embedded cache server advertises a reachable IP (the pod’s private IP) instead of a Tailscale hostname. This fixes cache discovery for clients using cluster DNS.

- **Bug Fixes**
  - Use `cacheAdvertiseHost()` in `createEmbeddedServer` to provide the advertised address.
  - `cacheAdvertiseHost()` selects an IP: return `podAddr` if it’s an IP, else `POD_IP`, else "" to let the server discover its private IP.
  - Added tests covering IP, Tailscale hostname with `POD_IP`, and fallback behavior.

<sup>Written for commit ea6cd7878f6cc39f929a6a16a93e0424e00bc0d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

