### PR TITLE
improve disk utilization check

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -24,8 +24,8 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -417,10 +417,7 @@ func (c *Client) addHost(host *Host) error {
 		return nil
 	}
 
-	addr := host.Addr
-	if host.PrivateAddr != "" {
-		addr = host.PrivateAddr
-	}
+	addr := cacheHostDialAddr(host, c.localNodeID)
 
 	transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
 	if isTLSEnabled(addr) {
@@ -1120,10 +1117,7 @@ func (c *Client) rawReadInto(ctx context.Context, host *Host, hash string, offse
 		return 0, ErrUnableToReachHost
 	}
 	hostID = host.HostId
-	addr = host.Addr
-	if host.PrivateAddr != "" {
-		addr = host.PrivateAddr
-	}
+	addr = cacheHostDialAddr(host, c.localNodeID)
 	if addr == "" {
 		status = "missing_addr"
 		atomic.AddInt64(&cachePathStats.clientRawErrors, 1)

--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ type DiscoveryClient struct {
 	hostMap       *HostMap
 	hostDirectory HostDirectory
 	locality      string
+	localNodeID   string
 }
 
 func NewDiscoveryClient(cfg GlobalConfig, hostMap *HostMap, hostDirectory HostDirectory, locality string) *DiscoveryClient {
@@ -27,6 +29,7 @@ func NewDiscoveryClient(cfg GlobalConfig, hostMap *HostMap, hostDirectory HostDi
 		hostMap:       hostMap,
 		hostDirectory: hostDirectory,
 		locality:      locality,
+		localNodeID:   os.Getenv("CACHE_NODE_ID"),
 	}
 }
 
@@ -256,11 +259,7 @@ func sameCacheHostEndpoint(a *Host, b *Host) bool {
 
 // GetHostState attempts to connect to the gRPC service and verifies its availability
 func (d *DiscoveryClient) GetHostState(ctx context.Context, host *Host) (*Host, error) {
-	addr := host.Addr
-
-	if host.PrivateAddr != "" {
-		addr = host.PrivateAddr
-	}
+	addr := cacheHostDialAddr(host, d.localNodeID)
 
 	transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
 	if isTLSEnabled(addr) {

--- a/pkg/cache/network.go
+++ b/pkg/cache/network.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -41,6 +42,35 @@ func isTLSEnabled(addr string) bool {
 		return false
 	}
 	return port == "443"
+}
+
+func cacheHostDialAddr(host *Host, localNodeID string) string {
+	if host == nil {
+		return ""
+	}
+
+	addr := host.Addr
+	if host.PrivateAddr != "" {
+		addr = host.PrivateAddr
+	}
+	if addr == "" {
+		return ""
+	}
+
+	if !cacheHostNetworkEnabled() || localNodeID == "" || host.NodeID == "" || host.NodeID != localNodeID {
+		return addr
+	}
+
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil || port == "" {
+		return addr
+	}
+	return net.JoinHostPort("127.0.0.1", port)
+}
+
+func cacheHostNetworkEnabled() bool {
+	enabled, err := strconv.ParseBool(os.Getenv("CACHE_HOST_NETWORK"))
+	return err == nil && enabled
 }
 
 func GetPublicIpAddr() (string, error) {

--- a/pkg/cache/network_test.go
+++ b/pkg/cache/network_test.go
@@ -12,3 +12,27 @@ func Test_IsTLSEnabled(t *testing.T) {
 	assert.True(t, isTLSEnabled("127.0.0.1:443"))
 	assert.False(t, isTLSEnabled("127.0.0.1:2049"))
 }
+
+func TestCacheHostDialAddrUsesLoopbackForSameNodeHostNetwork(t *testing.T) {
+	t.Setenv("CACHE_HOST_NETWORK", "true")
+
+	host := &Host{
+		NodeID:      "node-a",
+		PrivateAddr: "15.204.241.150:2050",
+	}
+
+	assert.Equal(t, "127.0.0.1:2050", cacheHostDialAddr(host, "node-a"))
+}
+
+func TestCacheHostDialAddrKeepsAdvertisedAddrForRemoteOrPodNetwork(t *testing.T) {
+	host := &Host{
+		NodeID:      "node-a",
+		PrivateAddr: "15.204.241.150:2050",
+	}
+
+	t.Setenv("CACHE_HOST_NETWORK", "false")
+	assert.Equal(t, "15.204.241.150:2050", cacheHostDialAddr(host, "node-a"))
+
+	t.Setenv("CACHE_HOST_NETWORK", "true")
+	assert.Equal(t, "15.204.241.150:2050", cacheHostDialAddr(host, "node-b"))
+}

--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -808,12 +808,7 @@ func (r *storeContentStreamReader) Read(p []byte) (int, error) {
 
 func (cs *Server) usagePct() float64 {
 	if cs.cas.maxCacheSizeMb <= 0 {
-		_, _, diskUsagePct, err := cs.cas.GetDiskCacheMetrics()
-		if err == nil {
-			return diskUsagePct
-		}
-
-		return 0
+		return cs.cas.CachedDiskUsagePct()
 	}
 
 	var memStats runtime.MemStats

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -9,6 +9,7 @@ import (
 	"hash/fnv"
 	"io"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,6 +55,7 @@ type Store struct {
 	prefetcher              *Prefetcher
 	pageLocks               [pageLockStripeCount]sync.RWMutex
 	closing                 atomic.Bool
+	diskUsagePctBits        atomic.Uint64
 }
 
 func NewStore(ctx context.Context, currentHost *Host, locality string, metadataStore CacheMetadataStore, config Config) (*Store, error) {
@@ -1346,33 +1348,18 @@ func (cas *Store) Cleanup() {
 }
 
 func (cas *Store) GetDiskCacheMetrics() (int64, int64, float64, error) {
-	var (
-		diskUsageMb      int64
-		totalDiskSpaceMb int64
-		usagePercentage  float64
-		err              error
-	)
+	return getFilesystemDiskMetricsMb(cas.diskCacheDir)
+}
 
-	// Get current disk usage
-	diskUsageMb, err = getDiskUsageMb(cas.diskCacheDir)
-	if err != nil {
-		return 0, 0, 0, err
+func (cas *Store) CachedDiskUsagePct() float64 {
+	if cas == nil {
+		return 0
 	}
+	return math.Float64frombits(cas.diskUsagePctBits.Load())
+}
 
-	// Get total disk capacity
-	totalDiskSpaceMb, err = getTotalDiskSpaceMb(cas.diskCacheDir)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	// Calculate usage ratio.
-	if totalDiskSpaceMb > 0 {
-		usagePercentage = float64(diskUsageMb) / float64(totalDiskSpaceMb)
-	} else {
-		usagePercentage = 0
-	}
-
-	return diskUsageMb, totalDiskSpaceMb, usagePercentage, nil
+func (cas *Store) setCachedDiskUsagePct(usagePercentage float64) {
+	cas.diskUsagePctBits.Store(math.Float64bits(usagePercentage))
 }
 
 func min(a, b int64) int64 {
@@ -1381,30 +1368,22 @@ func min(a, b int64) int64 {
 	}
 	return b
 }
-func getDiskUsageMb(path string) (int64, error) {
-	var totalUsage int64 = 0
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			totalUsage += info.Size()
-		}
-		return nil
-	})
-	if err != nil {
-		return 0, err
-	}
-	return totalUsage / (1024 * 1024), nil
-}
-
-func getTotalDiskSpaceMb(path string) (int64, error) {
+func getFilesystemDiskMetricsMb(path string) (int64, int64, float64, error) {
 	var stat syscall.Statfs_t
 	err := syscall.Statfs(path, &stat)
 	if err != nil {
-		return 0, err
+		return 0, 0, 0, err
 	}
-	return int64(stat.Blocks) * int64(stat.Bsize) / (1024 * 1024), nil
+	totalBytes := uint64(stat.Blocks) * uint64(stat.Bsize)
+	availableBytes := uint64(stat.Bavail) * uint64(stat.Bsize)
+	usedBytes := totalBytes - availableBytes
+	totalDiskSpaceMb := int64(totalBytes / (1024 * 1024))
+	diskUsageMb := int64(usedBytes / (1024 * 1024))
+	usagePercentage := 0.0
+	if totalBytes > 0 {
+		usagePercentage = float64(usedBytes) / float64(totalBytes)
+	}
+	return diskUsageMb, totalDiskSpaceMb, usagePercentage, nil
 }
 
 func getMemoryMb() (int64, int64) {
@@ -1439,6 +1418,7 @@ func (cas *Store) monitorDiskCacheUsage() {
 			cas.metrics.MemCacheUsagePct.Update(float64(usedMemoryMb) / float64(totalMemoryMb) * 100)
 			cas.metrics.DiskCacheUsageMB.Update(float64(currentUsage))
 			cas.metrics.DiskCacheUsagePct.Update(float64(usagePercentage))
+			cas.setCachedDiskUsagePct(usagePercentage)
 
 			Logger.Debugf("Memory Cache Usage: %dMB / %dMB (%.2f%%)", availableMemoryMb, totalMemoryMb, float64(availableMemoryMb)/float64(totalMemoryMb)*100)
 			Logger.Debugf("Disk Cache Usage: %dMB / %dMB (%.2f%%)", currentUsage, totalDiskSpace, usagePercentage*100)

--- a/pkg/cache/storage_test.go
+++ b/pkg/cache/storage_test.go
@@ -47,6 +47,16 @@ func newTestStore(t *testing.T, pageSize int64) *Store {
 	return store
 }
 
+func TestGetFilesystemDiskMetricsMb(t *testing.T) {
+	usedMb, totalMb, usagePct, err := getFilesystemDiskMetricsMb(t.TempDir())
+
+	require.NoError(t, err)
+	require.Greater(t, totalMb, int64(0))
+	require.GreaterOrEqual(t, usedMb, int64(0))
+	require.GreaterOrEqual(t, usagePct, 0.0)
+	require.LessOrEqual(t, usagePct, 1.0)
+}
+
 func TestStoreAddReaderStreamsToDiskCAS(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("streamed content spanning several cache pages")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch disk utilization to filesystem-based metrics and cache the percentage for stable reporting. Also route same-node connections over loopback when using host networking.

- **Bug Fixes**
  - Use `getFilesystemDiskMetricsMb()` (statfs) to compute used/total MB and usage pct; replaces directory walk and improves accuracy/perf.
  - Server now reads `Store.CachedDiskUsagePct()` when max cache size is unset to avoid transient errors or zero values.

- **Refactors**
  - Added `cacheHostDialAddr()` to pick dial address; uses `127.0.0.1` when `CACHE_HOST_NETWORK=true` and `CACHE_NODE_ID` matches the host, otherwise uses advertised/private addr. Updated client and discovery to use it. Tests included.

<sup>Written for commit 28d056573d589fcb1c7d89de98d6561226a60234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

