### PR TITLE
node usage fixes

### DIFF
--- a/pkg/agent/service/service_test.go
+++ b/pkg/agent/service/service_test.go
@@ -44,14 +44,20 @@ func TestSystemdInstallWritesUnitAndRestartsService(t *testing.T) {
 	unitText := string(unit)
 	for _, want := range []string{
 		`Description=Beam Agent`,
+		`WorkingDirectory=` + filepath.Join(tmp, "state"),
 		`Environment="BEAM_AGENT_STATE_DIR=` + filepath.Join(tmp, "state") + `"`,
 		`Environment="BEAM_WORKER_IMAGE=registry.example.com/worker:latest"`,
+		`Environment="HOME=` + filepath.Join(tmp, "state") + `"`,
 		`ExecStart="` + types.DefaultAgentBinaryPath + `" "join" "--gateway" "https://gateway.beam.cloud" "--join-token" "token with spaces"`,
 		`Restart=always`,
+		`Environment="XDG_CONFIG_HOME=` + filepath.Join(tmp, "state", ".config") + `"`,
 	} {
 		if !strings.Contains(unitText, want) {
 			t.Fatalf("unit missing %q:\n%s", want, unitText)
 		}
+	}
+	if strings.Contains(unitText, `WorkingDirectory="`) {
+		t.Fatalf("WorkingDirectory must not be quoted:\n%s", unitText)
 	}
 
 	if got, want := strings.Join(runner.commands, "\n"), strings.Join([]string{
@@ -60,6 +66,18 @@ func TestSystemdInstallWritesUnitAndRestartsService(t *testing.T) {
 		types.AgentSystemctlCommand + " restart " + types.DefaultAgentServiceName + types.AgentServiceUnitExtension,
 	}, "\n"); got != want {
 		t.Fatalf("unexpected commands:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestSystemdUnitEscapesSpecifierInWorkingDirectory(t *testing.T) {
+	unit := SystemdUnit(Spec{
+		Name:       types.DefaultAgentServiceName,
+		BinaryPath: types.DefaultAgentBinaryPath,
+		StateDir:   "/var/lib/beam/%agent",
+	})
+
+	if !strings.Contains(unit, "WorkingDirectory=/var/lib/beam/%%agent\n") {
+		t.Fatalf("unit did not escape systemd specifier:\n%s", unit)
 	}
 }
 

--- a/pkg/agent/service/systemd.go
+++ b/pkg/agent/service/systemd.go
@@ -73,6 +73,7 @@ func (m Systemd) runner() Runner {
 
 func SystemdUnit(spec Spec) string {
 	spec, _ = spec.normalized()
+	spec.Env = systemdEnv(spec.Env, spec.StateDir)
 
 	var b strings.Builder
 	writeLines(&b,
@@ -83,7 +84,7 @@ func SystemdUnit(spec Spec) string {
 		"",
 		"[Service]",
 		"Type=simple",
-		"WorkingDirectory="+systemdQuote(spec.StateDir),
+		"WorkingDirectory="+systemdPath(spec.StateDir),
 	)
 	for _, key := range sortedEnvKeys(spec.Env) {
 		b.WriteString("Environment=" + systemdQuote(key+"="+spec.Env[key]) + "\n")
@@ -117,6 +118,20 @@ func sortedEnvKeys(env map[string]string) []string {
 	return keys
 }
 
+func systemdEnv(env map[string]string, stateDir string) map[string]string {
+	out := make(map[string]string, len(env)+2)
+	for key, value := range env {
+		out[key] = value
+	}
+	if _, ok := out[types.AgentHomeEnv]; !ok {
+		out[types.AgentHomeEnv] = stateDir
+	}
+	if _, ok := out[types.AgentXDGConfigHomeEnv]; !ok {
+		out[types.AgentXDGConfigHomeEnv] = filepath.Join(stateDir, ".config")
+	}
+	return out
+}
+
 func systemdCommand(args []string) string {
 	quoted := make([]string, 0, len(args))
 	for _, arg := range args {
@@ -133,4 +148,8 @@ func systemdQuote(value string) string {
 		"%", "%%",
 	)
 	return `"` + replacer.Replace(value) + `"`
+}
+
+func systemdPath(value string) string {
+	return strings.ReplaceAll(value, "%", "%%")
 }

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	model "github.com/beam-cloud/beta9/pkg/compute"
+	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 )
@@ -466,6 +467,73 @@ func TestRecordAgentMetricsEmitsNodeUsage(t *testing.T) {
 	}
 }
 
+func TestRecordAgentMetricsKeepsAgentAliveWhenNodeUsageMetricsFail(t *testing.T) {
+	now := time.Now().UTC()
+	machine := &model.AgentTokenState{
+		TokenHash:       "agent-token-hash",
+		WorkspaceID:     "workspace-1",
+		PoolName:        "pool-1",
+		MachineID:       "machine-1",
+		CPUCount:        4,
+		CPUMillicores:   4000,
+		MemoryMB:        8192,
+		Executor:        types.DefaultAgentWorkerContainerMode,
+		LastJoinAt:      now.Add(-time.Minute),
+		LastHeartbeatAt: now.Add(-5 * time.Second),
+	}
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{WorkspaceID: "workspace-1", Name: "pool-1", Source: model.SourceCLIReservation},
+			},
+		},
+		machines: map[string][]*model.AgentTokenState{
+			fakeComputeKey("workspace-1", "pool-1"): {machine},
+		},
+	}
+	service := &Service{
+		computeRepo:      repo,
+		usageMetricsRepo: &fakeUsageMetricsRepo{err: errors.New("openmeter unavailable")},
+	}
+
+	err := service.recordAgentMetrics(context.Background(), machine, &pb.AgentMetricSnapshot{
+		TimestampUnixNano: now.UnixNano(),
+		MemoryTotalMb:     8192,
+	})
+	if err != nil {
+		t.Fatalf("recordAgentMetrics() error = %v", err)
+	}
+}
+
+func TestDisableMachineWorkerStopsActiveContainers(t *testing.T) {
+	machine := &model.AgentTokenState{
+		WorkspaceID: "workspace-1",
+		PoolName:    "pool-1",
+		MachineID:   "machine-1",
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{Id: workerID, MachineId: machine.MachineID, PoolName: machine.PoolName},
+	}
+	containerRepo := &fakeContainerRepo{
+		containers: []types.ContainerState{
+			{ContainerId: "container-running", Status: types.ContainerStatusRunning},
+			{ContainerId: "container-stopping", Status: types.ContainerStatusStopping},
+		},
+	}
+	service := &Service{workerRepo: workerRepo, containerRepo: containerRepo}
+
+	if !service.disableMachineWorker(context.Background(), machine, reconcileReasonCreditExhausted) {
+		t.Fatal("disableMachineWorker() = false, want true")
+	}
+	if got, want := workerRepo.status, types.WorkerStatusDisabled; got != want {
+		t.Fatalf("worker status = %q, want %q", got, want)
+	}
+	if got, want := containerRepo.stopped, []string{"container-running"}; !sameStrings(got, want) {
+		t.Fatalf("stopped containers = %v, want %v", got, want)
+	}
+}
+
 func TestNodeUsageSecondsSkipsStaleGap(t *testing.T) {
 	now := time.Now().UTC()
 	if got := nodeUsageSeconds(now.Add(-model.AgentHeartbeatTimeout-time.Second), now); got != 0 {
@@ -670,6 +738,36 @@ func TestReconcileManagedComputeRecordsUsageBeforeBalanceCheck(t *testing.T) {
 	}
 }
 
+func TestReconcileManagedComputeChecksBalanceAfterFreshUsageTick(t *testing.T) {
+	now := time.Now().UTC()
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:                 "reservation-1",
+				Source:             model.SourceCLIReservation,
+				Status:             model.ReservationActive,
+				CreatedAt:          now.Add(-time.Hour),
+				BillingCursorAt:    now.Add(-time.Minute),
+				LastBillingCheckAt: now.Add(-time.Second),
+				ExpiresAt:          now.Add(time.Hour),
+				HourlyCostMicros:   1_000_000,
+			},
+		},
+	}
+	repo := &fakeComputeRepo{pools: map[string][]*model.PoolState{"workspace-1": {state}}}
+	billing := &fakeManagedBilling{balanceDecision: billingDecision{OK: true, RequiredCents: 1, AvailableCents: 1000}}
+	service := &Service{computeRepo: repo, billing: billing}
+
+	if err := service.ReconcileManagedCompute(context.Background()); err != nil {
+		t.Fatalf("ReconcileManagedCompute() error = %v", err)
+	}
+	if got, want := billing.balanceCalls, 1; got != want {
+		t.Fatalf("balance calls = %d, want %d", got, want)
+	}
+}
+
 func TestReconcileManagedComputeBillsExpiredReservationBeforeTerminating(t *testing.T) {
 	now := time.Now().UTC()
 	cursor := now.Add(-10 * time.Minute)
@@ -709,6 +807,22 @@ func TestReconcileManagedComputeBillsExpiredReservationBeforeTerminating(t *test
 	}
 	if got, want := state.Reservations[0].Status, model.ReservationTerminating; got != want {
 		t.Fatalf("reservation status = %q, want %q", got, want)
+	}
+}
+
+func TestReservationBillingWindowSkipsTerminatingReservation(t *testing.T) {
+	now := time.Now().UTC()
+	reservation := &model.Reservation{
+		ID:              "reservation-1",
+		Source:          model.SourceCLIReservation,
+		Status:          model.ReservationTerminating,
+		CreatedAt:       now.Add(-time.Hour),
+		BillingCursorAt: now.Add(-time.Minute),
+		ExpiresAt:       now.Add(time.Hour),
+	}
+
+	if _, _, ok := reservationBillingWindow(reservation, now); ok {
+		t.Fatal("terminating reservation should not have a billing window")
 	}
 }
 
@@ -759,22 +873,18 @@ func TestReconcileManagedComputeDoesNotTerminateOnBillingError(t *testing.T) {
 	}
 }
 
