### PR TITLE
fix: bound discovery timeout

### DIFF
--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -87,6 +87,7 @@ func (d *DiscoveryClient) discoveryJitter() time.Duration {
 func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	hosts, err := d.hostDirectory.GetAvailableHosts(ctx, d.locality)
 	if err != nil {
+		Logger.Warnf("cache host discovery failed to list hosts for locality %s: %v", d.locality, err)
 		return nil, err
 	}
 
@@ -94,6 +95,10 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	hostGroups := cacheHostCandidateGroups(hosts)
 	var wg sync.WaitGroup
 	mu := sync.Mutex{}
+	totalCandidates := 0
+	endpointCandidates := 0
+	verifiedEndpoints := 0
+	var lastVerifyErr error
 	maxConcurrency := d.cfg.MaxDiscoveryConcurrency
 	if maxConcurrency <= 0 {
 		maxConcurrency = 8
@@ -101,6 +106,15 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	sem := make(chan struct{}, maxConcurrency)
 
 	for _, group := range hostGroups {
+		for _, candidate := range group.candidates {
+			if candidate == nil {
+				continue
+			}
+			totalCandidates++
+			if candidate.HasEndpoint() {
+				endpointCandidates++
+			}
+		}
 		if group.hasEndpoint(d.hostMap.Get(group.hostID)) {
 			continue
 		}
@@ -115,7 +129,15 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 				return
 			}
 
-			host, ok := group.firstReachable(ctx, d.GetHostState)
+			host, ok := group.firstReachable(ctx, func(ctx context.Context, candidate *Host) (*Host, error) {
+				host, err := d.GetHostState(ctx, candidate)
+				if err != nil {
+					mu.Lock()
+					lastVerifyErr = err
+					mu.Unlock()
+				}
+				return host, err
+			})
 			if !ok {
 				if logicalHost := group.logicalHost(); logicalHost != nil {
 					mu.Lock()
@@ -127,6 +149,7 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 
 			d.hostMap.Set(host)
 			mu.Lock()
+			verifiedEndpoints++
 			selectedHosts = append(selectedHosts, host)
 			mu.Unlock()
 
@@ -135,6 +158,11 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	}
 
 	wg.Wait()
+	if endpointCandidates > 0 && verifiedEndpoints == 0 {
+		Logger.Warnf("cache host discovery found %d endpoint candidates across %d hosts for locality %s, but none verified reachable (last_error=%v)", endpointCandidates, len(hostGroups), d.locality, lastVerifyErr)
+	} else if totalCandidates > 0 && endpointCandidates == 0 {
+		Logger.Warnf("cache host discovery found %d logical hosts for locality %s, but none had an active endpoint", totalCandidates, d.locality)
+	}
 	return selectedHosts, nil
 }
 

--- a/pkg/worker/cache_coordinator.go
+++ b/pkg/worker/cache_coordinator.go
@@ -25,7 +25,10 @@ func (d *gatewayCacheHostDirectory) GetAvailableHosts(ctx context.Context, local
 		return nil, cache.ErrHostNotFound
 	}
 
-	resp, err := handleGRPCResponse(d.client.ListCacheHosts(ctx, &pb.ListCacheHostsRequest{
+	rpcCtx, cancel := context.WithTimeout(ctx, cacheCoordinatorRPCTimeout)
+	defer cancel()
+
+	resp, err := handleGRPCResponse(d.client.ListCacheHosts(rpcCtx, &pb.ListCacheHostsRequest{
 		Locality: locality,
 	}))
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bound the cache host discovery RPC with a timeout and added clearer warnings during discovery so it won’t hang and failures are easier to diagnose.

- Bug Fixes
  - Wrapped `ListCacheHosts` with `context.WithTimeout` using `cacheCoordinatorRPCTimeout` to prevent stalled discovery.
  - Improved discovery logging: warn on list failures, count candidates/endpoints/verified hosts, and include the last verification error when no endpoints are reachable.

<sup>Written for commit 66b4411f291f6c1cc0bc217e31d68f2a48756134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

