### PR TITLE
fix keepalives

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -19,6 +19,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	gatewayGRPCKeepaliveTime    = 20 * time.Second
+	gatewayGRPCKeepaliveTimeout = 10 * time.Second
 )
 
 type Client struct {
@@ -46,7 +52,15 @@ func newGatewayGRPCClient(gatewayURL, host string, port int, useTLS bool) (pb.Ga
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	conn, err := grpc.DialContext(ctx, addr,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                gatewayGRPCKeepaliveTime,
+			Timeout:             gatewayGRPCKeepaliveTimeout,
+			PermitWithoutStream: true,
+		}),
+		grpc.WithBlock(),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -771,6 +771,74 @@ func TestRecordAgentMetricsKeepsAgentAliveWhenNodeUsageMetricsFail(t *testing.T)
 	}
 }
 
+func TestRecordAgentDisconnectIgnoresFreshHeartbeat(t *testing.T) {
+	now := time.Now().UTC()
+	machine := &model.AgentTokenState{
+		TokenHash:       "agent-token-hash",
+		WorkspaceID:     "workspace-1",
+		PoolName:        "pool-1",
+		MachineID:       "machine-1",
+		Schedulable:     true,
+		LastJoinAt:      now.Add(-time.Minute),
+		LastHeartbeatAt: now.Add(-5 * time.Second),
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{Id: workerID, MachineId: machine.MachineID, PoolName: machine.PoolName},
+	}
+	service := &Service{
+		computeRepo: &fakeComputeRepo{
+			machines: map[string][]*model.AgentTokenState{
+				fakeComputeKey("workspace-1", "pool-1"): {machine},
+			},
+		},
+		workerRepo: workerRepo,
+	}
+
+	service.recordAgentDisconnect(context.Background(), machine)
+
+	if !machine.LastDisconnectAt.IsZero() {
+		t.Fatalf("last disconnect = %s, want zero", machine.LastDisconnectAt)
+	}
+	if got := workerRepo.worker.Status; got == types.WorkerStatusDisabled {
+		t.Fatalf("worker status = %q, want not disabled", got)
+	}
+}
+
+func TestRecordAgentDisconnectDisablesStaleHeartbeat(t *testing.T) {
+	now := time.Now().UTC()
+	machine := &model.AgentTokenState{
+		TokenHash:       "agent-token-hash",
+		WorkspaceID:     "workspace-1",
+		PoolName:        "pool-1",
+		MachineID:       "machine-1",
+		Schedulable:     true,
+		LastJoinAt:      now.Add(-time.Minute),
+		LastHeartbeatAt: now.Add(-model.AgentHeartbeatTimeout - time.Second),
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{Id: workerID, MachineId: machine.MachineID, PoolName: machine.PoolName},
+	}
+	service := &Service{
+		computeRepo: &fakeComputeRepo{
+			machines: map[string][]*model.AgentTokenState{
+				fakeComputeKey("workspace-1", "pool-1"): {machine},
+			},
+		},
+		workerRepo: workerRepo,
+	}
+
+	service.recordAgentDisconnect(context.Background(), machine)
+
+	if machine.LastDisconnectAt.IsZero() {
+		t.Fatal("last disconnect is zero, want timestamp")
+	}
+	if got, want := workerRepo.status, types.WorkerStatusDisabled; got != want {
+		t.Fatalf("worker status = %q, want %q", got, want)
+	}
+}
+
 func TestDisableMachineWorkerStopsActiveContainers(t *testing.T) {
 	machine := &model.AgentTokenState{
 		WorkspaceID: "workspace-1",

--- a/pkg/gateway/services/compute/telemetry.go
+++ b/pkg/gateway/services/compute/telemetry.go
@@ -306,11 +306,15 @@ func (s *Service) recordAgentDisconnect(ctx context.Context, agentState *model.A
 	}
 	agentState = current
 	lastSeen := model.AgentMachineLastSeen(agentState)
+	now := time.Now().UTC()
+	if lastSeen.IsZero() || !lastSeen.Before(now.Add(-model.AgentHeartbeatTimeout)) {
+		return
+	}
 	if !agentState.LastDisconnectAt.IsZero() && !agentState.LastDisconnectAt.Before(lastSeen) {
 		s.disableMachineWorker(ctx, agentState, reconcileReasonAgentDisconnected)
 		return
 	}
-	agentState.LastDisconnectAt = time.Now().UTC()
+	agentState.LastDisconnectAt = now
 	if err := s.saveComputeAgentTokenState(ctx, agentState); err != nil {
 		return
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keeps agent connections alive and prevents false disconnects by enabling `grpc` client keepalives and only marking agents disconnected when their heartbeat is stale. Adds tests to cover both paths.

- **Bug Fixes**
  - Set `grpc` client keepalives: 20s ping, 10s timeout, `PermitWithoutStream=true`.
  - `recordAgentDisconnect` now skips agents with a fresh heartbeat and only timestamps/disables when past `AgentHeartbeatTimeout`.
  - Added tests for fresh vs. stale heartbeat handling.

<sup>Written for commit 3b7f98d2d4b04cbc1b01bf14ee4258eb937e8cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

