### PR TITLE
remove all redis scans

### DIFF
--- a/pkg/abstractions/map/map_redis.go
+++ b/pkg/abstractions/map/map_redis.go
@@ -3,12 +3,13 @@ package dmap
 import (
 	"context"
 	"fmt"
-	"strings"
+	"sort"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
 	pb "github.com/beam-cloud/beta9/proto"
+	"github.com/redis/go-redis/v9"
 )
 
 const (
@@ -40,7 +41,13 @@ func (m *RedisMapService) MapSet(ctx context.Context, in *pb.MapSetRequest) (*pb
 		return &pb.MapSetResponse{Ok: false, ErrMsg: "TTL cannot be longer than 1 week"}, nil
 	}
 
-	err := m.rdb.Set(ctx, Keys.MapEntry(authInfo.Workspace.Name, in.Name, in.Key), in.Value, time.Duration(in.Ttl)*time.Second).Err()
+	entryKey := Keys.MapEntry(authInfo.Workspace.Name, in.Name, in.Key)
+	indexKey := Keys.MapIndex(authInfo.Workspace.Name, in.Name)
+
+	pipe := m.rdb.TxPipeline()
+	pipe.Set(ctx, entryKey, in.Value, time.Duration(in.Ttl)*time.Second)
+	pipe.SAdd(ctx, indexKey, in.Key)
+	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return &pb.MapSetResponse{Ok: false}, nil
 	}
