### PR TITLE
more log fixes

### DIFF
--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -616,12 +616,8 @@ func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName 
 	var recordsScanned uint64
 	var scannedFromTail uint64
 	for scannedFromTail < tail.Tail.SeqNum && recordsScanned < scanLimit && uint64(len(response.Events)) < limit {
-		tailOffset := scannedFromTail + chunkSize
-		if tailOffset > tail.Tail.SeqNum {
-			tailOffset = tail.Tail.SeqNum
-		}
+		tailOffset, count := nextTailReadWindow(scannedFromTail, tail.Tail.SeqNum, chunkSize)
 		tailOffsetValue := int64(tailOffset)
-		count := chunkSize
 		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
 			TailOffset: &tailOffsetValue,
 			Count:      &count,
@@ -712,6 +708,7 @@ func (r *S2EventRepository) readEventHistoryStream(ctx context.Context, streamNa
 			if !ok || !eventRecordMatchesQuery(eventRecord, query) {
 				continue
 			}
+			augmentContainerEventResponse(&types.ContainerEventsResponse{}, &eventRecord)
 			response.Events = append(response.Events, eventRecord)
 			if uint64(len(response.Events)) >= limit {
 				break
@@ -752,6 +749,7 @@ func (s *s2EventStream) Next() bool {
 			if !ok || !eventRecordMatchesQuery(eventRecord, s.query) {
 				continue
 			}
+			augmentContainerEventResponse(s.response, &eventRecord)
 			s.current = eventRecord
 			return true
 		}

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -253,14 +253,13 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 
 	matchesNewestFirst := make([]types.LogRecord, 0, targetMatches)
 	recordsScanned := uint64(0)
+	scannedFromTail := uint64(0)
 	exhausted := false
-	for tailOffset := int64(chunkSize); tailOffset <= int64(tail.Tail.SeqNum) && recordsScanned < s2LogPageScanLimit; tailOffset += int64(chunkSize) {
-		if tailOffset > int64(tail.Tail.SeqNum) {
-			tailOffset = int64(tail.Tail.SeqNum)
-		}
-		count := chunkSize
+	for scannedFromTail < tail.Tail.SeqNum && recordsScanned < s2LogPageScanLimit {
+		tailOffset, count := nextTailReadWindow(scannedFromTail, tail.Tail.SeqNum, chunkSize)
+		tailOffsetValue := int64(tailOffset)
 		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
-			TailOffset: &tailOffset,
+			TailOffset: &tailOffsetValue,
 			Count:      &count,
 		})
 		if err != nil {
@@ -273,6 +272,7 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 			break
 		}
 		recordsScanned += uint64(len(batch.Records))
+		scannedFromTail = tailOffset
 
 		for i := len(batch.Records) - 1; i >= 0; i-- {
 			logRecord, ok := logRecordFromS2(batch.Records[i])
@@ -284,7 +284,7 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 				break
 			}
 		}
-		exhausted = uint64(len(batch.Records)) < chunkSize || tailOffset == int64(tail.Tail.SeqNum)
+		exhausted = uint64(len(batch.Records)) < count || scannedFromTail == tail.Tail.SeqNum
 		if len(matchesNewestFirst) >= targetMatches || exhausted {
 			break
 		}
@@ -306,6 +306,18 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 		filteredTotal = targetMatches + 1
 	}
 	return filteredTotal, logs, nil
+}
+
+// nextTailReadWindow returns the next tail offset and record count for scanning
+// a stream backwards from the tail in chunkSize windows. The count is clamped to
+// the unscanned remainder so the final (oldest) window does not re-read records
+// that earlier windows already covered.
+func nextTailReadWindow(scannedFromTail, tailSeqNum, chunkSize uint64) (uint64, uint64) {
+	tailOffset := tailSeqNum
+	if chunkSize != 0 && scannedFromTail+chunkSize < tailSeqNum {
+		tailOffset = scannedFromTail + chunkSize
+	}
+	return tailOffset, tailOffset - scannedFromTail
 }
 
 func logRecordFromS2(record s2.SequencedRecord) (types.LogRecord, bool) {
@@ -339,19 +351,26 @@ func logRecordFromS2(record s2.SequencedRecord) (types.LogRecord, bool) {
 	if eventRecord.Type != types.EventContainerLog {
 		return types.LogRecord{}, false
 	}
+	var entry types.EventContainerLogSchema
+	if err := json.Unmarshal(eventRecord.Data, &entry); err != nil || entry.Line == "" {
+		return types.LogRecord{}, false
+	}
+	if !entry.Timestamp.IsZero() {
+		timestamp = entry.Timestamp
+	}
 	return types.LogRecord{
 		SeqNum:      eventRecord.SeqNum,
 		StoredAtNs:  eventRecord.StoredAtNs,
 		Timestamp:   timestamp,
-		Message:     eventRecord.Line,
-		Stream:      eventRecord.Stream,
-		ContainerID: eventRecord.ContainerID,
-		StubID:      eventRecord.StubID,
-		StubType:    eventRecord.StubType,
-		TaskID:      eventRecord.TaskID,
-		WorkspaceID: eventRecord.WorkspaceID,
-		AppID:       eventRecord.AppID,
-		WorkerID:    eventRecord.WorkerID,
+		Message:     entry.Line,
+		Stream:      entry.Stream,
+		ContainerID: firstNonEmpty(entry.ContainerID, eventRecord.ContainerID),
+		StubID:      firstNonEmpty(entry.StubID, eventRecord.StubID),
+		StubType:    entry.StubType,
+		TaskID:      firstNonEmpty(entry.TaskID, eventRecord.TaskID),
+		WorkspaceID: firstNonEmpty(entry.WorkspaceID, eventRecord.WorkspaceID),
+		AppID:       firstNonEmpty(entry.AppID, eventRecord.AppID),
+		WorkerID:    firstNonEmpty(entry.WorkerID, eventRecord.WorkerID),
 	}, true
 }
 

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -463,6 +463,24 @@ func TestResolveLogStreamsUsesAliasForUnscopedContainerIDWithoutPrefixList(t *te
 	}
 }
 
