### PR TITLE
add token type migration

### DIFF
--- a/pkg/repository/backend_postgres_migrations/039_add_worker_private_token_type.go
+++ b/pkg/repository/backend_postgres_migrations/039_add_worker_private_token_type.go
@@ -1,0 +1,43 @@
+package backend_postgres_migrations
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(upAddWorkerPrivateTokenType, downRemoveWorkerPrivateTokenType)
+}
+
+func upAddWorkerPrivateTokenType(tx *sql.Tx) error {
+	newTokenTypes := []string{"worker_private"}
+
+	for _, tokenType := range newTokenTypes {
+		addEnumSQL := fmt.Sprintf(`
+DO $$
+BEGIN
+   IF NOT EXISTS (
+      SELECT 1 FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+      JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public' AND t.typname = 'token_type' AND e.enumlabel = '%s'
+   ) THEN
+      EXECUTE 'ALTER TYPE token_type ADD VALUE ' || quote_literal('%s');
+   END IF;
+END
+$$;`, tokenType, tokenType)
+
+		if _, err := tx.Exec(addEnumSQL); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downRemoveWorkerPrivateTokenType(tx *sql.Tx) error {
+	// PostgreSQL doesn't support removing values from an ENUM directly
+	return nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Postgres migration that introduces a `worker_private` token type to the `token_type` enum. This enables issuing private worker tokens.

- **Migration**
  - Idempotent: only adds the enum value if it doesn't exist.
  - Down migration is a no-op because Postgres can't remove enum values.

<sup>Written for commit c04b541f74eba2a0750541f7f4069dbf9e8b9f72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

