### PR TITLE
fix extend reservation

### DIFF
--- a/pkg/compute/shadeform.go
+++ b/pkg/compute/shadeform.go
@@ -11,6 +11,12 @@ import (
 
 const ShadeformDefaultBaseURL = "https://api.shadeform.ai/v1"
 
+// shadeformAutoDeleteGrace pads the provider-side auto-delete threshold past
+// our own expiry. The control plane owns reservation lifetime (renewal, final
+// billing, termination); Shadeform's threshold is only a runaway backstop and
+// must never fire before our reconciler has had a chance to act.
+const shadeformAutoDeleteGrace = time.Hour
+
 type ShadeformClient struct {
 	api HTTPClient
 }
@@ -103,7 +109,7 @@ func (c *ShadeformClient) CreateReservation(ctx context.Context, req Reservation
 	if req.TTL > 0 || req.MaxSpendMicros > 0 {
 		autoDelete := map[string]any{}
 		if req.TTL > 0 {
-			autoDelete["date_threshold"] = time.Now().Add(req.TTL).UTC().Format(time.RFC3339)
+			autoDelete["date_threshold"] = time.Now().Add(req.TTL + shadeformAutoDeleteGrace).UTC().Format(time.RFC3339)
 		}
 		if req.MaxSpendMicros > 0 {
 			autoDelete["spend_threshold"] = fmt.Sprintf("%.2f", MicrosToDollars(req.MaxSpendMicros))
@@ -163,6 +169,17 @@ func (c *ShadeformClient) GetReservation(ctx context.Context, id string) (*Reser
 		HourlyCostMicros: offer.HourlyCostMicros,
 		Status:           ReservationActive,
 	}, nil
+}
+
+// ExtendReservation pushes the renewed expiry to Shadeform's auto-delete
+// date threshold. spend_threshold is omitted so it stays unchanged.
+func (c *ShadeformClient) ExtendReservation(ctx context.Context, id string, expiresAt time.Time) error {
+	body := map[string]any{
+		"auto_delete": map[string]any{
+			"date_threshold": expiresAt.Add(shadeformAutoDeleteGrace).UTC().Format(time.RFC3339),
+		},
+	}
+	return c.api.Do(ctx, http.MethodPost, fmt.Sprintf("/instances/%s/update", id), body, nil)
 }
 
 func (c *ShadeformClient) DeleteReservation(ctx context.Context, id string) error {

--- a/pkg/compute/shadeform_test.go
+++ b/pkg/compute/shadeform_test.go
@@ -81,6 +81,35 @@ func TestCreateReservationConfiguresShadeformStartupScript(t *testing.T) {
 
 	autoDelete, ok := body["auto_delete"].(map[string]any)
 	require.True(t, ok)
-	require.NotEmpty(t, autoDelete["date_threshold"])
 	require.Equal(t, "80.00", autoDelete["spend_threshold"])
+
+	// The provider-side threshold must be a backstop past the TTL, not the
+	// enforcer of it; the control plane owns reservation lifetime.
+	threshold, err := time.Parse(time.RFC3339, autoDelete["date_threshold"].(string))
+	require.NoError(t, err)
+	require.True(t, threshold.After(time.Now().Add(6*time.Hour+30*time.Minute)))
+}
+
+func TestExtendReservationUpdatesShadeformAutoDelete(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/instances/reservation-123/update", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewShadeform(ShadeformConfig{APIKey: "test-key", BaseURL: server.URL})
+	expiresAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+	require.NoError(t, client.ExtendReservation(context.Background(), "reservation-123", expiresAt))
+
+	autoDelete, ok := body["auto_delete"].(map[string]any)
+	require.True(t, ok)
+	threshold, err := time.Parse(time.RFC3339, autoDelete["date_threshold"].(string))
+	require.NoError(t, err)
+	require.True(t, threshold.Equal(expiresAt.Add(shadeformAutoDeleteGrace)))
+	// spend_threshold is omitted so the existing value stays unchanged
+	_, hasSpend := autoDelete["spend_threshold"]
+	require.False(t, hasSpend)
 }

--- a/pkg/compute/vast.go
+++ b/pkg/compute/vast.go
@@ -159,6 +159,12 @@ func reservationCloud(cloud, fallback string) string {
 	return fallback
 }
 
+// ExtendReservation is a no-op: Vast has no provider-side auto-delete
+// threshold; reservation lifetime is enforced by our reconciler only.
+func (c *VastClient) ExtendReservation(ctx context.Context, id string, expiresAt time.Time) error {
+	return nil
+}
+
 func (c *VastClient) DeleteReservation(ctx context.Context, id string) error {
 	return c.api.Do(ctx, http.MethodDelete, fmt.Sprintf("/instances/%s/", id), nil, nil)
 }

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -780,6 +780,130 @@ func TestRecordManagedUsageEmitsOpenMeterMetrics(t *testing.T) {
 	}
 }
 
+type fakeVendor struct {
+	extended map[string]time.Time
+}
+
+func (v *fakeVendor) Name() string { return "shadeform" }
+func (v *fakeVendor) ListOffers(context.Context, model.OfferRequest) ([]model.Offer, error) {
+	return nil, nil
+}
+func (v *fakeVendor) CreateReservation(context.Context, model.ReservationRequest) (*model.Reservation, error) {
+	return nil, nil
+}
+func (v *fakeVendor) GetReservation(context.Context, string) (*model.Reservation, error) {
+	return nil, nil
+}
+func (v *fakeVendor) ExtendReservation(_ context.Context, id string, expiresAt time.Time) error {
+	if v.extended == nil {
+		v.extended = map[string]time.Time{}
+	}
+	v.extended[id] = expiresAt
+	return nil
+}
+func (v *fakeVendor) DeleteReservation(context.Context, string) error { return nil }
+
+func TestRenewManagedReservationsExtendsExpiringReservation(t *testing.T) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Minute)
+	state := &model.PoolState{
+		Name: "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:               "reservation-1",
+				Provider:         "shadeform",
+				InstanceID:       "instance-1",
+				Source:           model.SourceCLIReservation,
+				Status:           model.ReservationActive,
+				CreatedAt:        now.Add(-time.Hour),
+				ExpiresAt:        expiresAt,
+				HourlyCostMicros: 1_500_000,
+				CommittedMicros:  1_500_000,
+			},
+		},
+	}
+	vendor := &fakeVendor{}
+	service := &Service{}
+
+	// Plenty of balance: renew for another hour
+	decision := billingDecision{OK: true, AvailableCents: 10_000}
+	if !service.renewManagedReservations(context.Background(), "workspace-1", state, decision, 5, now, map[string]model.Vendor{"shadeform": vendor}) {
+		t.Fatal("renewManagedReservations() did not report a state change")
+	}
+	if got, want := state.Reservations[0].ExpiresAt, expiresAt.Add(time.Hour); !got.Equal(want) {
+		t.Fatalf("expires at = %s, want %s", got, want)
+	}
+	if got, want := state.Reservations[0].CommittedMicros, int64(3_000_000); got != want {
+		t.Fatalf("committed micros = %d, want %d", got, want)
+	}
+	if got, want := state.CommittedSpendMicros, int64(1_650_000); got != want {
+		t.Fatalf("pool committed spend = %d, want %d", got, want)
+	}
+	if got, want := vendor.extended["instance-1"], expiresAt.Add(time.Hour); !got.Equal(want) {
+		t.Fatalf("vendor extended to %s, want %s", got, want)
+	}
+}
+
+func TestRenewManagedReservationsSkipsWhenBalanceInsufficient(t *testing.T) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Minute)
+	state := &model.PoolState{
+		Name: "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:               "reservation-1",
+				Provider:         "shadeform",
+				InstanceID:       "instance-1",
+				Source:           model.SourceCLIReservation,
+				Status:           model.ReservationActive,
+				CreatedAt:        now.Add(-time.Hour),
+				ExpiresAt:        expiresAt,
+				HourlyCostMicros: 1_500_000,
+			},
+		},
+	}
+	vendor := &fakeVendor{}
+	service := &Service{}
+
+	// 16.5 cents/hr billable but only 10 cents headroom: do not renew
+	decision := billingDecision{OK: true, AvailableCents: 15}
+	if service.renewManagedReservations(context.Background(), "workspace-1", state, decision, 5, now, map[string]model.Vendor{"shadeform": vendor}) {
+		t.Fatal("renewManagedReservations() renewed without sufficient balance")
+	}
+	if !state.Reservations[0].ExpiresAt.Equal(expiresAt) {
+		t.Fatal("reservation expiry should be unchanged")
+	}
+	if len(vendor.extended) != 0 {
+		t.Fatal("vendor should not have been called")
+	}
+}
+
+func TestRenewManagedReservationsIgnoresDistantExpiry(t *testing.T) {
+	now := time.Now().UTC()
+	state := &model.PoolState{
+		Name: "pool-1",
+		Reservations: []model.Reservation{
+			{
+				ID:               "reservation-1",
+				Provider:         "shadeform",
+				InstanceID:       "instance-1",
+				Source:           model.SourceCLIReservation,
+				Status:           model.ReservationActive,
+				CreatedAt:        now,
+				ExpiresAt:        now.Add(time.Hour),
+				HourlyCostMicros: 1_500_000,
+			},
+		},
+	}
+	vendor := &fakeVendor{}
+	service := &Service{}
+
+	decision := billingDecision{OK: true, AvailableCents: 10_000}
+	if service.renewManagedReservations(context.Background(), "workspace-1", state, decision, 0, now, map[string]model.Vendor{"shadeform": vendor}) {
+		t.Fatal("renewManagedReservations() should not renew a reservation far from expiry")
+	}
+}
+
 func TestRecordAgentMetricsEmitsNodeUsage(t *testing.T) {
 	now := time.Now().UTC()
 	previous := now.Add(-5 * time.Second)

--- a/pkg/gateway/services/compute/pools.go
+++ b/pkg/gateway/services/compute/pools.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
@@ -156,30 +157,74 @@ func (s *Service) ExtendPoolCapacity(ctx context.Context, in *pb.ExtendPoolCapac
 	if workspaceID == "" {
 		return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: "missing workspace auth"}, nil
 	}
-	state, err := s.getOwnedPrivatePoolState(ctx, authInfo, in.Name)
-	if err != nil {
-		return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}, nil
-	}
-	if state == nil {
-		return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: "pool not found"}, nil
-	}
-	if in.Ttl != "" {
-		state.Config.Ttl = in.Ttl
-		ttl, err := model.ParseTTL(in.Ttl)
+
+	var response *pb.ExtendPoolCapacityResponse
+	lockErr := s.withPoolStateLock(ctx, workspaceID, in.Name, func() error {
+		state, err := s.getOwnedPrivatePoolState(ctx, authInfo, in.Name)
 		if err != nil {
-			return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}, nil
+			response = &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}
+			return nil
 		}
-		state.ExpiresAt = time.Now().Add(ttl)
+		if state == nil {
+			response = &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: "pool not found"}
+			return nil
+		}
+		if in.Ttl != "" {
+			state.Config.Ttl = in.Ttl
+			ttl, err := model.ParseTTL(in.Ttl)
+			if err != nil {
+				response = &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}
+				return nil
+			}
+			state.ExpiresAt = time.Now().Add(ttl)
+			s.extendManagedReservations(ctx, state, state.ExpiresAt)
+		}
+		if in.MaxSpend > 0 {
+			state.Config.MaxSpend = in.MaxSpend
+		}
+		state.UpdatedAt = time.Now()
+		if err := s.savePrivatePoolState(ctx, workspaceID, state); err != nil {
+			response = &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}
+			return nil
+		}
+		s.emitComputeEvent(types.EventComputePool, computePoolEvent(workspaceID, state, types.EventComputeActionPoolExtended, ""))
+		response = &pb.ExtendPoolCapacityResponse{Ok: true, Pool: s.privatePoolStateToProto(state)}
+		return nil
+	})
+	if lockErr != nil {
+		return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: lockErr.Error()}, nil
 	}
