### PR TITLE
cache layers during indexing

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -172,7 +172,11 @@ case "$TARGETARCH" in
         chmod +x /usr/local/bin/juicefs
         ;;
     arm64)
-        echo "Beam-pinned JuiceFS is not available for linux/arm64; skipping JuiceFS support"
+        # Beam-pinned JuiceFS build is amd64-only; use the upstream community release for arm64 (local dev)
+        curl -fsSL https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-arm64.tar.gz -o /tmp/juicefs.tar.gz
+        tar -xzf /tmp/juicefs.tar.gz -C /tmp juicefs
+        install /tmp/juicefs /usr/local/bin/juicefs
+        rm -f /tmp/juicefs.tar.gz /tmp/juicefs
         ;;
     *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;;
 esac

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877
+	github.com/beam-cloud/clip v0.0.0-20260611234218-ec3ed8959db3
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877 h1:R2G+m4w9VdKpzTEVpYqEI0XxMVCPHXPOdqLOb65dBF0=
-github.com/beam-cloud/clip v0.0.0-20260603183717-080bd5abb877/go.mod h1:+vn8fPGQKaUiDvOy5GLpduzYIQLtMIfnRn08/5fOz+s=
+github.com/beam-cloud/clip v0.0.0-20260611234218-ec3ed8959db3 h1:HzQtR78BiPh1WpQOCSfaQ/GdrQNUoF2RX/X5F0ISYtM=
+github.com/beam-cloud/clip v0.0.0-20260611234218-ec3ed8959db3/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd h1:qdvWIpwFIHK4yhLV27r7D2HZj80Umq/h3tHGITpgM6g=
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -294,7 +294,7 @@ cache:
     hostWatchIntervalSeconds: 5
   global:
     defaultLocality: default
-    serverPort: 2049
+    serverPort: 2050
     discoveryIntervalS: 5
     discoveryJitterS: 3
     maxDiscoveryConcurrency: 8

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -362,7 +362,15 @@ func (m *WorkerCacheManager) createEmbeddedServer(cacheConfig cache.Config, host
 		return nil, "", err
 	}
 
-	advertisedAddr, err := server.Serve(m.bindAddr(cacheConfig), m.cacheAdvertiseHost())
+	bindAddr := m.bindAddr(cacheConfig)
+	advertisedAddr, err := server.Serve(bindAddr, m.cacheAdvertiseHost())
+	if err != nil && m.allowEphemeralCachePortFallback(cacheConfig, err) {
+		log.Warn().
+			Err(err).
+			Str("bind_addr", bindAddr).
+			Msg("embedded cache default port unavailable, falling back to ephemeral port")
+		advertisedAddr, err = server.Serve(":0", m.cacheAdvertiseHost())
+	}
 	if err != nil {
 		_ = server.Close()
 		return nil, "", err
@@ -666,15 +674,19 @@ func (m *WorkerCacheManager) bindAddr(cacheConfig cache.Config) string {
 		port = cacheDefaultServerPort
 	}
 
-	// Host-network embedded workers default to an ephemeral port to avoid
-	// collisions when many share a node. The advertised address carries the real
-	// port. The one-per-node cache-server daemonset binds the fixed port, and an
-	// operator can force a fixed embedded-worker port with CACHE_SERVER_PORT.
-	if cacheHostNetwork(m.config) && !cacheServerOnlyMode() && cacheServerPortFromEnv() == 0 {
-		return ":0"
-	}
-
 	return fmt.Sprintf(":%d", port)
+}
+
+func (m *WorkerCacheManager) allowEphemeralCachePortFallback(cacheConfig cache.Config, err error) bool {
+	return cacheHostNetwork(m.config) &&
+		!cacheServerOnlyMode() &&
+		cacheServerPortFromEnv() == 0 &&
+		cacheConfig.Global.ServerPort == cacheDefaultServerPort &&
+		cacheBindAddrInUse(err)
+}
+
+func cacheBindAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
 }
 
 // cacheAdvertiseHost returns the address other cache clients should use to reach

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -616,19 +616,19 @@ func TestBindAddr(t *testing.T) {
 			expected:       ":2050",
 		},
 		{
-			name:           "embedded host-network without explicit port is ephemeral",
+			name:           "embedded host-network binds default fixed port",
 			hostNetwork:    "true",
 			cacheServer:    "false",
 			normalizedPort: 2050,
-			expected:       ":0",
+			expected:       ":2050",
 		},
 		{
-			name:           "embedded host-network ignores config port",
+			name:           "embedded host-network honors config port",
 			hostNetwork:    "true",
 			cacheServer:    "false",
 			configPort:     9000,
 			normalizedPort: 9000,
-			expected:       ":0",
+			expected:       ":9000",
 		},
 		{
 			name:           "embedded host-network honors CACHE_SERVER_PORT env",
@@ -672,4 +672,41 @@ func TestBindAddr(t *testing.T) {
 			require.Equal(t, tc.expected, m.bindAddr(cacheConfig))
 		})
 	}