+func TestNextTailReadWindow(t *testing.T) {
+	// Streams shorter than the chunk size must still be read in full.
+	if offset, count := nextTailReadWindow(0, 2, 100); offset != 2 || count != 2 {
+		t.Fatalf("unexpected short stream window: got offset=%d count=%d want offset=2 count=2", offset, count)
+	}
+	if offset, count := nextTailReadWindow(0, 250, 100); offset != 100 || count != 100 {
+		t.Fatalf("unexpected first window: got offset=%d count=%d want offset=100 count=100", offset, count)
+	}
+	// The final (oldest) window must clamp count so already scanned records
+	// are not re-read and returned as duplicates.
+	if offset, count := nextTailReadWindow(200, 250, 100); offset != 250 || count != 50 {
+		t.Fatalf("unexpected final window: got offset=%d count=%d want offset=250 count=50", offset, count)
+	}
+	if offset, count := nextTailReadWindow(0, 250, 0); offset != 250 || count != 250 {
+		t.Fatalf("unexpected zero chunk window: got offset=%d count=%d want offset=250 count=250", offset, count)
+	}
+}
+
 func TestS2ContainerLogRecordUsesLogTimestamp(t *testing.T) {
 	logAt := time.Date(2026, 5, 28, 12, 30, 0, 123000000, time.UTC)
 	eventRepo := &EventClientRepo{}
@@ -491,6 +509,55 @@ func TestS2ContainerLogRecordUsesLogTimestamp(t *testing.T) {
 	}
 	if got, want := *record.Timestamp, uint64(logAt.UnixMilli()); got != want {
 		t.Fatalf("unexpected s2 timestamp: got %d want %d", got, want)
+	}
+}
+
+func TestLogRecordFromS2ExtractsLineFromEventData(t *testing.T) {
+	logAt := time.Date(2026, 6, 12, 21, 38, 7, 0, time.UTC)
+	eventRepo := &EventClientRepo{}
+	event, err := eventRepo.createEventObject(types.EventContainerLog, types.EventContainerLogSchemaVersion, types.EventContainerLogSchema{
+		Timestamp:   logAt,
+		ContainerID: "container-789",
+		StubID:      "stub-456",
+		StubType:    "asgi",
+		TaskID:      "task-123",
+		WorkspaceID: "workspace-123",
+		AppID:       "app-123",
+		WorkerID:    "worker-1",
+		Stream:      "stdout",
+		Line:        "Starting gunicorn 22.0.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logRecord, ok := logRecordFromS2(s2.SequencedRecord{SeqNum: 7, Timestamp: uint64(logAt.UnixMilli()), Body: body})
+	if !ok {
+		t.Fatal("expected container log record to be accepted")
+	}
+	if got, want := logRecord.Message, "Starting gunicorn 22.0.0"; got != want {
+		t.Fatalf("unexpected log message: got %q want %q", got, want)
+	}
+	if got, want := logRecord.Stream, "stdout"; got != want {
+		t.Fatalf("unexpected log stream: got %q want %q", got, want)
+	}
+	if got, want := logRecord.ContainerID, "container-789"; got != want {
+		t.Fatalf("unexpected container id: got %q want %q", got, want)
+	}
+	if got, want := logRecord.TaskID, "task-123"; got != want {
+		t.Fatalf("unexpected task id: got %q want %q", got, want)
+	}
+	if !logRecord.Timestamp.Equal(logAt) {
+		t.Fatalf("unexpected timestamp: got %s want %s", logRecord.Timestamp, logAt)
+	}
+
+	// Records without a log line (e.g. malformed or non-log events) are skipped.
+	if _, ok := logRecordFromS2(s2.SequencedRecord{Body: []byte(`{"type":"container.log","data":{}}`)}); ok {
+		t.Fatal("expected record without a line to be rejected")
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes container log pagination and parsing to remove duplicates/gaps and use the correct log timestamp and metadata. Tail scanning now uses non-overlapping windows, and log fields are read from the event payload.

- **Bug Fixes**
  - Added `nextTailReadWindow` and updated tail scanning to clamp the final batch and track progress, preventing re-reads and missing records.
  - Updated `logRecordFromS2` to parse `line`, `stream`, IDs, and timestamp from event `data`; skips records without a log line.
  - Applied `augmentContainerEventResponse` to history and streaming paths for consistent event enrichment.
  - Added tests for tail windowing and log field extraction.

<sup>Written for commit 6bd0a4e4fb50843fccc2fe6056c8b98c40bd5a4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

