### PR TITLE
improve layer output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260611234218-ec3ed8959db3
+	github.com/beam-cloud/clip v0.0.0-20260612001657-67d9cda18d06
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.5
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,10 @@ github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260611234218-ec3ed8959db3 h1:HzQtR78BiPh1WpQOCSfaQ/GdrQNUoF2RX/X5F0ISYtM=
 github.com/beam-cloud/clip v0.0.0-20260611234218-ec3ed8959db3/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
+github.com/beam-cloud/clip v0.0.0-20260612000345-aac266139574 h1:3kTmRIagZskx3qMRwNXY40j4xMG3jYQSIWRltBI5O4g=
+github.com/beam-cloud/clip v0.0.0-20260612000345-aac266139574/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
+github.com/beam-cloud/clip v0.0.0-20260612001657-67d9cda18d06 h1:iv5PVdvnkdek1WX0LVjc6s1ELWxfrvzzYAW0Xr/0PVE=
+github.com/beam-cloud/clip v0.0.0-20260612001657-67d9cda18d06/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd h1:qdvWIpwFIHK4yhLV27r7D2HZj80Umq/h3tHGITpgM6g=
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=

--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -105,6 +105,17 @@ func workerCacheEnabled(config types.AppConfig, poolConfig types.WorkerPoolConfi
 	return config.Cache.Disk.Enabled
 }
 
+// workerImagesHostPath returns the host path backing the worker's /images
+// volume (clip decompressed-layer disk cache, layer index artifacts, and
+// image mounts). Pools can override it to place the cache on a different
+// host disk; the in-pod mount path stays /images.
+func workerImagesHostPath(poolConfig types.WorkerPoolConfig) string {
+	if poolConfig.ImagesPath != "" {
+		return poolConfig.ImagesPath
+	}
+	return defaultImagesPath
+}
+
 func workerCacheHostPath(config types.AppConfig, poolConfig types.WorkerPoolConfig) string {
 	if poolConfig.Cache.Disk.HostPath != "" {
 		return poolConfig.Cache.Disk.HostPath

--- a/pkg/scheduler/pool_external.go
+++ b/pkg/scheduler/pool_external.go
@@ -575,7 +575,7 @@ func (wpc *ExternalWorkerPoolController) getWorkerVolumes(workerMemory int64) []
 			Name: imagesVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: defaultImagesPath,
+					Path: workerImagesHostPath(wpc.workerPoolConfig),
 					Type: &hostPathType,
 				},
 			},

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -345,7 +345,7 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerVolumes(workerMemory in
 		}
 	} else {
 		volumeSource.HostPath = &corev1.HostPathVolumeSource{
-			Path: defaultImagesPath,
+			Path: workerImagesHostPath(wpc.workerPoolConfig),
 			Type: &hostPathType,
 		}
 	}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -465,6 +465,7 @@ type WorkerPoolConfig struct {
 	K3sInstallDir             string                            `key:"k3sInstallDir" json:"k3s_install_dir"`
 	StoragePath               string                            `key:"storagePath" json:"storage_path"`
 	StorageMode               string                            `key:"storageMode" json:"storage_mode"`
+	ImagesPath                string                            `key:"imagesPath" json:"images_path"` // Host path backing the worker's /images volume (clip layer cache + image mounts); defaults to /images
 	Cache                     WorkerPoolCacheConfig             `key:"cache" json:"cache"`
 }
 

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -1798,6 +1799,62 @@ func (c *ImageClient) getBuildahAuthArgs(ctx context.Context, imageRef string, c
 	return nil
 }
 
