### PR TITLE
fallback to public ip address

### DIFF
--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -350,6 +350,12 @@ func (cs *Server) advertiseAddr(listenerAddr net.Addr, advertiseHost string) str
 	if cs.privateIpAddr != "" {
 		return net.JoinHostPort(cs.privateIpAddr, port)
 	}
+	// No private IP available (e.g. a node whose only routable address is on the
+	// public/default interface). Advertise the public IP rather than an empty
+	// host, which would make the host undiallable.
+	if cs.publicIpAddr != "" {
+		return net.JoinHostPort(cs.publicIpAddr, port)
+	}
 	if advertiseAddr != "" {
 		return advertiseAddr
 	}

--- a/pkg/cache/server_test.go
+++ b/pkg/cache/server_test.go
@@ -15,6 +15,22 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func TestAdvertiseAddrFallsBackToPublicIP(t *testing.T) {
+	// Unspecified bind (e.g. ":2050"), no explicit advertise host.
+	listener := &net.TCPAddr{IP: net.IPv4zero, Port: 2050}
+
+	// No private IP: must advertise the public IP, not an empty host.
+	csPublic := &Server{cas: &Store{currentHost: &Host{}}, publicIpAddr: "15.204.241.150"}
+	require.Equal(t, "15.204.241.150:2050", csPublic.advertiseAddr(listener, ""))
+
+	// Private IP present: preferred over the public IP.
+	csPrivate := &Server{cas: &Store{currentHost: &Host{}}, privateIpAddr: "10.0.0.5", publicIpAddr: "15.204.241.150"}
+	require.Equal(t, "10.0.0.5:2050", csPrivate.advertiseAddr(listener, ""))
+
+	// Explicit advertise host wins over both.
+	require.Equal(t, "1.2.3.4:2050", csPrivate.advertiseAddr(listener, "1.2.3.4"))
+}
+
 func TestNormalizeAdvertiseHostForJoinHostPort(t *testing.T) {
 	host := normalizeAdvertiseHost("[2600:1f18:37a4:c02::c0dd]")
 	require.Equal(t, "2600:1f18:37a4:c02::c0dd", host)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Advertise the node’s public IP when no private IP is available to avoid emitting an empty host and undiallable addresses. Adds tests to cover the fallback and selection order.

- **Bug Fixes**
  - In `pkg/cache/server.go`, `advertiseAddr` now falls back to `publicIpAddr` when `privateIpAddr` is empty.
  - Added `TestAdvertiseAddrFallsBackToPublicIP` to verify fallback behavior, preference for private IP when present, and that an explicit advertise host still takes precedence.

<sup>Written for commit 62c32dd15b1e88d8849725f12f832914daa9b3aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