-func TestReleasePrivateMachineTransitionsManagedReservation(t *testing.T) {
+func TestReconcileManagedComputeRemovesMachineForDeletedReservation(t *testing.T) {
 	now := time.Now().UTC()
 	state := &model.PoolState{
 		WorkspaceID: "workspace-1",
 		Name:        "pool-1",
 		Reservations: []model.Reservation{
 			{
-				ID:               "reservation-1",
-				Provider:         "shadeform",
-				InstanceID:       "instance-1",
-				MachineID:        "machine-1",
-				Source:           model.SourceCLIReservation,
-				Status:           model.ReservationActive,
-				CreatedAt:        now.Add(-time.Hour),
-				ExpiresAt:        now.Add(time.Hour),
-				HourlyCostMicros: 1_000_000,
+				ID:        "reservation-1",
+				Provider:  "shadeform",
+				Source:    model.SourceCLIReservation,
+				Status:    model.ReservationDeleted,
+				MachineID: "machine-1",
 			},
 		},
 	}
@@ -788,6 +898,51 @@ func TestReleasePrivateMachineTransitionsManagedReservation(t *testing.T) {
 	repo := &fakeComputeRepo{
 		pools:    map[string][]*model.PoolState{"workspace-1": {state}},
 		machines: map[string][]*model.AgentTokenState{fakeComputeKey("workspace-1", "pool-1"): {machine}},
+	}
+	service := &Service{computeRepo: repo}
+
+	if err := service.ReconcileManagedCompute(context.Background()); err != nil {
+		t.Fatalf("ReconcileManagedCompute() error = %v", err)
+	}
+	if got := len(repo.machines[fakeComputeKey("workspace-1", "pool-1")]); got != 0 {
+		t.Fatalf("machine count after reconcile = %d, want 0", got)
+	}
+	if !repo.savedPool {
+		t.Fatal("ReconcileManagedCompute() did not persist closed reservation cleanup")
+	}
+}
+
+func TestReleasePrivateMachineTransitionsManagedReservation(t *testing.T) {
+	now := time.Now().UTC()
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:                    "reservation-1",
+				Provider:              "shadeform",
+				InstanceID:            "instance-1",
+				MachineID:             "machine-1",
+				Source:                model.SourceCLIReservation,
+				Status:                model.ReservationActive,
+				CreatedAt:             now.Add(-time.Hour),
+				ExpiresAt:             now.Add(time.Hour),
+				HourlyCostMicros:      1_000_000,
+				RegistrationTokenHash: "join-token-hash",
+			},
+		},
+	}
+	machine := &model.AgentTokenState{
+		WorkspaceID:     "workspace-1",
+		PoolName:        "pool-1",
+		MachineID:       "machine-1",
+		Schedulable:     true,
+		LastHeartbeatAt: now,
+	}
+	repo := &fakeComputeRepo{
+		pools:      map[string][]*model.PoolState{"workspace-1": {state}},
+		machines:   map[string][]*model.AgentTokenState{fakeComputeKey("workspace-1", "pool-1"): {machine}},
+		joinTokens: map[string]*model.JoinTokenState{"join-token-hash": {TokenHash: "join-token-hash", ExpiresAt: now.Add(time.Hour)}},
 	}
 	billing := &fakeManagedBilling{}
 	service := &Service{computeRepo: repo, billing: billing}
