### PR TITLE
pricing 2

### DIFF
--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -29,6 +29,7 @@ config:
     runner:
       baseImageRegistry: public.ecr.aws/n4e0e1y0
   managedCompute:
+    billableMarginPct: 0.10
     billing:
       mode: noop
       endpoint: ""

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -376,6 +376,7 @@ monitoring:
     serverUrl: ""
     apiKey: ""
 managedCompute:
+  billableMarginPct: 0.10
   billing:
     mode: noop
     endpoint: ""

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -458,6 +458,31 @@ func TestAgentInstallCommandDevModeRunsWithoutSudo(t *testing.T) {
 	}
 }
 
+func TestManagedComputeBillableMicros(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   int64
+		margin     float64
+		want       int64
+		wantBudget int64
+	}{
+		{name: "default margin", provider: 1_500_000, margin: 0.10, want: 1_650_000, wantBudget: 1_363_636},
+		{name: "explicit zero margin", provider: 1_500_000, margin: 0, want: 1_500_000, wantBudget: 1_500_000},
+		{name: "negative margin clamps", provider: 1_500_000, margin: -0.5, want: 1_500_000, wantBudget: 1_500_000},
+		{name: "keeps positive budgets positive", provider: 1, margin: 0.10, want: 2, wantBudget: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := billableMicros(tt.provider, tt.margin); got != tt.want {
+				t.Fatalf("billableMicros() = %d, want %d", got, tt.want)
+			}
+			if got := providerBudgetMicros(tt.provider, tt.margin); got != tt.wantBudget {
+				t.Fatalf("providerBudgetMicros() = %d, want %d", got, tt.wantBudget)
+			}
+		})
+	}
+}
+
 func TestCheckManagedLaunchCreditBuildsBillingRequest(t *testing.T) {
 	billing := &fakeManagedBilling{
 		launchDecision: billingDecision{OK: true, AvailableCents: 3000, RequiredCents: 2500},
@@ -507,11 +532,11 @@ func TestCheckManagedLaunchCreditBuildsBillingRequest(t *testing.T) {
 	if req.Quantity != 2 {
 		t.Fatalf("billing request quantity = %d, want 2", req.Quantity)
 	}
-	if req.EstimatedHourlyCostMicros != 3_000_000 {
-		t.Fatalf("billing request hourly micros = %d, want 3000000", req.EstimatedHourlyCostMicros)
+	if req.EstimatedHourlyCostMicros != 3_300_000 {
+		t.Fatalf("billing request hourly micros = %d, want 3300000", req.EstimatedHourlyCostMicros)
 	}
-	if req.EstimatedCommittedMicros != 42_000_000 {
-		t.Fatalf("billing request committed micros = %d, want 42000000", req.EstimatedCommittedMicros)
+	if req.EstimatedCommittedMicros != 46_200_000 {
+		t.Fatalf("billing request committed micros = %d, want 46200000", req.EstimatedCommittedMicros)
 	}
 }
 
@@ -615,7 +640,7 @@ func TestLaunchPoolCapacityAddsReservationToExistingPool(t *testing.T) {
 					Selector:             "pool-1",
 					CreatedByTokenID:     "token-1",
 					ReservedGPUs:         1,
-					CommittedSpendMicros: 1_500_000,
+					CommittedSpendMicros: 1_650_000,
 					Reservations: []model.Reservation{
 						{
 							ID:               "reservation-1",
@@ -687,7 +712,7 @@ func TestLaunchPoolCapacityAddsReservationToExistingPool(t *testing.T) {
 	if got, want := state.ReservedGPUs, uint32(2); got != want {
 		t.Fatalf("reserved gpus = %d, want %d", got, want)
 	}
-	if got, want := state.CommittedSpendMicros, int64(3_000_000); got != want {
+	if got, want := state.CommittedSpendMicros, int64(3_300_000); got != want {
 		t.Fatalf("committed spend micros = %d, want %d", got, want)
 	}
 }
@@ -743,6 +768,12 @@ func TestRecordManagedUsageEmitsOpenMeterMetrics(t *testing.T) {
 	}
 	if got, want := len(billing.usage), 1; got != want {
 		t.Fatalf("billing usage count = %d, want %d", got, want)
+	}
+	if got, want := billing.usage[0].HourlyCostMicros, int64(1_650_000); got != want {
+		t.Fatalf("billable hourly cost = %d, want %d", got, want)
+	}
+	if got, want := billing.usage[0].CostCents, 2.75; got < want-0.001 || got > want+0.001 {
+		t.Fatalf("billable cost cents = %f, want about %f", got, want)
 	}
 	if !state.Reservations[0].BillingCursorAt.Equal(now) {
 		t.Fatalf("billing cursor = %s, want %s", state.Reservations[0].BillingCursorAt, now)
@@ -1055,21 +1086,7 @@ func TestAgentNodeUsageMetadataMarksAttachedNodesAsBYO(t *testing.T) {
 func TestRecordManagedUsageAdvancesCursorWhenMetricsFailAfterBilling(t *testing.T) {
 	now := time.Now().UTC()
 	cursor := now.Add(-time.Minute)
-	state := &model.PoolState{
-		Name: "pool-1",
-		Reservations: []model.Reservation{
-			{
-				ID:               "reservation-1",
-				Provider:         "shadeform",
-				Source:           model.SourceCLIReservation,
-				Status:           model.ReservationActive,
-				CreatedAt:        now.Add(-time.Hour),
-				BillingCursorAt:  cursor,
-				ExpiresAt:        now.Add(time.Hour),
-				HourlyCostMicros: 1_500_000,
-			},
-		},
-	}
+	state := managedUsageTestState(now, cursor, now.Add(time.Hour), 1_500_000)
 	billing := &fakeManagedBilling{}
 	service := &Service{
 		billing:          billing,
@@ -1093,21 +1110,7 @@ func TestRecordManagedUsageAdvancesCursorWhenMetricsFailAfterBilling(t *testing.
 func TestRecordManagedUsageDoesNotEmitMetricsOrAdvanceCursorWhenBillingFails(t *testing.T) {
 	now := time.Now().UTC()
 	cursor := now.Add(-time.Minute)
-	state := &model.PoolState{
-		Name: "pool-1",
-		Reservations: []model.Reservation{
-			{
-				ID:               "reservation-1",
-				Provider:         "shadeform",
-				Source:           model.SourceCLIReservation,
-				Status:           model.ReservationActive,
-				CreatedAt:        now.Add(-time.Hour),
-				BillingCursorAt:  cursor,
-				ExpiresAt:        now.Add(time.Hour),
-				HourlyCostMicros: 1_500_000,
-			},
-		},
-	}
+	state := managedUsageTestState(now, cursor, now.Add(time.Hour), 1_500_000)
 	billing := &fakeManagedBilling{usageErr: errors.New("billing callback unavailable")}
 	usageRepo := &fakeUsageMetricsRepo{}
 	service := &Service{
@@ -1126,6 +1129,42 @@ func TestRecordManagedUsageDoesNotEmitMetricsOrAdvanceCursorWhenBillingFails(t *
 	}
 	if !strings.Contains(state.Reservations[0].LastError, "billing callback unavailable") {
 		t.Fatalf("last error = %q, want billing callback error", state.Reservations[0].LastError)
+	}
+}
+
+func TestRecordManagedUsageSkipsActiveSubCentWindow(t *testing.T) {
+	now := time.Now().UTC()
+	cursor := now.Add(-5 * time.Second)
+	state := managedUsageTestState(now, cursor, now.Add(time.Hour), 1_000_000)
+	billing := &fakeManagedBilling{}
+	service := &Service{billing: billing}
+
+	if service.recordManagedUsage(context.Background(), "workspace-1", state, now) {
+		t.Fatal("recordManagedUsage() reported a change for an active sub-cent window")
+	}
+	if got := len(billing.usage); got != 0 {
+		t.Fatalf("billing usage count = %d, want 0", got)
+	}
+	if !state.Reservations[0].BillingCursorAt.Equal(cursor) {
+		t.Fatalf("billing cursor advanced to %s, want %s", state.Reservations[0].BillingCursorAt, cursor)
+	}
+}
+
+func TestRecordManagedUsageBillsClosedSubCentWindow(t *testing.T) {
+	now := time.Now().UTC()
+	cursor := now.Add(-5 * time.Second)
+	state := managedUsageTestState(now, cursor, now, 1_000_000)
+	billing := &fakeManagedBilling{}
+	service := &Service{billing: billing}
+
+	if !service.recordManagedUsage(context.Background(), "workspace-1", state, now) {
+		t.Fatal("recordManagedUsage() did not bill a closed sub-cent window")
+	}
+	if got := len(billing.usage); got != 1 {
+		t.Fatalf("billing usage count = %d, want 1", got)
+	}
+	if !state.Reservations[0].BillingCursorAt.Equal(now) {
+		t.Fatalf("billing cursor = %s, want %s", state.Reservations[0].BillingCursorAt, now)
 	}
 }
 
@@ -1255,6 +1294,39 @@ func TestReconcileManagedComputeChecksBalanceAfterFreshUsageTick(t *testing.T) {
 
 	if err := service.ReconcileManagedCompute(context.Background()); err != nil {
 		t.Fatalf("ReconcileManagedCompute() error = %v", err)
+	}
+	if got, want := billing.balanceCalls, 1; got != want {
+		t.Fatalf("balance calls = %d, want %d", got, want)
+	}
+}
+
+func TestReconcileManagedComputeChecksBalanceWhenUsageCursorIsFresh(t *testing.T) {
+	now := time.Now().UTC()
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:                 "reservation-1",
+				Source:             model.SourceCLIReservation,
+				Status:             model.ReservationActive,
+				CreatedAt:          now.Add(-time.Hour),
+				BillingCursorAt:    now,
+				LastBillingCheckAt: now,
+				ExpiresAt:          now.Add(time.Hour),
+				HourlyCostMicros:   1_000_000,
+			},
+		},
+	}
+	repo := &fakeComputeRepo{pools: map[string][]*model.PoolState{"workspace-1": {state}}}
+	billing := &fakeManagedBilling{balanceDecision: billingDecision{OK: true, RequiredCents: 1, AvailableCents: 1000}}
+	service := &Service{computeRepo: repo, billing: billing}
+
+	if err := service.ReconcileManagedCompute(context.Background()); err != nil {
+		t.Fatalf("ReconcileManagedCompute() error = %v", err)
+	}
+	if got, want := len(billing.usage), 0; got != want {
+		t.Fatalf("managed usage records = %d, want %d", got, want)
 	}
 	if got, want := billing.balanceCalls, 1; got != want {
 		t.Fatalf("balance calls = %d, want %d", got, want)
@@ -1856,6 +1928,24 @@ func sameStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func managedUsageTestState(now, cursor, expiresAt time.Time, hourlyCostMicros int64) *model.PoolState {
+	return &model.PoolState{
+		Name: "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:               "reservation-1",
+				Provider:         "shadeform",
+				Source:           model.SourceCLIReservation,
+				Status:           model.ReservationActive,
+				CreatedAt:        now.Add(-time.Hour),
+				BillingCursorAt:  cursor,
+				ExpiresAt:        expiresAt,
+				HourlyCostMicros: hourlyCostMicros,
+			},
+		},
+	}
 }
 
 type fakeComputeRepo struct {

--- a/pkg/gateway/services/compute/launch.go
+++ b/pkg/gateway/services/compute/launch.go
@@ -29,7 +29,7 @@ func (s *Service) ListPoolOffers(ctx context.Context, in *pb.ListPoolOffersReque
 
 	out := make([]*pb.PoolOffer, 0, len(offers))
 	for _, offer := range offers {
-		out = append(out, poolOfferToProto(offer))
+		out = append(out, poolOfferToProto(s.billableOffer(offer)))
 	}
 	return &pb.ListPoolOffersResponse{Ok: true, Offers: out}, nil
 }
@@ -73,6 +73,7 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 	if existing != nil {
 		reservations = existing.Reservations
 	}
+	providerMaxSpendMicros := s.providerBudgetMicros(pool.MaxSpendMicros)
 
 	plan := model.NewSolver().Solve(model.SolveInput{
 		Demand: model.Demand{
@@ -82,7 +83,7 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 			TotalGPUs:      pool.TotalGPUs,
 			OfferID:        pool.OfferID,
 			TTL:            pool.TTL,
-			MaxSpendMicros: pool.MaxSpendMicros,
+			MaxSpendMicros: providerMaxSpendMicros,
 			Providers:      pool.Providers,
 			Regions:        pool.Regions,
 			MinReliability: pool.MinReliability,
@@ -141,7 +142,7 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 				Offer:             action.Offer,
 				Count:             1,
 				TTL:               pool.TTL,
-				MaxSpendMicros:    pool.MaxSpendMicros,
+				MaxSpendMicros:    providerMaxSpendMicros,
 				Source:            model.SourceCLIReservation,
 				RegistrationToken: registrationToken,
 				BootstrapCommand:  bootstrapCommand,
@@ -167,7 +168,7 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 		Config:               config,
 		Reservations:         newReservations,
 		ReservedGPUs:         activeReservationGPUs(newReservations, now),
-		CommittedSpendMicros: existingCommittedSpendMicros(existing) + plan.CommittedCostMicros,
+		CommittedSpendMicros: existingCommittedSpendMicros(existing) + s.billableMicros(plan.CommittedCostMicros),
 		Status:               "active",
 		Source:               model.SourceCLIReservation,
 		Mode:                 config.Mode,
@@ -195,7 +196,7 @@ func (s *Service) LaunchPoolCapacity(ctx context.Context, in *pb.LaunchPoolCapac
 	}
 	s.emitComputeEvent(types.EventComputePool, computePoolEvent(workspaceID, state, types.EventComputeActionPoolReserved, ""))
 
-	return &pb.LaunchPoolCapacityResponse{Ok: true, Pool: privatePoolStateToProto(state)}, nil
+	return &pb.LaunchPoolCapacityResponse{Ok: true, Pool: s.privatePoolStateToProto(state)}, nil
 }
 
 func activeReservationGPUs(reservations []model.Reservation, now time.Time) uint32 {
@@ -230,8 +231,8 @@ func (s *Service) checkManagedLaunchCredit(ctx context.Context, workspaceID, poo
 		PoolName:                  poolName,
 		RequiredCents:             s.appConfig.ManagedCompute.Billing.MinimumCreditCentsOrDefault(),
 		Quantity:                  quantity,
-		EstimatedHourlyCostMicros: managedHourlyCostMicros(plan.Actions),
-		EstimatedCommittedMicros:  plan.CommittedCostMicros,
+		EstimatedHourlyCostMicros: s.billableMicros(managedHourlyCostMicros(plan.Actions)),
+		EstimatedCommittedMicros:  s.billableMicros(plan.CommittedCostMicros),
 	})
 }
 

--- a/pkg/gateway/services/compute/pools.go
+++ b/pkg/gateway/services/compute/pools.go
@@ -39,7 +39,7 @@ func (s *Service) ListPrivatePools(ctx context.Context, in *pb.ListPrivatePoolsR
 		if err != nil {
 			return &pb.ListPrivatePoolsResponse{Ok: false, ErrMsg: err.Error()}, nil
 		}
-		pool := privatePoolStateToProtoWithMachines(state, machines)
+		pool := s.privatePoolStateToProtoWithMachines(state, machines)
 		pool.ReadyMachineCount = s.readyAgentMachineCount(machines)
 		out = append(out, pool)
 	}
@@ -110,7 +110,7 @@ func (s *Service) CreatePool(ctx context.Context, in *pb.CreatePoolRequest) (*pb
 		}
 	}
 	s.emitComputeEvent(types.EventComputePool, computePoolEvent(workspaceID, state, types.EventComputeActionPoolCreated, ""))
-	return &pb.CreatePoolResponse{Ok: true, Pool: privatePoolStateToProto(state)}, nil
+	return &pb.CreatePoolResponse{Ok: true, Pool: s.privatePoolStateToProto(state)}, nil
 }
 
 func (s *Service) DeletePool(ctx context.Context, in *pb.DeletePoolRequest) (*pb.DeletePoolResponse, error) {
@@ -178,7 +178,7 @@ func (s *Service) ExtendPoolCapacity(ctx context.Context, in *pb.ExtendPoolCapac
 		return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}, nil
 	}
 	s.emitComputeEvent(types.EventComputePool, computePoolEvent(workspaceID, state, types.EventComputeActionPoolExtended, ""))
-	return &pb.ExtendPoolCapacityResponse{Ok: true, Pool: privatePoolStateToProto(state)}, nil
+	return &pb.ExtendPoolCapacityResponse{Ok: true, Pool: s.privatePoolStateToProto(state)}, nil
 }
 
 func (s *Service) ListPoolMachines(ctx context.Context, in *pb.ListPoolMachinesRequest) (*pb.ListPoolMachinesResponse, error) {

--- a/pkg/gateway/services/compute/pricing.go
+++ b/pkg/gateway/services/compute/pricing.go
@@ -1,0 +1,47 @@
+package compute
+
+import (
+	"math"
+
+	model "github.com/beam-cloud/beta9/pkg/compute"
+)
+
+const microRoundingEpsilon = 1e-6
+
+func (s *Service) billableMicros(providerMicros int64) int64 {
+	return billableMicros(providerMicros, s.appConfig.ManagedCompute.BillableMarginPctOrDefault())
+}
+
+func (s *Service) providerBudgetMicros(billableMaxMicros int64) int64 {
+	return providerBudgetMicros(billableMaxMicros, s.appConfig.ManagedCompute.BillableMarginPctOrDefault())
+}
+
+func (s *Service) billableOffer(offer model.Offer) model.Offer {
+	offer.HourlyCostMicros = s.billableMicros(offer.HourlyCostMicros)
+	return offer
+}
+
+func billableMicros(providerMicros int64, marginPct float64) int64 {
+	if providerMicros <= 0 {
+		return 0
+	}
+	return int64(math.Ceil(float64(providerMicros)*costMultiplier(marginPct) - microRoundingEpsilon))
+}
+
+func providerBudgetMicros(billableMaxMicros int64, marginPct float64) int64 {
+	if billableMaxMicros <= 0 {
+		return 0
+	}
+	budget := int64(math.Floor(float64(billableMaxMicros) / costMultiplier(marginPct)))
+	if budget < 1 {
+		return 1
+	}
+	return budget
+}
+
+func costMultiplier(marginPct float64) float64 {
+	if marginPct < 0 {
+		return 1
+	}
+	return 1 + marginPct
+}

--- a/pkg/gateway/services/compute/proto.go
+++ b/pkg/gateway/services/compute/proto.go
@@ -104,7 +104,12 @@ func poolOfferToProto(offer model.Offer) *pb.PoolOffer {
 	}
 }
 
-func providerInstanceToProto(reservation model.Reservation) *pb.ProviderInstance {
+type computeCostProjector func(int64) int64
+
+func providerInstanceToProto(reservation model.Reservation, projectCost computeCostProjector) *pb.ProviderInstance {
+	if projectCost == nil {
+		projectCost = identityCost
+	}
 	return &pb.ProviderInstance{
 		Id:                reservation.ID,
 		PoolName:          reservation.PoolName,
@@ -113,7 +118,7 @@ func providerInstanceToProto(reservation model.Reservation) *pb.ProviderInstance
 		OfferId:           reservation.OfferID,
 		Status:            string(reservation.Status),
 		GpuCount:          reservation.GPUCount,
-		HourlyCostMicros:  reservation.HourlyCostMicros,
+		HourlyCostMicros:  projectCost(reservation.HourlyCostMicros),
 		Source:            string(reservation.Source),
 		CreatedAt:         timestampOrNil(reservation.CreatedAt),
 		ExpiresAt:         timestampOrNil(reservation.ExpiresAt),
@@ -122,6 +127,10 @@ func providerInstanceToProto(reservation model.Reservation) *pb.ProviderInstance
 		TerminatingReason: reservation.TerminatingReason,
 		MachineId:         reservation.MachineID,
 	}
+}
+
+func identityCost(value int64) int64 {
+	return value
 }
 
 func agentRouteToProto(route types.BackendRoute) *pb.AgentRoute {
@@ -144,17 +153,21 @@ func agentRouteToProto(route types.BackendRoute) *pb.AgentRoute {
 	}
 }
 
-func privatePoolStateToProto(state *model.PoolState) *pb.PrivatePool {
-	return privatePoolStateToProtoWithMachines(state, nil)
+func (s *Service) privatePoolStateToProto(state *model.PoolState) *pb.PrivatePool {
+	return s.privatePoolStateToProtoWithMachines(state, nil)
 }
 
-func privatePoolStateToProtoWithMachines(state *model.PoolState, machines []*model.AgentTokenState) *pb.PrivatePool {
+func (s *Service) privatePoolStateToProtoWithMachines(state *model.PoolState, machines []*model.AgentTokenState) *pb.PrivatePool {
+	return privatePoolStateToProtoWithMachines(state, machines, s.billableMicros)
+}
+
+func privatePoolStateToProtoWithMachines(state *model.PoolState, machines []*model.AgentTokenState, projectCost computeCostProjector) *pb.PrivatePool {
 	if state == nil {
 		return nil
 	}
 	reservations := make([]*pb.ProviderInstance, 0, len(state.Reservations))
 	for _, reservation := range state.Reservations {
-		reservations = append(reservations, providerInstanceToProto(reservation))
+		reservations = append(reservations, providerInstanceToProto(reservation, projectCost))
 	}
 	readyMachineCount := uint32(0)
 	now := time.Now()

--- a/pkg/gateway/services/compute/proto_test.go
+++ b/pkg/gateway/services/compute/proto_test.go
@@ -105,3 +105,22 @@ func TestAgentMachineMetricsUseScheduledCapacity(t *testing.T) {
 		t.Fatalf("container count = %d, want 2", metrics.ContainerCount)
 	}
 }
+
+func TestPrivatePoolProjectionUsesBillableReservationCost(t *testing.T) {
+	state := &model.PoolState{
+		Name: "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:               "reservation-1",
+				Source:           model.SourceCLIReservation,
+				Status:           model.ReservationActive,
+				HourlyCostMicros: 1_500_000,
+			},
+		},
+	}
+
+	pool := (&Service{}).privatePoolStateToProto(state)
+	if got, want := pool.Reservations[0].HourlyCostMicros, int64(1_650_000); got != want {
+		t.Fatalf("reservation hourly cost = %d, want %d", got, want)
+	}
+}

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	reconcileStatusCheckInterval  = time.Minute
-	reconcileBillingCheckInterval = time.Minute
+	reconcileStatusCheckInterval = time.Minute
+	minManagedUsageRecordCents   = 1
 
 	reconcileReasonAgentDisconnected   = "agent_disconnected"
 	reconcileReasonCreditExhausted     = "credit_exhausted"
@@ -112,9 +112,6 @@ func (s *Service) reconcileBilling(ctx context.Context, workspaceID string, stat
 		return false
 	}
 	changed := s.recordManagedUsage(ctx, workspaceID, state, now)
-	if !changed && billingCheckFresh(state, now) {
-		return changed
-	}
 
 	decision, err := s.billing.CheckBalance(ctx, workspaceID)
 	if err != nil {
@@ -129,20 +126,13 @@ func (s *Service) reconcileBilling(ctx context.Context, workspaceID string, stat
 	if !decision.OK {
 		reason := firstNonEmpty(decision.Message, "managed compute credits exhausted")
 		s.emitCreditExhaustedEvent(workspaceID, state, decision, reason)
+		changed = closeManagedReservationBillingWindows(state, now) || changed
+		changed = s.recordManagedUsage(ctx, workspaceID, state, now) || changed
 		s.disablePoolMachines(ctx, workspaceID, state.Name, reconcileReasonCreditExhausted)
 		return s.terminateManagedReservations(ctx, workspaceID, state, reconcileReasonCreditExhausted, reason) || changed
 	}
 
 	return changed
-}
-
-func billingCheckFresh(state *model.PoolState, now time.Time) bool {
-	for _, reservation := range state.Reservations {
-		if reservation.Managed() && reservation.ActiveAt(now) {
-			return !reservation.LastBillingCheckAt.IsZero() && now.Sub(reservation.LastBillingCheckAt) < reconcileBillingCheckInterval
-		}
-	}
-	return false
 }
 
 func (s *Service) recordManagedUsage(ctx context.Context, workspaceID string, state *model.PoolState, now time.Time) bool {
@@ -158,6 +148,11 @@ func (s *Service) recordManagedUsage(ctx context.Context, workspaceID string, st
 		}
 
 		duration := end.Sub(start)
+		hourlyCostMicros := s.billableMicros(reservation.HourlyCostMicros)
+		costCents := managedCostCents(hourlyCostMicros, duration)
+		if !managedUsageRecordable(reservation, now, end, costCents) {
+			continue
+		}
 		usage := managedUsage{
 			WorkspaceID:        workspaceID,
 			PoolName:           state.Name,
@@ -169,9 +164,9 @@ func (s *Service) recordManagedUsage(ctx context.Context, workspaceID string, st
 			GPUCount:           reservation.GPUCount,
 			CPUMillicores:      reservation.CPUMillicores,
 			MemoryMB:           reservation.MemoryMB,
-			HourlyCostMicros:   reservation.HourlyCostMicros,
+			HourlyCostMicros:   hourlyCostMicros,
 			DurationSeconds:    duration.Seconds(),
-			CostCents:          managedCostCents(reservation.HourlyCostMicros, duration),
+			CostCents:          costCents,
 			StartAt:            start,
 			EndAt:              end,
 		}
@@ -188,6 +183,35 @@ func (s *Service) recordManagedUsage(ctx context.Context, workspaceID string, st
 		changed = true
 	}
 	return changed
+}
+
+func managedUsageRecordable(reservation *model.Reservation, now, end time.Time, costCents float64) bool {
+	if costCents >= minManagedUsageRecordCents {
+		return true
+	}
+	return reservation != nil && !reservation.ExpiresAt.IsZero() && !now.Before(reservation.ExpiresAt) && end.Equal(reservation.ExpiresAt)
+}
+
+func closeManagedReservationBillingWindows(state *model.PoolState, now time.Time) bool {
+	if state == nil {
+		return false
+	}
+	changed := false
+	for i := range state.Reservations {
+		changed = closeReservationBillingWindow(&state.Reservations[i], now) || changed
+	}
+	return changed
+}
+
+func closeReservationBillingWindow(reservation *model.Reservation, now time.Time) bool {
+	if reservation == nil || !reservation.Managed() || reservation.Status != model.ReservationActive {
+		return false
+	}
+	if !reservation.ExpiresAt.IsZero() && !reservation.ExpiresAt.After(now) {
+		return false
+	}
+	reservation.ExpiresAt = now
+	return true
 }
 
 func reservationBillingWindow(reservation *model.Reservation, now time.Time) (time.Time, time.Time, bool) {
@@ -343,7 +367,7 @@ func (s *Service) terminateManagedReservations(ctx context.Context, workspaceID 
 	changed := false
 	for i := range state.Reservations {
 		reservation := &state.Reservations[i]
-		if !reservation.Managed() || !reservation.ActiveAt(time.Now()) {
+		if !reservation.Managed() || reservationClosed(reservation.Status) || reservation.Status == model.ReservationTerminating {
 			continue
 		}
 		changed = s.terminateReservation(ctx, workspaceID, state, reservation, vendors, reason, message) || changed

--- a/pkg/gateway/services/compute/release.go
+++ b/pkg/gateway/services/compute/release.go
@@ -77,7 +77,8 @@ func (s *Service) releaseManagedReservation(ctx context.Context, workspaceID str
 	}
 
 	now := time.Now().UTC()
-	changed := s.recordManagedUsage(ctx, workspaceID, state, now)
+	changed := closeReservationBillingWindow(reservation, now)
+	changed = s.recordManagedUsage(ctx, workspaceID, state, now) || changed
 	s.revokeReservationJoinToken(ctx, reservation)
 	changed = markReservationTerminating(reservation, reconcileReasonMachineReleased, machineReleasedMessage) || changed
 	if changed {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -626,10 +626,24 @@ type MonitoringConfig struct {
 	ContainerCostHookConfig  ContainerCostHookConfig `key:"containerCostHook" json:"container_cost_hook"`
 }
 
-const ManagedComputeDefaultMinimumCreditCents int64 = 2500
+const (
+	ManagedComputeDefaultMinimumCreditCents int64   = 2500
+	ManagedComputeDefaultBillableMarginPct  float64 = 0.10
+)
 
 type ManagedComputeConfig struct {
-	Billing ManagedComputeBillingConfig `key:"billing" json:"billing"`
+	BillableMarginPct *float64                    `key:"billableMarginPct" json:"billable_margin_pct"`
+	Billing           ManagedComputeBillingConfig `key:"billing" json:"billing"`
+}
+
+func (c ManagedComputeConfig) BillableMarginPctOrDefault() float64 {
+	if c.BillableMarginPct == nil {
+		return ManagedComputeDefaultBillableMarginPct
+	}
+	if *c.BillableMarginPct < 0 {
+		return 0
+	}
+	return *c.BillableMarginPct
 }
 
 type ManagedComputeBillingConfig struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a billable margin to managed compute pricing and projects all user-visible costs at the billable rate (default 10%), affecting offers, committed spend, credit checks, and usage records. Also improves usage recording by handling sub-cent windows and closing billing windows on release or credit exhaustion.

- **New Features**
  - New config `managedCompute.billableMarginPct` (default 0.10, negatives clamp to 0).
  - Offers and pool reservations now show billable hourly costs; APIs project costs with margin.
  - Launch credit checks, committed cost, and usage billing use billable micros.
  - `maxSpendMicros` is interpreted as billable; internally converted to provider budget to respect the cap.
  - Usage: skip active sub-cent (<$0.01) windows; bill closed sub-cent windows; close windows on release and credit exhaustion.
  - Balance checks run even when the usage cursor is fresh.

- **Migration**
  - No action required; default margin is 10%.
  - To keep previous pricing, set `managedCompute.billableMarginPct: 0`.
  - Expect reported hourly costs, committed spend, and billed usage to increase by the margin.
  - When specifying `maxSpendMicros`, provide the billable amount; the service converts to provider budget internally.

<sup>Written for commit f38982d0f06b4b257239a307c963562b2deb9539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

