### PR TITLE
fix agent install in stage

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -353,9 +353,9 @@ providers:
 tailscale:
   controlUrl:
   user: beta9
-  # Gateway tsnet auth key. Use a key tagged for gateway nodes, for example tag:beam-gateway.
+  # Gateway tsnet auth key. Use an environment-scoped gateway tag, for example tag:beam-staging-gateway.
   authKey:
-  # Private pool agent tsnet auth key. Use a separate key tagged for Beam agents, for example tag:beam-agent.
+  # Private pool agent tsnet auth key. Use a separate environment-scoped agent tag, for example tag:beam-staging-agent.
   agentAuthKey:
   enabled: false
   debug: false

--- a/pkg/gateway/agent_install.go
+++ b/pkg/gateway/agent_install.go
@@ -273,7 +273,13 @@ install_linux_agent_for_docker() {
     return
   fi
 
-	URL="${AGENT_DOWNLOAD_URL:-${GATEWAY}/install/agent/linux/${ARCH}?dev=1}"
+	if [ -n "$AGENT_DOWNLOAD_URL" ]; then
+		URL="$AGENT_DOWNLOAD_URL"
+	elif [ "$DEV" = "1" ]; then
+		URL="${GATEWAY}/install/agent/linux/${ARCH}?dev=1"
+	else
+		URL="${GATEWAY}/install/agent/linux/${ARCH}"
+	fi
 	install_from_url "$URL" "$BIN" "Installing Beam agent"
 }
 

--- a/pkg/gateway/agent_install_test.go
+++ b/pkg/gateway/agent_install_test.go
@@ -29,12 +29,15 @@ func TestAgentInstallScriptDownloadsAgentFromGateway(t *testing.T) {
 	}
 	for _, want := range []string{
 		"${GATEWAY}/install/agent/${OS_NAME}/${ARCH_NAME}",
-		"${GATEWAY}/install/agent/linux/${ARCH}?dev=1",
+		"${GATEWAY}/install/agent/linux/${ARCH}",
 		"ensure_linux_docker",
 	} {
 		if !strings.Contains(agentInstallScript, want) {
 			t.Fatalf("install script missing %q", want)
 		}
+	}
+	if !strings.Contains(agentInstallScript, `elif [ "$DEV" = "1" ]; then`) || !strings.Contains(agentInstallScript, `${GATEWAY}/install/agent/linux/${ARCH}?dev=1`) {
+		t.Fatal("install script should only request source-built Linux agent binaries in dev mode")
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes agent installation in staging by selecting the correct Linux agent binary. Uses `AGENT_DOWNLOAD_URL` when provided, falls back to release builds unless `DEV=1`.

- **Bug Fixes**
  - Linux agent install script now downloads release binaries by default; dev binaries only when `DEV=1`.
  - Respects `AGENT_DOWNLOAD_URL` override.
  - Updated tests to assert dev-only behavior.
  - Config comments clarify environment-scoped Tailscale tags for `authKey` and `agentAuthKey`.

<sup>Written for commit 25790e9ed20fe1d401065015545efdc1542181c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

