### PR TITLE
fix cdi edge case on a16x2

### DIFF
--- a/pkg/types/gpu_test.go
+++ b/pkg/types/gpu_test.go
@@ -33,6 +33,7 @@ func TestNormalizeGPUType(t *testing.T) {
 		"V100x8":                GPU_V100,
 		"RTX A4000":             GPU_A4000,
 		"NVIDIA RTX A4000":      GPU_A4000,
+		"NVIDIA A16-16Q":        GPU_A16,
 		"NVIDIA A100 80GB PCI":  GPU_A100_80,
 		"A100-SXM4-40GB":        GPU_A100_40,
 		"GeForce RTX 4090":      GPU_RTX4090,

--- a/pkg/worker/nvidia.go
+++ b/pkg/worker/nvidia.go
@@ -4,24 +4,40 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/rs/zerolog/log"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 
 	common "github.com/beam-cloud/beta9/pkg/common"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/sync"
 )
 
-const nvidiaDeviceKindPrefix string = "nvidia.com/gpu"
+const (
+	nvidiaDeviceKindPrefix string = "nvidia.com/gpu"
+	nvidiaFirstDevice      string = nvidiaDeviceKindPrefix + "=0"
+)
 
 var (
 	defaultContainerCudaVersion string   = "12.4"
 	defaultContainerPath        []string = []string{"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"}
 	defaultContainerLibrary     []string = []string{"/usr/lib/x86_64-linux-gnu", "/usr/lib/worker/x86_64-linux-gnu", "/usr/local/nvidia/lib64"}
+	// Keep generated CDI specs isolated from provider or host-managed CDI specs.
+	nvidiaCDIConfigPaths    []string = []string{"/var/run/beam/cdi/nvidia.yaml", "/var/run/cdi/nvidia.yaml", "/etc/cdi/nvidia.yaml"}
+	runNvidiaCTKCDIGenerate          = func(outputPath string) ([]byte, error) {
+		return exec.Command("nvidia-ctk", "cdi", "generate", "--output", outputPath).CombinedOutput()
+	}
+	configureNvidiaCDICache = func(specPath string) error {
+		return cdi.Configure(cdi.WithSpecDirs(filepath.Dir(specPath)))
+	}
+	nvidiaCDIDeviceResolvable = func() bool {
+		return cdi.GetDefaultCache().GetDevice(nvidiaFirstDevice) != nil
+	}
 )
 
 type GPUManager interface {
@@ -43,8 +59,7 @@ type ContainerNvidiaManager struct {
 
 func NewContainerNvidiaManager(gpuCount uint32) GPUManager {
 	if gpuCount > 0 {
-		err := exec.Command("nvidia-ctk", "cdi", "generate", "--output", "/etc/cdi/nvidia.yaml").Run()
-		if err != nil {
+		if err := ensureNvidiaCDIConfig(); err != nil {
 			log.Fatal().Msgf("failed to generate cdi config: %v", err)
 		}
 	}
@@ -60,6 +75,47 @@ func NewContainerNvidiaManager(gpuCount uint32) GPUManager {
 		infoClient:             &NvidiaInfoClient{visibleDevices: visibleDevices},
 		resolvedVisibleDevices: visibleDevices,
 	}
+}
+
+func ensureNvidiaCDIConfig() error {
+	failures := make([]string, 0, len(nvidiaCDIConfigPaths))
+	for _, path := range nvidiaCDIConfigPaths {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: create dir: %v", path, err))
+			continue
+		}
+
+		output, err := runNvidiaCTKCDIGenerate(path)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %s", path, nvidiaCDICommandError(output, err)))
+			continue
+		}
+
+		if err := configureNvidiaCDICache(path); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: configure cache: %v", path, err))
+			continue
+		}
+		if !nvidiaCDIDeviceResolvable() {
+			failures = append(failures, fmt.Sprintf("%s: %s is not resolvable after generation", path, nvidiaFirstDevice))
+			continue
+		}
+
+		log.Info().
+			Str("path", path).
+			Str("spec_dir", filepath.Dir(path)).
+			Msg("generated NVIDIA CDI config")
+		return nil
+	}
+
+	return fmt.Errorf("%s", strings.Join(failures, "; "))
+}
+
+func nvidiaCDICommandError(output []byte, err error) string {
+	msg := strings.TrimSpace(string(output))
+	if msg == "" {
+		return err.Error()
+	}
+	return fmt.Sprintf("%v: %s", err, msg)
 }
 
 type AssignedGpuDevices struct {

--- a/pkg/worker/nvidia_test.go
+++ b/pkg/worker/nvidia_test.go
@@ -1,9 +1,11 @@
 package worker
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -48,6 +50,147 @@ func (c *GPUInfoClientForTest) AvailableGPUDevices() ([]int, error) {
 
 func (c *GPUInfoClientForTest) GetGPUMemoryUsage(gpuId int) (GPUMemoryUsageStats, error) {
 	return GPUMemoryUsageStats{}, nil
+}
+
+func TestEnsureNvidiaCDIConfigFallsBackToRuntimeDir(t *testing.T) {
+	originalPaths := nvidiaCDIConfigPaths
+	originalGenerate := runNvidiaCTKCDIGenerate
+	originalConfigure := configureNvidiaCDICache
+	originalResolvable := nvidiaCDIDeviceResolvable
+	t.Cleanup(func() {
+		nvidiaCDIConfigPaths = originalPaths
+		runNvidiaCTKCDIGenerate = originalGenerate
+		configureNvidiaCDICache = originalConfigure
+		nvidiaCDIDeviceResolvable = originalResolvable
+	})
+
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "beam", "cdi", "nvidia.yaml")
+	secondPath := filepath.Join(dir, "run", "cdi", "nvidia.yaml")
+	nvidiaCDIConfigPaths = []string{firstPath, secondPath}
+
+	calls := []string{}
+	configureCalls := []string{}
+	runNvidiaCTKCDIGenerate = func(outputPath string) ([]byte, error) {
+		calls = append(calls, outputPath)
+		if outputPath == firstPath {
+			return []byte("first path failed"), errors.New("exit status 1")
+		}
+		if err := os.WriteFile(outputPath, []byte("cdi"), 0644); err != nil {
+			return nil, err
+		}
+		return []byte("ok"), nil
+	}
+	configureNvidiaCDICache = func(specPath string) error {
+		configureCalls = append(configureCalls, specPath)
+		return nil
+	}
+	nvidiaCDIDeviceResolvable = func() bool {
+		return true
+	}
+
+	if err := ensureNvidiaCDIConfig(); err != nil {
+		t.Fatalf("ensureNvidiaCDIConfig() error = %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("nvidia-ctk calls = %v, want both paths", calls)
+	}
+	if _, err := os.Stat(secondPath); err != nil {
+		t.Fatalf("fallback cdi config was not written: %v", err)
+	}
+	if len(configureCalls) != 1 || configureCalls[0] != secondPath {
+		t.Fatalf("configure calls = %v, want only fallback path", configureCalls)
+	}
+}
+
+func TestEnsureNvidiaCDIConfigUsesBeamRuntimeDir(t *testing.T) {
+	originalPaths := nvidiaCDIConfigPaths
+	originalGenerate := runNvidiaCTKCDIGenerate
+	originalConfigure := configureNvidiaCDICache
+	originalResolvable := nvidiaCDIDeviceResolvable
+	t.Cleanup(func() {
+		nvidiaCDIConfigPaths = originalPaths
+		runNvidiaCTKCDIGenerate = originalGenerate
+		configureNvidiaCDICache = originalConfigure
+		nvidiaCDIDeviceResolvable = originalResolvable
+	})
+
+	dir := t.TempDir()
+	beamPath := filepath.Join(dir, "beam", "cdi", "nvidia.yaml")
+	standardPath := filepath.Join(dir, "run", "cdi", "nvidia.yaml")
+	nvidiaCDIConfigPaths = []string{beamPath, standardPath}
+
+	calls := []string{}
+	configureCalls := []string{}
+	runNvidiaCTKCDIGenerate = func(outputPath string) ([]byte, error) {
+		calls = append(calls, outputPath)
+		if err := os.WriteFile(outputPath, []byte("cdi"), 0644); err != nil {
+			return nil, err
+		}
+		return []byte("ok"), nil
+	}
+	configureNvidiaCDICache = func(specPath string) error {
+		configureCalls = append(configureCalls, specPath)
+		return nil
+	}
+	nvidiaCDIDeviceResolvable = func() bool {
+		return true
+	}
+
+	if err := ensureNvidiaCDIConfig(); err != nil {
+		t.Fatalf("ensureNvidiaCDIConfig() error = %v", err)
+	}
+	if len(calls) != 1 || calls[0] != beamPath {
+		t.Fatalf("nvidia-ctk calls = %v, want only Beam runtime path", calls)
+	}
+	if len(configureCalls) != 1 || configureCalls[0] != beamPath {
+		t.Fatalf("configure calls = %v, want only Beam runtime path", configureCalls)
+	}
+	if _, err := os.Stat(standardPath); !os.IsNotExist(err) {
+		t.Fatalf("standard CDI path should be untouched, stat err = %v", err)
+	}
+}
+
+func TestEnsureNvidiaCDIConfigFallsBackWhenGeneratedDeviceIsUnresolvable(t *testing.T) {
+	originalPaths := nvidiaCDIConfigPaths
+	originalGenerate := runNvidiaCTKCDIGenerate
+	originalConfigure := configureNvidiaCDICache
+	originalResolvable := nvidiaCDIDeviceResolvable
+	t.Cleanup(func() {
+		nvidiaCDIConfigPaths = originalPaths
+		runNvidiaCTKCDIGenerate = originalGenerate
+		configureNvidiaCDICache = originalConfigure
+		nvidiaCDIDeviceResolvable = originalResolvable
+	})
+
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "beam", "cdi", "nvidia.yaml")
+	secondPath := filepath.Join(dir, "run", "cdi", "nvidia.yaml")
+	nvidiaCDIConfigPaths = []string{firstPath, secondPath}
+
+	calls := []string{}
+	runNvidiaCTKCDIGenerate = func(outputPath string) ([]byte, error) {
+		calls = append(calls, outputPath)
+		if err := os.WriteFile(outputPath, []byte("cdi"), 0644); err != nil {
+			return nil, err
+		}
+		return []byte("ok"), nil
+	}
+	resolveCalls := 0
+	configureNvidiaCDICache = func(specPath string) error {
+		return nil
+	}
+	nvidiaCDIDeviceResolvable = func() bool {
+		resolveCalls++
+		return resolveCalls > 1
+	}
+
+	if err := ensureNvidiaCDIConfig(); err != nil {
+		t.Fatalf("ensureNvidiaCDIConfig() error = %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("nvidia-ctk calls = %v, want retry after unresolvable generated spec", calls)
+	}
 }
 
 func TestInjectNvidiaEnvVarsNoCudaInImage(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve NVIDIA CDI generation with path fallback and validation to fix container startup on A16x2 hosts. Also map "NVIDIA A16-16Q" to `GPU_A16` for correct GPU detection.

- **Bug Fixes**
  - Generate CDI spec to `/var/run/beam/cdi/nvidia.yaml` first, then fall back to `/var/run/cdi/nvidia.yaml` and `/etc/cdi/nvidia.yaml`; create dirs when missing.
  - Configure CDI cache via `tags.cncf.io/container-device-interface/pkg/cdi` scoped to the spec dir and verify `nvidia.com/gpu=0` resolves; retry on failure.
  - Replace direct `/etc/cdi/nvidia.yaml` write with `ensureNvidiaCDIConfig` in `NewContainerNvidiaManager`.

<sup>Written for commit 2db10c682ba4a135fede28bc75230fb32836b14c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

