### PR TITLE
fix task execution in remote mode

### DIFF
--- a/pkg/gateway/services/task.go
+++ b/pkg/gateway/services/task.go
@@ -19,9 +19,14 @@ import (
 )
 
 func (gws *GatewayService) StartTask(ctx context.Context, in *pb.StartTaskRequest) (*pb.StartTaskResponse, error) {
+	if in == nil {
+		return &pb.StartTaskResponse{Ok: false}, nil
+	}
+
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	if !auth.HasPermission(authInfo) {
+	if !canUseTaskLifecycle(authInfo) {
+		log.Warn().Str("task_id", in.TaskId).Str("container_id", in.ContainerId).Msg("start task rejected by auth")
 		return &pb.StartTaskResponse{
 			Ok: false,
 		}, nil
@@ -29,20 +34,29 @@ func (gws *GatewayService) StartTask(ctx context.Context, in *pb.StartTaskReques
 
 	task, err := gws.backendRepo.GetTaskWithRelated(ctx, in.TaskId)
 	if err != nil {
+		log.Warn().Err(err).Str("task_id", in.TaskId).Str("container_id", in.ContainerId).Msg("start task failed to load task")
 		return &pb.StartTaskResponse{
 			Ok: false,
 		}, nil
 	}
 
 	if task == nil {
+		log.Warn().Str("task_id", in.TaskId).Str("container_id", in.ContainerId).Msg("start task missing task")
 		return &pb.StartTaskResponse{Ok: false}, nil
 	}
 
 	if task.Workspace.ExternalId != authInfo.Workspace.ExternalId {
+		log.Warn().
+			Str("task_id", in.TaskId).
+			Str("container_id", in.ContainerId).
+			Str("task_workspace_id", task.Workspace.ExternalId).
+			Str("auth_workspace_id", authInfo.Workspace.ExternalId).
+			Msg("start task rejected by workspace mismatch")
 		return &pb.StartTaskResponse{Ok: false}, nil
 	}
 
 	if task.Status.IsCompleted() {
+		log.Warn().Str("task_id", in.TaskId).Str("container_id", in.ContainerId).Str("status", string(task.Status)).Msg("start task rejected because task is completed")
 		return &pb.StartTaskResponse{Ok: false}, nil
 	}
 
@@ -73,21 +87,42 @@ func (gws *GatewayService) StartTask(ctx context.Context, in *pb.StartTaskReques
 
 	err = gws.taskDispatcher.Claim(ctx, task.Workspace.Name, task.Stub.ExternalId, task.ExternalId, task.ContainerId)
 	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("task_id", task.ExternalId).
+			Str("container_id", task.ContainerId).
+			Str("workspace_id", task.Workspace.ExternalId).
+			Str("workspace_name", task.Workspace.Name).
+			Str("stub_id", task.Stub.ExternalId).
+			Msg("start task failed to claim task")
 		return &pb.StartTaskResponse{
 			Ok: false,
 		}, nil
 	}
 
 	_, err = gws.backendRepo.UpdateTask(ctx, task.ExternalId, task.Task)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("task_id", task.ExternalId).
+			Str("container_id", task.ContainerId).
+			Str("workspace_id", task.Workspace.ExternalId).
+			Str("stub_id", task.Stub.ExternalId).
+			Msg("start task failed to update task")
+	}
 	return &pb.StartTaskResponse{
 		Ok: err == nil,
 	}, nil
 }
 
 func (gws *GatewayService) EndTask(ctx context.Context, in *pb.EndTaskRequest) (*pb.EndTaskResponse, error) {
+	if in == nil {
+		return &pb.EndTaskResponse{Ok: false}, nil
+	}
+
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	if !auth.HasPermission(authInfo) {
+	if !canUseTaskLifecycle(authInfo) {
 		return &pb.EndTaskResponse{
 			Ok: false,
 		}, nil
@@ -179,8 +214,18 @@ func (gws *GatewayService) EndTask(ctx context.Context, in *pb.EndTaskRequest) (
 	}, nil
 }
 
+func canUseTaskLifecycle(authInfo *auth.AuthInfo) bool {
+	if authInfo == nil || authInfo.Token == nil || authInfo.Workspace == nil {
+		return false
+	}
+	if authInfo.Token.TokenType == types.TokenTypeWorkspaceRestricted {
+		return true
+	}
+	return auth.HasPermission(authInfo)
+}
+
 func (gws *GatewayService) recordContainerToStartTaskPhases(ctx context.Context, task *types.TaskWithRelated, startedAt time.Time, labels map[string]string) {
-	if task == nil || task.ContainerId == "" {
+	if task == nil || task.ContainerId == "" || gws.containerRepo == nil {
 		return
 	}
 

--- a/pkg/gateway/services/task_test.go
+++ b/pkg/gateway/services/task_test.go
@@ -1,0 +1,147 @@
+package gatewayservices
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
+	taskdispatcher "github.com/beam-cloud/beta9/pkg/task"
+	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
+	"github.com/stretchr/testify/require"
+)
+
+type taskLifecycleBackendRepo struct {
+	repository.BackendRepository
+	task    *types.TaskWithRelated
+	updates []types.Task
+}
+
+func (r *taskLifecycleBackendRepo) GetTaskWithRelated(ctx context.Context, externalID string) (*types.TaskWithRelated, error) {
+	if r.task == nil || r.task.ExternalId != externalID {
+		return nil, nil
+	}
+	return r.task, nil
+}
+
+func (r *taskLifecycleBackendRepo) UpdateTask(ctx context.Context, externalID string, updatedTask types.Task) (*types.Task, error) {
+	r.updates = append(r.updates, updatedTask)
+	if r.task != nil && r.task.ExternalId == externalID {
+		r.task.Task = updatedTask
+	}
+	return &updatedTask, nil
+}
+
+func TestStartTaskAllowsRestrictedRuntimeToken(t *testing.T) {
+	gws, taskRepo := newTaskLifecycleGateway(t, "workspace-id")
+	ctx := restrictedTaskLifecycleContext("workspace-id")
+
+	resp, err := gws.StartTask(ctx, &pb.StartTaskRequest{
+		TaskId:      "task-id",
+		ContainerId: "container-id",
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Ok)
+	claimed, err := taskRepo.IsClaimed(context.Background(), "workspace", "stub-id", "task-id")
+	require.NoError(t, err)
+	require.True(t, claimed)
+	require.Equal(t, types.TaskStatusRunning, gws.backendRepo.(*taskLifecycleBackendRepo).task.Status)
+	require.Equal(t, "container-id", gws.backendRepo.(*taskLifecycleBackendRepo).task.ContainerId)
+}
+
+func TestStartTaskRejectsRestrictedRuntimeTokenForAnotherWorkspace(t *testing.T) {
+	gws, taskRepo := newTaskLifecycleGateway(t, "workspace-id")
+	ctx := restrictedTaskLifecycleContext("other-workspace")
+
+	resp, err := gws.StartTask(ctx, &pb.StartTaskRequest{
+		TaskId:      "task-id",
+		ContainerId: "container-id",
+	})
+
+	require.NoError(t, err)
+	require.False(t, resp.Ok)
+	claimed, err := taskRepo.IsClaimed(context.Background(), "workspace", "stub-id", "task-id")
+	require.NoError(t, err)
+	require.False(t, claimed)
+}
+
+func TestEndTaskAllowsRestrictedRuntimeToken(t *testing.T) {
+	gws, taskRepo := newTaskLifecycleGateway(t, "workspace-id")
+	task := gws.backendRepo.(*taskLifecycleBackendRepo).task
+	task.Status = types.TaskStatusRunning
+	task.ContainerId = "container-id"
+	require.NoError(t, taskRepo.ClaimTask(context.Background(), "workspace", "stub-id", "task-id", "container-id"))
+
+	resp, err := gws.EndTask(restrictedTaskLifecycleContext("workspace-id"), &pb.EndTaskRequest{
+		TaskId:          "task-id",
+		ContainerId:     "container-id",
+		TaskStatus:      string(types.TaskStatusComplete),
+		TaskDuration:    1,
+		KeepWarmSeconds: 10,
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Ok)
+	claimed, err := taskRepo.IsClaimed(context.Background(), "workspace", "stub-id", "task-id")
+	require.NoError(t, err)
+	require.False(t, claimed)
+	require.Equal(t, types.TaskStatusComplete, task.Status)
+}
+
+func newTaskLifecycleGateway(t *testing.T, workspaceID string) (*GatewayService, repository.TaskRepository) {
+	t.Helper()
+
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(server.Close)
+
+	rdb, err := common.NewRedisClient(types.RedisConfig{Addrs: []string{server.Addr()}, Mode: types.RedisModeSingle})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	taskRepo := repository.NewTaskRedisRepository(rdb)
+	dispatcher, err := taskdispatcher.NewDispatcher(ctx, taskRepo)
+	require.NoError(t, err)
+
+	backendRepo := &taskLifecycleBackendRepo{
+		task: &types.TaskWithRelated{
+			Task: types.Task{
+				ExternalId:  "task-id",
+				Status:      types.TaskStatusPending,
+				WorkspaceId: 1,
+				StubId:      2,
+			},
+			Workspace: types.Workspace{
+				Id:         1,
+				ExternalId: workspaceID,
+				Name:       "workspace",
+			},
+			Stub: types.Stub{
+				Id:         2,
+				ExternalId: "stub-id",
+				Type:       types.StubType(types.StubTypeEndpointServe),
+				Config:     "{}",
+			},
+		},
+	}
+
+	return &GatewayService{
+		backendRepo:    backendRepo,
+		redisClient:    rdb,
+		taskDispatcher: dispatcher,
+	}, taskRepo
+}
+
+func restrictedTaskLifecycleContext(workspaceID string) context.Context {
+	return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Workspace: &types.Workspace{Id: 1, ExternalId: workspaceID, Name: "workspace"},
+		Token:     &types.Token{TokenType: types.TokenTypeWorkspaceRestricted, Active: true},
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes remote task execution. `StartTask`/`EndTask` now allow workspace-restricted runtime tokens and add input/workspace validation to prevent failures.

- **Bug Fixes**
  - Added `canUseTaskLifecycle` to permit `TokenTypeWorkspaceRestricted` tokens while keeping existing permission checks.
  - Validate requests and workspace before processing; return `Ok: false` on nil input or mismatches. Added structured logs for load/claim/update errors.
  - Guard container phase recording when `containerRepo` is nil to avoid panics. Added tests for allowed/blocked token scenarios.

<sup>Written for commit 2fe4c9c55c47ac06110142a80e89a5ac6b39cb0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