+// formatImageBytes renders a byte count for user-facing build output.
+func formatImageBytes(n int64) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.2f GiB", float64(n)/(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(n)/(1<<20))
+	default:
+		return fmt.Sprintf("%d KiB", n/1024)
+	}
+}
+
+type activeOutputWriter struct {
+	logger       *slog.Logger
+	lastOutputNS *atomic.Int64
+}
+
+func newActiveOutputWriter(logger *slog.Logger) *activeOutputWriter {
+	w := &activeOutputWriter{logger: logger, lastOutputNS: &atomic.Int64{}}
+	w.lastOutputNS.Store(time.Now().UnixNano())
+	return w
+}
+
+func (w *activeOutputWriter) Write(p []byte) (int, error) {
+	w.lastOutputNS.Store(time.Now().UnixNano())
+	w.logger.Info(string(p))
+	return len(p), nil
+}
+
+const buildOutputHeartbeatInterval = 15 * time.Second
+
+// startSilentOutputHeartbeat emits a user-facing heartbeat only when the
+// wrapped command has produced no output for a while. This keeps noisy phases
+// like pip downloads readable while making silent buildah commit/push phases
+// understandable.
+func startSilentOutputHeartbeat(ctx context.Context, outputLogger *slog.Logger, started time.Time, writer *activeOutputWriter, message string) func() {
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		ticker := time.NewTicker(buildOutputHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				lastOutput := time.Unix(0, writer.lastOutputNS.Load())
+				if time.Since(lastOutput) < buildOutputHeartbeatInterval {
+					continue
+				}
+				outputLogger.Info(fmt.Sprintf("%s (%ds elapsed)\n", message, int(time.Since(started).Seconds())))
+			}
+		}
+	}()
+	return cancel
+}
+
 func (c *ImageClient) createOCIImageWithProgress(ctx context.Context, outputLogger *slog.Logger, request *types.ContainerRequest, imageRef, outputPath string, checkpointMiB int64) error {
 	outputLogger.Info("Indexing image...\n")
 	progressChan := make(chan clip.OCIIndexProgress, 100)
@@ -1806,22 +1863,50 @@ func (c *ImageClient) createOCIImageWithProgress(ctx context.Context, outputLogg
 	wg.Add(1)
 
 	// Process progress updates in goroutine. Layers index concurrently, so
-	// "starting" events arrive in bursts; only completions (which are ordered)
-	// are surfaced to the user.
+	// "starting" events arrive in bursts; per-layer byte progress and
+	// completions (with their source) are surfaced to the user as they happen.
 	go func() {
 		defer wg.Done()
+		cachedLayers := 0
+		var cachedBytes int64
 		for progress := range progressChan {
 			log.Debug().
 				Str("container_id", request.ContainerId).
 				Str("stage", progress.Stage).
+				Str("source", progress.Source).
 				Int("layer", progress.LayerIndex).
 				Int("total", progress.TotalLayers).
-				Int("files", progress.FilesIndexed).
+				Int64("bytes", progress.BytesProcessed).
 				Msg("image index progress")
 
-			if progress.Stage == "completed" {
-				outputLogger.Info(fmt.Sprintf("Indexed layer %d/%d (%d files)\n",
-					progress.LayerIndex, progress.TotalLayers, progress.FilesIndexed))
+			switch progress.Stage {
+			case "progress":
+				if progress.BytesProcessed < 256*1024*1024 {
+					continue
+				}
+				outputLogger.Info(fmt.Sprintf("Indexing layer %d/%d... %s processed\n",
+					progress.LayerIndex, progress.TotalLayers, formatImageBytes(progress.BytesProcessed)))
+			case "completed":
+				if progress.Source == clip.LayerSourceIndexCache || progress.Source == clip.LayerSourceContentCache {
+					cachedLayers++
+					cachedBytes += progress.BytesProcessed
+					continue
+				}
+
+				var detail string
+				if progress.BytesProcessed > 0 {
+					detail = formatImageBytes(progress.BytesProcessed)
+				} else {
+					detail = "done"
+				}
+				outputLogger.Info(fmt.Sprintf("Indexed layer %d/%d (%s)\n", progress.LayerIndex, progress.TotalLayers, detail))
+			}
+		}
+		if cachedLayers > 0 {
+			if cachedBytes > 0 {
+				outputLogger.Info(fmt.Sprintf("Indexed %d cached layers (%s)\n", cachedLayers, formatImageBytes(cachedBytes)))
+			} else {
+				outputLogger.Info(fmt.Sprintf("Indexed %d cached layers\n", cachedLayers))
 			}
 		}
 	}()
@@ -1976,11 +2061,17 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 		budArgs = append(budArgs, "-f", tempDockerFile, "-t", imageTag, buildCtxPath)
 		cmd := exec.CommandContext(ctx, "buildah", budArgs...)
 		cmd.Env = c.buildahEnv(runroot, tmpdir, storageConf)
-		cmd.Stdout = &common.ExecWriter{Logger: outputLogger}
-		cmd.Stderr = &common.ExecWriter{Logger: outputLogger}
-		if err = cmd.Run(); err != nil {
+		buildOutput := newActiveOutputWriter(outputLogger)
+		cmd.Stdout = buildOutput
+		cmd.Stderr = buildOutput
+		buildStart := time.Now()
+		stopHeartbeat := startSilentOutputHeartbeat(ctx, outputLogger, buildStart, buildOutput, "Still building image...")
+		err = cmd.Run()
+		stopHeartbeat()
+		if err != nil {
 			return err
 		}
+		outputLogger.Info(fmt.Sprintf("Image built in %.1fs\n", time.Since(buildStart).Seconds()))
 
 		outputLogger.Info(fmt.Sprintf("Pushing image to registry: %s\n", imageTag))
 
@@ -2006,11 +2097,20 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 
 		cmd = exec.CommandContext(ctx, "buildah", pushArgs...)
 		cmd.Env = c.buildahEnv(runroot, tmpdir, storageConf)
-		cmd.Stdout = &common.ExecWriter{Logger: outputLogger}
-		cmd.Stderr = &common.ExecWriter{Logger: outputLogger}
-		if err = cmd.Run(); err != nil {
+		pushOutput := newActiveOutputWriter(outputLogger)
+		cmd.Stdout = pushOutput
+		cmd.Stderr = pushOutput
+
+		// buildah push emits no progress for large blobs, so surface a
+		// heartbeat to the user while it runs
+		pushStart := time.Now()
+		stopHeartbeat = startSilentOutputHeartbeat(ctx, outputLogger, pushStart, pushOutput, "Still pushing image...")
+		err = cmd.Run()
+		stopHeartbeat()
+		if err != nil {
 			return err
 		}
+		outputLogger.Info(fmt.Sprintf("Image pushed in %.1fs\n", time.Since(pushStart).Seconds()))
 
 		c.v2ImageRefs.Set(request.ImageId, imageTag)
 		log.Info().Str("image_id", request.ImageId).Str("image_tag", imageTag).Msg("cached image reference")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves image build and layer indexing output for clearer progress and fewer “silent” waits, and adds a config option to choose the host path for the `/images` volume.

- **New Features**
  - Clearer layer indexing logs: per-layer byte progress, completion details, and a summary of cached layers (count and bytes).
  - Human-friendly size formatting (KiB/MiB/GiB) in build output.
  - Heartbeats during silent phases: emits “Still building/pushing image...” every 15s when no output; prints total build/push duration on completion.
  - Configurable worker images host path: new `imagesPath` in `WorkerPoolConfig` to override the host path that backs `/images` (defaults to `/images`).

- **Dependencies**
  - Bump `github.com/beam-cloud/clip` to `v0.0.0-20260612001657-67d9cda18d06`.

<sup>Written for commit 59b962135bdd733ea6b900fb4877d6a5546b5df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

