### PR TITLE
fix(scheduler): clamp backoff exponent to prevent duration overflow

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -977,6 +977,16 @@ func calculateBackoffDelay(retryCount int) time.Duration {
 
 	baseDelay := 1 * time.Second
 	maxDelay := 5 * time.Second
+
+	// Clamp the exponent before computing the power. Without this, large
+	// retry counts (which can reach ~120) overflow time.Duration's int64
+	// when converted from math.Pow, wrapping around to 0 or negative values
+	// that silently slip past the maxDelay clamp below.
+	const maxExponent = 32
+	if retryCount > maxExponent {
+		return maxDelay
+	}
+
 	delay := time.Duration(math.Pow(2, float64(retryCount))) * baseDelay
 	if delay > maxDelay {
 		delay = maxDelay

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2423,3 +2423,30 @@ func TestConcurrencyLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateBackoffDelay(t *testing.T) {
+	maxDelay := 5 * time.Second
+
+	tests := []struct {
+		retryCount int
+		want       time.Duration
+	}{
+		{retryCount: 0, want: 0},
+		{retryCount: 1, want: 2 * time.Second},
+		{retryCount: 2, want: 4 * time.Second},
+		{retryCount: 3, want: maxDelay},
+		{retryCount: 30, want: maxDelay},
+		// High retry counts (reachable up to maxScheduleRetryCount-1) must
+		// stay clamped at maxDelay rather than overflowing to 0 / negative.
+		{retryCount: 62, want: maxDelay},
+		{retryCount: 63, want: maxDelay},
+		{retryCount: 119, want: maxDelay},
+	}
+
+	for _, tt := range tests {
+		got := calculateBackoffDelay(tt.retryCount)
+		assert.GreaterOrEqual(t, got, time.Duration(0), "retryCount=%d produced a negative delay", tt.retryCount)
+		assert.LessOrEqual(t, got, maxDelay, "retryCount=%d exceeded maxDelay", tt.retryCount)
+		assert.Equal(t, tt.want, got, "retryCount=%d", tt.retryCount)
+	}
+}


### PR DESCRIPTION
## What's broken

`calculateBackoffDelay` computes retry backoff as `time.Duration(math.Pow(2, retryCount)) * baseDelay` and clamps it to a 5s `maxDelay`. For large `retryCount`, the `time.Duration` (int64 ns) overflows before the clamp, wrapping to `0` then negative — so the clamp never fires and failing requests get zero/negative backoff instead of the intended 5s cap. `retryCount` is reachable up to `maxScheduleRetryCount = 120`:

```
retryCount=3   -> 5s    (correct, clamped)
retryCount=62  -> 0s    (bug: no backoff)
retryCount=63  -> -1s   (bug: negative)
retryCount=119 -> -1s   (bug)
```

A negative/zero duration makes the backlog reschedule immediately, turning the backoff cap into a retry storm — the opposite of its purpose.

## Why it happens

`math.Pow(2, retryCount)` converted to `time.Duration` and multiplied by 1s overflows int64 around `retryCount >= 62`; the overflowed value is `<= maxDelay`, so `if delay > maxDelay` is skipped.

## Fix

Clamp the exponent before the power: if `retryCount` exceeds a safe bound, return `maxDelay` directly.

## Test

`TestCalculateBackoffDelay` asserts retryCount 62/63/119 return the 5s cap (not 0/negative); fails before, passes after. Full scheduler package still green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamps the retry backoff exponent in `pkg/scheduler` to prevent `time.Duration` overflow that caused zero/negative delays and retry storms. High retry counts now correctly return the 5s cap.

- **Bug Fixes**
  - Clamp before power: if `retryCount` > 32, return `maxDelay` (5s).
  - Added `TestCalculateBackoffDelay` to cover large counts (62, 63, 119) and assert non-negative, capped delays.

<sup>Written for commit 8f87ad082cc2bfabe243d80a77c16454c6b1b520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

