### PR TITLE
fix: refactor agent install

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -196,6 +196,7 @@ func TestGatewayGRPCAddrInfersLoopbackGRPCHost(t *testing.T) {
 func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 	t.Setenv(types.AgentTargetHostEnv, "host.docker.internal")
 	t.Setenv(types.AgentDockerHostsEnv, "registry.localhost:127.0.0.1,localstack:host-gateway")
+	t.Setenv(types.AgentWorkerPlatformEnv, "linux/amd64")
 
 	args := dockerRunArgs("slot-one", "worker:dev", "/tmp/config.json", bootstrapConfig{
 		GatewayHTTPURL:  "http://host.docker.internal:1994",
@@ -216,6 +217,9 @@ func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 
 	if !containsArg(args, "-e", types.WorkerRouteTargetEnv+"=host.docker.internal") {
 		t.Fatalf("expected route target host env in docker args: %#v", args)
+	}
+	if !containsArg(args, "--platform", "linux/amd64") {
+		t.Fatalf("expected worker platform in docker args: %#v", args)
 	}
 	for _, want := range []string{
 		types.CacheLocalityEnv + "=private",

--- a/pkg/agent/worker_container.go
+++ b/pkg/agent/worker_container.go
@@ -24,6 +24,9 @@ func dockerRunArgs(name, image, configPath string, bootstrap bootstrapConfig, sl
 		"--label", types.AgentDockerLabelMachineID + "=" + slot.MachineId,
 		"--label", types.AgentDockerLabelPoolName + "=" + slot.PoolName,
 	}
+	if platform := strings.TrimSpace(os.Getenv(types.AgentWorkerPlatformEnv)); platform != "" {
+		args = append(args, "--platform", platform)
+	}
 	for _, alias := range agentDockerHostAliases() {
 		args = append(args, "--add-host", alias)
 	}

--- a/pkg/gateway/agent_install.go
+++ b/pkg/gateway/agent_install.go
@@ -225,6 +225,9 @@ run_macos_docker_agent() {
   HOST_STATE_DIR="${BEAM_AGENT_STATE_DIR:-${HOST_HOME}/.beam/agent}"
   HOSTNAME_VALUE="$(hostname 2>/dev/null || echo macos-agent)"
   HOST_FINGERPRINT="$(host_fingerprint "$HOSTNAME_VALUE")"
+  if [ -z "${BEAM_AGENT_WORKER_PLATFORM:-}" ]; then
+    export BEAM_AGENT_WORKER_PLATFORM="linux/amd64"
+  fi
 
   mkdir -p "$(dirname "$AGENT_LINUX_BIN")" "$HOST_STATE_DIR"
   install_linux_agent_for_docker "$AGENT_LINUX_BIN"
@@ -244,6 +247,7 @@ run_macos_docker_agent() {
     -e BEAM_WORKER_IMAGE="$WORKER_IMAGE" \
     -e BEAM_AGENT_DOCKER_HOST_ALIASES \
     -e BEAM_AGENT_LOCAL_REGISTRY_FORWARD \
+    -e BEAM_AGENT_WORKER_PLATFORM \
     -e BEAM_AGENT_VERBOSE \
     -e NO_COLOR \
     "$AGENT_CONTAINER_IMAGE" /usr/local/bin/beam-agent "$@"

--- a/pkg/gateway/agent_install.go
+++ b/pkg/gateway/agent_install.go
@@ -343,6 +343,12 @@ install_from_url() {
   fi
   chmod 0755 "$TMP"
   mkdir -p "$(dirname "$DEST")"
+  if [ -d "$DEST" ]; then
+    rmdir "$DEST" 2>/dev/null || {
+      rm -f "$TMP"
+      fail "$DEST is a directory; remove it or set BEAM_AGENT_LINUX_BIN to a file path" 1
+    }
+  fi
   mv "$TMP" "$DEST"
 }
 

--- a/pkg/gateway/agent_install_test.go
+++ b/pkg/gateway/agent_install_test.go
@@ -55,6 +55,17 @@ func TestAgentInstallScriptUsesInvokingUserHomeForMacOSDocker(t *testing.T) {
 	}
 }
 
+func TestAgentInstallScriptDefaultsMacOSWorkerPlatform(t *testing.T) {
+	for _, want := range []string{
+		`export BEAM_AGENT_WORKER_PLATFORM="linux/amd64"`,
+		"-e BEAM_AGENT_WORKER_PLATFORM",
+	} {
+		if !strings.Contains(agentInstallScript, want) {
+			t.Fatalf("install script missing %q", want)
+		}
+	}
+}
+
 func TestAgentBinaryHandlerServesConfiguredBinary(t *testing.T) {
 	path := writeAgentBinary(t)
 	t.Setenv(types.AgentBinaryPathEnv, path)

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
@@ -106,5 +107,36 @@ func TestValidateAgentTransportConfig(t *testing.T) {
 	s.appConfig.Tailscale.AgentAuthKey = ""
 	if err := s.validateAgentTransportConfig(types.BackendRouteTransportTSNet); err == nil {
 		t.Fatal("expected missing agent auth key to fail")
+	}
+}
+
+func TestAgentInstallCommandDoesNotUseSudoOnDarwin(t *testing.T) {
+	command := agentInstallCommand("https://app.stage.beam.cloud", "join-token", false)
+
+	if !strings.Contains(command, `uname -s`) || !strings.Contains(command, `Darwin`) {
+		t.Fatalf("expected command to branch on Darwin, got %s", command)
+	}
+	if !strings.Contains(command, `then curl -fsSL 'https://app.stage.beam.cloud/install/agent' | sh -s -- --gateway 'https://app.stage.beam.cloud' --join-token 'join-token'`) {
+		t.Fatalf("expected Darwin/root path to run without sudo, got %s", command)
+	}
+	if !strings.Contains(command, `else curl -fsSL 'https://app.stage.beam.cloud/install/agent' | sudo sh -s -- --gateway 'https://app.stage.beam.cloud' --join-token 'join-token'`) {
+		t.Fatalf("expected non-root Linux path to use sudo, got %s", command)
+	}
+}
+
+func TestAgentInstallCommandDevModeRunsWithoutSudo(t *testing.T) {
+	command := agentInstallCommand("http://localhost:1994", "join-token", true)
+
+	if strings.Contains(command, "sudo") {
+		t.Fatalf("dev command should not use sudo: %s", command)
+	}
+	if !strings.Contains(command, "--dev") {
+		t.Fatalf("dev command should include --dev: %s", command)
+	}
+}
+
+func TestShellQuoteEscapesSingleQuotes(t *testing.T) {
+	if got := shellQuote("token'with'quote"); got != `'token'\''with'\''quote'` {
+		t.Fatalf("shellQuote() = %s", got)
 	}
 }

--- a/pkg/gateway/services/compute/tokens.go
+++ b/pkg/gateway/services/compute/tokens.go
@@ -102,12 +102,25 @@ func (s *Service) createPrivatePoolJoinCommandForOwner(ctx context.Context, work
 		return "", "", time.Time{}, err
 	}
 	gatewayURL := strings.TrimRight(s.appConfig.GatewayService.HTTP.GetExternalURL(), "/")
-	command := fmt.Sprintf(`curl -fsSL %s/install/agent | if [ "$(id -u)" -eq 0 ]; then sh -s -- --gateway %s --join-token %s; else sudo sh -s -- --gateway %s --join-token %s; fi`, gatewayURL, gatewayURL, token, gatewayURL, token)
 	devMode := isLocalGatewayURL(gatewayURL)
-	if devMode {
-		command = fmt.Sprintf("curl -fsSL %s/install/agent | sh -s -- --gateway %s --join-token %s --dev", gatewayURL, gatewayURL, token)
-	}
+	command := agentInstallCommand(gatewayURL, token, devMode)
 	return command, token, expiresAt, nil
+}
+
+func agentInstallCommand(gatewayURL, token string, devMode bool) string {
+	installURL := shellQuote(strings.TrimRight(gatewayURL, "/") + "/install/agent")
+	args := fmt.Sprintf("--gateway %s --join-token %s", shellQuote(gatewayURL), shellQuote(token))
+	if devMode {
+		return fmt.Sprintf("curl -fsSL %s | sh -s -- %s --dev", installURL, args)
+	}
+	return fmt.Sprintf(`if [ "$(uname -s)" = "Darwin" ] || [ "$(id -u)" -eq 0 ]; then curl -fsSL %[1]s | sh -s -- %[2]s; else curl -fsSL %[1]s | sudo sh -s -- %[2]s; fi`, installURL, args)
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
 func (s *Service) createPrivatePoolJoinToken(ctx context.Context, poolName, ttlValue string) (string, time.Time, error) {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -400,11 +400,27 @@ func (r *S2EventRepository) resolveEventHistoryStreams(ctx context.Context, quer
 		return addKnown(r.appStreamName(query.WorkspaceID, query.AppID))
 	case query.StubID != "" && query.WorkspaceID != "":
 		return addKnown(r.stubStreamName(query.WorkspaceID, query.StubID))
+	case query.WorkspaceID != "" && allComputeEventTypes(query.EventTypes):
+		return addKnown(r.workspaceComputeStreamName(query.WorkspaceID))
 	case query.WorkspaceID != "":
 		return addKnown(r.workspaceStreamName(query.WorkspaceID))
 	default:
 		return nil, nil
 	}
+}
+
+// allComputeEventTypes reports whether the query is scoped exclusively to
+// compute.* event types, so it can be served from the dense compute stream.
+func allComputeEventTypes(eventTypes []string) bool {
+	if len(eventTypes) == 0 {
+		return false
+	}
+	for _, eventType := range eventTypes {
+		if !strings.HasPrefix(strings.TrimSpace(eventType), "compute.") {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName s2.StreamName, limit uint64, query types.EventQuery, response *types.ContainerEventsResponse) error {
@@ -830,7 +846,10 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 		add(r.workspaceStreamName(metadata.WorkspaceID))
 	}
 	if isComputeEvent(eventType) && metadata.WorkspaceID != "" {
+		// Workspace stream powers the live workspace SSE; the compute stream keeps
+		// a dense history for fast compute-only history queries.
 		add(r.workspaceStreamName(metadata.WorkspaceID))
+		add(r.workspaceComputeStreamName(metadata.WorkspaceID))
 	}
 	if isTaskEvent(eventType) && metadata.WorkspaceID != "" {
 		add(r.workspaceStreamName(metadata.WorkspaceID))
@@ -945,6 +964,13 @@ func (r *S2EventRepository) workerPoolStreamName(poolName string) s2.StreamName 
 
 func (r *S2EventRepository) workspaceStreamName(workspaceID string) s2.StreamName {
 	return s2.StreamName(fmt.Sprintf("%s/workspaces/%s", r.streamPrefix, workspaceID))
+}
+
+// workspaceComputeStreamName is a dedicated, compute-only stream so that compute
+// event history reads stay dense and fast instead of paging through the busy
+// shared workspace stream (which also carries container metrics/lifecycle).
+func (r *S2EventRepository) workspaceComputeStreamName(workspaceID string) s2.StreamName {
+	return s2.StreamName(fmt.Sprintf("%s/workspaces/%s/compute", r.streamPrefix, eventStreamPart(workspaceID)))
 }
 
 func (r *S2EventRepository) stubStreamName(workspaceID, stubID string) s2.StreamName {

--- a/pkg/types/agent_worker.go
+++ b/pkg/types/agent_worker.go
@@ -57,6 +57,7 @@ const (
 	AgentDownloadURLEnv             = "BEAM_AGENT_URL"
 	AgentInstallDockerEnv           = "BEAM_AGENT_INSTALL_DOCKER"
 	AgentStorageModeEnv             = "BEAM_AGENT_WORKSPACE_STORAGE_MODE"
+	AgentWorkerPlatformEnv          = "BEAM_AGENT_WORKER_PLATFORM"
 	AgentVerboseEnv                 = "BEAM_AGENT_VERBOSE"
 	AgentNoColorEnv                 = "NO_COLOR"
 	AgentGatewayURLEnv              = "BEAM_GATEWAY_HTTP_URL"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors agent install to avoid sudo on macOS, support dev mode without sudo, and safely quote args. Adds a compute-only event stream for faster history reads; installer now fails if `BEAM_AGENT_LINUX_BIN` points to a directory.

- **Bug Fixes**
  - On macOS, run installer without sudo; on Linux, use sudo only when non-root.
  - Shell-escape gateway URLs and tokens to handle quotes/spaces safely.
  - Agent installer errors if `BEAM_AGENT_LINUX_BIN` is a directory.

- **Refactors**
  - Extracted `agentInstallCommand` and `shellQuote`; added tests for Darwin/no-sudo, dev mode, and quote escaping.
  - Created a workspace compute stream and route compute-only history queries to it; write compute events to both workspace and compute streams.

<sup>Written for commit 102f8986823aa3460bc99c11693bb640757a934b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