@@ -62,7 +69,13 @@ func (m *RedisMapService) MapGet(ctx context.Context, in *pb.MapGetRequest) (*pb
 func (m *RedisMapService) MapDelete(ctx context.Context, in *pb.MapDeleteRequest) (*pb.MapDeleteResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	err := m.rdb.Del(ctx, Keys.MapEntry(authInfo.Workspace.Name, in.Name, in.Key)).Err()
+	entryKey := Keys.MapEntry(authInfo.Workspace.Name, in.Name, in.Key)
+	indexKey := Keys.MapIndex(authInfo.Workspace.Name, in.Name)
+
+	pipe := m.rdb.TxPipeline()
+	pipe.Del(ctx, entryKey)
+	pipe.SRem(ctx, indexKey, in.Key)
+	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return &pb.MapDeleteResponse{Ok: false}, err
 	}
@@ -73,7 +86,7 @@ func (m *RedisMapService) MapDelete(ctx context.Context, in *pb.MapDeleteRequest
 func (m *RedisMapService) MapCount(ctx context.Context, in *pb.MapCountRequest) (*pb.MapCountResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	keys, err := m.rdb.Scan(ctx, Keys.MapEntry(authInfo.Workspace.Name, in.Name, "*"))
+	keys, err := m.liveMapKeys(ctx, authInfo.Workspace.Name, in.Name)
 	if err != nil {
 		return &pb.MapCountResponse{Ok: false, Count: 0}, err
 	}
@@ -84,23 +97,56 @@ func (m *RedisMapService) MapCount(ctx context.Context, in *pb.MapCountRequest) 
 func (m *RedisMapService) MapKeys(ctx context.Context, in *pb.MapKeysRequest) (*pb.MapKeysResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	keys, err := m.rdb.Scan(ctx, Keys.MapEntry(authInfo.Workspace.Name, in.Name, "*"))
+	keys, err := m.liveMapKeys(ctx, authInfo.Workspace.Name, in.Name)
 	if err != nil {
 		return &pb.MapKeysResponse{Ok: false, Keys: []string{}}, err
-	}
-
-	// Remove the prefix from each key
-	for i, key := range keys {
-		parts := strings.Split(key, ":")
-		keys[i] = parts[len(parts)-1]
 	}
 
 	return &pb.MapKeysResponse{Ok: true, Keys: keys}, nil
 }
 
+func (m *RedisMapService) liveMapKeys(ctx context.Context, workspaceName, name string) ([]string, error) {
+	indexKey := Keys.MapIndex(workspaceName, name)
+	keys, err := m.rdb.SMembers(ctx, indexKey).Result()
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return []string{}, nil
+	}
+
+	pipe := m.rdb.TxPipeline()
+	exists := make([]*redis.IntCmd, 0, len(keys))
+	for _, key := range keys {
+		exists = append(exists, pipe.Exists(ctx, Keys.MapEntry(workspaceName, name, key)))
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, err
+	}
+
+	liveKeys := make([]string, 0, len(keys))
+	staleKeys := make([]interface{}, 0)
+	for i, key := range keys {
+		if exists[i].Val() > 0 {
+			liveKeys = append(liveKeys, key)
+		} else {
+			staleKeys = append(staleKeys, key)
+		}
+	}
+	if len(staleKeys) > 0 {
+		if err := m.rdb.SRem(ctx, indexKey, staleKeys...).Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Strings(liveKeys)
+	return liveKeys, nil
+}
+
 // Redis keys
 var (
 	mapEntry string = "map:%s:%s:%s"
+	mapIndex string = "map:%s:%s:index"
 )
 
 var Keys = &keys{}
@@ -109,4 +155,8 @@ type keys struct{}
 
 func (k *keys) MapEntry(workspaceName, name, key string) string {
 	return fmt.Sprintf(mapEntry, workspaceName, name, key)
+}
+
+func (k *keys) MapIndex(workspaceName, name string) string {
+	return fmt.Sprintf(mapIndex, workspaceName, name)
 }

--- a/pkg/abstractions/map/map_redis_test.go
+++ b/pkg/abstractions/map/map_redis_test.go
@@ -1,0 +1,60 @@
+package dmap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapKeysAndCountUseIndexAndPruneStaleEntries(t *testing.T) {
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(server.Close)
+
+	rdb, err := common.NewRedisClient(types.RedisConfig{
+		Addrs: []string{server.Addr()},
+		Mode:  types.RedisModeSingle,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	service, err := NewRedisMapService(rdb)
+	require.NoError(t, err)
+
+	ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Workspace: &types.Workspace{Name: "workspace-a"},
+		Token:     &types.Token{},
+	})
+
+	_, err = service.MapSet(ctx, &pb.MapSetRequest{Name: "map-a", Key: "live-a", Value: []byte("a"), Ttl: 3600})
+	require.NoError(t, err)
+	_, err = service.MapSet(ctx, &pb.MapSetRequest{Name: "map-a", Key: "live-b", Value: []byte("b"), Ttl: 3600})
+	require.NoError(t, err)
+
+	indexKey := Keys.MapIndex("workspace-a", "map-a")
+	require.NoError(t, rdb.SAdd(ctx, indexKey, "stale").Err())
+	require.NoError(t, rdb.Set(ctx, Keys.MapEntry("workspace-a", "map-a", "expired"), []byte("expired"), time.Millisecond).Err())
+	require.NoError(t, rdb.SAdd(ctx, indexKey, "expired").Err())
+	server.FastForward(2 * time.Millisecond)
+
+	keys, err := service.MapKeys(ctx, &pb.MapKeysRequest{Name: "map-a"})
+	require.NoError(t, err)
+	require.True(t, keys.Ok)
+	require.Equal(t, []string{"live-a", "live-b"}, keys.Keys)
+
+	count, err := service.MapCount(ctx, &pb.MapCountRequest{Name: "map-a"})
+	require.NoError(t, err)
+	require.True(t, count.Ok)
+	require.Equal(t, uint32(2), count.Count)
+
+	indexMembers, err := rdb.SMembers(ctx, indexKey).Result()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"live-a", "live-b"}, indexMembers)
+}

--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -1615,7 +1615,7 @@ func orderedContainerLifecycleIDs() []types.ContainerLifecycleID {
 		types.ContainerLifecycleNetworkCreateNamespace,
 		types.ContainerLifecycleNetworkConfigureNamespace,
 		types.ContainerLifecycleNetworkIPLock,
-		types.ContainerLifecycleNetworkIPScan,
+		types.ContainerLifecycleNetworkIPLoad,
 		types.ContainerLifecycleNetworkIPAssign,
 		types.ContainerLifecycleNetworkSetContainerIP,
 		types.ContainerLifecycleNetworkRestrictions,

--- a/pkg/cache/metadata.go
+++ b/pkg/cache/metadata.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/bsm/redislock"
@@ -235,15 +234,19 @@ func (m *Metadata) AddRecentStub(ctx context.Context, locality, workspaceID, stu
 		return nil
 	}
 	key := MetadataKeys.MetadataReconcileRecent(locality)
+	allKey := MetadataKeys.MetadataReconcileRecentAll()
 	now := time.Now()
 	member := RecentStubKey(workspaceID, stubID)
 
 	pipe := m.rdb.TxPipeline()
 	pipe.ZAdd(ctx, key, redis.Z{Score: float64(now.UnixNano()), Member: member})
+	pipe.ZAdd(ctx, allKey, redis.Z{Score: float64(now.UnixNano()), Member: member})
 	if ttl > 0 {
 		cutoff := now.Add(-ttl).UnixNano()
 		pipe.ZRemRangeByScore(ctx, key, "-inf", fmt.Sprintf("%d", cutoff))
+		pipe.ZRemRangeByScore(ctx, allKey, "-inf", fmt.Sprintf("%d", cutoff))
 		pipe.Expire(ctx, key, ttl)
+		pipe.Expire(ctx, allKey, ttl)
 	}
 	_, err := pipe.Exec(ctx)
 	return err
@@ -290,36 +293,10 @@ func (m *Metadata) listRecentStubsFromKey(ctx context.Context, key string, ttl t
 	return stubs, nil
 }
 
-// ListRecentStubsAnyLocality returns recently used stubs across all locality
-// indexes, newest first, deduplicated by workspace/stub pair.
+// ListRecentStubsAnyLocality returns recently used stubs across all localities
+// from the global recent-stub index, newest first.
 func (m *Metadata) ListRecentStubsAnyLocality(ctx context.Context, ttl time.Duration) ([]RecentStub, error) {
-	keys, err := m.rdb.Scan(ctx, MetadataKeys.MetadataReconcileRecent("*"))
-	if err != nil {
-		return nil, err
-	}
-
-	latest := map[string]RecentStub{}
-	for _, key := range keys {
-		stubs, err := m.listRecentStubsFromKey(ctx, key, ttl, 0)
-		if err != nil {
-			return nil, err
-		}
-		for _, stub := range stubs {
-			member := RecentStubKey(stub.WorkspaceID, stub.StubID)
-			if existing, ok := latest[member]; !ok || stub.LastSeen.After(existing.LastSeen) {
-				latest[member] = stub
-			}
-		}
-	}
-
-	stubs := make([]RecentStub, 0, len(latest))
-	for _, stub := range latest {
-		stubs = append(stubs, stub)
-	}
-	sort.Slice(stubs, func(i, j int) bool {
-		return stubs[i].LastSeen.After(stubs[j].LastSeen)
-	})
-	return stubs, nil
+	return m.listRecentStubsFromKey(ctx, MetadataKeys.MetadataReconcileRecentAll(), ttl, 0)
 }
 
 // MarkStubReported atomically claims the one-time required-content generation
@@ -393,6 +370,7 @@ var (
 	metadataHostKeepAlive        string = "cache:host:keepalive:%s:%s"
 	metadataStoreFromContentLock string = "cache:store_from_content_lock:%s:%s"
 	metadataReconcileRecent      string = "cache:reconcile:recent:%s"
+	metadataReconcileRecentAll   string = "cache:reconcile:recent"
 	metadataReconcileLock        string = "cache:reconcile:lock:%s:%s:%s"
 	metadataReconcileReported    string = "cache:reconcile:reported:%s:%s"
 )
@@ -433,6 +411,10 @@ func (k *metadataKeys) MetadataStoreFromContentLock(locality, sourcePath string)
 
 func (k *metadataKeys) MetadataReconcileRecent(locality string) string {
 	return fmt.Sprintf(metadataReconcileRecent, locality)
+}
+
+func (k *metadataKeys) MetadataReconcileRecentAll() string {
+	return metadataReconcileRecentAll
 }
 
 func (k *metadataKeys) MetadataReconcileLock(locality, logicalHost, hash string) string {

--- a/pkg/cache/reconcile_test.go
+++ b/pkg/cache/reconcile_test.go
@@ -137,6 +137,13 @@ func TestRecentStubsAnyLocalityDedupesByNewestSeen(t *testing.T) {
 	require.NoError(t, m.AddRecentStub(ctx, "locality-b", "ws", "stub-a", time.Hour))
 	require.NoError(t, m.AddRecentStub(ctx, "locality-b", "ws", "stub-b", time.Hour))
 
+	indexMembers, err := m.rdb.ZRange(ctx, MetadataKeys.MetadataReconcileRecentAll(), 0, -1).Result()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		RecentStubKey("ws", "stub-a"),
+		RecentStubKey("ws", "stub-b"),
+	}, indexMembers)
+
 	stubs, err := m.ListRecentStubsAnyLocality(ctx, time.Hour)
 	require.NoError(t, err)
 

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -86,6 +86,50 @@ func (r *RedisClient) ToStruct(m map[string]string, out interface{}) error {
 	return ToStruct(m, out)
 }
 
+// Keys gets all keys using a pattern. Prefer explicit indexes for hot paths.
+func (r *RedisClient) Keys(ctx context.Context, pattern string) ([]string, error) {
+	return r.Scan(ctx, pattern)
+}
+
+func (r *RedisClient) Scan(ctx context.Context, pattern string) ([]string, error) {
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	keys := []string{}
+
+	scanAndCollect := func(rdb *redis.Client) error {
+		iter := rdb.Scan(ctx, 0, pattern, 10_000).Iterator()
+
+		for iter.Next(ctx) {
+			key := iter.Val()
+
+			mu.Lock()
+			if !seen[key] {
+				seen[key] = true
+				keys = append(keys, key)
+			}
+			mu.Unlock()
+		}
+
+		return iter.Err()
+	}
+
+	switch client := r.UniversalClient.(type) {
+	case *redis.Client:
+		if err := scanAndCollect(client); err != nil {
+			return nil, err
+		}
+
+	case *redis.ClusterClient:
+		if err := client.ForEachMaster(ctx, func(ctx context.Context, rdb *redis.Client) error {
+			return scanAndCollect(rdb)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return keys, nil
+}
+
 func (r *RedisClient) LRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
 	return r.UniversalClient.LRange(ctx, key, start, stop).Result()
 }

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -86,51 +86,6 @@ func (r *RedisClient) ToStruct(m map[string]string, out interface{}) error {
 	return ToStruct(m, out)
 }
 
-// Gets all keys using a pattern
-// Actually runs a scan since keys locks up the database.
-func (r *RedisClient) Keys(ctx context.Context, pattern string) ([]string, error) {
-	return r.Scan(ctx, pattern)
-}
-
-func (r *RedisClient) Scan(ctx context.Context, pattern string) ([]string, error) {
-	var mu sync.Mutex
-	seen := map[string]bool{}
-	keys := []string{}
-
-	scanAndCollect := func(rdb *redis.Client) error {
-		iter := rdb.Scan(ctx, 0, pattern, 10_000).Iterator()
-
-		for iter.Next(ctx) {
-			key := iter.Val()
-
-			mu.Lock()
-			if !seen[key] {
-				seen[key] = true
-				keys = append(keys, key)
-			}
-			mu.Unlock()
-		}
-
-		return iter.Err()
-	}
-
-	switch client := r.UniversalClient.(type) {
-	case *redis.Client:
-		if err := scanAndCollect(client); err != nil {
-			return nil, err
-		}
-
-	case *redis.ClusterClient:
-		if err := client.ForEachMaster(ctx, func(ctx context.Context, rdb *redis.Client) error {
-			return scanAndCollect(rdb)
-		}); err != nil {
-			return nil, err
-		}
-	}
-
-	return keys, nil
-}
-
 func (r *RedisClient) LRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
 	return r.UniversalClient.LRange(ctx, key, start, stop).Result()
 }

--- a/pkg/common/key_events.go
+++ b/pkg/common/key_events.go
@@ -37,37 +37,9 @@ func (kem *KeyEventManager) TrimKeyspacePrefix(key string) string {
 	return strings.TrimPrefix(key, keyspacePrefix)
 }
 
-func (kem *KeyEventManager) fetchExistingKeys(patternPrefix string) ([]string, error) {
-	pattern := fmt.Sprintf("%s*", patternPrefix)
-
-	keys, err := kem.rdb.Scan(context.Background(), pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	trimmedKeys := make([]string, len(keys))
-	for i, key := range keys {
-		trimmedKeys[i] = strings.TrimPrefix(key, patternPrefix)
-	}
-
-	return trimmedKeys, nil
-}
-
 func (kem *KeyEventManager) ListenForPattern(ctx context.Context, patternPrefix string, keyEventChan chan KeyEvent) error {
 	pattern := fmt.Sprintf("%s%s*", keyspacePrefix, patternPrefix)
 	messages, errs, close := kem.rdb.PSubscribe(ctx, pattern)
-
-	existingKeys, err := kem.fetchExistingKeys(patternPrefix)
-	if err != nil {
-		return err
-	}
-
-	for _, key := range existingKeys {
-		keyEventChan <- KeyEvent{
-			Key:       key,
-			Operation: KeyOperationSet,
-		}
-	}
 
 	go func() {
 		defer close()

--- a/pkg/common/key_events.go
+++ b/pkg/common/key_events.go
@@ -37,9 +37,37 @@ func (kem *KeyEventManager) TrimKeyspacePrefix(key string) string {
 	return strings.TrimPrefix(key, keyspacePrefix)
 }
 
+func (kem *KeyEventManager) fetchExistingKeys(patternPrefix string) ([]string, error) {
+	pattern := fmt.Sprintf("%s*", patternPrefix)
+
+	keys, err := kem.rdb.Scan(context.Background(), pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	trimmedKeys := make([]string, len(keys))
+	for i, key := range keys {
+		trimmedKeys[i] = strings.TrimPrefix(key, patternPrefix)
+	}
+
+	return trimmedKeys, nil
+}
+
 func (kem *KeyEventManager) ListenForPattern(ctx context.Context, patternPrefix string, keyEventChan chan KeyEvent) error {
 	pattern := fmt.Sprintf("%s%s*", keyspacePrefix, patternPrefix)
 	messages, errs, close := kem.rdb.PSubscribe(ctx, pattern)
+
+	existingKeys, err := kem.fetchExistingKeys(patternPrefix)
+	if err != nil {
+		return err
+	}
+
+	for _, key := range existingKeys {
+		keyEventChan <- KeyEvent{
+			Key:       key,
+			Operation: KeyOperationSet,
+		}
+	}
 
 	go func() {
 		defer close()

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -69,12 +69,13 @@ var (
 var (
 	workspacePrefix string = "workspace"
 
-	workspaceVolumePathDownloadToken     string = "workspace:volume_path_download_token:%s"
-	workspaceConcurrencyLimit            string = "workspace:concurrency_limit:%s"
-	workspaceConcurrencyLimitLock        string = "workspace:concurrency_limit:lock:%s"
-	workspaceConcurrencyLimitUsage       string = "workspace:{%s}:concurrency_limit:usage"
-	workspaceConcurrencyLimitReservation string = "workspace:{%s}:concurrency_limit:reservation:%s"
-	workspaceAuthorizedToken             string = "workspace:authorization:token:%s"
+	workspaceVolumePathDownloadToken          string = "workspace:volume_path_download_token:%s"
+	workspaceConcurrencyLimit                 string = "workspace:concurrency_limit:%s"
+	workspaceConcurrencyLimitLock             string = "workspace:concurrency_limit:lock:%s"
+	workspaceConcurrencyLimitUsage            string = "workspace:{%s}:concurrency_limit:usage"
+	workspaceConcurrencyLimitReservation      string = "workspace:{%s}:concurrency_limit:reservation:%s"
+	workspaceConcurrencyLimitReservationIndex string = "workspace:{%s}:concurrency_limit:reservation_index"
+	workspaceAuthorizedToken                  string = "workspace:authorization:token:%s"
 )
 
 var (
@@ -86,8 +87,9 @@ var (
 )
 
 var (
-	tailscalePrefix          string = "tailscale"
-	tailscaleServiceHostname string = "tailscale:%s:%s"
+	tailscalePrefix               string = "tailscale"
+	tailscaleServiceHostname      string = "tailscale:%s:%s"
+	tailscaleServiceHostnameIndex string = "tailscale:%s:index"
 )
 
 var (
@@ -320,6 +322,10 @@ func (rk *redisKeys) WorkspaceConcurrencyLimitReservation(workspaceId, container
 	return fmt.Sprintf(workspaceConcurrencyLimitReservation, workspaceId, containerId)
 }
 
+func (rk *redisKeys) WorkspaceConcurrencyLimitReservationIndex(workspaceId string) string {
+	return fmt.Sprintf(workspaceConcurrencyLimitReservationIndex, workspaceId)
+}
+
 func (rk *redisKeys) WorkspaceVolumePathDownloadToken(token string) string {
 	return fmt.Sprintf(workspaceVolumePathDownloadToken, token)
 }
@@ -335,6 +341,10 @@ func (rk *redisKeys) TailscalePrefix() string {
 
 func (rk *redisKeys) TailscaleServiceHostname(serviceName, hostName string) string {
 	return fmt.Sprintf(tailscaleServiceHostname, serviceName, hostName)
+}
+
+func (rk *redisKeys) TailscaleServiceHostnameIndex(serviceName string) string {
+	return fmt.Sprintf(tailscaleServiceHostnameIndex, serviceName)
 }
 
 // Provider keys

--- a/pkg/common/redis.go
+++ b/pkg/common/redis.go
@@ -85,6 +85,65 @@ func (r *RedisClient) ToStruct(m map[string]string, out interface{}) error {
 	return ToStruct(m, out)
 }
 
+// Keys gets all keys using a pattern. Prefer explicit indexes for hot paths.
+func (r *RedisClient) Keys(ctx context.Context, pattern string) ([]string, error) {
+	return r.Scan(ctx, pattern)
+}
+
+func (r *RedisClient) Scan(ctx context.Context, pattern string) ([]string, error) {
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	outCh := make(chan string)
+	errCh := make(chan error)
+
+	scanAndCollect := func(rdb *redis.Client) error {
+		iter := rdb.Scan(ctx, 0, pattern, 10_000).Iterator()
+
+		for iter.Next(ctx) {
+			key := iter.Val()
+
+			mu.Lock()
+			if !seen[key] {
+				seen[key] = true
+				outCh <- key
+			}
+			mu.Unlock()
+		}
+
+		return iter.Err()
+	}
+
+	go func() {
+		defer close(outCh)
+		defer close(errCh)
+
+		switch client := r.UniversalClient.(type) {
+		case *redis.Client:
+			if err := scanAndCollect(client); err != nil {
+				errCh <- err
+			}
+
+		case *redis.ClusterClient:
+			if err := client.ForEachMaster(ctx, func(ctx context.Context, rdb *redis.Client) error {
+				return scanAndCollect(rdb)
+			}); err != nil {
+				errCh <- err
+			}
+		}
+	}()
+
+	var keys []string
+	for key := range outCh {
+		keys = append(keys, key)
+	}
+
+	if err, ok := <-errCh; ok {
+		return nil, err
+	}
+
+	return keys, nil
+}
+
 func (r *RedisClient) LRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
 	return r.UniversalClient.LRange(ctx, key, start, stop).Result()
 }

--- a/pkg/common/redis.go
+++ b/pkg/common/redis.go
@@ -85,66 +85,6 @@ func (r *RedisClient) ToStruct(m map[string]string, out interface{}) error {
 	return ToStruct(m, out)
 }
 
-// Gets all keys using a pattern
-// Actually runs a scan since keys locks up the database.
-func (r *RedisClient) Keys(ctx context.Context, pattern string) ([]string, error) {
-	return r.Scan(ctx, pattern)
-}
-
-func (r *RedisClient) Scan(ctx context.Context, pattern string) ([]string, error) {
-	var mu sync.Mutex
-	seen := map[string]bool{}
-	outCh := make(chan string)
-	errCh := make(chan error)
-
-	scanAndCollect := func(rdb *redis.Client) error {
-		iter := rdb.Scan(ctx, 0, pattern, 10_000).Iterator()
-
-		for iter.Next(ctx) {
-			key := iter.Val()
-
-			mu.Lock()
-			if !seen[key] {
-				seen[key] = true
-				outCh <- key
-			}
-			mu.Unlock()
-		}
-
-		return iter.Err()
-	}
-
-	go func() {
-		defer close(outCh)
-		defer close(errCh)
-
-		switch client := r.UniversalClient.(type) {
-		case *redis.Client:
-			scanAndCollect(client)
-
-		case *redis.ClusterClient:
-			err := client.ForEachMaster(ctx, func(ctx context.Context, rdb *redis.Client) error {
-				return scanAndCollect(rdb)
-			})
-
-			if err != nil {
-				errCh <- err
-			}
-		}
-	}()
-
-	var keys []string
-	for key := range outCh {
-		keys = append(keys, key)
-	}
-
-	if err, ok := <-errCh; ok {
-		return nil, err
-	}
-
-	return keys, nil
-}
-
 func (r *RedisClient) LRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
 	return r.UniversalClient.LRange(ctx, key, start, stop).Result()
 }

--- a/pkg/common/redis_test.go
+++ b/pkg/common/redis_test.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -365,42 +364,6 @@ func TestRedisClientSetAndGet(t *testing.T) {
 	res, err := rdb.Get(ctx, key).Result()
 	assert.NoError(t, err)
 	assert.Equal(t, val, res)
-}
-
-func TestRedisClientScan(t *testing.T) {
-	rdb, err := NewRedisClientForTest()
-	assert.NotNil(t, rdb)
-	assert.NoError(t, err)
-	defer rdb.Close()
-
-	ctx := context.Background()
-
-	// Generate 1000 items, add to map var, add to redis
-	keys := map[string]string{}
-	for i := 0; i < 1000; i++ {
-		key := fmt.Sprint(i)
-		keys[key] = uuid.New().String()
-		err := rdb.Set(ctx, key, keys[key], 0).Err()
-		assert.NoError(t, err)
-	}
-
-	// Make sure 1000 items were added to redis
-	items, err := rdb.Scan(ctx, "*")
-	assert.NoError(t, err)
-	assert.Len(t, items, 1000)
-
-	// Scan/search for 100 items e.g. 800 - 899
-	items, err = rdb.Scan(ctx, "8??")
-	assert.NoError(t, err)
-	assert.Len(t, items, 100)
-
-	// Get values for all items, compare their values to map
-	for _, item := range items {
-		expect := keys[item]
-		actual, err := rdb.Get(ctx, item).Result()
-		assert.NoError(t, err)
-		assert.Equal(t, expect, actual)
-	}
 }
 
 // TODO: Need real redis service for pubsub testing

--- a/pkg/common/redis_test.go
+++ b/pkg/common/redis_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -364,6 +365,38 @@ func TestRedisClientSetAndGet(t *testing.T) {
 	res, err := rdb.Get(ctx, key).Result()
 	assert.NoError(t, err)
 	assert.Equal(t, val, res)
+}
+
+func TestRedisClientScan(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.NoError(t, err)
+	defer rdb.Close()
+
+	ctx := context.Background()
+
+	keys := map[string]string{}
+	for i := 0; i < 1000; i++ {
+		key := fmt.Sprint(i)
+		keys[key] = uuid.New().String()
+		err := rdb.Set(ctx, key, keys[key], 0).Err()
+		assert.NoError(t, err)
+	}
+
+	items, err := rdb.Scan(ctx, "*")
+	assert.NoError(t, err)
+	assert.Len(t, items, 1000)
+
+	items, err = rdb.Scan(ctx, "8??")
+	assert.NoError(t, err)
+	assert.Len(t, items, 100)
+
+	for _, item := range items {
+		expect := keys[item]
+		actual, err := rdb.Get(ctx, item).Result()
+		assert.NoError(t, err)
+		assert.Equal(t, expect, actual)
+	}
 }
 
 // TODO: Need real redis service for pubsub testing

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -46,6 +46,7 @@ local request_gpu = tonumber(ARGV[3])
 local request_cpu = tonumber(ARGV[4])
 
 if redis.call("EXISTS", KEYS[2]) == 1 then
+	redis.call("SADD", KEYS[3], ARGV[6])
 	return "ok"
 end
 
@@ -70,11 +71,13 @@ redis.call("HSET", KEYS[2],
 	"gpu_count", request_gpu,
 	"cpu", request_cpu,
 	"created_at", ARGV[7])
+redis.call("SADD", KEYS[3], ARGV[6])
 return "ok"
 `)
 
 var releaseConcurrencyReservationScript = redis.NewScript(`
 if redis.call("EXISTS", KEYS[2]) == 0 then
+	redis.call("SREM", KEYS[3], ARGV[2])
 	return 0
 end
 
@@ -104,6 +107,7 @@ end
 
 redis.call("HSET", KEYS[1], "updated_at", ARGV[1])
 redis.call("DEL", KEYS[2])
+redis.call("SREM", KEYS[3], ARGV[2])
 return 1
 `)
 
@@ -696,6 +700,7 @@ func (c *ContainerRedisRepository) rebuildWorkspaceConcurrencyCounter(ctx contex
 	nowTime := time.Now()
 	now := nowTime.Unix()
 	usageKey := common.RedisKeys.WorkspaceConcurrencyLimitUsage(workspaceId)
+	reservationIndexKey := common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(workspaceId)
 	// Make repairs visible to lock-free reserve/release scripts before taking
 	// the snapshot so they cannot race the final aggregate write.
 	if err := c.rdb.HSet(ctx, usageKey,
@@ -730,38 +735,51 @@ func (c *ContainerRedisRepository) rebuildWorkspaceConcurrencyCounter(ctx contex
 			"cpu", container.Cpu,
 			"created_at", now,
 		)
+		pipe.SAdd(ctx, reservationIndexKey, container.ContainerId)
 	}
 
-	reservationKeys, err := c.rdb.Scan(ctx, common.RedisKeys.WorkspaceConcurrencyLimitReservation(workspaceId, "*"))
+	reservationIds, err := c.rdb.SMembers(ctx, reservationIndexKey).Result()
 	if err != nil {
 		return err
 	}
 
-	for _, reservationKey := range reservationKeys {
+	for _, reservationId := range reservationIds {
+		if reservationId == "" {
+			pipe.SRem(ctx, reservationIndexKey, reservationId)
+			continue
+		}
+		reservationKey := common.RedisKeys.WorkspaceConcurrencyLimitReservation(workspaceId, reservationId)
 		res, err := c.rdb.HGetAll(ctx, reservationKey).Result()
 		if err != nil {
 			return err
 		}
 		if len(res) == 0 {
+			pipe.SRem(ctx, reservationIndexKey, reservationId)
 			continue
 		}
 
 		var reservation concurrencyReservation
 		if err := common.ToStruct(res, &reservation); err != nil {
 			pipe.Del(ctx, reservationKey)
+			pipe.SRem(ctx, reservationIndexKey, reservationId)
 			continue
+		}
+		if reservation.ContainerId == "" {
+			reservation.ContainerId = reservationId
 		}
 
 		state, stateExists := statesByContainerId[reservation.ContainerId]
 		if stateExists {
 			if state.Status == types.ContainerStatusStopping {
 				pipe.Del(ctx, reservationKey)
+				pipe.SRem(ctx, reservationIndexKey, reservation.ContainerId)
 			}
 			continue
 		}
 
 		if reservation.CreatedAt <= 0 || nowTime.Sub(time.Unix(reservation.CreatedAt, 0)) > concurrencyReservationInFlightTTL {
 			pipe.Del(ctx, reservationKey)
+			pipe.SRem(ctx, reservationIndexKey, reservation.ContainerId)
 			continue
 		}
 
@@ -830,6 +848,7 @@ func (c *ContainerRedisRepository) tryReserveContainerConcurrency(quota *types.C
 	result, err := reserveConcurrencyReservationScript.Run(ctx, c.rdb, []string{
 		common.RedisKeys.WorkspaceConcurrencyLimitUsage(request.WorkspaceId),
 		common.RedisKeys.WorkspaceConcurrencyLimitReservation(request.WorkspaceId, request.ContainerId),
+		common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(request.WorkspaceId),
 	},
 		int64(quota.GPULimit),
 		int64(quota.CPUMillicoreLimit),
@@ -866,7 +885,8 @@ func (c *ContainerRedisRepository) releaseContainerConcurrencyReservation(ctx co
 		result, err := releaseConcurrencyReservationScript.Run(ctx, c.rdb, []string{
 			common.RedisKeys.WorkspaceConcurrencyLimitUsage(workspaceId),
 			common.RedisKeys.WorkspaceConcurrencyLimitReservation(workspaceId, containerId),
-		}, time.Now().Unix()).Result()
+			common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(workspaceId),
+		}, time.Now().Unix(), containerId).Result()
 		if err != nil {
 			return err
 		}

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -171,6 +171,18 @@ func TestUpdateContainerStatusStoppingReleasesConcurrencyReservation(t *testing.
 	if err := repo.SetContainerStateWithConcurrencyLimit(quota, secondRequest); err != nil {
 		t.Fatalf("expected quota to be released after STOPPING status, got %v", err)
 	}
+
+	indexed, err := rdb.SIsMember(
+		context.Background(),
+		common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(firstRequest.WorkspaceId),
+		firstRequest.ContainerId,
+	).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexed {
+		t.Fatal("expected STOPPING release to remove reservation index entry")
+	}
 }
 
 func TestUpdateContainerStatusDoesNotMoveStoppingBackToRunning(t *testing.T) {
@@ -245,6 +257,18 @@ func TestUpdateContainerStatusStoppingRetriesConcurrencyReleaseAfterTransientFai
 	if err := repo.SetContainerStateWithConcurrencyLimit(quota, secondRequest); err != nil {
 		t.Fatalf("expected quota to be available after retry release, got %v", err)
 	}
+
+	indexed, err := rdb.SIsMember(
+		context.Background(),
+		common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(firstRequest.WorkspaceId),
+		firstRequest.ContainerId,
+	).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexed {
+		t.Fatal("expected retry release to remove reservation index entry")
+	}
 }
 
 func TestUpdateContainerStatusStoppingReleasesDuringCounterRepair(t *testing.T) {
@@ -302,6 +326,18 @@ func TestDeleteContainerStateReleasesConcurrencyReservation(t *testing.T) {
 	if err := repo.SetContainerStateWithConcurrencyLimit(quota, secondRequest); err != nil {
 		t.Fatalf("expected quota to be released after delete, got %v", err)
 	}
+
+	indexed, err := rdb.SIsMember(
+		context.Background(),
+		common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(firstRequest.WorkspaceId),
+		firstRequest.ContainerId,
+	).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexed {
+		t.Fatal("expected delete to remove reservation index entry")
+	}
 }
 
 func TestSetContainerStateWithConcurrencyLimitRepairsStaleConcurrencyCounter(t *testing.T) {
@@ -321,7 +357,7 @@ func TestSetContainerStateWithConcurrencyLimitRepairsStaleConcurrencyCounter(t *
 
 	// Simulate a state TTL expiry or missed cleanup after a worker failure. The
 	// hot path counter still says the workspace is full, but the active state
-	// scan used for repair no longer includes the first container.
+	// index used for repair no longer includes the first container.
 	if err := rdb.Del(context.Background(), common.RedisKeys.SchedulerContainerState(firstRequest.ContainerId)).Err(); err != nil {
 		t.Fatal(err)
 	}
@@ -347,6 +383,18 @@ func TestSetContainerStateWithConcurrencyLimitRepairsStaleConcurrencyCounter(t *
 	}
 	if usedCPU != secondRequest.Cpu {
 		t.Fatalf("expected repaired counter to track only active request CPU, got %d", usedCPU)
+	}
+
+	indexed, err := rdb.SIsMember(
+		context.Background(),
+		common.RedisKeys.WorkspaceConcurrencyLimitReservationIndex(firstRequest.WorkspaceId),
+		firstRequest.ContainerId,
+	).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexed {
+		t.Fatal("expected stale reservation index entry to be removed during repair")
 	}
 }
 

--- a/pkg/repository/tailscale_redis.go
+++ b/pkg/repository/tailscale_redis.go
@@ -22,33 +22,44 @@ func NewTailscaleRedisRepository(r *common.RedisClient, config types.AppConfig) 
 }
 
 func (ts *TailscaleRedisRepository) GetHostnamesForService(serviceName string) ([]string, error) {
+	ctx := context.TODO()
 	hostnames := []string{}
 
-	keys, err := ts.rdb.Keys(context.TODO(), common.RedisKeys.TailscaleServiceHostname(serviceName, "*"))
+	serviceIds, err := ts.rdb.SMembers(ctx, common.RedisKeys.TailscaleServiceHostnameIndex(serviceName)).Result()
 	if err != nil {
 		return hostnames, err
 	}
 
-	if len(keys) == 0 {
+	if len(serviceIds) == 0 {
 		return hostnames, fmt.Errorf("no hostname found for service<%s>", serviceName)
 	}
 
-	for _, key := range keys {
-		hostname, err := ts.rdb.Get(context.TODO(), key).Result()
+	for _, serviceId := range serviceIds {
+		hostname, err := ts.rdb.Get(ctx, common.RedisKeys.TailscaleServiceHostname(serviceName, serviceId)).Result()
 		if err != nil {
+			ts.rdb.SRem(ctx, common.RedisKeys.TailscaleServiceHostnameIndex(serviceName), serviceId)
 			continue
 		}
 
 		hostnames = append(hostnames, hostname)
 	}
 
+	if len(hostnames) == 0 {
+		return hostnames, fmt.Errorf("no hostname found for service<%s>", serviceName)
+	}
+
 	return hostnames, nil
 }
 
 func (ts *TailscaleRedisRepository) SetHostname(serviceName, serviceId string, hostName string) error {
-	return ts.rdb.SetEx(context.TODO(),
+	ctx := context.TODO()
+	pipe := ts.rdb.TxPipeline()
+	pipe.SAdd(ctx, common.RedisKeys.TailscaleServiceHostnameIndex(serviceName), serviceId)
+	pipe.SetEx(ctx,
 		common.RedisKeys.TailscaleServiceHostname(serviceName, serviceId),
 		hostName,
 		tailscaleHostNameExpiration,
-	).Err()
+	)
+	_, err := pipe.Exec(ctx)
+	return err
 }

--- a/pkg/repository/tailscale_redis_test.go
+++ b/pkg/repository/tailscale_redis_test.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTailscaleHostnamesUseServiceIndexAndPruneExpiredEntries(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	repo := &TailscaleRedisRepository{rdb: rdb}
+	require.NoError(t, repo.SetHostname("svc-a", "instance-a", "host-a"))
+	require.NoError(t, repo.SetHostname("svc-a", "instance-b", "host-b"))
+
+	ctx := context.Background()
+	require.NoError(t, rdb.SAdd(ctx, common.RedisKeys.TailscaleServiceHostnameIndex("svc-a"), "expired").Err())
+	require.NoError(t, rdb.Set(ctx, common.RedisKeys.TailscaleServiceHostname("svc-a", "expired"), "host-expired", time.Millisecond).Err())
+	time.Sleep(2 * time.Millisecond)
+
+	hostnames, err := repo.GetHostnamesForService("svc-a")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"host-a", "host-b"}, hostnames)
+
+	indexMembers, err := rdb.SMembers(ctx, common.RedisKeys.TailscaleServiceHostnameIndex("svc-a")).Result()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"instance-a", "instance-b"}, indexMembers)
+}

--- a/pkg/repository/tailscale_redis_test.go
+++ b/pkg/repository/tailscale_redis_test.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/stretchr/testify/require"
@@ -20,8 +19,6 @@ func TestTailscaleHostnamesUseServiceIndexAndPruneExpiredEntries(t *testing.T) {
 
 	ctx := context.Background()
 	require.NoError(t, rdb.SAdd(ctx, common.RedisKeys.TailscaleServiceHostnameIndex("svc-a"), "expired").Err())
-	require.NoError(t, rdb.Set(ctx, common.RedisKeys.TailscaleServiceHostname("svc-a", "expired"), "host-expired", time.Millisecond).Err())
-	time.Sleep(2 * time.Millisecond)
 
 	hostnames, err := repo.GetHostnamesForService("svc-a")
 	require.NoError(t, err)

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -926,36 +926,44 @@ func (r *WorkerRedisRepository) GetContainerIps(networkPrefix string) ([]string,
 
 func (r *WorkerRedisRepository) GetContainerIpAssignments(networkPrefix string) ([]types.ContainerIpAssignment, error) {
 	ctx := context.TODO()
-	keyPrefix := common.RedisKeys.WorkerNetworkContainerIp(networkPrefix, "")
-	pattern := common.RedisKeys.WorkerNetworkContainerIp(networkPrefix, "*")
 	assignments := []types.ContainerIpAssignment{}
 
-	keys, err := r.rdb.Scan(ctx, pattern)
+	ips, err := r.rdb.SMembers(ctx, common.RedisKeys.WorkerNetworkIpIndex(networkPrefix)).Result()
 	if err != nil {
 		return nil, err
 	}
 
-	if len(keys) > 0 {
-		values, err := r.rdb.MGet(ctx, keys...).Result()
+	if len(ips) > 0 {
+		ownerKeys := make([]string, 0, len(ips))
+		for _, ip := range ips {
+			ownerKeys = append(ownerKeys, common.RedisKeys.WorkerNetworkIpOwner(networkPrefix, ip))
+		}
+
+		owners, err := r.rdb.MGet(ctx, ownerKeys...).Result()
 		if err != nil {
 			return nil, err
 		}
 
-		for i, value := range values {
-			ip, ok := value.(string)
-			if !ok || ip == "" {
-				continue
-			}
-
-			containerId := strings.TrimPrefix(keys[i], keyPrefix)
-			if containerId == "" || containerId == keys[i] {
+		pipe := r.rdb.TxPipeline()
+		cleanupStaleIndexes := false
+		for i, value := range owners {
+			containerId, ok := value.(string)
+			if !ok || containerId == "" {
+				pipe.SRem(ctx, common.RedisKeys.WorkerNetworkIpIndex(networkPrefix), ips[i])
+				pipe.HDel(ctx, common.RedisKeys.WorkerNetworkIpRefCounts(networkPrefix), ips[i])
+				cleanupStaleIndexes = true
 				continue
 			}
 
 			assignments = append(assignments, types.ContainerIpAssignment{
 				ContainerID: containerId,
-				IPAddress:   ip,
+				IPAddress:   ips[i],
 			})
+		}
+		if cleanupStaleIndexes {
+			if _, err := pipe.Exec(ctx); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -754,6 +754,8 @@ func TestGetContainerIpAssignments(t *testing.T) {
 	assert.Nil(t, err)
 	err = repo.SetContainerIp(networkPrefix, "container-a", "192.168.0.3")
 	assert.Nil(t, err)
+	err = rdb.SAdd(context.TODO(), common.RedisKeys.WorkerNetworkIpIndex(networkPrefix), "192.168.0.99").Err()
+	assert.Nil(t, err)
 
 	assignments, err := repo.GetContainerIpAssignments(networkPrefix)
 	assert.Nil(t, err)
@@ -761,6 +763,10 @@ func TestGetContainerIpAssignments(t *testing.T) {
 		{ContainerID: "container-a", IPAddress: "192.168.0.3"},
 		{ContainerID: "network-slot:slot-a", IPAddress: "192.168.0.2"},
 	}, assignments)
+
+	ips, err := repo.GetContainerIps(networkPrefix)
+	assert.Nil(t, err)
+	assert.NotContains(t, ips, "192.168.0.99")
 }
 
 func TestRemoveContainerIpCleansLegacyIndexWithoutOwnerKey(t *testing.T) {

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -443,7 +443,7 @@ const (
 	ContainerLifecycleNetworkCreateNamespace      ContainerLifecycleID = "network.create_namespace"
 	ContainerLifecycleNetworkConfigureNamespace   ContainerLifecycleID = "network.configure_namespace"
 	ContainerLifecycleNetworkIPLock               ContainerLifecycleID = "network.ip_lock"
-	ContainerLifecycleNetworkIPScan               ContainerLifecycleID = "network.ip_scan"
+	ContainerLifecycleNetworkIPLoad               ContainerLifecycleID = "network.ip_load"
 	ContainerLifecycleNetworkIPAssign             ContainerLifecycleID = "network.ip_assign"
 	ContainerLifecycleNetworkSetContainerIP       ContainerLifecycleID = "network.set_container_ip"
 	ContainerLifecycleNetworkRestrictions         ContainerLifecycleID = "network.restrictions"
@@ -523,7 +523,7 @@ var ContainerLifecycleDefinitions = map[ContainerLifecycleID]ContainerLifecycleD
 	ContainerLifecycleNetworkCreateNamespace:      {ID: ContainerLifecycleNetworkCreateNamespace, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkSetup, Label: "Create namespace"},
 	ContainerLifecycleNetworkConfigureNamespace:   {ID: ContainerLifecycleNetworkConfigureNamespace, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkSetup, Label: "Configure namespace"},
 	ContainerLifecycleNetworkIPLock:               {ID: ContainerLifecycleNetworkIPLock, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkConfigureNamespace, Label: "Acquire IP lock"},
-	ContainerLifecycleNetworkIPScan:               {ID: ContainerLifecycleNetworkIPScan, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkConfigureNamespace, Label: "Scan allocated IPs"},
+	ContainerLifecycleNetworkIPLoad:               {ID: ContainerLifecycleNetworkIPLoad, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkConfigureNamespace, Label: "Load allocated IPs"},
 	ContainerLifecycleNetworkIPAssign:             {ID: ContainerLifecycleNetworkIPAssign, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkConfigureNamespace, Label: "Assign container IP"},
 	ContainerLifecycleNetworkSetContainerIP:       {ID: ContainerLifecycleNetworkSetContainerIP, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkConfigureNamespace, Label: "Persist container IP"},
 	ContainerLifecycleNetworkRestrictions:         {ID: ContainerLifecycleNetworkRestrictions, Domain: EventDomainNetwork, ParentID: ContainerLifecycleNetworkSetup, Label: "Network restrictions"},

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -1520,8 +1520,8 @@ func (m *ContainerNetworkManager) reserveContainerIP(opts *containerNetworkConfi
 
 	phaseStart = time.Now()
 	err := m.reloadAllocatedIPsLocked()
-	metrics.RecordWorkerStartupPhase("network_ip_scan", time.Since(phaseStart), opts.request, map[string]string{"success": fmt.Sprintf("%t", err == nil)})
-	m.recordNetworkLifecycle(opts.request, types.ContainerLifecycleNetworkIPScan, phaseStart, err == nil, map[string]string{
+	metrics.RecordWorkerStartupPhase("network_ip_load", time.Since(phaseStart), opts.request, map[string]string{"success": fmt.Sprintf("%t", err == nil)})
+	m.recordNetworkLifecycle(opts.request, types.ContainerLifecycleNetworkIPLoad, phaseStart, err == nil, map[string]string{
 		"source": "redis",
 	})
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Eliminated all Redis SCAN/KEYS usage by introducing explicit indexes with atomic pipelines, improving performance and reliability across map storage, networking, and scheduler paths. Also renamed the network lifecycle step and metric from ip_scan to ip_load.

- **Refactors**
  - Map service: added `map:%s:%s:index` set; `MapSet`/`MapDelete` update it; `MapKeys`/`MapCount` read from it, prune stale entries, and return sorted results.
  - Metadata: added global recent-stub index `cache:reconcile:recent`; `AddRecentStub` writes per-locality and global with TTL pruning; `ListRecentStubsAnyLocality` reads the global index.
  - Concurrency limits: added `workspace:{%s}:concurrency_limit:reservation_index` set; reserve/release Lua scripts maintain the index; repair uses the index and removes stale reservations.
  - Tailscale: added `tailscale:%s:index` set; `SetHostname` maintains index + TTL; `GetHostnamesForService` reads index, prunes expired entries, and errors when empty.
  - Worker networking: `GetContainerIpAssignments` reads from `WorkerNetworkIpIndex`, validates owners, and cleans stale IPs; lifecycle ID/metric renamed to ip_load.
  - Removed Redis scan helpers and eager pre-listing in key events; added key helpers for new indexes.

- **Migration**
  - Update any dashboards, alerts, or consumers that reference `network.ip_scan` (and metric `network_ip_scan`) to `network.ip_load` (`network_ip_load`).

<sup>Written for commit 2f3cbfc562d4aa4c599764defcd89561a1c9b61c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

