### PR TITLE
credentials fix

### DIFF
--- a/pkg/agent/log_writer.go
+++ b/pkg/agent/log_writer.go
@@ -32,7 +32,7 @@ func (w *detailLogWriter) Write(p []byte) (int, error) {
 
 	written := 0
 	for len(p) > 0 {
-		i := bytes.IndexByte(p, '\n')
+		i := bytes.IndexAny(p, "\n\r")
 		if i < 0 {
 			_, _ = w.buf.Write(p)
 			return written + len(p), nil

--- a/pkg/agent/worker_docker.go
+++ b/pkg/agent/worker_docker.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -72,16 +74,25 @@ func removeOtherManagedWorkerContainers(name string, slot *pb.AgentWorkerSlot) e
 	return nil
 }
 
-func pullDockerImage(ctx context.Context, image string) (string, error) {
-	args := []string{"pull", "-q"}
+func pullDockerImage(ctx context.Context, image string, output io.Writer) (string, error) {
+	args := []string{"pull"}
 	if platform := strings.TrimSpace(os.Getenv(types.AgentWorkerPlatformEnv)); platform != "" {
 		args = append(args, "--platform", platform)
 	}
 	args = append(args, image)
 
-	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("pull worker image %q: %w: %s", image, err, strings.TrimSpace(string(out)))
+	var out bytes.Buffer
+	if output == nil {
+		output = io.Discard
+	}
+	details := newDetailLogWriter(output)
+	defer closeRuntimeWriter(details)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = io.MultiWriter(details, &out)
+	cmd.Stderr = io.MultiWriter(details, &out)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("pull worker image %q: %w: %s", image, err, strings.TrimSpace(out.String()))
 	}
 	return inspectDockerImageID(image)
 }

--- a/pkg/agent/worker_runtime.go
+++ b/pkg/agent/worker_runtime.go
@@ -119,7 +119,7 @@ func (m *workerRuntimeManager) ensureSlot(ctx context.Context, slot *pb.AgentWor
 
 	slotCtx, cancel := context.WithCancel(ctx)
 	m.supervisors[slot.WorkerId] = &workerRuntimeSupervisor{slot: cloneAgentWorkerSlot(slot), cancel: cancel}
-	statusf(m.stdout, "Starting worker %q", slot.WorkerId)
+	statusf(m.stdout, "Preparing worker %q", slot.WorkerId)
 	go m.superviseSlot(slotCtx, slot)
 }
 
@@ -211,6 +211,7 @@ func (r *workerContainerRuntime) run(ctx context.Context, slot *pb.AgentWorkerSl
 	)
 
 	done := make(chan error, 1)
+	statusf(r.stdout, "Starting worker %q", slot.WorkerId)
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -236,10 +237,12 @@ func (r *workerContainerRuntime) pullImage(ctx context.Context, image string) (s
 	}
 	r.imageMu.Unlock()
 
-	imageID, err := pullDockerImage(ctx, image)
+	statusf(r.stdout, "Pulling worker image %q", image)
+	imageID, err := pullDockerImage(ctx, image, r.stdout)
 	if err != nil {
 		return "", err
 	}
+	statusf(r.stdout, "Worker image ready")
 
 	r.imageMu.Lock()
 	r.images[key] = imageID

--- a/pkg/gateway/services/repository/worker_runtime_credentials.go
+++ b/pkg/gateway/services/repository/worker_runtime_credentials.go
@@ -69,14 +69,33 @@ func (s *WorkerRepositoryService) authorizeWorkerRuntimeCredentialRequest(ctx co
 		return nil, fmt.Errorf("container %q is not assigned to workspace/stub", req.ContainerId)
 	}
 
-	workspace, err := s.backendRepo.GetWorkspace(ctx, workspaceID)
+	workspace, err := s.runtimeCredentialsWorkspace(ctx, workspaceID, req)
 	if err != nil {
 		return nil, err
 	}
-	if workspace == nil || workspace.SigningKey == nil || *workspace.SigningKey == "" {
-		return nil, fmt.Errorf("workspace signing key is unavailable")
-	}
 	return workspace, nil
+}
+
+func (s *WorkerRepositoryService) runtimeCredentialsWorkspace(ctx context.Context, workspaceID uint, req *pb.GetContainerRuntimeCredentialsRequest) (*types.Workspace, error) {
+	if runtimeCredentialsNeedsSigningKey(req) {
+		workspace, err := s.backendRepo.GetWorkspaceByExternalIdWithSigningKey(ctx, req.WorkspaceId)
+		if err != nil {
+			return nil, err
+		}
+		if workspace.Id != workspaceID {
+			return nil, fmt.Errorf("worker token cannot request credentials for workspace %q", req.WorkspaceId)
+		}
+		if workspace.SigningKey == nil || *workspace.SigningKey == "" {
+			return nil, fmt.Errorf("workspace signing key is unavailable")
+		}
+		return &workspace, nil
+	}
+
+	return s.backendRepo.GetWorkspace(ctx, workspaceID)
+}
+
+func runtimeCredentialsNeedsSigningKey(req *pb.GetContainerRuntimeCredentialsRequest) bool {
+	return req != nil && (len(req.SecretNames) > 0 || len(req.MountCredentials) > 0)
 }
 
 func (s *WorkerRepositoryService) workerTokenWorkspaceID(ctx context.Context, workspaceID string) (uint, error) {

--- a/pkg/gateway/services/repository/worker_runtime_credentials_test.go
+++ b/pkg/gateway/services/repository/worker_runtime_credentials_test.go
@@ -22,10 +22,18 @@ type workerRuntimeCredentialsBackendRepo struct {
 	tokens                     []types.Token
 	secrets                    []types.Secret
 	workspaceByExternalIDCalls int
+	workspaceWithSigningCalls  int
 }
 
 func (r *workerRuntimeCredentialsBackendRepo) GetWorkspaceByExternalId(ctx context.Context, externalID string) (types.Workspace, error) {
 	r.workspaceByExternalIDCalls++
+	workspace := *r.workspace
+	workspace.ExternalId = externalID
+	return workspace, nil
+}
+
+func (r *workerRuntimeCredentialsBackendRepo) GetWorkspaceByExternalIdWithSigningKey(ctx context.Context, externalID string) (types.Workspace, error) {
+	r.workspaceWithSigningCalls++
 	workspace := *r.workspace
 	workspace.ExternalId = externalID
 	return workspace, nil
@@ -186,6 +194,113 @@ func TestGetContainerRuntimeCredentialsUsesWorkerTokenWorkspaceID(t *testing.T) 
 	require.NoError(t, err)
 	require.True(t, resp.Ok)
 	require.Zero(t, backendRepo.workspaceByExternalIDCalls)
+}
+
+func TestGetContainerRuntimeCredentialsDoesNotRequireSigningKeyForStorageAndRuntimeToken(t *testing.T) {
+	storageID := uint(1)
+	storageBucket := "workspace-bucket"
+	storageAccess := "storage-access"
+	storageSecret := "storage-secret"
+	storageEndpoint := "https://storage.example.com"
+	storageRegion := "us-east-1"
+	backendRepo := &workerRuntimeCredentialsBackendRepo{
+		workspace: &types.Workspace{
+			Id:         7,
+			ExternalId: "workspace-id",
+			Name:       "workspace",
+			Storage: &types.WorkspaceStorage{
+				Id:          &storageID,
+				BucketName:  &storageBucket,
+				AccessKey:   &storageAccess,
+				SecretKey:   &storageSecret,
+				EndpointUrl: &storageEndpoint,
+				Region:      &storageRegion,
+			},
+		},
+		tokens: []types.Token{{
+			Key:       "restricted-runtime-token",
+			Active:    true,
+			TokenType: types.TokenTypeWorkspaceRestricted,
+		}},
+	}
+	service := &WorkerRepositoryService{
+		backendRepo: backendRepo,
+		containerRepo: &workerRuntimeCredentialsContainerRepo{
+			state: &types.ContainerState{ContainerId: "container-id", WorkspaceId: "workspace-id", StubId: "stub-id"},
+		},
+	}
+
+	resp, err := service.GetContainerRuntimeCredentials(
+		cacheRepositoryWorkspaceAuthContext("workspace-id"),
+		&pb.GetContainerRuntimeCredentialsRequest{
+			WorkspaceId:      "workspace-id",
+			StubId:           "stub-id",
+			ContainerId:      "container-id",
+			RuntimeToken:     true,
+			WorkspaceStorage: true,
+		},
+	)
+
+	require.NoError(t, err)
+	require.True(t, resp.Ok)
+	require.Equal(t, []string{"BETA9_TOKEN=restricted-runtime-token"}, resp.Env)
+	require.NotNil(t, resp.WorkspaceStorage)
+	require.Equal(t, "storage-access", resp.WorkspaceStorage.AccessKey)
+	require.Equal(t, "storage-secret", resp.WorkspaceStorage.SecretKey)
+	require.Zero(t, backendRepo.workspaceWithSigningCalls)
+}
+
+func TestGetContainerRuntimeCredentialsRequiresSigningKeyForSecrets(t *testing.T) {
+	service := &WorkerRepositoryService{
+		backendRepo: &workerRuntimeCredentialsBackendRepo{
+			workspace: &types.Workspace{Id: 7, ExternalId: "workspace-id"},
+		},
+		containerRepo: &workerRuntimeCredentialsContainerRepo{
+			state: &types.ContainerState{ContainerId: "container-id", WorkspaceId: "workspace-id", StubId: "stub-id"},
+		},
+	}
+
+	resp, err := service.GetContainerRuntimeCredentials(
+		cacheRepositoryWorkspaceAuthContext("workspace-id"),
+		&pb.GetContainerRuntimeCredentialsRequest{
+			WorkspaceId: "workspace-id",
+			StubId:      "stub-id",
+			ContainerId: "container-id",
+			SecretNames: []string{"SECRET"},
+		},
+	)
+
+	require.NoError(t, err)
+	require.False(t, resp.Ok)
+	require.Contains(t, resp.ErrorMsg, "workspace signing key is unavailable")
+}
+
+func TestGetContainerRuntimeCredentialsRequiresSigningKeyForMountCredentials(t *testing.T) {
+	service := &WorkerRepositoryService{
+		backendRepo: &workerRuntimeCredentialsBackendRepo{
+			workspace: &types.Workspace{Id: 7, ExternalId: "workspace-id"},
+		},
+		containerRepo: &workerRuntimeCredentialsContainerRepo{
+			state: &types.ContainerState{ContainerId: "container-id", WorkspaceId: "workspace-id", StubId: "stub-id"},
+		},
+	}
+
+	resp, err := service.GetContainerRuntimeCredentials(
+		cacheRepositoryWorkspaceAuthContext("workspace-id"),
+		&pb.GetContainerRuntimeCredentialsRequest{
+			WorkspaceId: "workspace-id",
+			StubId:      "stub-id",
+			ContainerId: "container-id",
+			MountCredentials: []*pb.RuntimeMountCredentialRequest{{
+				MountPath:  "/volumes/data",
+				BucketName: "mount-bucket",
+			}},
+		},
+	)
+
+	require.NoError(t, err)
+	require.False(t, resp.Ok)
+	require.Contains(t, resp.ErrorMsg, "workspace signing key is unavailable")
 }
 
 func TestGetContainerRuntimeCredentialsRejectsMismatchedContainerState(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes worker runtime credential checks to only require a workspace signing key when secrets or mount credentials are requested, and streams `docker pull` progress to worker logs with clearer status messages. Also fixes log line splitting for CR/LF outputs.

- **Bug Fixes**
  - Require signing key only when `SecretNames` or `MountCredentials` are requested; validate workspace by external ID and return a clear error if the key is missing.
  - Split log lines on both `\n` and `\r` to avoid fused lines from CRLF outputs.

- **Refactors**
  - Stream `docker pull` progress to the runtime output and add status updates: “Preparing worker”, “Pulling worker image”, “Worker image ready”, “Starting worker”.

<sup>Written for commit a609fc6c2450d1beddc0f73582c3b1b430eb38ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