-	if in.MaxSpend > 0 {
-		state.Config.MaxSpend = in.MaxSpend
+	return response, nil
+}
+
+// extendManagedReservations pushes a new expiry to the pool's open managed
+// reservations and their provider-side auto-delete thresholds, so extending a
+// pool actually extends the instances backing it.
+func (s *Service) extendManagedReservations(ctx context.Context, state *model.PoolState, expiresAt time.Time) {
+	vendors := s.computeVendors()
+	for i := range state.Reservations {
+		reservation := &state.Reservations[i]
+		if !reservation.Managed() || reservationClosed(reservation.Status) || reservation.Status == model.ReservationTerminating {
+			continue
+		}
+		if !reservation.ExpiresAt.IsZero() && !expiresAt.After(reservation.ExpiresAt) {
+			continue
+		}
+		vendor := vendors[reservation.Provider]
+		if vendor == nil {
+			reservation.LastError = fmt.Sprintf("vendor %q is not configured", reservation.Provider)
+			continue
+		}
+		if err := vendor.ExtendReservation(ctx, computeReservationInstanceID(*reservation), expiresAt); err != nil {
+			reservation.LastError = fmt.Sprintf("extension failed: %v", err)
+			continue
+		}
+		additional := expiresAt.Sub(reservation.ExpiresAt)
+		reservation.ExpiresAt = expiresAt
+		reservation.CommittedMicros += reservation.HourlyCostMicros * model.WholeHours(additional)
+		reservation.LastError = ""
+		state.CommittedSpendMicros += s.billableMicros(reservation.HourlyCostMicros * model.WholeHours(additional))
 	}
-	state.UpdatedAt = time.Now()
-	if err := s.savePrivatePoolState(ctx, workspaceID, state); err != nil {
-		return &pb.ExtendPoolCapacityResponse{Ok: false, ErrMsg: err.Error()}, nil
-	}
-	s.emitComputeEvent(types.EventComputePool, computePoolEvent(workspaceID, state, types.EventComputeActionPoolExtended, ""))
-	return &pb.ExtendPoolCapacityResponse{Ok: true, Pool: s.privatePoolStateToProto(state)}, nil
 }
 
 func (s *Service) ListPoolMachines(ctx context.Context, in *pb.ListPoolMachinesRequest) (*pb.ListPoolMachinesResponse, error) {

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -181,6 +181,56 @@ func (s *Service) reconcileBilling(ctx context.Context, workspaceID string, stat
 		return s.exhaustPoolCredit(ctx, workspaceID, state, decision, reconcileReasonCreditExhausted, reason, now) || changed
 	}
 
+	changed = s.renewManagedReservations(ctx, workspaceID, state, decision, accrued+buffer, now, s.computeVendors()) || changed
+
+	return changed
+}
+
+// renewManagedReservations extends reservations nearing expiry by one hour at
+// a time while the workspace can afford it, so an instance runs until it is
+// released or credits run out - not until an arbitrary launch TTL. Renewal is
+// skipped (and the reservation expires and terminates normally) when the
+// balance cannot cover the accrued cost plus another hour.
+func (s *Service) renewManagedReservations(ctx context.Context, workspaceID string, state *model.PoolState, decision billingDecision, reservedCents float64, now time.Time, vendors map[string]model.Vendor) bool {
+	renewLead := 2 * s.appConfig.ManagedCompute.Billing.ReconcileIntervalOrDefault()
+	changed := false
+	for i := range state.Reservations {
+		reservation := &state.Reservations[i]
+		if !reservation.Managed() || !reservation.ActiveAt(now) || reservation.ExpiresAt.IsZero() {
+			continue
+		}
+		if reservation.ExpiresAt.Sub(now) > renewLead {
+			continue
+		}
+
+		hourlyCents := managedCostCents(s.billableMicros(reservation.HourlyCostMicros), time.Hour)
+		if float64(decision.AvailableCents) < reservedCents+hourlyCents {
+			continue
+		}
+
+		vendor := vendors[reservation.Provider]
+		if vendor == nil {
+			reservation.LastError = fmt.Sprintf("vendor %q is not configured", reservation.Provider)
+			changed = true
+			continue
+		}
+		newExpiry := reservation.ExpiresAt.Add(time.Hour)
+		if err := vendor.ExtendReservation(ctx, computeReservationInstanceID(*reservation), newExpiry); err != nil {
+			reservation.LastError = fmt.Sprintf("renewal failed: %v", err)
+			changed = true
+			continue
+		}
+		reservation.ExpiresAt = newExpiry
+		reservation.CommittedMicros += reservation.HourlyCostMicros
+		reservation.LastError = ""
+		state.CommittedSpendMicros += s.billableMicros(reservation.HourlyCostMicros)
+		if state.ExpiresAt.Before(newExpiry) {
+			state.ExpiresAt = newExpiry
+		}
+		reservedCents += hourlyCents
+		s.emitComputeEvent(types.EventComputePool, computeReservationEvent(workspaceID, state, *reservation, types.EventComputeActionReservationRenewed, string(reservation.Status)))
+		changed = true
+	}
 	return changed
 }
 

