### PR TITLE
fix reconciler cpu spamming

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -263,6 +263,30 @@ func (i *AutoscaledInstance) HandleScalingEvent(desiredContainers int) error {
 	return err
 }
 
+func (i *AutoscaledInstance) CheckConcurrencyLimit() error {
+	if i.Scheduler == nil || i.StubConfig == nil || i.Workspace == nil {
+		return nil
+	}
+
+	gpuCount := i.StubConfig.Runtime.GpuCount
+	if i.StubConfig.RequiresGPU() && gpuCount == 0 {
+		gpuCount = 1
+	}
+
+	request := &types.ContainerRequest{
+		Cpu:         i.StubConfig.Runtime.Cpu,
+		GpuCount:    uint32(gpuCount),
+		WorkspaceId: i.Workspace.ExternalId,
+		Workspace:   *i.Workspace,
+	}
+	if i.Stub != nil {
+		request.StubId = i.Stub.ExternalId
+		request.Stub = *i.Stub
+	}
+
+	return i.Scheduler.CheckConcurrencyLimit(request)
+}
+
 // Sync updates any persistent state that can be changed on the instance.
 // If a stub has a deployment associated with it, we update the IsActive field.
 func (i *AutoscaledInstance) Sync() error {

--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -73,6 +73,10 @@ func (i *endpointInstance) startContainers(containersToRun int) error {
 	}
 
 	for c := 0; c < containersToRun; c++ {
+		if err := i.CheckConcurrencyLimit(); err != nil {
+			return err
+		}
+
 		containerId := i.genContainerId()
 
 		mounts, err := abstractions.ConfigureContainerRequestMounts(

--- a/pkg/abstractions/function/task.go
+++ b/pkg/abstractions/function/task.go
@@ -35,6 +35,30 @@ func (t *FunctionTask) Execute(ctx context.Context, options ...interface{}) erro
 
 	t.containerId = containerId
 
+	cpu := stubConfig.Runtime.Cpu
+	if cpu <= 0 {
+		cpu = defaultFunctionContainerCpu
+	}
+	gpuCount := stubConfig.Runtime.GpuCount
+	if stubConfig.RequiresGPU() && gpuCount == 0 {
+		gpuCount = 1
+	}
+	if t.fs.scheduler != nil {
+		if err := t.fs.scheduler.CheckConcurrencyLimit(&types.ContainerRequest{
+			Cpu:         cpu,
+			GpuCount:    uint32(gpuCount),
+			WorkspaceId: stub.Workspace.ExternalId,
+			Workspace:   stub.Workspace,
+			StubId:      stub.ExternalId,
+			Stub:        *stub,
+		}); err != nil {
+			if _, ok := err.(*types.ThrottledByConcurrencyLimitError); ok {
+				log.Info().Str("task_id", taskId).Str("reason", err.Error()).Msg("task rejected due to concurrency limit")
+			}
+			return err
+		}
+	}
+
 	var externalWorkspaceId *uint
 	if stubConfig.Pricing != nil && stub.Workspace.ExternalId != authInfo.Workspace.ExternalId {
 		abstractions.TrackTaskCount(stub, t.fs.usageMetricsRepo, t.msg.TaskId, authInfo.Workspace.ExternalId)

--- a/pkg/abstractions/pod/instance.go
+++ b/pkg/abstractions/pod/instance.go
@@ -56,6 +56,10 @@ func (i *podInstance) startContainers(containersToRun int) error {
 	}
 
 	for c := 0; c < containersToRun; c++ {
+		if err := i.CheckConcurrencyLimit(); err != nil {
+			return err
+		}
+
 		containerId := i.genContainerId()
 		mounts, err := abstractions.ConfigureContainerRequestMounts(
 			containerId,

--- a/pkg/abstractions/taskqueue/instance.go
+++ b/pkg/abstractions/taskqueue/instance.go
@@ -70,6 +70,10 @@ func (i *taskQueueInstance) startContainers(containersToRun int) error {
 	}
 
 	for c := 0; c < containersToRun; c++ {
+		if err := i.CheckConcurrencyLimit(); err != nil {
+			return err
+		}
+
 		containerId := i.genContainerId()
 
 		mounts, err := abstractions.ConfigureContainerRequestMounts(

--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -1,6 +1,7 @@
 package apiv1
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
@@ -24,6 +26,8 @@ type EventGroup struct {
 	containerRepo repository.ContainerRepository
 	eventRepo     repository.EventRepository
 }
+
+const containerEventsBatchReadConcurrency = 24
 
 type ContainerEventsBatchRequest struct {
 	ContainerIDs         []string                     `json:"container_ids"`
@@ -528,47 +532,7 @@ func (g *EventGroup) GetContainerEventsBatch(ctx echo.Context) error {
 	authInfo := authInfoFromContext(cc)
 	workspaceID = requestedEventWorkspaceID(ctx, authInfo)
 
-	items := make([]ContainerEventSummary, 0, len(targets))
-	for _, target := range targets {
-		if target.TaskID != "" {
-			task, err := g.backendRepo.GetTaskWithRelated(ctx.Request().Context(), target.TaskID)
-			if err != nil || task == nil || !hasWorkspaceTaskAccess(task, authInfo, workspaceID) || task.ContainerId == "" {
-				items = append(items, ContainerEventSummary{TaskID: target.TaskID, ContainerID: target.ContainerID, StubID: target.StubID, Error: "task not found"})
-				continue
-			}
-
-			events, err := g.loadContainerEvents(ctx, task.ContainerId, types.EventQuery{
-				Limit:       req.Limit,
-				WorkspaceID: task.Workspace.ExternalId,
-				StubID:      task.Stub.ExternalId,
-				TaskID:      task.ExternalId,
-				EventTypes:  eventQueryTypes(req.EventTypes),
-			})
-			if err != nil {
-				items = append(items, ContainerEventSummary{ContainerID: task.ContainerId, TaskID: target.TaskID, Error: err.Error()})
-				continue
-			}
-			summary := summarizeContainerEvents(events, req.TopLifecycle, req.IncludeEvents)
-			summary.TaskID = task.ExternalId
-			if summary.ContainerID == "" {
-				summary.ContainerID = task.ContainerId
-			}
-			items = append(items, summary)
-			continue
-		}
-
-		events, err := g.loadContainerEvents(ctx, target.ContainerID, types.EventQuery{
-			Limit:       req.Limit,
-			WorkspaceID: workspaceID,
-			StubID:      target.StubID,
-			EventTypes:  eventQueryTypes(req.EventTypes),
-		})
-		if err != nil {
-			items = append(items, ContainerEventSummary{ContainerID: target.ContainerID, StubID: target.StubID, Error: err.Error()})
-			continue
-		}
-		items = append(items, summarizeContainerEvents(events, req.TopLifecycle, req.IncludeEvents))
-	}
+	items := g.loadContainerEventsBatch(ctx.Request().Context(), authInfo, workspaceID, targets, req)
 
 	return ctx.JSON(http.StatusOK, summarizeContainerEventsBatch(
 		items,
@@ -576,6 +540,86 @@ func (g *EventGroup) GetContainerEventsBatch(ctx echo.Context) error {
 		requiredLifecycleIDs(req.RequiredLifecycleIDs),
 		requiredMetricKeys(req.RequiredMetrics),
 	))
+}
+
+func (g *EventGroup) loadContainerEventsBatch(
+	ctx context.Context,
+	authInfo *auth.AuthInfo,
+	workspaceID string,
+	targets []ContainerEventsBatchTarget,
+	req ContainerEventsBatchRequest,
+) []ContainerEventSummary {
+	items := make([]ContainerEventSummary, len(targets))
+	sem := make(chan struct{}, containerEventsBatchReadConcurrency)
+	var wg sync.WaitGroup
+
+	for i, target := range targets {
+		wg.Add(1)
+		go func(i int, target ContainerEventsBatchTarget) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				items[i] = ContainerEventSummary{
+					ContainerID: target.ContainerID,
+					TaskID:      target.TaskID,
+					StubID:      target.StubID,
+					Error:       ctx.Err().Error(),
+				}
+				return
+			}
+
+			items[i] = g.loadContainerEventsBatchTarget(ctx, authInfo, workspaceID, target, req)
+		}(i, target)
+	}
+
+	wg.Wait()
+	return items
+}
+
+func (g *EventGroup) loadContainerEventsBatchTarget(
+	ctx context.Context,
+	authInfo *auth.AuthInfo,
+	workspaceID string,
+	target ContainerEventsBatchTarget,
+	req ContainerEventsBatchRequest,
+) ContainerEventSummary {
+	if target.TaskID != "" {
+		task, err := g.backendRepo.GetTaskWithRelated(ctx, target.TaskID)
+		if err != nil || task == nil || !hasWorkspaceTaskAccess(task, authInfo, workspaceID) || task.ContainerId == "" {
+			return ContainerEventSummary{TaskID: target.TaskID, ContainerID: target.ContainerID, StubID: target.StubID, Error: "task not found"}
+		}
+
+		events, err := g.loadContainerEventsForAuth(ctx, authInfo, workspaceID, task.ContainerId, types.EventQuery{
+			Limit:       req.Limit,
+			WorkspaceID: task.Workspace.ExternalId,
+			StubID:      task.Stub.ExternalId,
+			TaskID:      task.ExternalId,
+			EventTypes:  eventQueryTypes(req.EventTypes),
+		})
+		if err != nil {
+			return ContainerEventSummary{ContainerID: task.ContainerId, TaskID: target.TaskID, Error: err.Error()}
+		}
+
+		summary := summarizeContainerEvents(events, req.TopLifecycle, req.IncludeEvents)
+		summary.TaskID = task.ExternalId
+		if summary.ContainerID == "" {
+			summary.ContainerID = task.ContainerId
+		}
+		return summary
+	}
+
+	events, err := g.loadContainerEventsForAuth(ctx, authInfo, workspaceID, target.ContainerID, types.EventQuery{
+		Limit:       req.Limit,
+		WorkspaceID: workspaceID,
+		StubID:      target.StubID,
+		EventTypes:  eventQueryTypes(req.EventTypes),
+	})
+	if err != nil {
+		return ContainerEventSummary{ContainerID: target.ContainerID, StubID: target.StubID, Error: err.Error()}
+	}
+	return summarizeContainerEvents(events, req.TopLifecycle, req.IncludeEvents)
 }
 
 func normalizeContainerEventsBatchTargets(req ContainerEventsBatchRequest) []ContainerEventsBatchTarget {
@@ -650,16 +694,26 @@ func (g *EventGroup) loadContainerEvents(ctx echo.Context, containerID string, q
 	cc, _ := ctx.(*auth.HttpAuthContext)
 	authInfo := authInfoFromContext(cc)
 	routeWorkspaceID := requestedEventWorkspaceID(ctx, authInfo)
+	return g.loadContainerEventsForAuth(ctx.Request().Context(), authInfo, routeWorkspaceID, containerID, query)
+}
+
+func (g *EventGroup) loadContainerEventsForAuth(
+	ctx context.Context,
+	authInfo *auth.AuthInfo,
+	routeWorkspaceID string,
+	containerID string,
+	query types.EventQuery,
+) (*types.ContainerEventsResponse, error) {
 	if g.eventRepo == nil {
 		return nil, HTTPInternalServerError("Event repository is unavailable")
 	}
 
-	query, state, err := g.authorizeContainerEventQuery(ctx, containerID, query)
+	query, state, err := g.authorizeContainerEventQueryForAuth(authInfo, routeWorkspaceID, containerID, query)
 	if err != nil {
 		return nil, err
 	}
 
-	events, err := g.eventRepo.GetContainerEvents(ctx.Request().Context(), containerID, query)
+	events, err := g.eventRepo.GetContainerEvents(ctx, containerID, query)
 	if err != nil {
 		if errors.Is(err, repository.ErrEventReadUnsupported) {
 			return nil, NewHTTPError(http.StatusServiceUnavailable, "Event reads are not configured")
@@ -695,7 +749,10 @@ func (g *EventGroup) authorizeContainerEventQuery(ctx echo.Context, containerID 
 	cc, _ := ctx.(*auth.HttpAuthContext)
 	authInfo := authInfoFromContext(cc)
 	routeWorkspaceID := requestedEventWorkspaceID(ctx, authInfo)
+	return g.authorizeContainerEventQueryForAuth(authInfo, routeWorkspaceID, containerID, query)
+}
 
+func (g *EventGroup) authorizeContainerEventQueryForAuth(authInfo *auth.AuthInfo, routeWorkspaceID string, containerID string, query types.EventQuery) (types.EventQuery, *types.ContainerState, error) {
 	state, stateErr := g.containerRepo.GetContainerState(containerID)
 	if stateErr == nil && state != nil {
 		if !eventWorkspaceAccessAllowed(authInfo, routeWorkspaceID, state.WorkspaceId) {

--- a/pkg/cache/discovery.go
+++ b/pkg/cache/discovery.go
@@ -167,7 +167,7 @@ func (d *DiscoveryClient) discoverHosts(ctx context.Context) ([]*Host, error) {
 	if unresolvedEndpointCandidates > 0 && verifiedEndpoints == 0 {
 		Logger.Warnf("cache host discovery found %d endpoint candidates across %d unresolved hosts for locality %s, but none verified reachable (last_error=%v)", unresolvedEndpointCandidates, unresolvedHosts, d.locality, lastVerifyErr)
 	} else if unresolvedCandidates > 0 && unresolvedEndpointCandidates == 0 {
-		Logger.Warnf("cache host discovery found %d unresolved logical hosts for locality %s, but none had an active endpoint", unresolvedHosts, d.locality)
+		Logger.Debugf("cache host discovery found %d unresolved logical hosts for locality %s, but none had an active endpoint", unresolvedHosts, d.locality)
 	}
 	return selectedHosts, nil
 }

--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -964,9 +964,6 @@ func (cs *Server) storeContentFromSource(ctx context.Context, req *proto.CacheSt
 
 	Logger.Debugf("StoreFromContent[OK] - [%s]", hash)
 
-	// HOTFIX: Manually trigger garbage collection
-	go runtime.GC()
-
 	return &proto.CacheStoreContentFromSourceResponse{Ok: true, Hash: hash}, nil
 }
 

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -39,6 +39,7 @@ type ReconciliationConfig struct {
 	RecentStubTTLSeconds  int   `key:"recentStubTTLSeconds" json:"recent_stub_ttl_seconds"`
 	LockTTLSeconds        int   `key:"lockTTLSeconds" json:"lock_ttl_seconds"`
 	MaxStubsPerCycle      int   `key:"maxStubsPerCycle" json:"max_stubs_per_cycle"`
+	MaxItemsPerCycle      int   `key:"maxItemsPerCycle" json:"max_items_per_cycle"`
 	VolumeMinBytes        int64 `key:"volumeMinBytes" json:"volume_min_bytes"`
 	OriginFallbackEnabled bool  `key:"originFallbackEnabled" json:"origin_fallback_enabled"`
 }

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -339,6 +339,7 @@ cache:
     recentStubTTLSeconds: 604800 # keep required content warm for 7 days after a stub's last container
     lockTTLSeconds: 300
     maxStubsPerCycle: 256
+    maxItemsPerCycle: 32
     volumeMinBytes: 134217728 # 128MiB; only large geesefs volume objects are reconciled
     originFallbackEnabled: false
 

--- a/pkg/gateway/services/compute/telemetry_credentials.go
+++ b/pkg/gateway/services/compute/telemetry_credentials.go
@@ -75,7 +75,6 @@ func (s *Service) issueTelemetryCredential(ctx context.Context, workspaceID, kin
 			Streams: &s2.ResourceSet{Prefix: s2.Ptr(streamPrefix)},
 			Ops: []string{
 				s2.OperationAppend,
-				s2.OperationCreateStream,
 			},
 		},
 	})

--- a/pkg/gateway/services/compute/telemetry_credentials_test.go
+++ b/pkg/gateway/services/compute/telemetry_credentials_test.go
@@ -61,7 +61,7 @@ func TestScopedTelemetryConfigUsesWorkspaceWriteOnlyPrefixes(t *testing.T) {
 		t.Fatalf("expected two issued tokens, got %d", len(issuer.args))
 	}
 
-	wantOps := []string{s2.OperationAppend, s2.OperationCreateStream}
+	wantOps := []string{s2.OperationAppend}
 	for _, args := range issuer.args {
 		if args.Scope.Basins == nil || args.Scope.Basins.Exact == nil || *args.Scope.Basins.Exact != "events-basin" {
 			t.Fatalf("unexpected basin scope: %#v", args.Scope.Basins)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -66,6 +66,7 @@ type ContainerRepository interface {
 	GetWorkerAddress(ctx context.Context, containerId string) (string, error)
 	SetContainerAddressMap(containerId string, addressMap map[int32]string) error
 	GetContainerAddressMap(containerId string) (map[int32]string, error)
+	CheckContainerConcurrencyLimit(quota *types.ConcurrencyLimit, request *types.ContainerRequest) error
 	SetContainerStateWithConcurrencyLimit(quota *types.ConcurrencyLimit, request *types.ContainerRequest) error
 	GetActiveContainersByStubId(stubId string) ([]types.ContainerState, error)
 	GetActiveContainersByWorkspaceId(workspaceId string) ([]types.ContainerState, error)

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -797,6 +797,49 @@ func (c *ContainerRedisRepository) SetContainerStateWithConcurrencyLimit(quota *
 	return nil
 }
 
+func (c *ContainerRedisRepository) CheckContainerConcurrencyLimit(quota *types.ConcurrencyLimit, request *types.ContainerRequest) error {
+	if quota == nil {
+		return nil
+	}
+
+	if err := c.ensureWorkspaceConcurrencyCounter(request.WorkspaceId); err != nil {
+		return err
+	}
+
+	reason, err := c.checkContainerConcurrencyLimit(quota, request)
+	if errors.Is(err, errConcurrencyCounterRepairing) {
+		if err := c.ensureWorkspaceConcurrencyCounter(request.WorkspaceId); err != nil {
+			return err
+		}
+		reason, err = c.checkContainerConcurrencyLimit(quota, request)
+	}
+	if err == nil {
+		return nil
+	}
+
+	var throttled *types.ThrottledByConcurrencyLimitError
+	if !errors.As(err, &throttled) {
+		return err
+	}
+
+	repaired, repairErr := c.repairWorkspaceConcurrencyCounterAfterThrottle(request.WorkspaceId)
+	if repairErr != nil {
+		return repairErr
+	}
+	if repaired {
+		reason, err = c.checkContainerConcurrencyLimit(quota, request)
+	}
+	if err != nil && reason != "" {
+		var finalThrottle *types.ThrottledByConcurrencyLimitError
+		if !errors.As(err, &finalThrottle) {
+			return err
+		}
+		metrics.RecordConcurrencyLimitThrottle(reason, request)
+	}
+
+	return err
+}
+
 func (c *ContainerRedisRepository) reserveContainerConcurrency(quota *types.ConcurrencyLimit, request *types.ContainerRequest) error {
 	if err := c.ensureWorkspaceConcurrencyCounter(request.WorkspaceId); err != nil {
 		return err
@@ -835,6 +878,47 @@ func (c *ContainerRedisRepository) reserveContainerConcurrency(quota *types.Conc
 	}
 
 	return err
+}
+
+func (c *ContainerRedisRepository) checkContainerConcurrencyLimit(quota *types.ConcurrencyLimit, request *types.ContainerRequest) (string, error) {
+	ctx := context.TODO()
+	usageKey := common.RedisKeys.WorkspaceConcurrencyLimitUsage(request.WorkspaceId)
+
+	initialized, err := c.rdb.HGet(ctx, usageKey, "initialized").Result()
+	if err != nil && err != redis.Nil {
+		return "", err
+	}
+	if err == redis.Nil || initialized != concurrencyCounterInitialized {
+		return "repairing", errConcurrencyCounterRepairing
+	}
+
+	usedGpuCount, err := c.workspaceConcurrencyUsageValue(ctx, usageKey, "gpu_count")
+	if err != nil {
+		return "", err
+	}
+
+	usedCpu, err := c.workspaceConcurrencyUsageValue(ctx, usageKey, "cpu")
+	if err != nil {
+		return "", err
+	}
+
+	if usedGpuCount+int64(request.GpuCount) > int64(quota.GPULimit) {
+		return "gpu", &types.ThrottledByConcurrencyLimitError{Reason: "gpu quota exceeded"}
+	}
+
+	if usedCpu+request.Cpu > int64(quota.CPUMillicoreLimit) {
+		return "cpu", &types.ThrottledByConcurrencyLimitError{Reason: "cpu quota exceeded"}
+	}
+
+	return "", nil
+}
+
+func (c *ContainerRedisRepository) workspaceConcurrencyUsageValue(ctx context.Context, usageKey, field string) (int64, error) {
+	value, err := c.rdb.HGet(ctx, usageKey, field).Int64()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	return value, err
 }
 
 func (c *ContainerRedisRepository) ensureWorkspaceConcurrencyCounter(workspaceId string) error {

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -142,6 +142,76 @@ func TestSetContainerStateWithConcurrencyLimitAllowsOnlyQuotaUnderParallelLoad(t
 	}
 }
 
+func TestCheckContainerConcurrencyLimitRejectsWithoutReservation(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	quota := &types.ConcurrencyLimit{GPULimit: 0, CPUMillicoreLimit: 100}
+	firstRequest := testContainerRequest("sandbox-test-stub-check-first", "test-workspace", 100)
+	secondRequest := testContainerRequest("sandbox-test-stub-check-second", "test-workspace", 1)
+
+	if err := repo.SetContainerStateWithConcurrencyLimit(quota, firstRequest); err != nil {
+		t.Fatal(err)
+	}
+
+	err = repo.CheckContainerConcurrencyLimit(quota, secondRequest)
+	var throttled *types.ThrottledByConcurrencyLimitError
+	if !errors.As(err, &throttled) {
+		t.Fatalf("expected preflight to throttle second request, got %v", err)
+	}
+
+	if _, err := repo.GetContainerState(secondRequest.ContainerId); err == nil {
+		t.Fatal("expected preflight not to create container state")
+	}
+
+	reservationExists, err := rdb.Exists(
+		context.Background(),
+		common.RedisKeys.WorkspaceConcurrencyLimitReservation(secondRequest.WorkspaceId, secondRequest.ContainerId),
+	).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reservationExists != 0 {
+		t.Fatal("expected preflight not to create a concurrency reservation")
+	}
+}
+
+func TestCheckContainerConcurrencyLimitDoesNotReserveCapacity(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	quota := &types.ConcurrencyLimit{GPULimit: 0, CPUMillicoreLimit: 100}
+	firstRequest := testContainerRequest("sandbox-test-stub-check-capacity-first", "test-workspace", 40)
+	secondRequest := testContainerRequest("sandbox-test-stub-check-capacity-second", "test-workspace", 60)
+
+	if err := repo.SetContainerStateWithConcurrencyLimit(quota, firstRequest); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.CheckContainerConcurrencyLimit(quota, secondRequest); err != nil {
+		t.Fatalf("expected preflight to allow second request, got %v", err)
+	}
+
+	usageKey := common.RedisKeys.WorkspaceConcurrencyLimitUsage(firstRequest.WorkspaceId)
+	usedCPU, err := rdb.HGet(context.Background(), usageKey, "cpu").Int64()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usedCPU != firstRequest.Cpu {
+		t.Fatalf("expected preflight not to reserve CPU, got %d", usedCPU)
+	}
+
+	if err := repo.SetContainerStateWithConcurrencyLimit(quota, secondRequest); err != nil {
+		t.Fatalf("expected authoritative reservation to admit second request, got %v", err)
+	}
+}
+
 func TestUpdateContainerStatusStoppingReleasesConcurrencyReservation(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	if err != nil {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -26,18 +26,22 @@ const (
 	// will page through. Required content is coalesced to a small number of events
 	// per stub, so this is far above realistic sizes; it exists only to guarantee
 	// the read terminates even if the stream is continuously appended.
-	maxStubCacheReadRecords = 200000
-	s2EventHistoryReadLimit = uint64(1000)
-	s2EventQueueSize        = 16384
-	s2EventBatchSize        = 256
-	s2EventWriteTimeout     = 5 * time.Second
-	s2EventEnqueueTimeout   = 250 * time.Millisecond
-	s2EventFlushInterval    = 100 * time.Millisecond
-	s2StreamResumeDelay     = time.Second
-	s2ScopedWriteWarnEvery  = time.Minute
+	maxStubCacheReadRecords   = 200000
+	s2EventHistoryReadLimit   = uint64(1000)
+	s2EventQueueSize          = 16384
+	s2EventBatchSize          = 256
+	s2EventWriteTimeout       = 5 * time.Second
+	s2EventEnqueueTimeout     = 250 * time.Millisecond
+	s2EventFlushInterval      = 100 * time.Millisecond
+	s2StreamResumeDelay       = time.Second
+	s2ScopedWriteWarnEvery    = time.Minute
+	s2EventAggregateScanLimit = 50000
 )
 
-var lastScopedS2WriteWarning atomic.Int64
+var (
+	lastS2WriteWarning       atomic.Int64
+	lastScopedS2WriteWarning atomic.Int64
+)
 
 type S2EventRepository struct {
 	basin              *s2.BasinClient
@@ -197,16 +201,24 @@ func (r *ScopedS2EventRepository) runWriter() {
 }
 
 func warnScopedS2WriteFailure(err error, eventCount int) {
+	warnS2WriteFailureWith(&lastScopedS2WriteWarning, err, eventCount, "failed to append scoped event batch to s2")
+}
+
+func warnS2WriteFailure(err error, eventCount int) {
+	warnS2WriteFailureWith(&lastS2WriteWarning, err, eventCount, "failed to append event batch to s2")
+}
+
+func warnS2WriteFailureWith(lastWarning *atomic.Int64, err error, eventCount int, message string) {
 	now := time.Now()
-	last := lastScopedS2WriteWarning.Load()
+	last := lastWarning.Load()
 	if last != 0 && now.Sub(time.Unix(0, last)) < s2ScopedWriteWarnEvery {
 		return
 	}
-	if !lastScopedS2WriteWarning.CompareAndSwap(last, now.UnixNano()) {
+	if !lastWarning.CompareAndSwap(last, now.UnixNano()) {
 		return
 	}
 
-	log.Warn().Err(err).Int("event_count", eventCount).Msg("failed to append scoped event batch to s2")
+	log.Warn().Err(err).Int("event_count", eventCount).Msg(message)
 }
 
 func (r *ScopedS2EventRepository) appendEventBatch(events []cloudevents.Event) error {
@@ -302,7 +314,7 @@ func (r *S2EventRepository) runWriter() {
 			return
 		}
 		if err := r.appendEventBatch(batch); err != nil {
-			log.Debug().Err(err).Int("event_count", len(batch)).Msg("failed to append event batch to s2")
+			warnS2WriteFailure(err, len(batch))
 		}
 		batch = batch[:0]
 	}
@@ -390,6 +402,7 @@ func (r *S2EventRepository) GetContainerEvents(ctx context.Context, containerID 
 	if limit == 0 {
 		limit = defaultS2EventReadLimit
 	}
+	query.ContainerID = containerID
 
 	streams, err := r.resolveContainerStreams(ctx, containerID, query)
 	if err != nil {
@@ -462,6 +475,7 @@ func (r *S2EventRepository) StreamContainerEvents(ctx context.Context, container
 		return nil, fmt.Errorf("workspace id and stub id are required to stream container events")
 	}
 
+	query.ContainerID = containerID
 	streamName := r.containerStreamName(query.WorkspaceID, query.StubID, containerID)
 	return r.streamEvents(ctx, streamName, containerID, query)
 }
@@ -480,8 +494,7 @@ func (r *S2EventRepository) StreamTaskEvents(ctx context.Context, query types.Ev
 		return nil, fmt.Errorf("task id is required to stream task events")
 	}
 
-	streamName := r.taskStreamName(query.TaskID)
-	return r.streamEvents(ctx, streamName, "", query)
+	return r.streamEvents(ctx, r.taskStreamName(query.TaskID), "", query)
 }
 
 func (r *S2EventRepository) StreamWorkspaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
@@ -578,25 +591,64 @@ func allComputeEventTypes(eventTypes []string) bool {
 }
 
 func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName s2.StreamName, limit uint64, query types.EventQuery, response *types.ContainerEventsResponse) error {
-	seqNum := uint64(0)
-	batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
-		SeqNum: &seqNum,
-		Count:  &limit,
-	})
+	response.Streams = append(response.Streams, string(streamName))
+
+	tail, err := r.basin.Stream(streamName).CheckTail(ctx)
 	if err != nil {
 		if isS2ReadEmpty(err) {
 			return nil
 		}
-		return fmt.Errorf("read container events from s2 stream %q: %w", streamName, err)
+		return fmt.Errorf("check tail for container events s2 stream %q: %w", streamName, err)
+	}
+	if tail.Tail.SeqNum == 0 {
+		return nil
 	}
 
-	response.Streams = append(response.Streams, string(streamName))
-	for _, record := range batch.Records {
-		eventRecord, ok := containerEventRecordFromS2(record, query, response)
-		if !ok {
-			continue
+	chunkSize := uint64(s2EventHistoryReadLimit)
+	if chunkSize == 0 {
+		chunkSize = 1000
+	}
+	scanLimit := uint64(s2EventAggregateScanLimit)
+	if limit > scanLimit {
+		scanLimit = limit
+	}
+
+	var recordsScanned uint64
+	var scannedFromTail uint64
+	for scannedFromTail < tail.Tail.SeqNum && recordsScanned < scanLimit && uint64(len(response.Events)) < limit {
+		tailOffset := scannedFromTail + chunkSize
+		if tailOffset > tail.Tail.SeqNum {
+			tailOffset = tail.Tail.SeqNum
 		}
-		response.Events = append(response.Events, eventRecord)
+		tailOffsetValue := int64(tailOffset)
+		count := chunkSize
+		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
+			TailOffset: &tailOffsetValue,
+			Count:      &count,
+		})
+		if err != nil {
+			if isS2ReadEmpty(err) {
+				return nil
+			}
+			return fmt.Errorf("read container events from s2 stream %q: %w", streamName, err)
+		}
+		if len(batch.Records) == 0 {
+			return nil
+		}
+		recordsScanned += uint64(len(batch.Records))
+		scannedFromTail = tailOffset
+
+		for i := len(batch.Records) - 1; i >= 0; i-- {
+			eventRecord, ok := containerEventRecordFromS2(batch.Records[i], query, response)
+			if !ok || !eventRecordMatchesQuery(eventRecord, query) {
+				continue
+			}
+			augmentContainerEventResponse(response, &eventRecord)
+			response.Events = append(response.Events, eventRecord)
+			if uint64(len(response.Events)) >= limit {
+				break
+			}
+		}
 	}
 	return nil
 }
@@ -697,7 +749,7 @@ func (s *s2EventStream) Next() bool {
 			record := s.session.Record()
 			s.setNextSeqNum(record.SeqNum + 1)
 			eventRecord, ok := containerEventRecordFromS2(record, s.query, s.response)
-			if !ok {
+			if !ok || !eventRecordMatchesQuery(eventRecord, s.query) {
 				continue
 			}
 			s.current = eventRecord
@@ -847,7 +899,6 @@ func containerEventRecordFromS2(record s2.SequencedRecord, query types.EventQuer
 	if !eventQueryAllowsType(query, eventRecord.Type) {
 		return types.ContainerEventRecord{}, false
 	}
-	augmentContainerEventResponse(response, &eventRecord)
 	if eventRecord.ContainerID == "" {
 		eventRecord.ContainerID = envelope.ContainerID
 	}
@@ -1166,7 +1217,7 @@ func (r *S2EventRepository) containerAliasStreamName(workspaceID, containerID st
 }
 
 func (r *S2EventRepository) taskStreamName(taskID string) s2.StreamName {
-	return s2.StreamName(fmt.Sprintf("%s/tasks/%s", r.streamPrefix, taskID))
+	return s2.StreamName(fmt.Sprintf("%s/tasks/%s", r.streamPrefix, eventStreamPart(taskID)))
 }
 
 func (r *S2EventRepository) workerStreamName(workerID string) s2.StreamName {

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -20,6 +20,7 @@ const (
 	defaultS2LogReadLimit = 100
 	maxS2LogReadLimit     = 1000
 	s2MetricsReadLimit    = 1000
+	s2LogPageScanLimit    = 50000
 )
 
 func (r *S2EventRepository) GetLogs(ctx context.Context, query types.LogQuery) (*types.LogsResponse, error) {
@@ -240,30 +241,71 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 		return total, []types.LogRecord{}, nil
 	}
 
-	tailOffset := int64((query.Page + 1) * limit)
-	if tailOffset > int64(tail.Tail.SeqNum) {
-		tailOffset = int64(tail.Tail.SeqNum)
+	targetMatches := int((query.Page + 1) * limit)
+	skipMatches := int(query.Page * limit)
+	chunkSize := limit
+	if chunkSize < defaultS2LogReadLimit {
+		chunkSize = defaultS2LogReadLimit
 	}
-	batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
-		TailOffset: &tailOffset,
-		Count:      &limit,
-	})
-	if err != nil {
-		if isS2ReadEmpty(err) {
-			return total, []types.LogRecord{}, nil
-		}
-		return 0, nil, fmt.Errorf("read logs from s2 stream %q: %w", streamName, err)
+	if chunkSize > maxS2LogReadLimit {
+		chunkSize = maxS2LogReadLimit
 	}
 
-	logs := make([]types.LogRecord, 0, len(batch.Records))
-	for _, record := range batch.Records {
-		logRecord, ok := logRecordFromS2(record)
-		if !ok || !logRecordMatchesQuery(logRecord, query) {
-			continue
+	matchesNewestFirst := make([]types.LogRecord, 0, targetMatches)
+	recordsScanned := uint64(0)
+	exhausted := false
+	for tailOffset := int64(chunkSize); tailOffset <= int64(tail.Tail.SeqNum) && recordsScanned < s2LogPageScanLimit; tailOffset += int64(chunkSize) {
+		if tailOffset > int64(tail.Tail.SeqNum) {
+			tailOffset = int64(tail.Tail.SeqNum)
 		}
-		logs = append(logs, logRecord)
+		count := chunkSize
+		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
+			TailOffset: &tailOffset,
+			Count:      &count,
+		})
+		if err != nil {
+			if isS2ReadEmpty(err) {
+				break
+			}
+			return 0, nil, fmt.Errorf("read logs from s2 stream %q: %w", streamName, err)
+		}
+		if len(batch.Records) == 0 {
+			break
+		}
+		recordsScanned += uint64(len(batch.Records))
+
+		for i := len(batch.Records) - 1; i >= 0; i-- {
+			logRecord, ok := logRecordFromS2(batch.Records[i])
+			if !ok || !logRecordMatchesQuery(logRecord, query) {
+				continue
+			}
+			matchesNewestFirst = append(matchesNewestFirst, logRecord)
+			if len(matchesNewestFirst) >= targetMatches {
+				break
+			}
+		}
+		exhausted = uint64(len(batch.Records)) < chunkSize || tailOffset == int64(tail.Tail.SeqNum)
+		if len(matchesNewestFirst) >= targetMatches || exhausted {
+			break
+		}
 	}
-	return total, logs, nil
+
+	if skipMatches >= len(matchesNewestFirst) {
+		return len(matchesNewestFirst), []types.LogRecord{}, nil
+	}
+	end := targetMatches
+	if end > len(matchesNewestFirst) {
+		end = len(matchesNewestFirst)
+	}
+	logs := append([]types.LogRecord(nil), matchesNewestFirst[skipMatches:end]...)
+	for i, j := 0, len(logs)-1; i < j; i, j = i+1, j-1 {
+		logs[i], logs[j] = logs[j], logs[i]
+	}
+	filteredTotal := len(matchesNewestFirst)
+	if !exhausted && len(matchesNewestFirst) >= targetMatches {
+		filteredTotal = targetMatches + 1
+	}
+	return filteredTotal, logs, nil
 }
 
 func logRecordFromS2(record s2.SequencedRecord) (types.LogRecord, bool) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -288,6 +288,15 @@ func (s *Scheduler) getConcurrencyLimit(request *types.ContainerRequest) (*types
 	return quota, nil
 }
 
+func (s *Scheduler) CheckConcurrencyLimit(request *types.ContainerRequest) error {
+	quota, err := s.getConcurrencyLimit(request)
+	if err != nil {
+		return err
+	}
+
+	return s.containerRepo.CheckContainerConcurrencyLimit(quota, request)
+}
+
 func (s *Scheduler) Stop(stopArgs *types.StopContainerArgs) error {
 	log.Info().Interface("stop_args", stopArgs).Msg("received stop request")
 	reason := types.NormalizeEventReason(string(stopArgs.Reason))

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -58,7 +58,9 @@ const (
 	cacheDefaultReconcileRecentStubTTLS = cache.DefaultReconcileRecentStubTTLS
 	cacheDefaultReconcileLockTTLS       = 300
 	cacheDefaultReconcileMaxStubsCycle  = 256
+	cacheDefaultReconcileMaxItemsCycle  = 32
 	cacheDefaultVolumeReportMinBytes    = 128 * 1024 * 1024
+	cacheReconcileSuccessBackoff        = time.Hour
 )
 
 type WorkerCacheManager struct {
@@ -84,6 +86,8 @@ type WorkerCacheManager struct {
 	originCredsCache      map[string]*originCredentials
 	reconcileFailuresMu   sync.Mutex
 	reconcileFailures     map[string]time.Time
+	reconcileSuccessesMu  sync.Mutex
+	reconcileSuccesses    map[string]time.Time
 	reconcileNow          chan struct{}
 	client                *cache.Client
 	server                *cache.Server
@@ -121,6 +125,7 @@ func NewWorkerCacheManager(ctx context.Context, config types.AppConfig, poolConf
 		accelerator:        cacheAccelerator(poolConfig),
 		originCredsCache:   make(map[string]*originCredentials),
 		reconcileFailures:  make(map[string]time.Time),
+		reconcileSuccesses: make(map[string]time.Time),
 		reconcileNow:       make(chan struct{}, 1),
 	}
 }

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -89,6 +89,14 @@ func (m *WorkerCacheManager) reconcileLockTTLSeconds() int {
 	return seconds
 }
 
+func (m *WorkerCacheManager) reconcileMaxItemsPerCycle() int {
+	items := m.config.Cache.Reconciliation.MaxItemsPerCycle
+	if items <= 0 {
+		items = cacheDefaultReconcileMaxItemsCycle
+	}
+	return items
+}
+
 // cacheContentReporter coalesces required-content reports per (stub, kind) and
 // flushes them to S2 as bounded events, while keeping a fast-moving recent-stub
 // index in Redis. It is created only when reconciliation is enabled; when nil,
@@ -424,6 +432,7 @@ func (m *WorkerCacheManager) reconcileOnce() {
 	}
 
 	m.pruneReconcileFailures()
+	m.pruneReconcileSuccesses()
 
 	maxStubs := m.config.Cache.Reconciliation.MaxStubsPerCycle
 	if maxStubs <= 0 {
@@ -439,23 +448,27 @@ func (m *WorkerCacheManager) reconcileOnce() {
 	}
 
 	activeCheckpointIDs := map[string]struct{}{}
+	budget := newReconcileBudget(m.reconcileMaxItemsPerCycle())
 	for _, stub := range stubs {
 		select {
 		case <-m.ctx.Done():
 			return
 		default:
 		}
-		for _, checkpointID := range m.reconcileStub(server, localHostID, stub) {
+		for _, checkpointID := range m.reconcileStub(server, localHostID, stub, budget) {
 			activeCheckpointIDs[checkpointID] = struct{}{}
 		}
+		if budget.exhausted() {
+			break
+		}
 	}
-	if len(stubs) < maxStubs {
+	if len(stubs) < maxStubs && !budget.exhausted() {
 		m.pruneLocalCheckpoints(activeCheckpointIDs)
 		m.pruneStaleCacheCheckpoints()
 	}
 }
 
-func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID string, stub cache.RecentStub) []string {
+func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID string, stub cache.RecentStub, budget *reconcileBudget) []string {
 	items, err := m.eventRepo.ReadStubCacheRequiredContent(m.ctx, stub.WorkspaceID, stub.StubID)
 	if err != nil {
 		log.Debug().Err(err).Str("workspace_id", stub.WorkspaceID).Str("stub_id", stub.StubID).Msg("cache reconciliation failed to read required content")
@@ -493,6 +506,9 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 		if m.requiredContentComplete(server, item, routingKey) {
 			continue
 		}
+		if m.reconcileRecentlySucceeded(item.Hash, routingKey) {
+			continue
+		}
 
 		// Back off items that recently failed to materialize (e.g. an
 		// unresolvable origin source) so they are not retried and re-logged
@@ -500,10 +516,39 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 		if m.reconcileBackingOff(item.Hash, routingKey, stub.LastSeen) {
 			continue
 		}
+		if !budget.take() {
+			return checkpointIDs
+		}
 
 		m.materializeOwnedItem(server, localHostID, stub, item, routingKey)
 	}
 	return checkpointIDs
+}
+
+type reconcileBudget struct {
+	remaining int
+	limited   bool
+	empty     bool
+}
+
+func newReconcileBudget(limit int) *reconcileBudget {
+	return &reconcileBudget{remaining: limit, limited: limit > 0}
+}
+
+func (b *reconcileBudget) take() bool {
+	if b == nil || !b.limited {
+		return true
+	}
+	if b.remaining <= 0 {
+		b.empty = true
+		return false
+	}
+	b.remaining--
+	return true
+}
+
+func (b *reconcileBudget) exhausted() bool {
+	return b != nil && b.empty
 }
 
 func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHostID string, stub cache.RecentStub, item types.CacheRequiredContentItem, routingKey string) {
@@ -539,6 +584,7 @@ func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHos
 	switch {
 	case status == types.CacheAuditStatusMaterialized:
 		m.clearReconcileFailure(item.Hash, routingKey)
+		m.recordReconcileSuccess(item.Hash, routingKey)
 		m.reconcileLogFields(log.Info(), localHostID, stub, item).
 			Str("status", status).Dur("duration", elapsed).
 			Msg("cache content reconciled")
@@ -577,7 +623,7 @@ func reconcileStatusIsFailure(status string) bool {
 // should be skipped until the backoff window elapses. Expired entries are pruned
 // so the map only tracks currently-failing items.
 func (m *WorkerCacheManager) reconcileBackingOff(hash, routingKey string, stubLastSeen time.Time) bool {
-	key := hash + "\x00" + routingKey
+	key := reconcileItemKey(hash, routingKey)
 	m.reconcileFailuresMu.Lock()
 	defer m.reconcileFailuresMu.Unlock()
 
@@ -610,17 +656,60 @@ func reconcileStubSeenAfterFailure(stubLastSeen, failedAt time.Time) bool {
 }
 
 func (m *WorkerCacheManager) recordReconcileFailure(hash, routingKey string) {
-	key := hash + "\x00" + routingKey
+	key := reconcileItemKey(hash, routingKey)
 	m.reconcileFailuresMu.Lock()
+	if m.reconcileFailures == nil {
+		m.reconcileFailures = make(map[string]time.Time)
+	}
 	m.reconcileFailures[key] = time.Now()
 	m.reconcileFailuresMu.Unlock()
 }
 
 func (m *WorkerCacheManager) clearReconcileFailure(hash, routingKey string) {
-	key := hash + "\x00" + routingKey
+	key := reconcileItemKey(hash, routingKey)
 	m.reconcileFailuresMu.Lock()
 	delete(m.reconcileFailures, key)
 	m.reconcileFailuresMu.Unlock()
+}
+
+func (m *WorkerCacheManager) reconcileRecentlySucceeded(hash, routingKey string) bool {
+	key := reconcileItemKey(hash, routingKey)
+	m.reconcileSuccessesMu.Lock()
+	defer m.reconcileSuccessesMu.Unlock()
+
+	succeededAt, ok := m.reconcileSuccesses[key]
+	if !ok {
+		return false
+	}
+	if time.Since(succeededAt) < cacheReconcileSuccessBackoff {
+		return true
+	}
+	delete(m.reconcileSuccesses, key)
+	return false
+}
+
+func (m *WorkerCacheManager) recordReconcileSuccess(hash, routingKey string) {
+	key := reconcileItemKey(hash, routingKey)
+	m.reconcileSuccessesMu.Lock()
+	if m.reconcileSuccesses == nil {
+		m.reconcileSuccesses = make(map[string]time.Time)
+	}
+	m.reconcileSuccesses[key] = time.Now()
+	m.reconcileSuccessesMu.Unlock()
+}
+
+func (m *WorkerCacheManager) pruneReconcileSuccesses() {
+	m.reconcileSuccessesMu.Lock()
+	defer m.reconcileSuccessesMu.Unlock()
+	for key, succeededAt := range m.reconcileSuccesses {
+		if time.Since(succeededAt) >= cacheReconcileSuccessBackoff {
+			delete(m.reconcileSuccesses, key)
+		}
+	}
+}
+
+func reconcileItemKey(hash, routingKey string) string {
+	return hash + "\x00" + routingKey
 }
 
 // pruneReconcileFailures drops expired backoff entries so the map stays bounded

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -280,6 +280,30 @@ func TestReconcileBackoffIsBypassedBySecondPrecisionStubSighting(t *testing.T) {
 	require.Empty(t, manager.reconcileFailures)
 }
 
+func TestReconcileSuccessBackoffSkipsRecentMaterialization(t *testing.T) {
+	manager := &WorkerCacheManager{}
+
+	manager.recordReconcileSuccess("hash", "route")
+	require.True(t, manager.reconcileRecentlySucceeded("hash", "route"))
+
+	manager.reconcileSuccesses[reconcileItemKey("hash", "route")] = time.Now().Add(-cacheReconcileSuccessBackoff - time.Second)
+	require.False(t, manager.reconcileRecentlySucceeded("hash", "route"))
+	require.Empty(t, manager.reconcileSuccesses)
+}
+
+func TestReconcileBudgetCapsMaterializationAttempts(t *testing.T) {
+	budget := newReconcileBudget(1)
+
+	require.True(t, budget.take())
+	require.False(t, budget.exhausted())
+	require.False(t, budget.take())
+	require.True(t, budget.exhausted())
+
+	var unlimited *reconcileBudget
+	require.True(t, unlimited.take())
+	require.False(t, unlimited.exhausted())
+}
+
 func TestReconcileOnceUsesOnlyCurrentLocalityRecentStubs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -327,6 +351,64 @@ func TestReconcileOnceUsesOnlyCurrentLocalityRecentStubs(t *testing.T) {
 
 	require.Equal(t, []string{"locality-b"}, metadata.listed)
 	require.Equal(t, []string{"workspace-b|stub-b"}, fake.readKeys)
+}
+
+func TestReconcileStubSkipsRecentlyMaterializedMissingContent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := testCacheManagerConfig(t.TempDir()).Cache
+	cfg.Client.NTopHosts = 1
+
+	localServer, err := cache.NewServerWithOptions(ctx, cfg, "test", cache.WithServerMetadataStore(cache.NewMockCacheMetadataStore()), cache.WithServerHostID("local-host"))
+	require.NoError(t, err)
+	localAddr, err := localServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, localServer.Close()) })
+
+	localHost := localServer.Host()
+	require.NotNil(t, localHost)
+	localHost.Addr = localAddr
+	localHost.PrivateAddr = localAddr
+
+	clientCfg := cfg
+	clientCfg.Server.DiskCacheDir = t.TempDir()
+	client, err := cache.NewClientWithHostDirectory(ctx, clientCfg, cache.NewMockCacheMetadataStore(), testHostDirectoryFunc(func(context.Context, string) ([]*cache.Host, error) {
+		return []*cache.Host{localHost}, nil
+	}), "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Cleanup()) })
+
+	routingKey := "route"
+	require.Eventually(t, func() bool {
+		primary, err := client.PrimaryReadHost(routingKey)
+		return err == nil && primary != nil && primary.HostId == localHost.HostId
+	}, 3*time.Second, 20*time.Millisecond)
+
+	hash := strings.Repeat("a", 64)
+	fake := &fakeEventRepo{items: []types.CacheRequiredContentItem{{
+		Kind:       types.CacheContentKindClipV1,
+		Hash:       hash,
+		RoutingKey: routingKey,
+		SizeBytes:  1,
+		Source:     "image.clip",
+	}}}
+	manager := &WorkerCacheManager{
+		ctx:                ctx,
+		locality:           "test",
+		metadataStore:      cache.NewMockCacheMetadataStore(),
+		eventRepo:          fake,
+		client:             client,
+		checkpointRoot:     t.TempDir(),
+		reconcileFailures:  make(map[string]time.Time),
+		reconcileSuccesses: map[string]time.Time{reconcileItemKey(hash, routingKey): time.Now()},
+	}
+
+	checkpointIDs := manager.reconcileStub(localServer, localHost.HostId, cache.RecentStub{WorkspaceID: "workspace", StubID: "stub"}, nil)
+
+	require.Empty(t, checkpointIDs)
+	require.Empty(t, fake.cacheEvents)
+	require.False(t, localServer.HasCompleteContent(hash, 1))
 }
 
 // The gateway no longer vends S3 archive credentials; private-pool workers
@@ -500,7 +582,7 @@ func TestReconcileStubFansOutCheckpointsAcrossMatchingHosts(t *testing.T) {
 		reconcileFailures: make(map[string]time.Time),
 	}
 
-	checkpointIDs := manager.reconcileStub(localServer, localHost.HostId, cache.RecentStub{WorkspaceID: "workspace", StubID: "stub"})
+	checkpointIDs := manager.reconcileStub(localServer, localHost.HostId, cache.RecentStub{WorkspaceID: "workspace", StubID: "stub"}, nil)
 
 	require.Equal(t, []string{"checkpoint-a"}, checkpointIDs)
 	require.Len(t, fake.cacheEvents, 1)
@@ -513,7 +595,7 @@ func TestReconcileStubFansOutCheckpointsAcrossMatchingHosts(t *testing.T) {
 	fake.items[0].Accelerator = "T4"
 	fake.mu.Unlock()
 
-	checkpointIDs = manager.reconcileStub(localServer, localHost.HostId, cache.RecentStub{WorkspaceID: "workspace", StubID: "stub"})
+	checkpointIDs = manager.reconcileStub(localServer, localHost.HostId, cache.RecentStub{WorkspaceID: "workspace", StubID: "stub"}, nil)
 	require.Empty(t, checkpointIDs)
 	require.Empty(t, fake.cacheEvents)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops reconciler CPU spikes by capping work per cycle and tightening event/log reads, and adds preflight concurrency checks to prevent overscheduling. This reduces unnecessary retries and heavy scans while keeping container launches within CPU/GPU quotas.

- **Bug Fixes**
  - Cap reconciliation work per cycle via `maxItemsPerCycle` (default 32) and add a 1h success backoff to skip recently materialized items.
  - Bound container event and log reads by scanning from `s2` tail with limits, reducing large forward scans.
  - Lower noisy discovery logs and remove forced `runtime.GC()`.

- **New Features**
  - Add `CheckConcurrencyLimit` preflight in the scheduler/Redis repo and call it before starting endpoint/pod/task-queue containers and function tasks; rejects when CPU/GPU quotas would be exceeded without reserving capacity.
  - Speed up the batch events API with bounded-concurrency reads per target.

<sup>Written for commit 38aa369a581d610eb898567f64c35fb73a15b1fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

