### PR TITLE
fix worker ttl

### DIFF
--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -591,6 +591,107 @@ func TestLaunchPoolCapacityCreatesProviderReservation(t *testing.T) {
 	}
 }
 
+func TestLaunchPoolCapacityAddsReservationToExistingPool(t *testing.T) {
+	var createCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/instances/types":
+			_, _ = w.Write([]byte(`{"instance_types":[{"id":"sf-a10g-1","cloud":"lambda","shade_instance_type":"A10Gx1","hourly_price":150,"deployment_type":"vm","configuration":{"gpu_type":"A10G","num_gpus":1,"vcpus":4,"memory_in_gb":16,"storage_in_gb":128},"availability":[{"region":"us-east","available":true}]}]}`))
+		case "/instances/create":
+			createCalls++
+			_, _ = w.Write([]byte(`{"id":"reservation-2"}`))
+		default:
+			t.Fatalf("unexpected shadeform path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Now().UTC()
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{
+					Name:                 "pool-1",
+					Selector:             "pool-1",
+					CreatedByTokenID:     "token-1",
+					ReservedGPUs:         1,
+					CommittedSpendMicros: 1_500_000,
+					Reservations: []model.Reservation{
+						{
+							ID:               "reservation-1",
+							PoolName:         "pool-1",
+							Selector:         "pool-1",
+							Provider:         "shadeform",
+							OfferID:          "sf-a10g-1",
+							MachineID:        "machine-1",
+							GPU:              "A10G",
+							GPUCount:         1,
+							HourlyCostMicros: 1_500_000,
+							Source:           model.SourceCLIReservation,
+							Status:           model.ReservationActive,
+							CreatedAt:        now.Add(-time.Minute),
+							ExpiresAt:        now.Add(time.Hour),
+						},
+					},
+				},
+			},
+		},
+	}
+	service := &Service{
+		computeRepo: repo,
+		billing: &fakeManagedBilling{
+			launchDecision: billingDecision{OK: true, AvailableCents: 5000, RequiredCents: 2500},
+		},
+		appConfig: types.AppConfig{
+			GatewayService: types.GatewayServiceConfig{
+				HTTP: types.HTTPConfig{ExternalHost: "app.beam.test", ExternalPort: 443, TLS: true},
+			},
+			Tailscale: types.TailscaleConfig{Enabled: true, AuthKey: "gateway-key", AgentAuthKey: "agent-key"},
+			Providers: types.ProviderConfig{
+				Shadeform: types.ShadeformProviderConfig{ApiKey: "shadeform-key", BaseURL: server.URL},
+			},
+			ManagedCompute: types.ManagedComputeConfig{
+				Billing: types.ManagedComputeBillingConfig{MinimumCreditCents: 2500},
+			},
+		},
+	}
+
+	res, err := service.LaunchPoolCapacity(testAuthContext("workspace-1", "token-1"), &pb.LaunchPoolCapacityRequest{
+		Pool: &pb.PoolConfig{
+			Name:      "pool-1",
+			Gpu:       []string{"A10G"},
+			Gpus:      1,
+			OfferId:   "sf-a10g-1",
+			Ttl:       "1h",
+			MaxSpend:  2,
+			Providers: []string{"shadeform"},
+			Regions:   []string{"us-east"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("LaunchPoolCapacity() error = %v", err)
+	}
+	if !res.Ok {
+		t.Fatalf("LaunchPoolCapacity() not ok: code=%s msg=%s", res.ErrorCode, res.ErrMsg)
+	}
+	if createCalls != 1 {
+		t.Fatalf("shadeform create calls = %d, want 1", createCalls)
+	}
+	state := repo.pools["workspace-1"][0]
+	if got, want := len(state.Reservations), 2; got != want {
+		t.Fatalf("reservation count = %d, want %d", got, want)
+	}
+	if got, want := state.Reservations[1].ID, "reservation-2"; got != want {
+		t.Fatalf("new reservation id = %q, want %q", got, want)
+	}
+	if got, want := state.ReservedGPUs, uint32(2); got != want {
+		t.Fatalf("reserved gpus = %d, want %d", got, want)
+	}
+	if got, want := state.CommittedSpendMicros, int64(3_000_000); got != want {
+		t.Fatalf("committed spend micros = %d, want %d", got, want)
+	}
+}
+
 func TestRecordManagedUsageEmitsOpenMeterMetrics(t *testing.T) {
 	now := time.Now().UTC()
 	state := &model.PoolState{

--- a/pkg/gateway/services/compute/launch.go
+++ b/pkg/gateway/services/compute/launch.go
@@ -88,7 +88,7 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 			MinReliability: pool.MinReliability,
 		},
 		Offers:       offers,
-		Reservations: reservations,
+		Reservations: nil,
 		Now:          time.Now(),
 	})
 	if !plan.Feasible {
@@ -166,8 +166,8 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 		Selector:             pool.Selector,
 		Config:               config,
 		Reservations:         newReservations,
-		ReservedGPUs:         plan.TotalGPUs,
-		CommittedSpendMicros: plan.CommittedCostMicros,
+		ReservedGPUs:         activeReservationGPUs(newReservations, now),
+		CommittedSpendMicros: existingCommittedSpendMicros(existing) + plan.CommittedCostMicros,
 		Status:               "active",
 		Source:               model.SourceCLIReservation,
 		Mode:                 config.Mode,
@@ -196,6 +196,23 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 	s.emitComputeEvent(types.EventComputePool, computePoolEvent(workspaceID, state, types.EventComputeActionPoolReserved, ""))
 
 	return &pb.LaunchPoolCapacityResponse{Ok: true, Pool: privatePoolStateToProto(state)}, nil
+}
+
+func activeReservationGPUs(reservations []model.Reservation, now time.Time) uint32 {
+	var total uint32
+	for _, reservation := range reservations {
+		if reservation.ActiveAt(now) {
+			total += reservation.GPUCount
+		}
+	}
+	return total
+}
+
+func existingCommittedSpendMicros(state *model.PoolState) int64 {
+	if state == nil || state.CommittedSpendMicros < 0 {
+		return 0
+	}
+	return state.CommittedSpendMicros
 }
 
 func (s *Service) checkManagedLaunchCredit(ctx context.Context, workspaceID, poolName string, plan model.SolvePlan) (billingDecision, error) {

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -442,10 +442,22 @@ func maxInt64(a, b int64) int64 {
 }
 
 func (r *WorkerRedisRepository) SetWorkerKeepAlive(workerId string) error {
+	ctx := context.TODO()
 	stateKey := common.RedisKeys.SchedulerWorkerState(workerId)
 
+	status, err := r.rdb.HGet(ctx, stateKey, "status").Result()
+	if err == redis.Nil {
+		return &types.ErrWorkerNotFound{WorkerId: workerId}
+	}
+	if err != nil {
+		return err
+	}
+	if types.WorkerStatus(status) == types.WorkerStatusPending {
+		return r.ToggleWorkerAvailable(workerId)
+	}
+
 	// Set TTL on state key
-	err := r.rdb.Expire(context.TODO(), stateKey, time.Duration(types.WorkerStateTtlS)*time.Second).Err()
+	err = r.rdb.Expire(ctx, stateKey, time.Duration(types.WorkerStateTtlS)*time.Second).Err()
 	if err != nil {
 		return fmt.Errorf("failed to set worker state ttl <%v>: %w", stateKey, err)
 	}

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -172,6 +172,52 @@ func TestToggleWorkerAvailable(t *testing.T) {
 	assert.Equal(t, types.WorkerStatusAvailable, worker.Status)
 }
 
+func TestSetWorkerKeepAlivePromotesPendingWorker(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:          "worker-keepalive-pending",
+		Status:      types.WorkerStatusPending,
+		TotalCpu:    1000,
+		TotalMemory: 1000,
+		FreeCpu:     1000,
+		FreeMemory:  1000,
+	}
+	assert.Nil(t, repo.AddWorker(worker))
+
+	assert.Nil(t, repo.SetWorkerKeepAlive(worker.Id))
+
+	updatedWorker, err := repo.GetWorkerById(worker.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, types.WorkerStatusAvailable, updatedWorker.Status)
+}
+
+func TestSetWorkerKeepAliveDoesNotPromoteDisabledWorker(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:          "worker-keepalive-disabled",
+		Status:      types.WorkerStatusDisabled,
+		TotalCpu:    1000,
+		TotalMemory: 1000,
+		FreeCpu:     1000,
+		FreeMemory:  1000,
+	}
+	assert.Nil(t, repo.AddWorker(worker))
+
+	assert.Nil(t, repo.SetWorkerKeepAlive(worker.Id))
+
+	updatedWorker, err := repo.GetWorkerById(worker.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, types.WorkerStatusDisabled, updatedWorker.Status)
+}
+
 func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -923,12 +923,24 @@ func (s *Worker) keepalive() {
 	ticker := time.NewTicker(types.WorkerKeepAliveInterval)
 	defer ticker.Stop()
 
+	consecutiveFailures := 0
 	for {
 		select {
 		case <-ticker.C:
-			s.workerRepoClient.SetWorkerKeepAlive(s.ctx, &pb.SetWorkerKeepAliveRequest{
+			_, err := handleGRPCResponse(s.workerRepoClient.SetWorkerKeepAlive(s.ctx, &pb.SetWorkerKeepAliveRequest{
 				WorkerId: s.workerId,
-			})
+			}))
+			if err != nil {
+				consecutiveFailures++
+				if consecutiveFailures == 1 || consecutiveFailures%20 == 0 {
+					log.Warn().Err(err).Int("consecutive_failures", consecutiveFailures).Str("worker_id", s.workerId).Msg("worker keepalive failed")
+				}
+				continue
+			}
+			if consecutiveFailures > 0 {
+				log.Info().Int("consecutive_failures", consecutiveFailures).Str("worker_id", s.workerId).Msg("worker keepalive recovered")
+				consecutiveFailures = 0
+			}
 		case <-s.ctx.Done():
 			return
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes worker TTL handling so pending workers become available on first keepalive and TTL is refreshed. Also corrects pool capacity accounting to add reservations to existing pools and compute reserved GPUs and committed spend accurately.

- **Bug Fixes**
  - `pkg/repository/worker_redis.go`: `SetWorkerKeepAlive` now promotes `pending` workers to `available`, keeps `disabled` unchanged, refreshes TTL, and returns not found if the worker state is missing.
  - `pkg/worker/worker.go`: Keepalive loop now handles RPC errors with concise logging and logs recovery after failures.
  - `pkg/gateway/services/compute/launch.go`: Do not pass existing reservations to the solver; compute `ReservedGPUs` from active reservations and add to existing `CommittedSpendMicros`; append new reservations to existing pools.
  - Tests added for pending/disabled keepalive behavior and for adding capacity to an existing pool (`compute_test.go`, `worker_redis_test.go`).

<sup>Written for commit 40aec4cfad70ae4bd202bd36d5fca74c5c6e4304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

