### PR TITLE
fix slack notifications

### DIFF
--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -8,20 +8,6 @@ global:
 # -- Beta9's configuration.
 # https://github.com/beam-cloud/beta9/blob/main/pkg/common/config.default.yaml
 config:
-  events:
-    callbacks:
-    - url: ""
-      format: beta9_webhook
-      headers:
-        Authorization: ""
-      eventTypes:
-      - stub.deploy
-      - stub.serve
-      - stub.run
-      - stub.clone
-      - workerpool.degraded
-      - workerpool.healthy
-      - gateway.endpoint.called
   worker:
     imageRegistry: public.ecr.aws/n4e0e1y0
     imagePVCName: ""

--- a/manifests/kustomize/components/beta9-gateway/.config.yaml
+++ b/manifests/kustomize/components/beta9-gateway/.config.yaml
@@ -13,20 +13,6 @@ worker:
         volumeMounts:
         - mountPath: /etc/beta9
           name: config
-events:
-  callbacks:
-  - url: ""
-    format: beta9_webhook
-    headers:
-      Authorization: ""
-    eventTypes:
-    - stub.deploy
-    - stub.serve
-    - stub.run
-    - stub.clone
-    - workerpool.degraded
-    - workerpool.healthy
-    - gateway.endpoint.called
 managedCompute:
   billing:
     mode: noop


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed empty `events.callbacks` config from the Beta9 chart and kustomize component so we don’t override global webhook settings. This restores Slack notifications for deploy/run/gateway events.

- **Bug Fixes**
  - Deleted the stubbed `events.callbacks` blocks in `deploy/charts/beta9/values.yaml` and `manifests/kustomize/components/beta9-gateway/.config.yaml`.
  - Beta9 now uses the default event sink, sending events to the configured Slack webhook.

<sup>Written for commit 25f271ec4ca1124b3ad1194ebbfafffa12b8bb75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

