### PR TITLE
disable cachefs

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -766,6 +766,50 @@ func TestWriteWorkerConfigUsesGeeseForWorkspaceStorage(t *testing.T) {
 	if got := cacheFS["mountPoint"]; got != types.AgentCacheFSMountPath {
 		t.Fatalf("cachefs mount point = %v, want %q", got, types.AgentCacheFSMountPath)
 	}
+	if got := cacheFS["enabled"]; got != true {
+		t.Fatalf("cachefs enabled = %v, want true", got)
+	}
+}
+
+func TestWriteWorkerConfigDisablesCacheFSInAgentContainer(t *testing.T) {
+	t.Setenv(types.AgentInContainerEnv, "1")
+	path := filepath.Join(t.TempDir(), "config.json")
+	slot := &pb.AgentWorkerSlot{
+		PoolName:  "private-dev",
+		MachineId: "machine-a",
+	}
+
+	if err := writeWorkerConfig(path, bootstrapConfig{}, slot); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+
+	storageConfig := config["storage"].(map[string]any)
+	workspaceStorage := storageConfig["workspaceStorage"].(map[string]any)
+	if got := workspaceStorage["defaultStorageMode"]; got != types.StorageModeGeese {
+		t.Fatalf("workspace storage mode = %v, want %q", got, types.StorageModeGeese)
+	}
+	workerConfig := config["worker"].(map[string]any)
+	pools := workerConfig["pools"].(map[string]any)
+	pool := pools["private-dev"].(map[string]any)
+	if got := pool["storageMode"]; got != types.StorageModeGeese {
+		t.Fatalf("pool storage mode = %v, want %q", got, types.StorageModeGeese)
+	}
+
+	cacheConfig := config["cache"].(map[string]any)
+	cacheClient := cacheConfig["client"].(map[string]any)
+	cacheFS := cacheClient["cachefs"].(map[string]any)
+	if got := cacheFS["enabled"]; got != false {
+		t.Fatalf("cachefs enabled = %v, want false", got)
+	}
 }
 
 func containsArg(args []string, prefix, value string) bool {

--- a/pkg/agent/worker_config.go
+++ b/pkg/agent/worker_config.go
@@ -138,6 +138,7 @@ func newAgentWorkerConfig(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) a
 	workspaceStorageMode := firstNonEmpty(os.Getenv(types.AgentStorageModeEnv), types.StorageModeGeese)
 	cache := agentDiskCacheConfig()
 	httpHost, httpPort, httpTLS := agentGatewayHTTPParts(bootstrap)
+	cacheFSEnabled := !envBool(types.AgentInContainerEnv)
 
 	return agentWorkerConfig{
 		ClusterName: types.DefaultAgentName,
@@ -212,7 +213,7 @@ func newAgentWorkerConfig(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) a
 			},
 			Client: &agentConfigCacheClient{
 				CacheFS: agentConfigCacheFS{
-					Enabled:    true,
+					Enabled:    cacheFSEnabled,
 					MountPoint: types.AgentCacheFSMountPath,
 				},
 			},

--- a/pkg/cache/cachefs.go
+++ b/pkg/cache/cachefs.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 
 type StorageLayer interface {
 }
+
+const readAheadUpdateTimeout = 2 * time.Second
 
 // Generates a directory ID based on parent ID and name.
 func GenerateFsID(name string) string {
@@ -160,16 +163,39 @@ func updateReadAheadKB(mountPoint string, valueKB int) error {
 		return fmt.Errorf("mount point %s not found", mountPoint)
 	}
 
-	// Construct path to read_ahead_kb
 	readAheadPath := fmt.Sprintf("/sys/class/bdi/%s/read_ahead_kb", deviceID)
+	return writeReadAheadKB(readAheadPath, valueKB, readAheadUpdateTimeout)
+}
 
-	// Update read_ahead_kb
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("echo %d > %s", valueKB, readAheadPath))
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to update read_ahead_kb: %w read_ahead_path: %s", err, readAheadPath)
+func writeReadAheadKB(path string, valueKB int, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = readAheadUpdateTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.Command("sh", "-c", "cat > \"$1\"", "sh", path)
+	cmd.Stdin = strings.NewReader(strconv.Itoa(valueKB))
+	done := make(chan error, 1)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to update read_ahead_kb: %w read_ahead_path: %s", err, path)
 	}
 
-	return nil
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("failed to update read_ahead_kb: %w read_ahead_path: %s", err, path)
+		}
+		return nil
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		go func() { <-done }()
+		return fmt.Errorf("timed out updating read_ahead_kb read_ahead_path: %s", path)
+	}
 }
 
 // NewFileSystem initializes a new CacheFS with root metadata.

--- a/pkg/cache/cachefs_test.go
+++ b/pkg/cache/cachefs_test.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWriteReadAheadKBTimeout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "read_ahead_kb")
+	if err := unix.Mkfifo(path, 0600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	defer os.Remove(path)
+
+	start := time.Now()
+	err := writeReadAheadKB(path, 128, 25*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("writeReadAheadKB took %s, want bounded timeout", elapsed)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable `cachefs` when the agent runs inside a container, and add a bounded timeout when updating `read_ahead_kb` to prevent hangs.

- **New Features**
  - `pkg/agent`: Worker config sets `cache.client.cachefs.enabled` to false when `AGENT_IN_CONTAINER` is set; true otherwise.
  - Tests ensure `cachefs` is enabled by default and disabled in-container.

- **Bug Fixes**
  - `pkg/cache`: Update `read_ahead_kb` via `writeReadAheadKB` with a 2s default timeout; kills the process on timeout.
  - Added a test that verifies the write times out and stays bounded.

<sup>Written for commit 46112cd6c734f9ad7c4fee49443051a24a68e9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