@@ -820,6 +975,9 @@ func TestReleasePrivateMachineTransitionsManagedReservation(t *testing.T) {
 	}
 	if got, want := len(billing.usage), 1; got != want {
 		t.Fatalf("managed usage records = %d, want %d", got, want)
+	}
+	if token := repo.joinTokens["join-token-hash"]; token == nil || !token.Revoked {
+		t.Fatal("releasePrivateMachine() did not revoke the reservation join token")
 	}
 }
 
@@ -1146,6 +1304,33 @@ func TestAssignManagedReservationToMachineUsesJoinTokenHash(t *testing.T) {
 	}
 }
 
+func TestAssignManagedReservationToMachineRejectsClosedManagedJoinToken(t *testing.T) {
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:                    "reservation-1",
+				Provider:              "shadeform",
+				Source:                model.SourceCLIReservation,
+				Status:                model.ReservationDeleted,
+				MachineID:             "machine-1",
+				RegistrationTokenHash: "join-token-hash",
+			},
+		},
+	}
+	token := &model.JoinTokenState{
+		TokenHash: "join-token-hash",
+		MachineID: "machine-1",
+	}
+	machine := &model.AgentTokenState{MachineID: "machine-1"}
+
+	err := (&Service{}).assignManagedReservationToMachine(context.Background(), state, token, machine)
+	if err == nil {
+		t.Fatal("assignManagedReservationToMachine() accepted a closed managed reservation")
+	}
+}
+
 func testAuthContext(workspaceID, tokenID string) context.Context {
 	return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
 		Workspace: &types.Workspace{ExternalId: workspaceID},
@@ -1181,9 +1366,10 @@ func sameStrings(a, b []string) bool {
 }
 
 type fakeComputeRepo struct {
-	pools     map[string][]*model.PoolState
-	machines  map[string][]*model.AgentTokenState
-	savedPool bool
+	pools      map[string][]*model.PoolState
+	machines   map[string][]*model.AgentTokenState
+	joinTokens map[string]*model.JoinTokenState
+	savedPool  bool
 }
 
 func (r *fakeComputeRepo) SavePoolState(ctx context.Context, workspaceID string, state *model.PoolState) error {
@@ -1243,11 +1429,18 @@ func (r *fakeComputeRepo) DeletePoolState(ctx context.Context, workspaceID, name
 }
 
 func (r *fakeComputeRepo) SaveJoinTokenState(ctx context.Context, state *model.JoinTokenState, ttl time.Duration) error {
+	if state == nil {
+		return nil
+	}
+	if r.joinTokens == nil {
+		r.joinTokens = map[string]*model.JoinTokenState{}
+	}
+	r.joinTokens[state.TokenHash] = state
 	return nil
 }
 
 func (r *fakeComputeRepo) GetJoinTokenState(ctx context.Context, tokenHash string) (*model.JoinTokenState, error) {
-	return nil, nil
+	return r.joinTokens[tokenHash], nil
 }
 
 func (r *fakeComputeRepo) SaveAgentTokenState(ctx context.Context, state *model.AgentTokenState, ttl time.Duration) error {
@@ -1403,6 +1596,45 @@ func (r *fakeUsageMetricsRepo) IncrementCounter(name string, metadata map[string
 func (r *fakeUsageMetricsRepo) SetGauge(name string, metadata map[string]interface{}, value float64) error {
 	if r.err != nil {
 		return r.err
+	}
+	return nil
+}
+
+type fakeWorkerRepo struct {
+	repository.WorkerRepository
+	worker *types.Worker
+	status types.WorkerStatus
+}
+
+func (r *fakeWorkerRepo) GetWorkerById(workerID string) (*types.Worker, error) {
+	if r.worker == nil || r.worker.Id != workerID {
+		return nil, &types.ErrWorkerNotFound{WorkerId: workerID}
+	}
+	return r.worker, nil
+}
+
+func (r *fakeWorkerRepo) UpdateWorkerStatus(workerID string, status types.WorkerStatus) error {
+	if r.worker == nil || r.worker.Id != workerID {
+		return &types.ErrWorkerNotFound{WorkerId: workerID}
+	}
+	r.worker.Status = status
+	r.status = status
+	return nil
+}
+
+type fakeContainerRepo struct {
+	repository.ContainerRepository
+	containers []types.ContainerState
+	stopped    []string
+}
+
+func (r *fakeContainerRepo) GetActiveContainersByWorkerId(string) ([]types.ContainerState, error) {
+	return append([]types.ContainerState(nil), r.containers...), nil
+}
+
+func (r *fakeContainerRepo) UpdateContainerStatus(containerID string, status types.ContainerStatus, _ int64) error {
+	if status == types.ContainerStatusStopping {
+		r.stopped = append(r.stopped, containerID)
 	}
 	return nil
 }

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -75,6 +75,10 @@ func (s *Service) reconcilePool(ctx context.Context, workspaceID string, state *
 		if !reservation.Managed() {
 			continue
 		}
+		if reservationClosed(reservation.Status) {
+			changed = s.reconcileClosedReservationMachine(ctx, workspaceID, state, reservation) || changed
+			continue
+		}
 		if reservation.Status == model.ReservationTerminating {
 			changed = s.reconcileTerminatingReservation(ctx, workspaceID, state, reservation, vendors, now) || changed
 			continue
@@ -108,7 +112,7 @@ func (s *Service) reconcileBilling(ctx context.Context, workspaceID string, stat
 		return false
 	}
 	changed := s.recordManagedUsage(ctx, workspaceID, state, now)
-	if billingCheckFresh(state, now) {
+	if !changed && billingCheckFresh(state, now) {
 		return changed
 	}
 
@@ -190,7 +194,9 @@ func reservationBillingWindow(reservation *model.Reservation, now time.Time) (ti
 	if reservation == nil || !reservation.Managed() {
 		return time.Time{}, time.Time{}, false
 	}
-	if reservation.Status == model.ReservationDeleted || reservation.Status == model.ReservationFailed {
+	if reservation.Status == model.ReservationDeleted ||
+		reservation.Status == model.ReservationFailed ||
+		reservation.Status == model.ReservationTerminating {
 		return time.Time{}, time.Time{}, false
 	}
 
@@ -296,6 +302,26 @@ func (s *Service) reconcileReservationExpiry(ctx context.Context, workspaceID st
 	return s.terminateReservation(ctx, workspaceID, state, reservation, vendors, reconcileReasonReservationExpired, "reservation ttl expired")
 }
 
+func (s *Service) reconcileClosedReservationMachine(ctx context.Context, workspaceID string, state *model.PoolState, reservation *model.Reservation) bool {
+	if reservation.MachineID == "" {
+		return false
+	}
+	machine, err := s.computeRepo.GetAgentMachineState(ctx, workspaceID, state.Name, reservation.MachineID)
+	if err != nil {
+		reservation.LastError = err.Error()
+		return true
+	}
+	if machine == nil {
+		return false
+	}
+	if err := s.removePrivateMachine(ctx, machine); err != nil {
+		reservation.LastError = err.Error()
+		return true
+	}
+	reservation.LastError = ""
+	return true
+}
+
 func (s *Service) reconcileTerminatingReservation(ctx context.Context, workspaceID string, state *model.PoolState, reservation *model.Reservation, vendors map[string]model.Vendor, now time.Time) bool {
 	if reservation.Status != model.ReservationTerminating {
 		return false
@@ -375,7 +401,7 @@ func (s *Service) disablePoolMachines(ctx context.Context, workspaceID, poolName
 	}
 }
 
-func (s *Service) disableMachineWorker(_ context.Context, machine *model.AgentTokenState, reason string) bool {
+func (s *Service) disableMachineWorker(ctx context.Context, machine *model.AgentTokenState, reason string) bool {
 	if s.workerRepo == nil || machine == nil {
 		return false
 	}
@@ -390,6 +416,7 @@ func (s *Service) disableMachineWorker(_ context.Context, machine *model.AgentTo
 	if err := s.workerRepo.UpdateWorkerStatus(workerID, types.WorkerStatusDisabled); err != nil {
 		return false
 	}
+	s.stopWorkerContainers(ctx, workerID, reason)
 	s.emitComputeEvent(types.EventComputeMachine, types.EventComputeSchema{
 		WorkspaceID: machine.WorkspaceID,
 		PoolName:    machine.PoolName,
@@ -400,6 +427,39 @@ func (s *Service) disableMachineWorker(_ context.Context, machine *model.AgentTo
 		Message:     "machine worker disabled: " + reason,
 	})
 	return true
+}
+
+func (s *Service) stopWorkerContainers(ctx context.Context, workerID, reason string) {
+	if s.containerRepo == nil || workerID == "" {
+		return
+	}
+	containers, err := s.containerRepo.GetActiveContainersByWorkerId(workerID)
+	if err != nil {
+		log.Warn().Err(err).Str("worker_id", workerID).Msg("failed to list containers for disabled worker")
+		return
+	}
+	for _, container := range containers {
+		if container.ContainerId == "" || container.Status == types.ContainerStatusStopping {
+			continue
+		}
+		s.stopContainerForDisabledWorker(ctx, container.ContainerId, reason)
+	}
+}
+
+func (s *Service) stopContainerForDisabledWorker(_ context.Context, containerID, reason string) {
+	stopReason := types.StopContainerReasonScheduler
+	if reason == reconcileReasonMachineReleased {
+		stopReason = types.StopContainerReasonUser
+	}
+	if s.scheduler != nil {
+		if err := s.scheduler.Stop(&types.StopContainerArgs{ContainerId: containerID, Force: true, Reason: stopReason}); err != nil {
+			log.Warn().Err(err).Str("container_id", containerID).Msg("failed to stop container on disabled worker")
+		}
+		return
+	}
+	if err := s.containerRepo.UpdateContainerStatus(containerID, types.ContainerStatusStopping, types.ContainerStateTtlSWhilePending); err != nil {
+		log.Warn().Err(err).Str("container_id", containerID).Msg("failed to mark container stopping on disabled worker")
+	}
 }
 
 func (s *Service) emitCreditExhaustedEvent(workspaceID string, state *model.PoolState, decision billingDecision, message string) {

--- a/pkg/gateway/services/compute/release.go
+++ b/pkg/gateway/services/compute/release.go
@@ -78,6 +78,7 @@ func (s *Service) releaseManagedReservation(ctx context.Context, workspaceID str
 
 	now := time.Now().UTC()
 	changed := s.recordManagedUsage(ctx, workspaceID, state, now)
+	s.revokeReservationJoinToken(ctx, reservation)
 	changed = markReservationTerminating(reservation, reconcileReasonMachineReleased, machineReleasedMessage) || changed
 	if changed {
 		// Persist terminating state before provider deletion so reconcile can retry cleanup.
@@ -92,6 +93,22 @@ func (s *Service) releaseManagedReservation(ctx context.Context, workspaceID str
 		return s.savePrivatePoolState(ctx, workspaceID, state)
 	}
 	return nil
+}
+
+func (s *Service) revokeReservationJoinToken(ctx context.Context, reservation *model.Reservation) {
+	if s == nil || s.computeRepo == nil || reservation == nil || reservation.RegistrationTokenHash == "" {
+		return
+	}
+	token, err := s.computeRepo.GetJoinTokenState(ctx, reservation.RegistrationTokenHash)
+	if err != nil || token == nil || token.Revoked {
+		return
+	}
+	token.Revoked = true
+	ttl := time.Until(token.ExpiresAt)
+	if ttl <= 0 {
+		ttl = time.Second
+	}
+	_ = s.saveComputeJoinTokenState(ctx, token, ttl)
 }
 
 func (s *Service) removePrivateMachineWorker(machine *model.AgentTokenState) error {
@@ -120,6 +137,9 @@ func (s *Service) assignManagedReservationToMachine(ctx context.Context, state *
 	}
 	reservation := managedReservationForToken(state, token)
 	if reservation == nil {
+		if token != nil && token.MachineID != "" {
+			return fmt.Errorf("managed reservation for machine %q is not active", token.MachineID)
+		}
 		return nil
 	}
 	if reservation.MachineID != "" && reservation.MachineID != machine.MachineID {
@@ -141,7 +161,7 @@ func managedReservationForToken(state *model.PoolState, token *model.JoinTokenSt
 		if !reservation.Managed() || reservation.RegistrationTokenHash != token.TokenHash {
 			continue
 		}
-		if reservationClosed(reservation.Status) {
+		if reservationClosed(reservation.Status) || reservation.Status == model.ReservationTerminating {
 			continue
 		}
 		return reservation

--- a/pkg/gateway/services/compute/telemetry.go
+++ b/pkg/gateway/services/compute/telemetry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/cockroachdb/redact"
+	"github.com/rs/zerolog/log"
 )
 
 const telemetrySensitiveLogKeyPattern = `[A-Za-z0-9_.-]*(?:access[_-]?key|accesskey|api[_-]?key|apikey|secret|token|password|credentials?)[A-Za-z0-9_.-]*`
@@ -163,7 +164,14 @@ func (s *Service) recordAgentMetrics(ctx context.Context, agentState *model.Agen
 	}
 	worker := s.agentMachineStatusWorker(agentState)
 	capacityMetrics := agentMachineMetrics(agentState, worker)
-	s.recordAgentNodeUsage(agentState, poolState, capacityMetrics, previousSeen, metrics.Timestamp)
+	if err := s.recordAgentNodeUsage(agentState, poolState, capacityMetrics, previousSeen, metrics.Timestamp); err != nil {
+		log.Warn().
+			Err(err).
+			Str("workspace_id", agentState.WorkspaceID).
+			Str("pool_name", agentState.PoolName).
+			Str("machine_id", agentState.MachineID).
+			Msg("failed to record node usage telemetry")
+	}
 
 	if s.scheduler != nil && poolState != nil {
 		if err := s.scheduler.RegisterAgentPool(agentState.WorkspaceID, poolState); err != nil {
@@ -201,19 +209,22 @@ func (s *Service) recordAgentMetrics(ctx context.Context, agentState *model.Agen
 	return nil
 }
 
-func (s *Service) recordAgentNodeUsage(agentState *model.AgentTokenState, poolState *model.PoolState, metrics *pb.MachineMetrics, previousSeen, currentSeen time.Time) {
+func (s *Service) recordAgentNodeUsage(agentState *model.AgentTokenState, poolState *model.PoolState, metrics *pb.MachineMetrics, previousSeen, currentSeen time.Time) error {
 	if s == nil || s.usageMetricsRepo == nil || agentState == nil {
-		return
+		return nil
 	}
 	seconds := nodeUsageSeconds(previousSeen, currentSeen)
 	if seconds <= 0 {
-		return
+		return nil
 	}
-	_ = s.usageMetricsRepo.IncrementCounter(
+	if err := s.usageMetricsRepo.IncrementCounter(
 		types.UsageMetricsNodeUsage,
 		agentNodeUsageMetadata(agentState, poolState, metrics, seconds),
 		seconds,
-	)
+	); err != nil {
+		return fmt.Errorf("record node usage: %w", err)
+	}
+	return nil
 }
 
 func nodeUsageSeconds(previousSeen, currentSeen time.Time) float64 {

--- a/pkg/types/agent_worker.go
+++ b/pkg/types/agent_worker.go
@@ -28,6 +28,8 @@ const (
 	AgentServiceDefaultPath         = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	AgentServiceLogFile             = "agent.log"
 	AgentServiceErrorLogFile        = "agent.err.log"
+	AgentHomeEnv                    = "HOME"
+	AgentXDGConfigHomeEnv           = "XDG_CONFIG_HOME"
 	AgentRegistryAddr               = "127.0.0.1:5000"
 	AgentWorkerEntrypoint           = "/usr/local/bin/worker"
 	AgentTmpSizeLimit               = "30Gi"

--- a/pkg/worker/usage.go
+++ b/pkg/worker/usage.go
@@ -18,6 +18,7 @@ type WorkerUsageMetrics struct {
 	ctx                 context.Context
 	containerCostClient *clients.ContainerCostClient
 	gpuType             string
+	poolMode            types.PoolMode
 }
 
 func NewWorkerUsageMetrics(
@@ -25,6 +26,7 @@ func NewWorkerUsageMetrics(
 	workerId string,
 	config types.MonitoringConfig,
 	gpuType string,
+	poolMode types.PoolMode,
 ) (*WorkerUsageMetrics, error) {
 	metricsRepo, err := usage.NewUsageMetricsRepository(config, string(usage.MetricsSourceWorker))
 	if err != nil {
@@ -37,6 +39,7 @@ func NewWorkerUsageMetrics(
 		ctx:                 ctx,
 		workerId:            workerId,
 		gpuType:             gpuType,
+		poolMode:            poolMode,
 		metricsRepo:         metricsRepo,
 		containerCostClient: containerCostClient,
 	}, nil
@@ -76,6 +79,9 @@ func (wm *WorkerUsageMetrics) metricsContainerCost(request *types.ContainerReque
 
 // Periodically send metrics to track container duration
 func (wm *WorkerUsageMetrics) EmitContainerUsage(ctx context.Context, request *types.ContainerRequest) {
+	if wm == nil || wm.poolMode == types.PoolModePrivate {
+		return
+	}
 	cursorTime := time.Now()
 	ticker := time.NewTicker(types.ContainerDurationEmissionInterval)
 	defer ticker.Stop()

--- a/pkg/worker/usage_test.go
+++ b/pkg/worker/usage_test.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestEmitContainerUsageSkipsPrivatePools(t *testing.T) {
+	repo := &usageMetricsRecorder{}
+	metrics := &WorkerUsageMetrics{
+		workerId:    "worker-1",
+		metricsRepo: repo,
+		poolMode:    types.PoolModePrivate,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	metrics.EmitContainerUsage(ctx, &types.ContainerRequest{ContainerId: "container-1"})
+
+	if repo.count != 0 {
+		t.Fatalf("private pool emitted %d usage counters, want 0", repo.count)
+	}
+}
+
+func TestEmitContainerUsageRecordsNonPrivatePools(t *testing.T) {
+	repo := &usageMetricsRecorder{}
+	metrics := &WorkerUsageMetrics{
+		workerId:    "worker-1",
+		metricsRepo: repo,
+		poolMode:    types.PoolModeLocal,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	metrics.EmitContainerUsage(ctx, &types.ContainerRequest{ContainerId: "container-1"})
+
+	if repo.count != 2 {
+		t.Fatalf("local pool emitted %d usage counters, want duration and cost", repo.count)
+	}
+}
+
+type usageMetricsRecorder struct {
+	count int
+}
+
+func (r *usageMetricsRecorder) Init(string) error {
+	return nil
+}
+
+func (r *usageMetricsRecorder) IncrementCounter(string, map[string]interface{}, float64) error {
+	r.count++
+	return nil
+}
+
+func (r *usageMetricsRecorder) SetGauge(string, map[string]interface{}, float64) error {
+	return nil
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -407,7 +407,7 @@ func NewWorker() (*Worker, error) {
 		return nil, err
 	}
 
-	workerMetrics, err := NewWorkerUsageMetrics(ctx, workerId, config.Monitoring, gpuType)
+	workerMetrics, err := NewWorkerUsageMetrics(ctx, workerId, config.Monitoring, gpuType, poolConfig.Mode)
 	if err != nil {
 		cancel()
 		return nil, err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes node usage and managed compute edge cases: agents no longer fail when usage metrics can’t be recorded, private pools stop emitting container usage, and managed reservations/workers reconcile correctly. Also hardens the systemd unit with a correct working directory and default envs.

- **Bug Fixes**
  - Telemetry: node usage increment errors now warn-only; agent stays healthy and continues processing. Billing now checks balance even right after a fresh usage tick.
  - Worker metrics: skip container duration/cost emission for private pools.
  - Managed reservations: skip billing windows for terminating reservations; remove machines for closed reservations; revoke reservation join tokens on release; reject closed/terminating managed join tokens and error if a token’s machine isn’t active.
  - Worker disable: disabling a machine’s worker now stops active containers (via scheduler or marks as stopping).
  - systemd unit: set `HOME` and `XDG_CONFIG_HOME` defaults, write an unquoted WorkingDirectory, and escape `%` in paths.

<sup>Written for commit 3d57bbfec51b3b49414083a9426d6b464a9674c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

