### PR TITLE
fix usage and worker events

### DIFF
--- a/pkg/gateway/services/repository/worker_events.go
+++ b/pkg/gateway/services/repository/worker_events.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	workerEventSinkBufferSize = 128
-	workerEventRetryDelay     = 5 * time.Second
+	workerEventSinkBufferSize          = 128
+	workerEventRetryDelay              = 5 * time.Second
+	workerEventStreamHeartbeatInterval = 30 * time.Second
 )
 
 type workerEventSink struct {
@@ -201,6 +202,10 @@ func stringArg(args map[string]any, key string) (string, bool) {
 }
 
 func (s *WorkerRepositoryService) StreamWorkerEvents(req *pb.StreamWorkerEventsRequest, stream pb.WorkerRepositoryService_StreamWorkerEventsServer) error {
+	return s.streamWorkerEvents(req, stream, workerEventStreamHeartbeatInterval)
+}
+
+func (s *WorkerRepositoryService) streamWorkerEvents(req *pb.StreamWorkerEventsRequest, stream pb.WorkerRepositoryService_StreamWorkerEventsServer, heartbeatInterval time.Duration) error {
 	if req.WorkerId == "" {
 		return status.Error(codes.InvalidArgument, "worker_id is required")
 	}
@@ -211,12 +216,23 @@ func (s *WorkerRepositoryService) StreamWorkerEvents(req *pb.StreamWorkerEventsR
 	sinkID, events := s.workerEvents.register(req.WorkerId)
 	defer s.workerEvents.unregister(sinkID)
 
+	var heartbeat <-chan time.Time
+	if heartbeatInterval > 0 {
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		heartbeat = ticker.C
+	}
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			return s.ctx.Err()
 		case <-stream.Context().Done():
 			return stream.Context().Err()
+		case <-heartbeat:
+			if err := stream.Send(&pb.WorkerEvent{EventId: types.WorkerEventHeartbeatID}); err != nil {
+				return err
+			}
 		case event, ok := <-events:
 			if !ok {
 				return nil

--- a/pkg/gateway/services/repository/worker_events_test.go
+++ b/pkg/gateway/services/repository/worker_events_test.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -104,6 +105,61 @@ func TestStreamWorkerEventsRejectsInvalidRequests(t *testing.T) {
 	err = service.StreamWorkerEvents(&pb.StreamWorkerEventsRequest{WorkerId: "worker-a"}, nil)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
+
+func TestStreamWorkerEventsSendsHeartbeat(t *testing.T) {
+	broker, _ := newWorkerEventBrokerForTest(t)
+	service := &WorkerRepositoryService{
+		ctx:          context.Background(),
+		workerEvents: broker,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &fakeWorkerEventStream{
+		ctx:  ctx,
+		sent: make(chan *pb.WorkerEvent, 8),
+	}
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- service.streamWorkerEvents(
+			&pb.StreamWorkerEventsRequest{WorkerId: "worker-a"},
+			stream,
+			10*time.Millisecond,
+		)
+	}()
+
+	event := receiveWorkerEvent(t, stream.sent)
+	require.Equal(t, types.WorkerEventHeartbeatID, event.EventId)
+	require.Nil(t, event.Event)
+
+	cancel()
+	select {
+	case err := <-errs:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream to close")
+	}
+}
+
+type fakeWorkerEventStream struct {
+	ctx  context.Context
+	sent chan *pb.WorkerEvent
+}
+
+func (s *fakeWorkerEventStream) Send(event *pb.WorkerEvent) error {
+	select {
+	case s.sent <- event:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+func (s *fakeWorkerEventStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fakeWorkerEventStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeWorkerEventStream) SetTrailer(metadata.MD)       {}
+func (s *fakeWorkerEventStream) Context() context.Context     { return s.ctx }
+func (s *fakeWorkerEventStream) SendMsg(any) error            { return nil }
+func (s *fakeWorkerEventStream) RecvMsg(any) error            { return nil }
 
 func receiveWorkerEvent(t *testing.T, events <-chan *pb.WorkerEvent) *pb.WorkerEvent {
 	t.Helper()

--- a/pkg/types/worker.go
+++ b/pkg/types/worker.go
@@ -12,6 +12,7 @@ import (
 const (
 	WorkerLifecycleStatsKey                  string        = "beta9.worker.usage.spawner.lifecycle"
 	WorkerDurationStatsKey                   string        = "beta9.worker.usage.spawner.duration"
+	WorkerEventHeartbeatID                   string        = "__heartbeat__"
 	WorkerUserCodeVolume                     string        = "/mnt/code"
 	WorkerUserOutputVolume                   string        = "/outputs"
 	WorkerContainerVolumePath                string        = "/volumes"

--- a/pkg/worker/worker_events.go
+++ b/pkg/worker/worker_events.go
@@ -77,6 +77,12 @@ func (s *Worker) handleWorkerEvent(event *pb.WorkerEvent) {
 	if event == nil {
 		return
 	}
+	if event.Event == nil {
+		if event.EventId != types.WorkerEventHeartbeatID {
+			log.Warn().Str("event_id", event.EventId).Msg("received empty worker event")
+		}
+		return
+	}
 
 	switch e := event.Event.(type) {
 	case *pb.WorkerEvent_StopContainer:

--- a/pkg/worker/worker_events_test.go
+++ b/pkg/worker/worker_events_test.go
@@ -71,6 +71,23 @@ func TestHandleWorkerEventIgnoresUnknownContainerStop(t *testing.T) {
 	}
 }
 
+func TestHandleWorkerEventIgnoresHeartbeat(t *testing.T) {
+	worker := &Worker{
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		stopContainerChan:  make(chan stopContainerEvent, 1),
+	}
+
+	worker.handleWorkerEvent(&pb.WorkerEvent{
+		EventId: types.WorkerEventHeartbeatID,
+	})
+
+	select {
+	case event := <-worker.stopContainerChan:
+		t.Fatalf("unexpected stop container event: %+v", event)
+	default:
+	}
+}
+
 func TestHandleWorkerEventCancelsMatchingBuild(t *testing.T) {
 	worker := &Worker{
 		buildCancels: common.NewSafeMap[context.CancelFunc](),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a heartbeat to the worker event stream to prevent idle disconnects. Workers now ignore heartbeat and empty events, improving the reliability of the control channel.

- **Bug Fixes**
  - `WorkerRepositoryService.StreamWorkerEvents` sends a heartbeat every 30s using `types.WorkerEventHeartbeatID` (`__heartbeat__`) with no payload.
  - `Worker.handleWorkerEvent` ignores heartbeats and empty events; only warns on unexpected empty non-heartbeat events.
  - Added tests for server heartbeats and worker handling; factored `streamWorkerEvents` to allow a test heartbeat interval.

<sup>Written for commit 52ba114c1bf9b05c848b237e9b3f0c4b8b4e02e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

