### PR TITLE
fix agent install cmd

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -159,6 +159,40 @@ func TestNormalizeBootstrapForAgentRuntimePreservesPublicGRPCHost(t *testing.T) 
 	}
 }
 
+func TestNormalizeBootstrapForAgentRuntimeKeepsEmptyPublicGRPCHost(t *testing.T) {
+	t.Setenv(types.AgentInContainerEnv, "1")
+
+	got := normalizeBootstrapForAgentRuntime("https://app.stage.beam.cloud", bootstrapConfig{
+		GatewayHTTPURL:  "https://app.stage.beam.cloud",
+		GatewayGRPCPort: 443,
+		GatewayGRPCTLS:  true,
+	})
+
+	if got.GatewayGRPCHost != "" {
+		t.Fatalf("expected empty public grpc host to remain unset, got %q", got.GatewayGRPCHost)
+	}
+}
+
+func TestGatewayGRPCAddrDoesNotInferPublicGRPCHost(t *testing.T) {
+	_, err := gatewayGRPCAddr("https://app.stage.beam.cloud", "", 443)
+	if err == nil {
+		t.Fatal("expected missing public grpc host to fail")
+	}
+	if !strings.Contains(err.Error(), "gateway.grpc.externalHost") {
+		t.Fatalf("expected config-specific error, got %v", err)
+	}
+}
+
+func TestGatewayGRPCAddrInfersLoopbackGRPCHost(t *testing.T) {
+	addr, err := gatewayGRPCAddr("http://localhost:1994", "", 1993)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != "localhost:1993" {
+		t.Fatalf("addr = %q, want localhost:1993", addr)
+	}
+}
+
 func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 	t.Setenv(types.AgentTargetHostEnv, "host.docker.internal")
 	t.Setenv(types.AgentDockerHostsEnv, "registry.localhost:127.0.0.1,localstack:host-gateway")

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -62,14 +62,12 @@ func gatewayGRPCAddr(gatewayURL, host string, port int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if isLoopbackHost(u.Hostname()) {
-		host = u.Hostname()
+	gatewayHost := u.Hostname()
+	if isLoopbackHost(gatewayHost) {
+		host = gatewayHost
 	}
 	if host == "" {
-		host = u.Hostname()
-	}
-	if host == "" {
-		return "", fmt.Errorf("gateway grpc host is required")
+		return "", fmt.Errorf("gateway grpc host is required; check gateway.grpc.externalHost in the control plane config")
 	}
 	return net.JoinHostPort(host, strconv.Itoa(port)), nil
 }

--- a/pkg/gateway/agent_install.go
+++ b/pkg/gateway/agent_install.go
@@ -220,8 +220,9 @@ run_macos_docker_agent() {
   fi
 
   require_docker_desktop
-  AGENT_LINUX_BIN="${BEAM_AGENT_LINUX_BIN:-${HOME}/.beam/bin/beam-agent-linux-${ARCH}}"
-  HOST_STATE_DIR="${BEAM_AGENT_STATE_DIR:-${HOME}/.beam/agent}"
+  HOST_HOME="$(agent_host_home)"
+  AGENT_LINUX_BIN="${BEAM_AGENT_LINUX_BIN:-${HOST_HOME}/.beam/bin/beam-agent-linux-${ARCH}}"
+  HOST_STATE_DIR="${BEAM_AGENT_STATE_DIR:-${HOST_HOME}/.beam/agent}"
   HOSTNAME_VALUE="$(hostname 2>/dev/null || echo macos-agent)"
   HOST_FINGERPRINT="$(host_fingerprint "$HOSTNAME_VALUE")"
 
@@ -378,6 +379,38 @@ docker_reachable_url() {
         -e 's#://localhost/#://host.docker.internal/#' \
         -e 's#://127\.0\.0\.1:#://host.docker.internal:#' \
         -e 's#://127\.0\.0\.1/#://host.docker.internal/#'
+}
+
+agent_host_home() {
+  if [ -n "${BEAM_AGENT_HOME:-}" ]; then
+    printf '%s\n' "$BEAM_AGENT_HOME"
+    return
+  fi
+  if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    if command -v dscl >/dev/null 2>&1; then
+      HOME_DIR="$(dscl . -read "/Users/${SUDO_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2; exit}')"
+      if [ -n "$HOME_DIR" ]; then
+        printf '%s\n' "$HOME_DIR"
+        return
+      fi
+    fi
+    if command -v getent >/dev/null 2>&1; then
+      HOME_DIR="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+      if [ -n "$HOME_DIR" ]; then
+        printf '%s\n' "$HOME_DIR"
+        return
+      fi
+    fi
+    if [ -d "/Users/${SUDO_USER}" ]; then
+      printf '%s\n' "/Users/${SUDO_USER}"
+      return
+    fi
+    if [ -d "/home/${SUDO_USER}" ]; then
+      printf '%s\n' "/home/${SUDO_USER}"
+      return
+    fi
+  fi
+  printf '%s\n' "$HOME"
 }
 
 host_fingerprint() {

--- a/pkg/gateway/agent_install_test.go
+++ b/pkg/gateway/agent_install_test.go
@@ -41,6 +41,20 @@ func TestAgentInstallScriptDownloadsAgentFromGateway(t *testing.T) {
 	}
 }
 
+func TestAgentInstallScriptUsesInvokingUserHomeForMacOSDocker(t *testing.T) {
+	for _, want := range []string{
+		"HOST_HOME=\"$(agent_host_home)\"",
+		"${HOST_HOME}/.beam/bin/beam-agent-linux-${ARCH}",
+		"${HOST_HOME}/.beam/agent",
+		"${SUDO_USER:-}",
+		"${BEAM_AGENT_HOME:-}",
+	} {
+		if !strings.Contains(agentInstallScript, want) {
+			t.Fatalf("install script missing %q", want)
+		}
+	}
+}
+
 func TestAgentBinaryHandlerServesConfiguredBinary(t *testing.T) {
 	path := writeAgentBinary(t)
 	t.Setenv(types.AgentBinaryPathEnv, path)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the agent install command to use the invoking user's home on macOS Docker, preventing sudo-related permission issues. Also tightens gRPC host resolution to avoid incorrect public host inference and adds clearer errors.

- **Bug Fixes**
  - macOS Docker install now uses `agent_host_home`; `AGENT_LINUX_BIN` and `HOST_STATE_DIR` are placed under that home and respect `BEAM_AGENT_HOME`.
  - `gatewayGRPCAddr` only infers loopback hosts from the `gatewayURL`; if `host` is empty, returns a config-specific error referencing `gateway.grpc.externalHost`.
  - Keeps an empty public gRPC host unset in bootstrap; adds tests covering script home selection and gRPC host resolution.

<sup>Written for commit 153a0340b478a013bcc30ee91eb172b7b21b9db2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