--- a/pkg/types/compute.go
+++ b/pkg/types/compute.go
@@ -50,6 +50,10 @@ type ComputeVendor interface {
 	ListOffers(ctx context.Context, req ComputeOfferRequest) ([]ComputeOffer, error)
 	CreateReservation(ctx context.Context, req ComputeReservationRequest) (*ComputeReservation, error)
 	GetReservation(ctx context.Context, id string) (*ComputeReservation, error)
+	// ExtendReservation pushes a new expiry to any provider-side auto-delete
+	// threshold so the provider cannot kill an instance our control plane
+	// still considers alive. Vendors without provider-side thresholds no-op.
+	ExtendReservation(ctx context.Context, id string, expiresAt time.Time) error
 	DeleteReservation(ctx context.Context, id string) error
 }
 

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -179,6 +179,7 @@ const (
 	EventComputeActionPoolCreditExhausted       = "pool.credit_exhausted"
 	EventComputeActionPoolBillingDegraded       = "pool.billing_degraded"
 	EventComputeActionReservationUsageRecorded  = "reservation.usage_recorded"
+	EventComputeActionReservationRenewed        = "reservation.renewed"
 	EventComputeActionReservationTerminating    = "reservation.terminating"
 	EventComputeActionReservationStatusUpdated  = "reservation.status_updated"
 	EventComputeActionJoinTokenCreated          = "join_token.created"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents premature instance termination by correctly extending provider auto-delete thresholds and renewing managed reservations when credits allow. Extending a pool now also extends its active reservations and updates billing.

- **Bug Fixes**
  - `shadeform`: pad `auto_delete.date_threshold` by 1h and update it on reservation extension; leave `spend_threshold` unchanged.
  - `ExtendPoolCapacity`: lock pool state and push the new expiry to managed reservations; update committed spend.

- **New Features**
  - Added `ExtendReservation` to `ComputeVendor`; implemented for `shadeform` (updates threshold) and `vast` (no-op).
  - Reconciler renews expiring managed reservations hourly when balance covers the next hour; emits `reservation.renewed` and updates pool expiry and committed totals.

<sup>Written for commit bb8a75a917f809e80a911b91adaad682e06a1625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