+}
+
+func TestCacheBindAddrInUse(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+
+	second, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", port))
+	if err == nil {
+		_ = second.Close()
+		t.Fatal("expected duplicate listener bind to fail")
+	}
+	require.True(t, cacheBindAddrInUse(err))
+
+	t.Setenv(types.CacheHostNetworkEnv, "true")
+	t.Setenv(types.CacheServerOnlyEnv, "false")
+	require.True(t, (&WorkerCacheManager{}).allowEphemeralCachePortFallback(cache.Config{
+		Global: cache.GlobalConfig{ServerPort: cacheDefaultServerPort},
+	}, err))
+
+	require.False(t, (&WorkerCacheManager{}).allowEphemeralCachePortFallback(cache.Config{
+		Global: cache.GlobalConfig{ServerPort: 9000},
+	}, err))
+
+	t.Setenv(types.CacheServerPortEnv, "2050")
+	require.False(t, (&WorkerCacheManager{}).allowEphemeralCachePortFallback(cache.Config{
+		Global: cache.GlobalConfig{ServerPort: cacheDefaultServerPort},
+	}, err))
+	t.Setenv(types.CacheServerPortEnv, "")
+
+	t.Setenv(types.CacheServerOnlyEnv, "true")
+	require.False(t, (&WorkerCacheManager{}).allowEphemeralCachePortFallback(cache.Config{
+		Global: cache.GlobalConfig{ServerPort: cacheDefaultServerPort},
+	}, err))
 }

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -1805,44 +1805,23 @@ func (c *ImageClient) createOCIImageWithProgress(ctx context.Context, outputLogg
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	// Process progress updates in goroutine
+	// Process progress updates in goroutine. Layers index concurrently, so
+	// "starting" events arrive in bursts; only completions (which are ordered)
+	// are surfaced to the user.
 	go func() {
 		defer wg.Done()
 		for progress := range progressChan {
-			percent := float64(progress.LayerIndex) / float64(progress.TotalLayers) * 100
+			log.Debug().
+				Str("container_id", request.ContainerId).
+				Str("stage", progress.Stage).
+				Int("layer", progress.LayerIndex).
+				Int("total", progress.TotalLayers).
+				Int("files", progress.FilesIndexed).
+				Msg("image index progress")
 
-			switch progress.Stage {
-			case "starting":
-				log.Info().
-					Str("container_id", request.ContainerId).
-					Int("layer", progress.LayerIndex).
-					Int("total", progress.TotalLayers).
-					Msgf("Indexing layer %d/%d (%.0f%%)", progress.LayerIndex, progress.TotalLayers, percent)
-
-				outputLogger.Info(fmt.Sprintf("Indexing layer %d/%d (%.0f%%)\n",
-					progress.LayerIndex, progress.TotalLayers, percent))
-
-			case "completed":
-				log.Info().
-					Str("container_id", request.ContainerId).
-					Int("layer", progress.LayerIndex).
-					Int("total", progress.TotalLayers).
-					Int("files", progress.FilesIndexed).
-					Msgf("Completed layer %d/%d (%.0f%%, %d files indexed)", progress.LayerIndex, progress.TotalLayers, percent, progress.FilesIndexed)
-
-				outputLogger.Info(fmt.Sprintf("Completed layer %d/%d (%.0f%%, %d files indexed)\n",
-					progress.LayerIndex, progress.TotalLayers, percent, progress.FilesIndexed))
-
-			default:
-				log.Info().
-					Str("container_id", request.ContainerId).
-					Str("stage", progress.Stage).
-					Int("layer", progress.LayerIndex).
-					Int("total", progress.TotalLayers).
-					Msgf("Index progress [%s]: layer %d/%d", progress.Stage, progress.LayerIndex, progress.TotalLayers)
-
-				outputLogger.Info(fmt.Sprintf("Index progress [%s]: layer %d/%d\n",
-					progress.Stage, progress.LayerIndex, progress.TotalLayers))
+			if progress.Stage == "completed" {
+				outputLogger.Info(fmt.Sprintf("Indexed layer %d/%d (%d files)\n",
+					progress.LayerIndex, progress.TotalLayers, progress.FilesIndexed))
 			}
 		}
 	}()
@@ -1856,6 +1835,7 @@ func (c *ImageClient) createOCIImageWithProgress(ctx context.Context, outputLogg
 		CredProvider:    c.getCredentialProviderForImage(ctx, request.ImageId, request),
 		ContentCache:    newImageContentCache(c.cacheClient, request.ImageId, "oci-layer-build"),
 		ContentCacheDir: filepath.Dir(outputPath),
+		LayerIndexCache: newImageLayerIndexCache(c.cacheClient),
 	})
 
 	// Close channel and wait for all progress messages to be logged

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +35,118 @@ const (
 	imageContentCacheResultStoredOrPresent    = "stored_or_present"
 	imageContentCacheResultSkippedUnavailable = "skipped_unavailable"
 )
+
+const layerIndexCacheMaxArtifactSize = 256 * 1024 * 1024
+
+// imageLayerIndexCache caches per-layer index artifacts (tiny metadata blobs
+// keyed by layer digest) in two tiers:
+//
+//   - worker-local disk, so repeat builds on the same worker skip re-indexing
+//     without any network round trip
+//   - the embedded content cache (the same mechanism used to seed and restore
+//     image archives across workers), so any worker in the locality can reuse
+//     artifacts produced elsewhere
+//
+// The layer bytes themselves are cached separately in the content cache keyed
+// by layer digest, so even a full artifact miss never re-pulls a layer the
+// cluster has already seen.
+type imageLayerIndexCache struct {
+	client *cache.Client
+	disk   clipStorage.LayerIndexCache
+}
+
+func newImageLayerIndexCache(client *cache.Client) clipStorage.LayerIndexCache {
+	var disk clipStorage.LayerIndexCache
+	if diskCache, err := clipStorage.NewDiskLayerIndexCache(filepath.Join(getImageCachePath(), "layer-index")); err != nil {
+		log.Warn().Err(err).Msg("failed to initialize local layer index cache")
+	} else {
+		disk = diskCache
+	}
+
+	if client == nil && disk == nil {
+		return nil
+	}
+	return &imageLayerIndexCache{client: client, disk: disk}
+}
+
+// layerIndexCachePath maps a clip layer-index cache key (e.g.
+// "clip-layer-index/v1/cp2/sha256_<digest>") to an embedded cache path.
+func layerIndexCachePath(key string) string {
+	return "/" + key
+}
+
+func (c *imageLayerIndexCache) GetLayerIndex(ctx context.Context, key string) ([]byte, error) {
+	if c.disk != nil {
+		if data, err := c.disk.GetLayerIndex(ctx, key); err == nil && data != nil {
+			return data, nil
+		}
+	}
+
+	if c.client == nil {
+		return nil, nil
+	}
+
+	cachePath := layerIndexCachePath(key)
+	metadata, err := c.client.CacheFSMetadata(ctx, cachePath)
+	if err != nil {
+		if isEmbeddedImageCacheMiss(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if metadata == nil || metadata.Hash == "" || metadata.Size == 0 {
+		return nil, nil
+	}
+	if metadata.Size > layerIndexCacheMaxArtifactSize {
+		return nil, fmt.Errorf("layer index artifact too large: %d bytes", metadata.Size)
+	}
+
+	data := make([]byte, metadata.Size)
+	read, err := c.client.ReadContentInto(ctx, metadata.Hash, 0, data, cache.ClientOptions{RoutingKey: cachePath})
+	if err != nil {
+		if isEmbeddedImageCacheMiss(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if read != int64(metadata.Size) {
+		return nil, fmt.Errorf("short layer index artifact read: expected %d bytes, got %d", metadata.Size, read)
+	}
+
+	// Seed the local disk tier so subsequent builds on this worker skip the
+	// network read
+	if c.disk != nil {
+		if err := c.disk.PutLayerIndex(ctx, key, data); err != nil {
+			log.Debug().Err(err).Str("key", key).Msg("failed to seed local layer index cache")
+		}
+	}
+	return data, nil
+}
+
+func (c *imageLayerIndexCache) PutLayerIndex(ctx context.Context, key string, data []byte) error {
+	if c.disk != nil {
+		if err := c.disk.PutLayerIndex(ctx, key, data); err != nil {
+			log.Debug().Err(err).Str("key", key).Msg("failed to store layer index artifact on local disk")
+		}
+	}
+
+	if c.client == nil {
+		return nil
+	}
+
+	cachePath := layerIndexCachePath(key)
+	if _, err := c.client.StoreContentAtPath(data, cachePath, cache.StoreContentOptions{
+		RoutingKey: cachePath,
+		Lock:       true,
+	}); err != nil {
+		return err
+	}
+
+	log.Debug().Str("key", key).Int("bytes", len(data)).Msg("seeded layer index artifact in embedded cache")
+	return nil
+}
+
+var _ clipStorage.LayerIndexCache = (*imageLayerIndexCache)(nil)
 
 type imageContentCache struct {
 	client  *cache.Client
@@ -269,6 +382,55 @@ func (c *imageContentCache) ContentExists(hash string, opts struct{ RoutingKey s
 	// whether the store can be skipped.
 	return false, nil
 }
+
+// ContentExistsWithSize performs a size-aware completeness check on the
+// selected cache host. Unlike ContentExists, a positive response guarantees
+// the cached content is complete, so callers (e.g. CLIP's build-time layer
+// warm) can safely skip re-spooling and re-storing the layer.
+func (c *imageContentCache) ContentExistsWithSize(hash string, size int64, opts struct{ RoutingKey string }) (exists bool, err error) {
+	if c == nil || c.client == nil {
+		return false, cache.ErrClientNotFound
+	}
+	if size <= 0 {
+		return false, nil
+	}
+	if opts.RoutingKey == "" {
+		opts.RoutingKey = hash
+	}
+
+	started := time.Now()
+	c.existsRequests.Add(1)
+	defer func() {
+		elapsed := time.Since(started)
+		if err != nil {
+			c.existsErrors.Add(1)
+			log.Warn().
+				Err(err).
+				Str("image_id", c.imageID).
+				Str("kind", c.kind).
+				Str("hash", shortHash(hash)).
+				Str("routing_key", shortHash(opts.RoutingKey)).
+				Int64("size", size).
+				Dur("elapsed", elapsed).
+				Msg("clip image content cache exists-with-size result")
+		} else if exists {
+			c.existsHits.Add(1)
+			log.Debug().
+				Str("image_id", c.imageID).
+				Str("kind", c.kind).
+				Str("hash", shortHash(hash)).
+				Str("routing_key", shortHash(opts.RoutingKey)).
+				Int64("size", size).
+				Dur("elapsed", elapsed).
+				Msg("clip image content cache exists-with-size hit")
+		}
+		c.maybeLogSummary()
+	}()
+
+	return c.client.IsCachedOnSelectedHost(hash, opts.RoutingKey, size)
+}
+
+var _ clipStorage.ContentCacheExistsWithSize = (*imageContentCache)(nil)
 
 func (c *imageContentCache) ClientLocalPageFileViews(hash string, offset int64, length int64, opts struct{ RoutingKey string }) (views []clipStorage.ClientLocalPageFileView, err error) {
 	if c == nil || c.client == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cache per-layer index artifacts during image indexing to avoid re-indexing and speed up repeat builds. Also improve cache server port handling and arm64 worker setup.

- **New Features**
  - Added two-tier layer index cache: worker-local disk + embedded content cache (keyed by layer digest).
  - Implemented size-aware layer existence check (`ContentExistsWithSize`) to skip re-spooling complete layers.
  - Streamlined progress logs: only print completed layer messages; other events go to debug.

- **Refactors**
  - Cache server now binds the configured port by default; falls back to an ephemeral port only on EADDRINUSE, with tests.
  - Changed default `cache.global.serverPort` to 2050.
  - Added `linux/arm64` JuiceFS binary in `Dockerfile.worker` for local dev.
  - Bumped `github.com/beam-cloud/clip` to integrate layer index caching.

<sup>Written for commit 3b15fa6cca6c854f50f7931854feffada8c7f218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

