### PR TITLE
another agent fix

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -141,6 +141,24 @@ func TestNormalizeBootstrapForAgentRuntimeUsesReachableGatewayHost(t *testing.T)
 	}
 }
 
+func TestNormalizeBootstrapForAgentRuntimePreservesPublicGRPCHost(t *testing.T) {
+	t.Setenv(types.AgentInContainerEnv, "1")
+
+	got := normalizeBootstrapForAgentRuntime("https://app.stage.beam.cloud", bootstrapConfig{
+		GatewayHTTPURL:  "https://app.stage.beam.cloud",
+		GatewayGRPCHost: "gateway.stage.beam.cloud",
+		GatewayGRPCPort: 443,
+		GatewayGRPCTLS:  true,
+	})
+
+	if got.GatewayHTTPURL != "https://app.stage.beam.cloud" {
+		t.Fatalf("expected public http url to be preserved, got %q", got.GatewayHTTPURL)
+	}
+	if got.GatewayGRPCHost != "gateway.stage.beam.cloud" {
+		t.Fatalf("expected public grpc host to be preserved, got %q", got.GatewayGRPCHost)
+	}
+}
+
 func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 	t.Setenv(types.AgentTargetHostEnv, "host.docker.internal")
 	t.Setenv(types.AgentDockerHostsEnv, "registry.localhost:127.0.0.1,localstack:host-gateway")

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -93,7 +93,9 @@ func normalizeBootstrapForAgentRuntime(gatewayURL string, bootstrap bootstrapCon
 		return bootstrap
 	}
 
-	bootstrap.GatewayGRPCHost = runtimeHost
+	if bootstrap.GatewayHTTPURL == "" || urlHostIsLoopback(bootstrap.GatewayHTTPURL) || isLoopbackHost(bootstrap.GatewayGRPCHost) {
+		bootstrap.GatewayGRPCHost = runtimeHost
+	}
 
 	if bootstrap.GatewayHTTPURL == "" || urlHostIsLoopback(bootstrap.GatewayHTTPURL) {
 		bootstrap.GatewayHTTPURL = gatewayURL


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves the public gRPC host when the agent runs in a container, only overriding it when the bootstrap points to loopback or is empty. Adds a test to lock this behavior.

- **Bug Fixes**
  - Only override the gRPC host when the HTTP URL is empty/loopback or the existing gRPC host is loopback; keep the public host otherwise.
  - Added test to verify public HTTP URL and gRPC host are preserved in containerized runtime.

<sup>Written for commit 905b6c1c5fdbd202ff910fd7f6b72b94e7e616fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

