### PR TITLE
prewarm route

### DIFF
--- a/pkg/gateway/services/compute/agent.go
+++ b/pkg/gateway/services/compute/agent.go
@@ -470,6 +470,10 @@ func (s *Service) UpdateAgentRouteStatus(ctx context.Context, in *pb.UpdateAgent
 	if err := s.containerRepo.SetBackendRoute(ctx, *route); err != nil {
 		return &pb.UpdateAgentRouteStatusResponse{Ok: false, ErrMsg: err.Error()}, nil
 	}
+	if route.State == types.BackendRouteStateReady &&
+		(previousState != types.BackendRouteStateReady || previousProxyTarget != route.ProxyTarget) {
+		s.prewarmRoute(*route, agentState)
+	}
 	if previousState != route.State || previousProxyTarget != route.ProxyTarget || previousError != route.Error {
 		attrs := map[string]string{
 			"kind":     route.Kind,

--- a/pkg/gateway/services/compute/route_prewarm.go
+++ b/pkg/gateway/services/compute/route_prewarm.go
@@ -1,0 +1,148 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	model "github.com/beam-cloud/beta9/pkg/compute"
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+const (
+	routePrewarmInterval = 30 * time.Second
+	routePrewarmTimeout  = 3 * time.Second
+)
+
+type routePrewarmer struct {
+	mu          sync.Mutex
+	lastAttempt map[string]time.Time
+}
+
+func (p *routePrewarmer) shouldAttempt(proxyTarget string, now time.Time) bool {
+	proxyTarget = strings.TrimSpace(proxyTarget)
+	if proxyTarget == "" {
+		return false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.lastAttempt == nil {
+		p.lastAttempt = map[string]time.Time{}
+	}
+	if last := p.lastAttempt[proxyTarget]; !last.IsZero() && now.Sub(last) < routePrewarmInterval {
+		return false
+	}
+	p.lastAttempt[proxyTarget] = now
+	return true
+}
+
+func (s *Service) prewarmRoute(route types.BackendRoute, agentState *model.AgentTokenState) {
+	if s.tailscale == nil || route.Transport != types.BackendRouteTransportTSNet || strings.TrimSpace(route.ProxyTarget) == "" {
+		return
+	}
+	if !s.routePrewarm.shouldAttempt(route.ProxyTarget, time.Now()) {
+		return
+	}
+
+	go s.prewarmRouteOnce(route, agentState)
+}
+
+func (s *Service) prewarmRouteOnce(route types.BackendRoute, agentState *model.AgentTokenState) {
+	start := time.Now()
+	conn, err := s.tailscale.DialTimeout("tcp", route.ProxyTarget, routePrewarmTimeout)
+	dialLatency := time.Since(start)
+	if conn != nil {
+		_ = conn.Close()
+	}
+
+	attrs := map[string]string{
+		"proxy_target": route.ProxyTarget,
+		"dial_ms":      strconv.FormatInt(dialLatency.Milliseconds(), 10),
+	}
+	for key, value := range s.routePeerAttrs(route.ProxyTarget) {
+		attrs[key] = value
+	}
+
+	status := "ready"
+	message := ""
+	if err != nil {
+		status = "error"
+		message = err.Error()
+		attrs["reason"] = message
+	}
+
+	s.emitComputeEvent(types.EventComputeTransport, types.EventComputeSchema{
+		WorkspaceID: agentState.WorkspaceID,
+		PoolName:    agentState.PoolName,
+		MachineID:   agentState.MachineID,
+		WorkerID:    route.WorkerID,
+		ContainerID: route.ContainerID,
+		RouteID:     route.RouteID,
+		Action:      types.EventComputeActionTransportPrewarm,
+		Status:      status,
+		Transport:   route.Transport,
+		Message:     message,
+		Attrs:       attrs,
+	})
+}
+
+func (s *Service) routePeerAttrs(proxyTarget string) map[string]string {
+	if s.tailscale == nil || s.tailscale.GetServer() == nil {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(proxyTarget)
+	if err != nil {
+		host = proxyTarget
+	}
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	if host == "" {
+		return nil
+	}
+
+	client, err := s.tailscale.GetServer().LocalClient()
+	if err != nil {
+		return map[string]string{"peer_status_error": err.Error()}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	status, err := client.Status(ctx)
+	if err != nil {
+		return map[string]string{"peer_status_error": err.Error()}
+	}
+
+	for _, peer := range status.Peer {
+		if peer == nil || !peerMatchesHost(peer.HostName, peer.DNSName, host) {
+			continue
+		}
+		attrs := map[string]string{
+			"peer_online": strconv.FormatBool(peer.Online),
+			"peer_active": strconv.FormatBool(peer.Active),
+			"peer_direct": strconv.FormatBool(peer.CurAddr != ""),
+		}
+		if peer.Relay != "" {
+			attrs["peer_relay"] = peer.Relay
+		}
+		if !peer.LastHandshake.IsZero() {
+			age := time.Since(peer.LastHandshake)
+			if age < 0 {
+				age = 0
+			}
+			attrs["peer_last_handshake_age_ms"] = fmt.Sprintf("%d", age.Milliseconds())
+		}
+		return attrs
+	}
+	return map[string]string{"peer_status": "not_found"}
+}
+
+func peerMatchesHost(hostName, dnsName, target string) bool {
+	target = strings.TrimSuffix(target, ".")
+	hostName = strings.TrimSuffix(hostName, ".")
+	dnsName = strings.TrimSuffix(dnsName, ".")
+	return target == hostName || target == dnsName || strings.HasPrefix(dnsName, target+".")
+}

--- a/pkg/gateway/services/compute/route_prewarm_test.go
+++ b/pkg/gateway/services/compute/route_prewarm_test.go
@@ -1,0 +1,74 @@
+package compute
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRoutePrewarmerThrottlesByProxyTarget(t *testing.T) {
+	prewarmer := routePrewarmer{}
+	now := time.Unix(100, 0)
+
+	if !prewarmer.shouldAttempt("agent.tailnet:29443", now) {
+		t.Fatal("expected first prewarm attempt")
+	}
+	if prewarmer.shouldAttempt("agent.tailnet:29443", now.Add(routePrewarmInterval-time.Millisecond)) {
+		t.Fatal("expected second prewarm attempt inside interval to be throttled")
+	}
+	if !prewarmer.shouldAttempt("agent.tailnet:29443", now.Add(routePrewarmInterval)) {
+		t.Fatal("expected prewarm attempt after interval")
+	}
+	if !prewarmer.shouldAttempt("other-agent.tailnet:29443", now.Add(time.Second)) {
+		t.Fatal("expected distinct proxy target to have independent throttle")
+	}
+}
+
+func TestRoutePrewarmerSkipsEmptyProxyTarget(t *testing.T) {
+	prewarmer := routePrewarmer{}
+	if prewarmer.shouldAttempt(" ", time.Now()) {
+		t.Fatal("expected empty proxy target to be skipped")
+	}
+}
+
+func TestPeerMatchesHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostName string
+		dnsName  string
+		target   string
+		want     bool
+	}{
+		{
+			name:    "dns match",
+			dnsName: "beam-agent-machine.tailnet.ts.net.",
+			target:  "beam-agent-machine.tailnet.ts.net",
+			want:    true,
+		},
+		{
+			name:    "short target matches dns prefix",
+			dnsName: "beam-agent-machine.tailnet.ts.net",
+			target:  "beam-agent-machine",
+			want:    true,
+		},
+		{
+			name:     "host match",
+			hostName: "beam-agent-machine",
+			target:   "beam-agent-machine",
+			want:     true,
+		},
+		{
+			name:    "no match",
+			dnsName: "beam-agent-other.tailnet.ts.net",
+			target:  "beam-agent-machine",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := peerMatchesHost(tt.hostName, tt.dnsName, tt.target); got != tt.want {
+				t.Fatalf("peerMatchesHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/gateway/services/compute/service.go
+++ b/pkg/gateway/services/compute/service.go
@@ -1,7 +1,10 @@
 package compute
 
 import (
+	"time"
+
 	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/network"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/scheduler"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -17,6 +20,8 @@ type Service struct {
 	computeRepo          repository.ComputeRepository
 	keyEventManager      *common.KeyEventManager
 	telemetryCredentials telemetryCredentialIssuer
+	tailscale            *network.Tailscale
+	routePrewarm         routePrewarmer
 }
 
 type Options struct {
@@ -28,6 +33,7 @@ type Options struct {
 	WorkerRepo      repository.WorkerRepository
 	ComputeRepo     repository.ComputeRepository
 	KeyEventManager *common.KeyEventManager
+	Tailscale       *network.Tailscale
 }
 
 func New(opts Options) *Service {
@@ -40,6 +46,8 @@ func New(opts Options) *Service {
 		workerRepo:      opts.WorkerRepo,
 		computeRepo:     opts.ComputeRepo,
 		keyEventManager: opts.KeyEventManager,
+		tailscale:       opts.Tailscale,
+		routePrewarm:    routePrewarmer{lastAttempt: map[string]time.Time{}},
 	}
 	service.telemetryCredentials = newTelemetryCredentialIssuer(opts.Config.Database.S2)
 	return service

--- a/pkg/gateway/services/compute/telemetry_credentials.go
+++ b/pkg/gateway/services/compute/telemetry_credentials.go
@@ -75,6 +75,7 @@ func (s *Service) issueTelemetryCredential(ctx context.Context, workspaceID, kin
 			Streams: &s2.ResourceSet{Prefix: s2.Ptr(streamPrefix)},
 			Ops: []string{
 				s2.OperationAppend,
+				s2.OperationCreateStream,
 			},
 		},
 	})

--- a/pkg/gateway/services/compute/telemetry_credentials_test.go
+++ b/pkg/gateway/services/compute/telemetry_credentials_test.go
@@ -61,7 +61,7 @@ func TestScopedTelemetryConfigUsesWorkspaceWriteOnlyPrefixes(t *testing.T) {
 		t.Fatalf("expected two issued tokens, got %d", len(issuer.args))
 	}
 
-	wantOps := []string{s2.OperationAppend}
+	wantOps := []string{s2.OperationAppend, s2.OperationCreateStream}
 	for _, args := range issuer.args {
 		if args.Scope.Basins == nil || args.Scope.Basins.Exact == nil || *args.Scope.Basins.Exact != "events-basin" {
 			t.Fatalf("unexpected basin scope: %#v", args.Scope.Basins)
@@ -69,7 +69,7 @@ func TestScopedTelemetryConfigUsesWorkspaceWriteOnlyPrefixes(t *testing.T) {
 		if !reflect.DeepEqual(args.Scope.Ops, wantOps) {
 			t.Fatalf("ops = %#v, want %#v", args.Scope.Ops, wantOps)
 		}
-		for _, forbidden := range []string{s2.OperationCreateStream, s2.OperationRead, s2.OperationDeleteStream, s2.OperationListBasins, s2.OperationIssueAccessToken} {
+		for _, forbidden := range []string{s2.OperationRead, s2.OperationDeleteStream, s2.OperationListBasins, s2.OperationIssueAccessToken} {
 			for _, op := range args.Scope.Ops {
 				if op == forbidden {
 					t.Fatalf("scoped token includes forbidden op %q", forbidden)

--- a/pkg/gateway/services/service.go
+++ b/pkg/gateway/services/service.go
@@ -75,6 +75,7 @@ func NewGatewayService(opts *GatewayServiceOpts) (*GatewayService, error) {
 		WorkerRepo:      opts.WorkerRepo,
 		ComputeRepo:     computeRepo,
 		KeyEventManager: keyEventManager,
+		Tailscale:       opts.Tailscale,
 	})
 
 	return &GatewayService{

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -185,6 +185,7 @@ const (
 	EventComputeActionWorkerSlotCreated         = "worker_slot.created"
 	EventComputeActionWorkerSlotPruned          = "worker_slot.pruned"
 	EventComputeActionTransportCredentialVended = "transport.credential_vended"
+	EventComputeActionTransportPrewarm          = "transport.prewarm"
 	EventComputeActionTransportSnapshot         = "transport.snapshot"
 	EventComputeActionRouteStatusUpdated        = "route.status_updated"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prewarms TSNet routes by dialing the route’s proxy target when a route becomes Ready to reduce first-request latency. Emits `transport.prewarm` events with dial latency and peer diagnostics; telemetry tokens now allow creating streams.

- **New Features**
  - Auto-prewarm for `tailscale` routes when a route enters Ready or proxy target changes; throttled per target (30s) with a 3s dial timeout and runs async.
  - Emits `EventComputeActionTransportPrewarm` with `dial_ms` and peer attrs (`peer_online`, `peer_active`, `peer_direct`, `peer_relay`, `peer_last_handshake_age_ms` or `peer_status[_error]`).
  - Injects `Tailscale` via `compute.Service` options and gateway wiring; adds a peer lookup to enrich telemetry.
  - Grants telemetry credentials `CreateStream` in addition to `Append` so event streams can be created.

<sup>Written for commit 6cefe11c20f3b9da05cab41dad0431d9034d3867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

