### PR TITLE
fix overlay

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -308,9 +308,6 @@ COPY ./sdk/src/beta9 /workspace/sdk
 COPY --from=uv /root/.local/bin/uv /usr/local/bin/uv
 COPY --from=dropbear /usr/local/bin/dropbear /usr/local/bin/dropbear
 
-VOLUME "/usr/lib/x86_64-linux-gnu"
-VOLUME "/usr/lib/aarch64-linux-gnu"
-
 RUN mkdir -p /etc/criu
 RUN touch /etc/criu/default.conf
 # add the following options to the default.conf file on new lines

--- a/pkg/compute/shadeform.go
+++ b/pkg/compute/shadeform.go
@@ -82,15 +82,19 @@ func (c *ShadeformClient) CreateReservation(ctx context.Context, req Reservation
 	if cloud == "" {
 		cloud = req.Offer.Cloud
 	}
-	if cloud == "" {
-		cloud = req.Offer.Provider
+	// Shadeform's create API requires a cloud, so fall back to the aggregator
+	// name for the request only; the reservation's recorded cloud must stay
+	// the underlying vendor (or empty until reconciliation fills it in).
+	requestCloud := cloud
+	if requestCloud == "" {
+		requestCloud = req.Offer.Provider
 	}
 	instanceType := req.Offer.InstanceType
 	if instanceType == "" {
 		instanceType = req.Offer.ID
 	}
 	body := map[string]any{
-		"cloud":               cloud,
+		"cloud":               requestCloud,
 		"shade_instance_type": instanceType,
 		"shade_cloud":         true,
 		"name":                ReservationNodeName(req),
@@ -131,7 +135,7 @@ func (c *ShadeformClient) CreateReservation(ctx context.Context, req Reservation
 		Name:             ReservationNodeName(req),
 		Selector:         req.Selector,
 		Provider:         c.Name(),
-		Cloud:            req.Offer.Cloud,
+		Cloud:            cloud,
 		Region:           req.Offer.Region,
 		OfferID:          req.Offer.ID,
 		InstanceType:     req.Offer.InstanceType,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes overlay mount issues in the worker image by removing unnecessary library volumes, and stabilizes Shadeform reservations by handling missing cloud values correctly.

- **Bug Fixes**
  - Docker: Remove `VOLUME /usr/lib/x86_64-linux-gnu` and `/usr/lib/aarch64-linux-gnu` to prevent overlay conflicts in the worker image.
  - Shadeform: When `cloud` is empty, send the provider as the request cloud but keep the reservation’s stored cloud as the vendor value (or empty for reconciliation). This prevents create API failures while preserving correct state.

<sup>Written for commit 933f4638ae11efa4c4bfae50f840dcf16da88996. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

