### PR TITLE
grpc keepalive fix

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -24,8 +24,19 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+)
+
+// gRPC keepalive for cache peer connections so a connection broken by a cache
+// server rollout is detected and replaced rather than left to hang. The client
+// Time must be >= the cache server's keepalive EnforcementPolicy MinTime to
+// avoid "too_many_pings" GOAWAYs.
+const (
+	cacheKeepaliveTime    = 20 * time.Second
+	cacheKeepaliveTimeout = 10 * time.Second
+	cacheKeepaliveMinTime = 10 * time.Second
 )
 
 const (
@@ -449,6 +460,11 @@ func (c *Client) addHost(host *Host) error {
 		grpc.WithInitialConnWindowSize(int32(initialConnWindowSize)),
 		grpc.WithWriteBufferSize(writeBufferSize),
 		grpc.WithReadBufferSize(readBufferSize),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                cacheKeepaliveTime,
+			Timeout:             cacheKeepaliveTimeout,
+			PermitWithoutStream: true,
+		}),
 	}
 
 	if c.clientConfig.Token != "" {

--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 type DiscoveryClient struct {
@@ -242,6 +243,11 @@ func (d *DiscoveryClient) GetHostState(ctx context.Context, host *Host) (*Host, 
 			grpc.MaxCallRecvMsgSize(d.cfg.GRPCMessageSizeBytes),
 			grpc.MaxCallSendMsgSize(d.cfg.GRPCMessageSizeBytes),
 		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                cacheKeepaliveTime,
+			Timeout:             cacheKeepaliveTimeout,
+			PermitWithoutStream: true,
+		}),
 	}
 
 	timeout := time.Duration(d.cfg.GRPCDialTimeoutS) * time.Second

--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -21,6 +21,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 )
 
