### PR TITLE
fix resolv conf on remote machines

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -594,6 +594,10 @@ func TestWriteWorkerConfigUsesGatewayBootstrapParts(t *testing.T) {
 	if got := httpConfig["externalPort"]; got != float64(1994) {
 		t.Fatalf("http external port = %v, want 1994", got)
 	}
+	workerConfig := config["worker"].(map[string]any)
+	if got := workerConfig["useHostResolvConf"]; got != true {
+		t.Fatalf("useHostResolvConf = %v, want true", got)
+	}
 }
 
 func TestAgentLocalRegistryForwardTargetUsesLocalK3DPort(t *testing.T) {

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -800,6 +800,64 @@ func TestDisableMachineWorkerStopsActiveContainers(t *testing.T) {
 	}
 }
 
+func TestDisableMachineWorkerKeepsActiveContainersOnDisconnect(t *testing.T) {
+	machine := &model.AgentTokenState{
+		WorkspaceID: "workspace-1",
+		PoolName:    "pool-1",
+		MachineID:   "machine-1",
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{Id: workerID, MachineId: machine.MachineID, PoolName: machine.PoolName},
+	}
+	containerRepo := &fakeContainerRepo{
+		containers: []types.ContainerState{
+			{ContainerId: "container-running", Status: types.ContainerStatusRunning},
+		},
+	}
+	service := &Service{workerRepo: workerRepo, containerRepo: containerRepo}
+
+	if !service.disableMachineWorker(context.Background(), machine, reconcileReasonAgentDisconnected) {
+		t.Fatal("disableMachineWorker() = false, want true")
+	}
+	if got, want := workerRepo.status, types.WorkerStatusDisabled; got != want {
+		t.Fatalf("worker status = %q, want %q", got, want)
+	}
+	if len(containerRepo.stopped) != 0 {
+		t.Fatalf("stopped containers = %v, want none", containerRepo.stopped)
+	}
+}
+
+func TestDisableMachineWorkerStopsContainersWhenAlreadyDisabledForHardTeardown(t *testing.T) {
+	machine := &model.AgentTokenState{
+		WorkspaceID: "workspace-1",
+		PoolName:    "pool-1",
+		MachineID:   "machine-1",
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{
+			Id:        workerID,
+			MachineId: machine.MachineID,
+			PoolName:  machine.PoolName,
+			Status:    types.WorkerStatusDisabled,
+		},
+	}
+	containerRepo := &fakeContainerRepo{
+		containers: []types.ContainerState{
+			{ContainerId: "container-running", Status: types.ContainerStatusRunning},
+		},
+	}
+	service := &Service{workerRepo: workerRepo, containerRepo: containerRepo}
+
+	if service.disableMachineWorker(context.Background(), machine, reconcileReasonCreditExhausted) {
+		t.Fatal("disableMachineWorker() = true, want false for already-disabled worker")
+	}
+	if got, want := containerRepo.stopped, []string{"container-running"}; !sameStrings(got, want) {
+		t.Fatalf("stopped containers = %v, want %v", got, want)
+	}
+}
+
 func TestNodeUsageSecondsSkipsStaleGap(t *testing.T) {
 	now := time.Now().UTC()
 	if got := nodeUsageSeconds(now.Add(-model.AgentHeartbeatTimeout-time.Second), now); got != 0 {

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -415,12 +415,17 @@ func (s *Service) disableMachineWorker(ctx context.Context, machine *model.Agent
 		return false
 	}
 	if worker.Status == types.WorkerStatusDisabled {
+		if shouldStopContainersForDisabledWorker(reason) {
+			s.stopWorkerContainers(ctx, workerID, reason)
+		}
 		return false
 	}
 	if err := s.workerRepo.UpdateWorkerStatus(workerID, types.WorkerStatusDisabled); err != nil {
 		return false
 	}
-	s.stopWorkerContainers(ctx, workerID, reason)
+	if shouldStopContainersForDisabledWorker(reason) {
+		s.stopWorkerContainers(ctx, workerID, reason)
+	}
 	s.emitComputeEvent(types.EventComputeMachine, types.EventComputeSchema{
 		WorkspaceID: machine.WorkspaceID,
 		PoolName:    machine.PoolName,
@@ -431,6 +436,15 @@ func (s *Service) disableMachineWorker(ctx context.Context, machine *model.Agent
 		Message:     "machine worker disabled: " + reason,
 	})
 	return true
+}
+
+func shouldStopContainersForDisabledWorker(reason string) bool {
+	switch reason {
+	case reconcileReasonAgentDisconnected, reconcileReasonMachineDisconnected:
+		return false
+	default:
+		return true
+	}
 }
 
 func (s *Service) stopWorkerContainers(ctx context.Context, workerID, reason string) {

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -933,13 +933,23 @@ func cacheServerPortFromEnv() uint {
 }
 
 func cacheWorkerInstanceID(workerID string) string {
-	for _, env := range []string{types.WorkerPodUIDEnv, types.WorkerPodHostEnv, types.WorkerHostnameEnv} {
-		if value := os.Getenv(env); value != "" {
+	for _, env := range []string{types.WorkerPodUIDEnv, types.WorkerMachineEnv, types.WorkerPodIPEnv, types.WorkerPodHostEnv, types.WorkerHostnameEnv} {
+		if value := strings.TrimSpace(os.Getenv(env)); usableCacheWorkerInstanceID(value) {
 			return value
 		}
 	}
 
 	return workerID
+}
+
+func usableCacheWorkerInstanceID(value string) bool {
+	if value == "" {
+		return false
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		return usableCacheAdvertiseIP(ip)
+	}
+	return true
 }
 
 var cacheNameRe = regexp.MustCompile(`[^a-zA-Z0-9_.-]+`)

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -581,6 +581,22 @@ func TestCacheAdvertiseHost(t *testing.T) {
 	}
 }
 
+func TestCacheWorkerInstanceIDPrefersMachineAndSkipsLoopback(t *testing.T) {
+	t.Setenv(types.WorkerPodHostEnv, "127.0.0.1")
+	t.Setenv(types.WorkerPodIPEnv, "127.0.0.1")
+	t.Setenv(types.WorkerMachineEnv, "machine-a")
+	t.Setenv(types.WorkerHostnameEnv, "container-host")
+
+	require.Equal(t, "machine-a", cacheWorkerInstanceID("worker-a"))
+}
+
+func TestCacheWorkerInstanceIDUsesReachablePodIP(t *testing.T) {
+	t.Setenv(types.WorkerPodIPEnv, "10.0.0.8")
+	t.Setenv(types.WorkerPodHostEnv, "127.0.0.1")
+
+	require.Equal(t, "10.0.0.8", cacheWorkerInstanceID("worker-a"))
+}
+
 func TestBindAddr(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,8 +39,38 @@ const (
 	sandboxCPUQuotaApplyTimeout        = 2 * time.Second
 )
 
+const (
+	hostResolvConfPath   = "/etc/resolv.conf"
+	workerResolvConfPath = "/workspace/etc/resolv.conf"
+)
+
 type containerResourceUpdater interface {
 	UpdateResources(ctx context.Context, containerID string, resources *specs.LinuxResources) error
+}
+
+func containerResolvConfSource(useHostResolvConf bool, hostPath string) string {
+	if useHostResolvConf && resolvConfHasUsableNameserver(hostPath) {
+		return hostPath
+	}
+	return workerResolvConfPath
+}
+
+func resolvConfHasUsableNameserver(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "nameserver" {
+			continue
+		}
+		ip := net.ParseIP(fields[1])
+		if ip != nil && !ip.IsLoopback() && !ip.IsUnspecified() {
+			return true
+		}
+	}
+	return false
 }
 
 // handleStopContainerArgs queues a stop for a locally owned container.
@@ -748,7 +779,7 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 	// Configure resolv.conf
 	resolvMount := specs.Mount{
 		Type:        "none",
-		Source:      "/workspace/etc/resolv.conf",
+		Source:      containerResolvConfSource(s.config.Worker.UseHostResolvConf, hostResolvConfPath),
 		Destination: "/etc/resolv.conf",
 		Options: []string{
 			"ro",
@@ -758,10 +789,6 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 			"noexec",
 			"nodev",
 		},
-	}
-
-	if s.config.Worker.UseHostResolvConf {
-		resolvMount.Source = "/etc/resolv.conf"
 	}
 
 	spec.Mounts = append(spec.Mounts, resolvMount)

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -54,6 +54,21 @@ func TestWaitForRuntimeStartedReturnsWhenRuntimeDoneWithoutPID(t *testing.T) {
 	require.False(t, handled)
 }
 
+func TestContainerResolvConfSourceFallsBackForLoopbackHostResolver(t *testing.T) {
+	hostResolv := filepath.Join(t.TempDir(), "resolv.conf")
+	require.NoError(t, os.WriteFile(hostResolv, []byte("nameserver 127.0.0.53\noptions edns0\n"), 0o644))
+
+	require.Equal(t, workerResolvConfPath, containerResolvConfSource(true, hostResolv))
+}
+
+func TestContainerResolvConfSourceUsesHostResolverWhenReachable(t *testing.T) {
+	hostResolv := filepath.Join(t.TempDir(), "resolv.conf")
+	require.NoError(t, os.WriteFile(hostResolv, []byte("nameserver 1.1.1.1\n"), 0o644))
+
+	require.Equal(t, hostResolv, containerResolvConfSource(true, hostResolv))
+	require.Equal(t, workerResolvConfPath, containerResolvConfSource(false, hostResolv))
+}
+
 func TestStartupPortBindingsForSandboxSkipsInternalPorts(t *testing.T) {
 	request := &types.ContainerRequest{
 		Ports: []uint32{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix DNS in containers on remote machines by only mounting the host resolv.conf when it has a reachable nameserver; otherwise fall back to the worker’s resolv.conf. Also keep containers running when a machine/agent disconnects, and improve worker instance ID selection to avoid loopback addresses.

- **Bug Fixes**
  - Resolv.conf mount now checks for a non-loopback nameserver and falls back to the worker’s resolver when the host uses 127.x.x.x.
  - Disabled workers no longer stop containers on agent/machine disconnect; containers only stop for hard teardown reasons.
  - Worker cache instance ID prefers stable machine/pod identifiers and skips loopback or unusable IPs.

<sup>Written for commit e5ab4cad748927cee8ed3b4e36b51f68a5f6d260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

