### PR TITLE
cleanup discovery logs

### DIFF
--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -95,8 +95,9 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	hostGroups := cacheHostCandidateGroups(hosts)
 	var wg sync.WaitGroup
 	mu := sync.Mutex{}
-	totalCandidates := 0
-	endpointCandidates := 0
+	unresolvedHosts := 0
+	unresolvedCandidates := 0
+	unresolvedEndpointCandidates := 0
 	verifiedEndpoints := 0
 	var lastVerifyErr error
 	maxConcurrency := d.cfg.MaxDiscoveryConcurrency
@@ -106,17 +107,19 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	sem := make(chan struct{}, maxConcurrency)
 
 	for _, group := range hostGroups {
+		if group.hasEndpoint(d.hostMap.Get(group.hostID)) {
+			continue
+		}
+
+		unresolvedHosts++
 		for _, candidate := range group.candidates {
 			if candidate == nil {
 				continue
 			}
-			totalCandidates++
+			unresolvedCandidates++
 			if candidate.HasEndpoint() {
-				endpointCandidates++
+				unresolvedEndpointCandidates++
 			}
-		}
-		if group.hasEndpoint(d.hostMap.Get(group.hostID)) {
-			continue
 		}
 
 		wg.Add(1)
@@ -158,10 +161,10 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	}
 
 	wg.Wait()
-	if endpointCandidates > 0 && verifiedEndpoints == 0 {
-		Logger.Warnf("cache host discovery found %d endpoint candidates across %d hosts for locality %s, but none verified reachable (last_error=%v)", endpointCandidates, len(hostGroups), d.locality, lastVerifyErr)
-	} else if totalCandidates > 0 && endpointCandidates == 0 {
-		Logger.Warnf("cache host discovery found %d logical hosts for locality %s, but none had an active endpoint", totalCandidates, d.locality)
+	if unresolvedEndpointCandidates > 0 && verifiedEndpoints == 0 {
+		Logger.Warnf("cache host discovery found %d endpoint candidates across %d unresolved hosts for locality %s, but none verified reachable (last_error=%v)", unresolvedEndpointCandidates, unresolvedHosts, d.locality, lastVerifyErr)
+	} else if unresolvedCandidates > 0 && unresolvedEndpointCandidates == 0 {
+		Logger.Warnf("cache host discovery found %d unresolved logical hosts for locality %s, but none had an active endpoint", unresolvedHosts, d.locality)
 	}
 	return selectedHosts, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened cache discovery warnings to count only unresolved hosts and candidates, reducing noisy and misleading logs. Resolved groups are skipped before counting and verification.

- **Bug Fixes**
  - Count `unresolvedHosts`, `unresolvedCandidates`, and `unresolvedEndpointCandidates` only for groups without an endpoint in `pkg/cache/discovery.go`.
  - Early-continue when a group already has an endpoint; exclude from warning totals.
  - Updated warning text to say "unresolved" and report accurate host/candidate counts with the last error.

<sup>Written for commit 938c0a373d99c9777c2dfa9f6d377f852fcf6604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