@@ -280,6 +281,17 @@ func (cs *Server) grpcServerOptions() []grpc.ServerOption {
 		grpc.ReadBufferSize(readBufferSize),
 		grpc.MaxConcurrentStreams(uint32(maxConcurrentStreams)),
 		grpc.NumStreamWorkers(uint32(numStreamWorkers)),
+		// Permit client keepalive pings (incl. without active streams) so cache
+		// clients can detect a connection broken by a server rollout. MinTime must
+		// be <= the client's keepalive Time to avoid "too_many_pings" GOAWAYs.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             cacheKeepaliveMinTime,
+			PermitWithoutStream: true,
+		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    cacheKeepaliveTime,
+			Timeout: cacheKeepaliveTimeout,
+		}),
 	}
 	if cs.globalConfig.GRPCPayloadCodecV2 {
 		opts = append(opts, grpc.ForceServerCodecV2(cachegrpc.New(cs.globalConfig.GRPCPayloadCodecMinBytes)))

--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -350,6 +350,12 @@ func (cs *Server) advertiseAddr(listenerAddr net.Addr, advertiseHost string) str
 	if cs.privateIpAddr != "" {
 		return net.JoinHostPort(cs.privateIpAddr, port)
 	}
+	// No private IP available (e.g. a node whose only routable address is on the
+	// public/default interface). Advertise the public IP rather than an empty
+	// host, which would make the host undiallable.
+	if cs.publicIpAddr != "" {
+		return net.JoinHostPort(cs.publicIpAddr, port)
+	}
 	if advertiseAddr != "" {
 		return advertiseAddr
 	}

--- a/pkg/cache/server_test.go
+++ b/pkg/cache/server_test.go
@@ -15,6 +15,22 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func TestAdvertiseAddrFallsBackToPublicIP(t *testing.T) {
+	// Unspecified bind (e.g. ":2050"), no explicit advertise host.
+	listener := &net.TCPAddr{IP: net.IPv4zero, Port: 2050}
+
+	// No private IP: must advertise the public IP, not an empty host.
+	csPublic := &Server{cas: &Store{currentHost: &Host{}}, publicIpAddr: "15.204.241.150"}
+	require.Equal(t, "15.204.241.150:2050", csPublic.advertiseAddr(listener, ""))
+
+	// Private IP present: preferred over the public IP.
+	csPrivate := &Server{cas: &Store{currentHost: &Host{}}, privateIpAddr: "10.0.0.5", publicIpAddr: "15.204.241.150"}
+	require.Equal(t, "10.0.0.5:2050", csPrivate.advertiseAddr(listener, ""))
+
+	// Explicit advertise host wins over both.
+	require.Equal(t, "1.2.3.4:2050", csPrivate.advertiseAddr(listener, "1.2.3.4"))
+}
+
 func TestNormalizeAdvertiseHostForJoinHostPort(t *testing.T) {
 	host := normalizeAdvertiseHost("[2600:1f18:37a4:c02::c0dd]")
 	require.Equal(t, "2600:1f18:37a4:c02::c0dd", host)

--- a/pkg/clients/storage.go
+++ b/pkg/clients/storage.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -55,7 +57,7 @@ func NewWorkspaceStorageClientWithPresignEndpoint(ctx context.Context, workspace
 	}
 
 	s3Client := newS3Client(cfg, endpointUrl)
-	presignClient := s3.NewPresignClient(newS3Client(cfg, firstNonEmpty(presignEndpointUrl, endpointUrl)))
+	presignClient := s3.NewPresignClient(newS3Client(cfg, presignEndpointForStorage(endpointUrl, presignEndpointUrl)))
 
 	return &WorkspaceStorageClient{
 		WorkspaceName:    workspaceName,
@@ -84,7 +86,10 @@ func NewDefaultStorageClient(ctx context.Context, cfg types.AppConfig) (*Storage
 	s3Client := newS3Client(s3Cfg, cfg.Storage.WorkspaceStorage.DefaultEndpointUrl)
 	presignClient := s3.NewPresignClient(newS3Client(
 		s3Cfg,
-		firstNonEmpty(cfg.Storage.WorkspaceStorage.DefaultPresignedEndpointUrl, cfg.Storage.WorkspaceStorage.DefaultEndpointUrl),
+		presignEndpointForStorage(
+			cfg.Storage.WorkspaceStorage.DefaultEndpointUrl,
+			cfg.Storage.WorkspaceStorage.DefaultPresignedEndpointUrl,
+		),
 	))
 
 	return &StorageClient{
@@ -109,6 +114,75 @@ func firstNonEmpty(values ...string) string {
 			return value
 		}
 	}
+	return ""
+}
+
+func presignEndpointForStorage(storageEndpointUrl, presignEndpointUrl string) string {
+	return firstNonEmpty(presignEndpointOverride(storageEndpointUrl, presignEndpointUrl), storageEndpointUrl)
+}
+
+func presignEndpointOverride(storageEndpointUrl, presignEndpointUrl string) string {
+	presignEndpointUrl = strings.TrimSpace(presignEndpointUrl)
+	if presignEndpointUrl == "" {
+		return ""
+	}
+
+	// The default config is LocalStack-friendly, but production configs often
+	// overlay only the storage endpoint. Do not let that inherited loopback
+	// presign endpoint leak into remote buckets.
+	if isLoopbackEndpoint(presignEndpointUrl) && !isLocalS3DevEndpoint(storageEndpointUrl) {
+		return ""
+	}
+
+	return presignEndpointUrl
+}
+
+func isLocalS3DevEndpoint(endpoint string) bool {
+	host := endpointHostname(endpoint)
+	if host == "" {
+		return false
+	}
+
+	return isLoopbackHost(host) || isLocalstackHost(host)
+}
+
+func isLocalstackHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localstack" || strings.HasPrefix(host, "localstack.")
+}
+
+func isLoopbackEndpoint(endpoint string) bool {
+	return isLoopbackHost(endpointHostname(endpoint))
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func endpointHostname(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ""
+	}
+
+	parsedURL, err := url.Parse(endpoint)
+	if err == nil && parsedURL.Hostname() != "" {
+		return strings.ToLower(parsedURL.Hostname())
+	}
+
+	if !strings.Contains(endpoint, "://") {
+		parsedURL, err = url.Parse("//" + endpoint)
+		if err == nil && parsedURL.Hostname() != "" {
+			return strings.ToLower(parsedURL.Hostname())
+		}
+	}
+
 	return ""
 }
 

--- a/pkg/clients/storage_test.go
+++ b/pkg/clients/storage_test.go
@@ -1,0 +1,161 @@
+package clients
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestPresignEndpointForStorage(t *testing.T) {
+	tests := []struct {
+		name            string
+		storageEndpoint string
+		presignEndpoint string
+		want            string
+	}{
+		{
+			name:            "uses storage endpoint when override is empty",
+			storageEndpoint: "https://s3.amazonaws.com",
+			presignEndpoint: "",
+			want:            "https://s3.amazonaws.com",
+		},
+		{
+			name:            "allows loopback override for localstack service endpoint",
+			storageEndpoint: "http://localstack:4566",
+			presignEndpoint: "http://127.0.0.1:4566",
+			want:            "http://127.0.0.1:4566",
+		},
+		{
+			name:            "allows loopback override for localstack fqdn endpoint",
+			storageEndpoint: "http://localstack.beta9.svc.cluster.local:4566",
+			presignEndpoint: "http://localhost:4566",
+			want:            "http://localhost:4566",
+		},
+		{
+			name:            "rejects loopback override for remote endpoint",
+			storageEndpoint: "https://s3.amazonaws.com",
+			presignEndpoint: "http://127.0.0.1:4566",
+			want:            "https://s3.amazonaws.com",
+		},
+		{
+			name:            "rejects loopback override for hostname containing localstack",
+			storageEndpoint: "https://notlocalstack.example.com",
+			presignEndpoint: "http://127.0.0.1:4566",
+			want:            "https://notlocalstack.example.com",
+		},
+		{
+			name:            "rejects loopback override when storage endpoint is implicit aws",
+			storageEndpoint: "",
+			presignEndpoint: "http://127.0.0.1:4566",
+			want:            "",
+		},
+		{
+			name:            "allows non-loopback public override for remote endpoint",
+			storageEndpoint: "http://minio.internal:9000",
+			presignEndpoint: "https://storage.example.com",
+			want:            "https://storage.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := presignEndpointForStorage(tt.storageEndpoint, tt.presignEndpoint); got != tt.want {
+				t.Fatalf("presignEndpointForStorage(%q, %q) = %q, want %q", tt.storageEndpoint, tt.presignEndpoint, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceStorageClientPresignedURLRejectsLoopbackOverrideForRemoteStorage(t *testing.T) {
+	storageClient, err := NewWorkspaceStorageClientWithPresignEndpoint(
+		context.Background(),
+		"workspace",
+		testWorkspaceStorage("https://s3.amazonaws.com"),
+		"http://127.0.0.1:4566",
+	)
+	if err != nil {
+		t.Fatalf("NewWorkspaceStorageClientWithPresignEndpoint() error = %v", err)
+	}
+
+	presignedURL, err := storageClient.GeneratePresignedPutURL(context.Background(), "objects/object-id", 60)
+	if err != nil {
+		t.Fatalf("GeneratePresignedPutURL() error = %v", err)
+	}
+
+	parsedURL, err := url.Parse(presignedURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", presignedURL, err)
+	}
+	if got, want := parsedURL.Hostname(), "s3.amazonaws.com"; got != want {
+		t.Fatalf("presigned URL hostname = %q, want %q; url=%s", got, want, presignedURL)
+	}
+}
+
+func TestWorkspaceStorageClientPresignedURLAllowsLoopbackOverrideForLocalstack(t *testing.T) {
+	storageClient, err := NewWorkspaceStorageClientWithPresignEndpoint(
+		context.Background(),
+		"workspace",
+		testWorkspaceStorage("http://localstack:4566"),
+		"http://127.0.0.1:4566",
+	)
+	if err != nil {
+		t.Fatalf("NewWorkspaceStorageClientWithPresignEndpoint() error = %v", err)
+	}
+
+	presignedURL, err := storageClient.GeneratePresignedPutURL(context.Background(), "objects/object-id", 60)
+	if err != nil {
+		t.Fatalf("GeneratePresignedPutURL() error = %v", err)
+	}
+
+	parsedURL, err := url.Parse(presignedURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", presignedURL, err)
+	}
+	if got, want := parsedURL.Hostname(), "127.0.0.1"; got != want {
+		t.Fatalf("presigned URL hostname = %q, want %q; url=%s", got, want, presignedURL)
+	}
+}
+
+func TestDefaultStorageClientPresignedURLRejectsInheritedLoopbackOverrideForRemoteStorage(t *testing.T) {
+	cfg := types.AppConfig{}
+	cfg.Storage.WorkspaceStorage.DefaultEndpointUrl = "https://s3.amazonaws.com"
+	cfg.Storage.WorkspaceStorage.DefaultPresignedEndpointUrl = "http://127.0.0.1:4566"
+	cfg.Storage.WorkspaceStorage.DefaultAccessKey = "test"
+	cfg.Storage.WorkspaceStorage.DefaultSecretKey = "test"
+	cfg.Storage.WorkspaceStorage.DefaultRegion = "us-east-1"
+
+	storageClient, err := NewDefaultStorageClient(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewDefaultStorageClient() error = %v", err)
+	}
+
+	presignedURL, err := storageClient.GeneratePresignedPutURL(context.Background(), "objects/object-id", 60, "workspace-prod-test")
+	if err != nil {
+		t.Fatalf("GeneratePresignedPutURL() error = %v", err)
+	}
+
+	parsedURL, err := url.Parse(presignedURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", presignedURL, err)
+	}
+	if got, want := parsedURL.Hostname(), "s3.amazonaws.com"; got != want {
+		t.Fatalf("presigned URL hostname = %q, want %q; url=%s", got, want, presignedURL)
+	}
+}
+
+func testWorkspaceStorage(endpoint string) *types.WorkspaceStorage {
+	bucketName := "workspace-prod-test"
+	accessKey := "test"
+	secretKey := "test"
+	region := "us-east-1"
+
+	return &types.WorkspaceStorage{
+		BucketName:  &bucketName,
+		AccessKey:   &accessKey,
+		SecretKey:   &secretKey,
+		EndpointUrl: &endpoint,
+		Region:      &region,
+	}
+}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/labstack/echo-contrib/pprof"
@@ -52,6 +53,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -251,6 +253,20 @@ func (g *Gateway) initGrpc() error {
 		grpc.StreamInterceptor(authInterceptor.Stream()),
 		grpc.MaxRecvMsgSize(g.Config.GatewayService.GRPC.MaxRecvMsgSize * 1024 * 1024),
 		grpc.MaxSendMsgSize(g.Config.GatewayService.GRPC.MaxSendMsgSize * 1024 * 1024),
+		// Permit client keepalive pings (including without active streams) so
+		// long-lived clients like workers can detect a connection broken by a
+		// gateway rollout. MinTime must be <= the client's keepalive Time to
+		// avoid sending "too_many_pings" GOAWAYs.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
+		// Server-side keepalive so the gateway also detects and reaps dead client
+		// connections rather than holding them open.
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    20 * time.Second,
+			Timeout: 10 * time.Second,
+		}),
 	}
 
 	g.grpcServer = grpc.NewServer(

--- a/pkg/worker/repository.go
+++ b/pkg/worker/repository.go
@@ -14,11 +14,18 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 const (
 	defaultGRPCMaxRetries = 3
 	defaultGRPCRetryDelay = time.Second
+	// gRPC client keepalive: actively ping the gateway so a connection broken by
+	// a gateway rollout or load-balancer idle timeout is detected and replaced,
+	// instead of leaving RPCs to hang until their deadline. Time must be >= the
+	// gateway's keepalive EnforcementPolicy MinTime to avoid "too_many_pings".
+	grpcClientKeepaliveTime    = 20 * time.Second
+	grpcClientKeepaliveTimeout = 10 * time.Second
 )
 
 // NewWorkerRepositoryClient creates a new worker repository client
@@ -63,6 +70,11 @@ func newGRPCConn(host string, token string) (*grpc.ClientConn, error) {
 
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                grpcClientKeepaliveTime,
+			Timeout:             grpcClientKeepaliveTimeout,
+			PermitWithoutStream: true,
+		}),
 	}
 
 	if token != "" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables gRPC keepalives across cache, gateway, and workers to quickly detect broken connections and prevent hung RPCs after rollouts. Also hardens S3 presign endpoint selection and fixes cache address advertising to avoid undiallable hosts.

- **Bug Fixes**
  - Added `grpc` client keepalives to cache clients and workers, and server keepalives plus enforcement in cache and gateway, with aligned timings to avoid "too_many_pings" GOAWAYs.
  - Cache server now falls back to advertising the public IP when no private IP is available, preventing empty-host addresses; tests added.
  - Storage presign endpoint selection now rejects loopback overrides for non-local endpoints while allowing LocalStack; updated `PresignClient` construction and added targeted tests.

<sup>Written for commit 52c4ec90a0e85ce8d2d93e2b1ef1770cdac51323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

