### PR TITLE
update billing tests

### DIFF
--- a/pkg/gateway/services/compute/billing.go
+++ b/pkg/gateway/services/compute/billing.go
@@ -139,7 +139,7 @@ func (h *httpManagedBilling) CheckLaunchCredit(ctx context.Context, req billingC
 		req.RequiredCents = h.minimumCents
 	}
 	var decision billingDecision
-	if err := h.post(ctx, "launch-check", req, &decision); err != nil {
+	if err := h.post(ctx, "launch-check/", req, &decision); err != nil {
 		return billingDecision{OK: false, ErrorCode: launchErrorBillingUnavailable, RequiredCents: req.RequiredCents}, err
 	}
 	if decision.RequiredCents <= 0 {
@@ -151,7 +151,7 @@ func (h *httpManagedBilling) CheckLaunchCredit(ctx context.Context, req billingC
 func (h *httpManagedBilling) CheckBalance(ctx context.Context, workspaceID string) (billingDecision, error) {
 	req := map[string]string{"workspace_id": workspaceID}
 	var decision billingDecision
-	if err := h.post(ctx, "balance", req, &decision); err != nil {
+	if err := h.post(ctx, "balance/", req, &decision); err != nil {
 		return billingDecision{OK: false, ErrorCode: launchErrorBillingUnavailable}, err
 	}
 	if decision.RequiredCents <= 0 {
@@ -165,7 +165,7 @@ func (h *httpManagedBilling) RecordManagedUsage(ctx context.Context, usage manag
 		OK      bool   `json:"ok"`
 		Message string `json:"message"`
 	}
-	if err := h.post(ctx, "usage", usage, &response); err != nil {
+	if err := h.post(ctx, "usage/", usage, &response); err != nil {
 		return err
 	}
 	if !response.OK {

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -642,6 +642,21 @@ func fakeComputeKey(workspaceID, poolName string) string {
 	return workspaceID + "\x00" + poolName
 }
 
+func TestManagedBillingURLMatchesInternalAPIActionRoutes(t *testing.T) {
+	base := "https://api.stage.beam.cloud/v2/payment/managed-compute/"
+	tests := map[string]string{
+		"launch-check/": "https://api.stage.beam.cloud/v2/payment/managed-compute/launch-check/",
+		"balance/":      "https://api.stage.beam.cloud/v2/payment/managed-compute/balance/",
+		"usage/":        "https://api.stage.beam.cloud/v2/payment/managed-compute/usage/",
+	}
+
+	for path, want := range tests {
+		if got := joinBillingURL(base, path); got != want {
+			t.Fatalf("joinBillingURL(%q, %q) = %q, want %q", base, path, got, want)
+		}
+	}
+}
+
 type fakeManagedBilling struct {
 	launchDecision  billingDecision
 	launchErr       error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated managed billing endpoints to use trailing slashes and aligned URL building with internal action routes. Adds a unit test to lock in the correct URLs and prevent misrouted requests for launch-check, balance, and usage.

- **Bug Fixes**
  - Append trailing slashes to endpoints in `pkg/gateway/services/compute/billing.go` (`launch-check/`, `balance/`, `usage/`).
  - Add `TestManagedBillingURLMatchesInternalAPIActionRoutes` to verify `joinBillingURL` builds the expected full URLs under the base `https://api.stage.beam.cloud/v2/payment/managed-compute/`.

<sup>Written for commit db5a93a449a67fa98d571b45a96aa16a0372e414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

