### PR TITLE
remote node network improvements

### DIFF
--- a/pkg/agent/transport.go
+++ b/pkg/agent/transport.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/beam-cloud/beta9/proto"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tsnet"
+	"tailscale.com/types/key"
 )
 
 const (
@@ -231,54 +232,58 @@ func tsnetSnapshotAttrs(status *ipnstate.Status, proxyTarget string, full bool) 
 		attrs["tailscale_ips"] = strings.Join(ips, ",")
 	}
 
-	if !full {
-		return attrs
+	if full {
+		addPeerStatsAttrs(attrs, status.Peer)
 	}
+	return attrs
+}
 
-	onlinePeers := 0
-	directPeers := 0
-	relayPeers := 0
-	activePeers := 0
-	recentHandshakePeers := 0
+// addPeerStatsAttrs summarizes per-peer connectivity (online, direct vs relay,
+// handshake freshness) into event attributes.
+func addPeerStatsAttrs(attrs map[string]string, peers map[key.NodePublic]*ipnstate.PeerStatus) {
+	online := 0
+	direct := 0
+	relayed := 0
+	active := 0
+	recentHandshakes := 0
 	newestHandshakeAge := time.Duration(0)
 	relayRegions := map[string]struct{}{}
 	now := time.Now()
-	for _, peer := range status.Peer {
+
+	for _, peer := range peers {
 		if peer == nil {
 			continue
 		}
 		if peer.Online {
-			onlinePeers++
+			online++
+		}
+		if peer.Active {
+			active++
 		}
 		if peer.CurAddr != "" {
-			directPeers++
+			direct++
 		} else if peer.Relay != "" {
-			relayPeers++
+			relayed++
 		}
 		if peer.Relay != "" {
 			relayRegions[peer.Relay] = struct{}{}
 		}
-		if peer.Active {
-			activePeers++
-		}
 		if !peer.LastHandshake.IsZero() {
-			age := now.Sub(peer.LastHandshake)
-			if age < 0 {
-				age = 0
-			}
+			age := max(now.Sub(peer.LastHandshake), 0)
 			if age <= 2*time.Minute {
-				recentHandshakePeers++
+				recentHandshakes++
 			}
 			if newestHandshakeAge == 0 || age < newestHandshakeAge {
 				newestHandshakeAge = age
 			}
 		}
 	}
-	attrs["online_peer_count"] = strconv.Itoa(onlinePeers)
-	attrs["direct_peer_count"] = strconv.Itoa(directPeers)
-	attrs["relay_peer_count"] = strconv.Itoa(relayPeers)
-	attrs["active_peer_count"] = strconv.Itoa(activePeers)
-	attrs["recent_handshake_peer_count"] = strconv.Itoa(recentHandshakePeers)
+
+	attrs["online_peer_count"] = strconv.Itoa(online)
+	attrs["direct_peer_count"] = strconv.Itoa(direct)
+	attrs["relay_peer_count"] = strconv.Itoa(relayed)
+	attrs["active_peer_count"] = strconv.Itoa(active)
+	attrs["recent_handshake_peer_count"] = strconv.Itoa(recentHandshakes)
 	if newestHandshakeAge > 0 {
 		attrs["newest_handshake_age_ms"] = strconv.FormatInt(newestHandshakeAge.Milliseconds(), 10)
 	}
@@ -290,7 +295,6 @@ func tsnetSnapshotAttrs(status *ipnstate.Status, proxyTarget string, full bool) 
 		sort.Strings(regions)
 		attrs["relay_regions"] = strings.Join(regions, ",")
 	}
-	return attrs
 }
 
 // joinAttrValues joins messages into a single event attribute value, capped

--- a/pkg/agent/transport.go
+++ b/pkg/agent/transport.go
@@ -208,7 +208,14 @@ func tsnetSnapshotAttrs(status *ipnstate.Status, proxyTarget string, full bool) 
 	attrs["backend_state"] = status.BackendState
 	attrs["full_snapshot"] = strconv.FormatBool(full)
 	attrs["health_count"] = strconv.Itoa(len(status.Health))
-	attrs["peer_count"] = strconv.Itoa(len(status.Peer))
+	if health := joinAttrValues(status.Health); health != "" {
+		attrs["health"] = health
+	}
+	// Peer data is only present on full snapshots (StatusWithoutPeers always
+	// reports zero peers, which reads as a false outage).
+	if full {
+		attrs["peer_count"] = strconv.Itoa(len(status.Peer))
+	}
 	if status.Self != nil {
 		attrs["self_dns"] = strings.TrimSuffix(status.Self.DNSName, ".")
 		attrs["self_online"] = strconv.FormatBool(status.Self.Online)
@@ -284,6 +291,17 @@ func tsnetSnapshotAttrs(status *ipnstate.Status, proxyTarget string, full bool) 
 		attrs["relay_regions"] = strings.Join(regions, ",")
 	}
 	return attrs
+}
+
+// joinAttrValues joins messages into a single event attribute value, capped
+// so oversized tailscale health strings can't bloat telemetry events.
+func joinAttrValues(values []string) string {
+	const maxAttrLen = 240
+	joined := strings.Join(values, "; ")
+	if len(joined) > maxAttrLen {
+		joined = joined[:maxAttrLen-3] + "..."
+	}
+	return joined
 }
 
 func agentTSNetLogf(stderr io.Writer) func(string, ...any) {

--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -825,13 +825,14 @@ func eventHistoryQueryFromContext(ctx echo.Context, authInfo *auth.AuthInfo) (ty
 		return types.EventQuery{}, HTTPBadRequest("Invalid event limit")
 	}
 	query := types.EventQuery{
-		Limit:       limit,
-		WorkspaceID: requestedEventWorkspaceID(ctx, authInfo),
-		StubID:      ctx.QueryParam("stub_id"),
-		AppID:       ctx.QueryParam("app_id"),
-		TaskID:      ctx.QueryParam("task_id"),
-		ContainerID: ctx.QueryParam("container_id"),
-		EventTypes:  eventQueryTypesFromParam(ctx.QueryParam("event_types")),
+		Limit:          limit,
+		WorkspaceID:    requestedEventWorkspaceID(ctx, authInfo),
+		StubID:         ctx.QueryParam("stub_id"),
+		AppID:          ctx.QueryParam("app_id"),
+		TaskID:         ctx.QueryParam("task_id"),
+		ContainerID:    ctx.QueryParam("container_id"),
+		EventTypes:     eventQueryTypesFromParam(ctx.QueryParam("event_types")),
+		ExcludeActions: eventQueryTypesFromParam(ctx.QueryParam("exclude_actions")),
 	}
 
 	if raw := ctx.QueryParam("start_time"); raw != "" {

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -2603,6 +2603,21 @@ func (c *Client) PrimaryReadHost(routingKey string) (*Host, error) {
 	return nil, ErrHostNotFound
 }
 
+// RankedReadHosts returns the HRW-ranked hosts for routingKey, including
+// hosts whose endpoints are currently unavailable. Callers that make
+// placement decisions (e.g. proactive reconciliation) need the full ranking
+// so they can apply their own liveness policy; reads should keep using
+// PrimaryReadHost, which prefers reachable hosts.
+func (c *Client) RankedReadHosts(routingKey string) []*Host {
+	if routingKey == "" {
+		return nil
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.hasher.GetN(c.readReplicaHostCount(), routingKey)
+}
+
 // MaterializeFromReplica streams the content for (hash, routingKey) from a
 // reachable peer that already holds it into the given local server's store. It
 // returns true when the content is complete locally afterward. size must be

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -56,6 +56,8 @@ type Store struct {
 	pageLocks               [pageLockStripeCount]sync.RWMutex
 	closing                 atomic.Bool
 	diskUsagePctBits        atomic.Uint64
+	accessTouchMu           sync.Mutex
+	accessTouches           map[string]time.Time
 }
 
 func NewStore(ctx context.Context, currentHost *Host, locality string, metadataStore CacheMetadataStore, config Config) (*Store, error) {
@@ -74,6 +76,7 @@ func NewStore(ctx context.Context, currentHost *Host, locality string, metadataS
 		memoryCacheEnabled: config.Server.MaxCachePct > 0,
 		mu:                 sync.Mutex{},
 		metrics:            initMetrics(ctx, config.Metrics, currentHost, locality),
+		accessTouches:      make(map[string]time.Time),
 	}
 
 	Logger.Infof("Disk cache directory located at: '%s'", cas.diskCacheDir)
@@ -1021,6 +1024,10 @@ func (cas *Store) ReadAt(hash string, offset int64, dst []byte) (read int64, err
 			throughputMBps := (float64(dstOffset) / (1024 * 1024)) / (float64(time.Since(start).Microseconds()) / 1e6)
 			cas.metrics.ReadThroughputMBps.Update(throughputMBps)
 		}
+		// Record read recency so LRU eviction prefers newer content
+		if read > 0 {
+			cas.touchContentAccess(hash)
+		}
 		if elapsed := time.Since(start); elapsed > time.Second || (err != nil && !errors.Is(err, ErrContentNotFound)) {
 			Logger.Warnf("cache store read-at result: hash=%s offset=%d length=%d read=%d err=%v elapsed=%s", hash, offset, len(dst), read, err, elapsed.Truncate(time.Millisecond))
 		}
@@ -1422,6 +1429,16 @@ func (cas *Store) monitorDiskCacheUsage() {
 
 			Logger.Debugf("Memory Cache Usage: %dMB / %dMB (%.2f%%)", availableMemoryMb, totalMemoryMb, float64(availableMemoryMb)/float64(totalMemoryMb)*100)
 			Logger.Debugf("Disk Cache Usage: %dMB / %dMB (%.2f%%)", currentUsage, totalDiskSpace, usagePercentage*100)
+
+			// Evict least-recently-read content when above the eviction
+			// watermark, then refresh usage so the write gate below reflects
+			// the post-eviction state
+			if cas.maybeEvictDiskCache(usagePercentage, totalDiskSpace) {
+				if _, _, refreshedPct, err := cas.GetDiskCacheMetrics(); err == nil {
+					usagePercentage = refreshedPct
+					cas.setCachedDiskUsagePct(usagePercentage)
+				}
+			}
 
 			// Update internal state for disk usage exceeded
 			cas.mu.Lock()

--- a/pkg/cache/storage_eviction.go
+++ b/pkg/cache/storage_eviction.go
@@ -1,0 +1,219 @@
+package cache
+
+// LRU disk eviction. Content recency is the complete marker file's
+// mtime, refreshed on read (throttled), so it survives restarts with no extra
+// index. When filesystem usage crosses the eviction watermark, the
+// least-recently-read content is deleted until enough space is reclaimed.
+// Content read very recently is never evicted.
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+const (
+	// defaultDiskCacheEvictWatermarkPct keeps eviction comfortably below
+	// kubelet DiskPressure thresholds (typically ~0.85-0.90).
+	defaultDiskCacheEvictWatermarkPct = 0.85
+	// evictionAccessTouchInterval throttles per-hash marker mtime updates on
+	// the read path.
+	evictionAccessTouchInterval = 5 * time.Minute
+	// evictionRecentAccessGuard prevents evicting content that was read this
+	// recently, regardless of space pressure.
+	evictionRecentAccessGuard = 10 * time.Minute
+	// accessTouchMapSweepSize bounds the in-memory touch throttle map.
+	accessTouchMapSweepSize = 65536
+)
+
+type evictionCandidate struct {
+	hash       string
+	dir        string
+	lastAccess time.Time
+	sizeBytes  int64
+}
+
+func (cas *Store) evictWatermarkPct() float64 {
+	pct := cas.serverConfig.DiskCacheEvictWatermarkPct
+	if pct <= 0 || pct > 1 {
+		pct = defaultDiskCacheEvictWatermarkPct
+	}
+	return pct
+}
+
+// touchContentAccess records a successful read of hash so eviction prefers
+// newer content. Throttled per hash; persisted via the complete marker mtime.
+func (cas *Store) touchContentAccess(hash string) {
+	if hash == "" {
+		return
+	}
+
+	now := time.Now()
+	cas.accessTouchMu.Lock()
+	if last, ok := cas.accessTouches[hash]; ok && now.Sub(last) < evictionAccessTouchInterval {
+		cas.accessTouchMu.Unlock()
+		return
+	}
+	cas.accessTouches[hash] = now
+	if len(cas.accessTouches) > accessTouchMapSweepSize {
+		// Entries past the throttle window are already persisted as marker
+		// mtimes and carry no extra information.
+		for h, t := range cas.accessTouches {
+			if now.Sub(t) >= evictionAccessTouchInterval {
+				delete(cas.accessTouches, h)
+			}
+		}
+	}
+	cas.accessTouchMu.Unlock()
+
+	// Best-effort; legacy-layout content without a v2 marker falls back to
+	// directory mtime during eviction.
+	_ = os.Chtimes(cas.completeMarkerPath(hash), now, now)
+}
+
+// maybeEvictDiskCache evicts least-recently-read content when filesystem usage
+// is above the eviction watermark. It reports whether anything was evicted.
+func (cas *Store) maybeEvictDiskCache(usagePct float64, totalDiskMb int64) bool {
+	watermark := cas.evictWatermarkPct()
+	if usagePct <= watermark || totalDiskMb <= 0 {
+		return false
+	}
+
+	bytesToFree := int64((usagePct - watermark) * float64(totalDiskMb) * 1024 * 1024)
+	started := time.Now()
+	evicted, freed := cas.evictLRU(bytesToFree)
+	if evicted == 0 {
+		Logger.Warnf("disk cache eviction found nothing evictable: usage=%.2f watermark=%.2f want_free=%d bytes", usagePct, watermark, bytesToFree)
+		return false
+	}
+
+	Logger.Infof("disk cache eviction freed %d bytes across %d objects in %s (usage=%.2f watermark=%.2f)", freed, evicted, time.Since(started).Truncate(time.Millisecond), usagePct, watermark)
+	return true
+}
+
+// evictLRU deletes least-recently-read content until roughly bytesToFree bytes
+// have been reclaimed. Returns the number of objects evicted and the bytes
+// freed.
+func (cas *Store) evictLRU(bytesToFree int64) (int, int64) {
+	if bytesToFree <= 0 {
+		return 0, 0
+	}
+
+	candidates := cas.evictionCandidates()
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].lastAccess.Before(candidates[j].lastAccess)
+	})
+
+	evicted := 0
+	var freed int64
+	cutoff := time.Now().Add(-evictionRecentAccessGuard)
+	for _, candidate := range candidates {
+		if freed >= bytesToFree {
+			break
+		}
+		// Oldest-first order: once we reach recently-read content, nothing
+		// after it is evictable either.
+		if candidate.lastAccess.After(cutoff) {
+			break
+		}
+		if err := cas.removeContent(candidate); err != nil {
+			Logger.Warnf("disk cache eviction failed to remove %s: %v", candidate.hash, err)
+			continue
+		}
+		evicted++
+		freed += candidate.sizeBytes
+	}
+	return evicted, freed
+}
+
+// evictionCandidates lists all on-disk content with its last access time and
+// size, covering both the v2 (pages/<bucket>/<hash>) and legacy (<hash>)
+// layouts.
+func (cas *Store) evictionCandidates() []evictionCandidate {
+	candidates := []evictionCandidate{}
+
+	buckets, _ := os.ReadDir(filepath.Join(cas.diskCacheDir, "pages"))
+	for _, bucket := range buckets {
+		if !bucket.IsDir() {
+			continue
+		}
+		bucketDir := filepath.Join(cas.diskCacheDir, "pages", bucket.Name())
+		entries, _ := os.ReadDir(bucketDir)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				candidates = cas.appendCandidate(candidates, entry.Name(), filepath.Join(bucketDir, entry.Name()))
+			}
+		}
+	}
+
+	entries, _ := os.ReadDir(cas.diskCacheDir)
+	for _, entry := range entries {
+		if entry.IsDir() && entry.Name() != "pages" && len(entry.Name()) == 64 {
+			candidates = cas.appendCandidate(candidates, entry.Name(), filepath.Join(cas.diskCacheDir, entry.Name()))
+		}
+	}
+
+	return candidates
+}
+
+func (cas *Store) appendCandidate(candidates []evictionCandidate, hash, dir string) []evictionCandidate {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return candidates
+	}
+
+	// Prefer the complete marker mtime: it is refreshed on read and reflects
+	// content recency rather than page churn.
+	lastAccess := info.ModTime()
+	if markerInfo, err := os.Stat(filepath.Join(dir, cacheCompleteMarkerName)); err == nil {
+		lastAccess = markerInfo.ModTime()
+	}
+
+	// An in-memory touch may be fresher than the on-disk mtime since Chtimes
+	// is throttled
+	cas.accessTouchMu.Lock()
+	if touched, ok := cas.accessTouches[hash]; ok && touched.After(lastAccess) {
+		lastAccess = touched
+	}
+	cas.accessTouchMu.Unlock()
+
+	return append(candidates, evictionCandidate{
+		hash:       hash,
+		dir:        dir,
+		lastAccess: lastAccess,
+		sizeBytes:  dirSizeBytes(dir),
+	})
+}
+
+// removeContent deletes one object's pages. The complete marker is removed
+// first so concurrent completeness checks stop treating the content as present
+// before its pages disappear; in-flight readers degrade to a normal cache
+// miss.
+func (cas *Store) removeContent(candidate evictionCandidate) error {
+	if err := os.Remove(filepath.Join(candidate.dir, cacheCompleteMarkerName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if cas.memoryCacheEnabled && cas.cache != nil {
+		cas.cache.Del(candidate.hash)
+	}
+	if err := os.RemoveAll(candidate.dir); err != nil {
+		return err
+	}
+
+	cas.accessTouchMu.Lock()
+	delete(cas.accessTouches, candidate.hash)
+	cas.accessTouchMu.Unlock()
+	return nil
+}
+
+func dirSizeBytes(dir string) int64 {
+	var total int64
+	entries, _ := os.ReadDir(dir)
+	for _, entry := range entries {
+		if info, err := entry.Info(); err == nil && !info.IsDir() {
+			total += info.Size()
+		}
+	}
+	return total
+}

--- a/pkg/cache/storage_eviction_test.go
+++ b/pkg/cache/storage_eviction_test.go
@@ -1,0 +1,89 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func addEvictionTestContent(t *testing.T, store *Store, content string, lastAccess time.Time) string {
+	t.Helper()
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader([]byte(content)))
+	require.NoError(t, err)
+	require.True(t, store.Exists(hash))
+	require.NoError(t, os.Chtimes(store.completeMarkerPath(hash), lastAccess, lastAccess))
+	return hash
+}
+
+func TestEvictLRURemovesOldestContentFirst(t *testing.T) {
+	store := newTestStore(t, 5)
+
+	now := time.Now()
+	oldest := addEvictionTestContent(t, store, "oldest-content", now.Add(-3*time.Hour))
+	older := addEvictionTestContent(t, store, "older-content!", now.Add(-2*time.Hour))
+	newest := addEvictionTestContent(t, store, "newest-content", now.Add(-time.Hour))
+
+	// Freeing one object's worth of bytes must evict only the oldest
+	evicted, freed := store.evictLRU(int64(len("oldest-content")))
+	require.Equal(t, 1, evicted)
+	require.GreaterOrEqual(t, freed, int64(len("oldest-content")))
+	require.False(t, store.Exists(oldest))
+	require.True(t, store.Exists(older))
+	require.True(t, store.Exists(newest))
+
+	// A larger target evicts in LRU order
+	evicted, _ = store.evictLRU(1 << 30)
+	require.Equal(t, 2, evicted)
+	require.False(t, store.Exists(older))
+	require.False(t, store.Exists(newest))
+}
+
+func TestEvictLRUNeverRemovesRecentlyReadContent(t *testing.T) {
+	store := newTestStore(t, 5)
+
+	hash := addEvictionTestContent(t, store, "hot-content", time.Now())
+
+	evicted, freed := store.evictLRU(1 << 30)
+	require.Zero(t, evicted)
+	require.Zero(t, freed)
+	require.True(t, store.Exists(hash))
+}
+
+func TestTouchContentAccessRefreshesMarkerAndThrottles(t *testing.T) {
+	store := newTestStore(t, 5)
+
+	stale := time.Now().Add(-time.Hour)
+	hash := addEvictionTestContent(t, store, "touched-content", stale)
+
+	store.touchContentAccess(hash)
+	info, err := os.Stat(store.completeMarkerPath(hash))
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), info.ModTime(), time.Minute)
+
+	// A second touch within the throttle window must not hit the filesystem
+	require.NoError(t, os.Chtimes(store.completeMarkerPath(hash), stale, stale))
+	store.touchContentAccess(hash)
+	info, err = os.Stat(store.completeMarkerPath(hash))
+	require.NoError(t, err)
+	require.WithinDuration(t, stale, info.ModTime(), time.Minute)
+}
+
+func TestEvictionCandidateUsesInMemoryTouchWhenFresher(t *testing.T) {
+	store := newTestStore(t, 5)
+
+	stale := time.Now().Add(-2 * time.Hour)
+	hash := addEvictionTestContent(t, store, "in-memory-touch", stale)
+
+	// Simulate a throttled touch that never reached the filesystem
+	store.accessTouchMu.Lock()
+	store.accessTouches[hash] = time.Now()
+	store.accessTouchMu.Unlock()
+
+	evicted, _ := store.evictLRU(1 << 30)
+	require.Zero(t, evicted)
+	require.True(t, store.Exists(hash))
+}

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -42,6 +42,11 @@ type ReconciliationConfig struct {
 	MaxItemsPerCycle      int   `key:"maxItemsPerCycle" json:"max_items_per_cycle"`
 	VolumeMinBytes        int64 `key:"volumeMinBytes" json:"volume_min_bytes"`
 	OriginFallbackEnabled bool  `key:"originFallbackEnabled" json:"origin_fallback_enabled"`
+	// MaxDiskUsagePct pauses proactive materialization on a host whose disk
+	// usage exceeds this fraction (0-1). Proactive cache fill must stop well
+	// before the kubelet's DiskPressure thresholds; demand-driven reads are
+	// unaffected.
+	MaxDiskUsagePct float64 `key:"maxDiskUsagePct" json:"max_disk_usage_pct"`
 }
 
 type DiskConfig struct {
@@ -103,8 +108,13 @@ func (c *GlobalConfig) GetLocality() string {
 }
 
 type ServerConfig struct {
-	DiskCacheDir                 string                    `key:"diskCacheDir" json:"disk_cache_dir"`
-	DiskCacheMaxUsagePct         float64                   `key:"diskCacheMaxUsagePct" json:"disk_cache_max_usage_pct"`
+	DiskCacheDir         string  `key:"diskCacheDir" json:"disk_cache_dir"`
+	DiskCacheMaxUsagePct float64 `key:"diskCacheMaxUsagePct" json:"disk_cache_max_usage_pct"`
+	// DiskCacheEvictWatermarkPct is the filesystem usage fraction (0-1) above
+	// which the store evicts least-recently-accessed content until usage
+	// falls back below the watermark. It must sit below the kubelet's
+	// DiskPressure thresholds so the node never reaches them. Defaults to 0.85.
+	DiskCacheEvictWatermarkPct   float64                   `key:"diskCacheEvictWatermarkPct" json:"disk_cache_evict_watermark_pct"`
 	ObjectTtlS                   int                       `key:"objectTtlS" json:"object_ttl_s"`
 	MaxCachePct                  int64                     `key:"maxCachePct" json:"max_cache_pct"`
 	PageSizeBytes                int64                     `key:"pageSizeBytes" json:"page_size_bytes"`

--- a/pkg/compute/shadeform.go
+++ b/pkg/compute/shadeform.go
@@ -14,9 +14,10 @@ const ShadeformDefaultBaseURL = "https://api.shadeform.ai/v1"
 
 // shadeformAutoDeleteGrace pads the provider-side auto-delete threshold past
 // our own expiry. The control plane owns reservation lifetime (renewal, final
-// billing, termination); Shadeform's threshold is only a runaway backstop and
-// must never fire before our reconciler has had a chance to act.
-const shadeformAutoDeleteGrace = time.Hour
+// billing, termination, credit exhaustion); Shadeform's threshold is only a
+// runaway backstop in case the reconciler dies, and must never fire before
+// our reconciler has had a chance to act. Renewals keep pushing it forward.
+const shadeformAutoDeleteGrace = 7 * 24 * time.Hour
 
 type ShadeformClient struct {
 	api HTTPClient
@@ -111,15 +112,15 @@ func (c *ShadeformClient) CreateReservation(ctx context.Context, req Reservation
 			},
 		}
 	}
-	if req.TTL > 0 || req.MaxSpendMicros > 0 {
-		autoDelete := map[string]any{}
-		if req.TTL > 0 {
-			autoDelete["date_threshold"] = time.Now().Add(req.TTL + shadeformAutoDeleteGrace).UTC().Format(time.RFC3339)
+	if req.TTL > 0 {
+		// Only a date backstop is sent. A spend_threshold is deliberately
+		// omitted: reservations renew hourly past the launch TTL, so a spend
+		// cap derived from the launch budget would kill long-running nodes
+		// (Shadeform never raises it). Spend enforcement happens in our
+		// reconciler via workspace credit checks.
+		body["auto_delete"] = map[string]any{
+			"date_threshold": time.Now().Add(req.TTL + shadeformAutoDeleteGrace).UTC().Format(time.RFC3339),
 		}
-		if req.MaxSpendMicros > 0 {
-			autoDelete["spend_threshold"] = fmt.Sprintf("%.2f", MicrosToDollars(req.MaxSpendMicros))
-		}
-		body["auto_delete"] = autoDelete
 	}
 
 	var raw map[string]any
@@ -198,7 +199,8 @@ func shadeformReservationStatus(status string) ReservationStatus {
 }
 
 // ExtendReservation pushes the renewed expiry to Shadeform's auto-delete
-// date threshold. spend_threshold is omitted so it stays unchanged.
+// date threshold, keeping the runaway backstop ahead of the reservation's
+// control-plane expiry. No spend_threshold is ever set on the instance.
 func (c *ShadeformClient) ExtendReservation(ctx context.Context, id string, expiresAt time.Time) error {
 	body := map[string]any{
 		"auto_delete": map[string]any{

--- a/pkg/compute/shadeform_test.go
+++ b/pkg/compute/shadeform_test.go
@@ -81,13 +81,18 @@ func TestCreateReservationConfiguresShadeformStartupScript(t *testing.T) {
 
 	autoDelete, ok := body["auto_delete"].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "80.00", autoDelete["spend_threshold"])
 
-	// The provider-side threshold must be a backstop past the TTL, not the
-	// enforcer of it; the control plane owns reservation lifetime.
+	// No spend_threshold: reservations renew hourly past the launch budget,
+	// and Shadeform would otherwise kill the node once the initial budget's
+	// worth of spend accrues. Spend enforcement lives in our reconciler.
+	_, hasSpend := autoDelete["spend_threshold"]
+	require.False(t, hasSpend)
+
+	// The provider-side threshold must be a generous backstop past the TTL,
+	// not the enforcer of it; the control plane owns reservation lifetime.
 	threshold, err := time.Parse(time.RFC3339, autoDelete["date_threshold"].(string))
 	require.NoError(t, err)
-	require.True(t, threshold.After(time.Now().Add(6*time.Hour+30*time.Minute)))
+	require.True(t, threshold.After(time.Now().Add(6*time.Hour+shadeformAutoDeleteGrace-time.Minute)))
 }
 
 func TestGetReservationMapsShadeformStatus(t *testing.T) {
@@ -132,7 +137,8 @@ func TestExtendReservationUpdatesShadeformAutoDelete(t *testing.T) {
 	threshold, err := time.Parse(time.RFC3339, autoDelete["date_threshold"].(string))
 	require.NoError(t, err)
 	require.True(t, threshold.Equal(expiresAt.Add(shadeformAutoDeleteGrace)))
-	// spend_threshold is omitted so the existing value stays unchanged
+	// spend_threshold is never set on Shadeform instances; spend enforcement
+	// lives in the control-plane reconciler.
 	_, hasSpend := autoDelete["spend_threshold"]
 	require.False(t, hasSpend)
 }

--- a/pkg/compute/state.go
+++ b/pkg/compute/state.go
@@ -113,7 +113,11 @@ type PreflightCheckState struct {
 	Severity string `json:"severity"`
 }
 
-const AgentHeartbeatTimeout = 30 * time.Second
+// AgentHeartbeatTimeout is how long a machine stays "connected" after its
+// last heartbeat. Heartbeats arrive every ~5s (telemetry) and ~10s
+// (StreamAgent), so 60s tolerates brief dual-stream reconnects without
+// disabling the machine's worker and flickering its status.
+const AgentHeartbeatTimeout = 60 * time.Second
 
 func AgentMachineStatus(state *AgentTokenState, now time.Time) string {
 	if AgentMachineConnected(state, now) {

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -1017,8 +1017,10 @@ func TestRecordAgentMetricsEmitsNodeUsage(t *testing.T) {
 	if got, want := counter.name, types.UsageMetricsNodeUsage; got != want {
 		t.Fatalf("usage counter = %q, want %q", got, want)
 	}
-	if got, want := counter.value, float64(5); got != want {
-		t.Fatalf("node usage value = %f, want %f", got, want)
+	// Usage seconds are measured on the gateway clock, so allow a small delta
+	// between the test's reference time and the call's time.Now().
+	if got, want := counter.value, float64(5); got < want || got > want+1 {
+		t.Fatalf("node usage value = %f, want ~%f", got, want)
 	}
 	if got, want := counter.metadata["workspace_id"], "workspace-1"; got != want {
 		t.Fatalf("workspace metadata = %v, want %s", got, want)

--- a/pkg/gateway/services/compute/telemetry.go
+++ b/pkg/gateway/services/compute/telemetry.go
@@ -139,6 +139,7 @@ func (s *Service) recordAgentMetrics(ctx context.Context, agentState *model.Agen
 	}
 	agentState = current
 	previousSeen := model.AgentMachineLastSeen(agentState)
+	now := time.Now().UTC()
 
 	metrics := model.AgentMachineMetrics{
 		Timestamp:            timeFromUnixNano(snapshot.TimestampUnixNano),
@@ -159,14 +160,20 @@ func (s *Service) recordAgentMetrics(ctx context.Context, agentState *model.Agen
 		poolState, _ = s.getPrivatePoolState(ctx, agentState.WorkspaceID, agentState.PoolName)
 	}
 	agentState.Metrics = metrics
-	agentState.LastHeartbeatAt = metrics.Timestamp
+	// Liveness is always tracked on the gateway clock: agent-supplied
+	// timestamps can be skewed or stale (buffered telemetry after a
+	// reconnect), which would oscillate the machine across the heartbeat
+	// timeout and flicker its status. Never move the heartbeat backwards.
+	if now.After(agentState.LastHeartbeatAt) {
+		agentState.LastHeartbeatAt = now
+	}
 	agentState.LastDisconnectAt = time.Time{}
 	if err := s.saveComputeAgentTokenState(ctx, agentState); err != nil {
 		return err
 	}
 	worker := s.agentMachineStatusWorker(agentState)
 	capacityMetrics := agentMachineMetrics(agentState, worker)
-	if err := s.recordAgentNodeUsage(agentState, poolState, capacityMetrics, previousSeen, metrics.Timestamp); err != nil {
+	if err := s.recordAgentNodeUsage(agentState, poolState, capacityMetrics, previousSeen, now); err != nil {
 		log.Warn().
 			Err(err).
 			Str("workspace_id", agentState.WorkspaceID).
@@ -182,12 +189,12 @@ func (s *Service) recordAgentMetrics(ctx context.Context, agentState *model.Agen
 	}
 
 	s.emitComputeEvent(types.EventComputeMachine, types.EventComputeSchema{
-		Timestamp:   metrics.Timestamp,
+		Timestamp:   now,
 		WorkspaceID: agentState.WorkspaceID,
 		PoolName:    agentState.PoolName,
 		MachineID:   agentState.MachineID,
 		Action:      types.EventComputeActionMachineHeartbeat,
-		Status:      string(agentMachineStatus(agentState, worker, metrics.Timestamp)),
+		Status:      string(agentMachineStatus(agentState, worker, now)),
 		CPUCount:    agentState.CPUCount,
 		MemoryMB:    firstNonZeroUint64(metrics.MemoryTotalMB, agentState.MemoryMB),
 		GPUCount:    agentState.GPUCount,
@@ -333,9 +340,17 @@ func (s *Service) recordAgentDisconnect(ctx context.Context, agentState *model.A
 	})
 }
 
+// timeFromUnixNano converts an agent-supplied timestamp, clamping future
+// values to the gateway clock so skewed agent clocks cannot produce events
+// "from the future".
 func timeFromUnixNano(value int64) time.Time {
+	now := time.Now().UTC()
 	if value <= 0 {
-		return time.Now().UTC()
+		return now
 	}
-	return time.Unix(0, value).UTC()
+	timestamp := time.Unix(0, value).UTC()
+	if timestamp.After(now) {
+		return now
+	}
+	return timestamp
 }

--- a/pkg/gateway/services/worker.go
+++ b/pkg/gateway/services/worker.go
@@ -38,6 +38,7 @@ func (gws *GatewayService) ListWorkers(ctx context.Context, in *pb.ListWorkersRe
 		}, nil
 	}
 
+	workers = gws.filterControlPlaneWorkers(workers)
 	sortWorkers(workers)
 
 	pbWorkers := make([]*pb.Worker, len(workers))
@@ -78,6 +79,29 @@ func (gws *GatewayService) ListWorkers(ctx context.Context, in *pb.ListWorkersRe
 		Ok:      true,
 		Workers: pbWorkers,
 	}, nil
+}
+
+// filterControlPlaneWorkers drops workers belonging to workspace private
+// pools. Pool names are not namespaced by workspace, so listing every
+// workspace's private-pool agent workers produces duplicate-looking rows
+// that are not actionable for cluster operators; those machines are managed
+// through the workspace-scoped compute APIs instead.
+func (gws *GatewayService) filterControlPlaneWorkers(workers []*types.Worker) []*types.Worker {
+	filtered := make([]*types.Worker, 0, len(workers))
+	for _, worker := range workers {
+		poolConfig, ok := gws.appConfig.Worker.Pools[worker.PoolName]
+		if !ok || poolConfig.Mode == types.PoolModePrivate {
+			continue
+		}
+		// Agent (private pool) workers always set RequiresPoolSelector; if the
+		// config pool of the same name does not, this worker belongs to a
+		// private pool whose name collides with a control-plane pool.
+		if worker.RequiresPoolSelector && !poolConfig.RequiresPoolSelector {
+			continue
+		}
+		filtered = append(filtered, worker)
+	}
+	return filtered
 }
 
 func sortWorkers(w []*types.Worker) {

--- a/pkg/network/backend_dialer.go
+++ b/pkg/network/backend_dialer.go
@@ -92,25 +92,16 @@ func (d *BackendDialer) Dial(ctx context.Context, address string) (net.Conn, err
 func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.BackendRoute, routeID string, deadline time.Time) (net.Conn, error) {
 	host := tailnetHostFromAddr(route.ProxyTarget)
 	var lastErr error
-	for {
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			if lastErr != nil {
-				return nil, fmt.Errorf("backend route %s dial timed out: %w", routeID, lastErr)
-			}
-			return nil, fmt.Errorf("backend route %s dial timed out", routeID)
-		}
 
+	for remaining := time.Until(deadline); remaining > 0; remaining = time.Until(deadline) {
 		if host != "" {
 			// Leave headroom for the dial itself: a peer that appears at the
 			// very end of the budget still needs time to handshake.
-			waitBudget := remaining - tsnetDialReserve(remaining)
-			if err := d.tailscale.WaitForPeer(ctx, host, waitBudget); err != nil {
+			if err := d.tailscale.WaitForPeer(ctx, host, remaining-tsnetDialReserve(remaining)); err != nil {
 				return nil, fmt.Errorf("backend route %s: %w", routeID, err)
 			}
-			remaining = time.Until(deadline)
-			if remaining <= 0 {
-				continue
+			if remaining = time.Until(deadline); remaining <= 0 {
+				break
 			}
 		}
 
@@ -126,6 +117,11 @@ func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.Backend
 		case <-time.After(backendRouteReadyPollInterval):
 		}
 	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("backend route %s dial timed out: %w", routeID, lastErr)
+	}
+	return nil, fmt.Errorf("backend route %s dial timed out", routeID)
 }
 
 func (d *BackendDialer) dialTSNetTarget(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
@@ -136,19 +132,10 @@ func (d *BackendDialer) dialTSNetTarget(ctx context.Context, addr string, timeou
 }
 
 // tsnetDialReserve is how much of the remaining dial budget is held back for
-// the connect itself when waiting for the peer to appear in the netmap.
+// the connect itself while waiting for the peer to appear in the netmap:
+// a third of the budget, clamped to [100ms, 2s], never more than remains.
 func tsnetDialReserve(remaining time.Duration) time.Duration {
-	reserve := remaining / 3
-	if reserve > 2*time.Second {
-		reserve = 2 * time.Second
-	}
-	if reserve < 100*time.Millisecond {
-		reserve = 100 * time.Millisecond
-	}
-	if reserve > remaining {
-		reserve = remaining
-	}
-	return reserve
+	return min(max(remaining/3, 100*time.Millisecond), 2*time.Second, remaining)
 }
 
 // resolveReadyRoute returns the backend route once it is ready to accept

--- a/pkg/network/backend_dialer.go
+++ b/pkg/network/backend_dialer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -24,6 +25,9 @@ type BackendDialer struct {
 	tsConfig  types.TailscaleConfig
 	resolver  BackendRouteResolver
 	timeout   time.Duration
+
+	// tsnetDial overrides the tsnet dial in tests.
+	tsnetDial func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error)
 }
 
 func NewBackendDialer(tailscale *Tailscale, tsConfig types.TailscaleConfig, resolver BackendRouteResolver, timeout time.Duration) *BackendDialer {
@@ -74,14 +78,77 @@ func (d *BackendDialer) Dial(ctx context.Context, address string) (net.Conn, err
 		if d.tailscale == nil {
 			return nil, fmt.Errorf("tailscale dialer is unavailable for backend route %s", routeID)
 		}
-		conn, err := d.tailscale.DialContextTimeout(ctx, "tcp", route.ProxyTarget, remaining)
-		if err != nil {
-			return nil, err
-		}
-		return writeBackendRoutePreface(conn, routeID)
+		return d.dialTSNetRoute(ctx, route, routeID, deadline)
 	default:
 		return nil, fmt.Errorf("unsupported backend route transport %q", route.Transport)
 	}
+}
+
+// dialTSNetRoute connects to the agent's tsnet proxy target. It first
+// confirms the agent peer is visible in this node's netmap (a MagicDNS dial
+// for an unknown peer silently falls back to the system resolver and fails
+// with a misleading NXDOMAIN), then dials, retrying transient failures until
+// the dial budget is exhausted so single blips never surface to callers.
+func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.BackendRoute, routeID string, deadline time.Time) (net.Conn, error) {
+	host := tailnetHostFromAddr(route.ProxyTarget)
+	var lastErr error
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			if lastErr != nil {
+				return nil, fmt.Errorf("backend route %s dial timed out: %w", routeID, lastErr)
+			}
+			return nil, fmt.Errorf("backend route %s dial timed out", routeID)
+		}
+
+		if host != "" {
+			// Leave headroom for the dial itself: a peer that appears at the
+			// very end of the budget still needs time to handshake.
+			waitBudget := remaining - tsnetDialReserve(remaining)
+			if err := d.tailscale.WaitForPeer(ctx, host, waitBudget); err != nil {
+				return nil, fmt.Errorf("backend route %s: %w", routeID, err)
+			}
+			remaining = time.Until(deadline)
+			if remaining <= 0 {
+				continue
+			}
+		}
+
+		conn, err := d.dialTSNetTarget(ctx, route.ProxyTarget, remaining)
+		if err == nil {
+			return writeBackendRoutePreface(conn, routeID)
+		}
+		lastErr = err
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backendRouteReadyPollInterval):
+		}
+	}
+}
+
+func (d *BackendDialer) dialTSNetTarget(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
+	if d.tsnetDial != nil {
+		return d.tsnetDial(ctx, addr, timeout)
+	}
+	return d.tailscale.DialContextTimeout(ctx, "tcp", addr, timeout)
+}
+
+// tsnetDialReserve is how much of the remaining dial budget is held back for
+// the connect itself when waiting for the peer to appear in the netmap.
+func tsnetDialReserve(remaining time.Duration) time.Duration {
+	reserve := remaining / 3
+	if reserve > 2*time.Second {
+		reserve = 2 * time.Second
+	}
+	if reserve < 100*time.Millisecond {
+		reserve = 100 * time.Millisecond
+	}
+	if reserve > remaining {
+		reserve = remaining
+	}
+	return reserve
 }
 
 // resolveReadyRoute returns the backend route once it is ready to accept
@@ -130,4 +197,17 @@ func writeBackendRoutePreface(conn net.Conn, routeID string) (net.Conn, error) {
 		return nil, err
 	}
 	return conn, nil
+}
+
+// tailnetHostFromAddr extracts the bare host from a "host:port" proxy target.
+func tailnetHostFromAddr(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	return strings.TrimSuffix(host, ".")
 }

--- a/pkg/network/backend_dialer_test.go
+++ b/pkg/network/backend_dialer_test.go
@@ -134,6 +134,119 @@ func TestBackendDialerFailsFastForNonTransientStates(t *testing.T) {
 	}
 }
 
+// tsnetRouteResolver always returns a ready tsnet route.
+type tsnetRouteResolver struct {
+	proxyTarget string
+}
+
+func (f *tsnetRouteResolver) GetBackendRoute(ctx context.Context, routeID string) (*types.BackendRoute, error) {
+	return &types.BackendRoute{
+		RouteID:     routeID,
+		State:       types.BackendRouteStateReady,
+		Transport:   types.BackendRouteTransportTSNet,
+		ProxyTarget: f.proxyTarget,
+	}, nil
+}
+
+func TestBackendDialerTSNetRetriesTransientDialFailures(t *testing.T) {
+	withFastRoutePolling(t)
+	withFastPeerPolling(t)
+
+	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
+	resolver := &tsnetRouteResolver{proxyTarget: "beam-agent-machine.tailnet.ts.net:29443"}
+
+	var attempts int
+	var serverSide net.Conn
+	dialer := NewBackendDialer(ts, types.TailscaleConfig{Enabled: true}, resolver, 2*time.Second)
+	dialer.tsnetDial = func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, context.DeadlineExceeded
+		}
+		client, server := net.Pipe()
+		serverSide = server
+		return client, nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := dialer.Dial(context.Background(), types.BackendRouteAddress("route-ts"))
+		if conn != nil {
+			defer conn.Close()
+		}
+		done <- err
+	}()
+
+	// The preface is written synchronously on the pipe; consume it.
+	deadline := time.After(2 * time.Second)
+	for serverSide == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("dial finished early: %v", err)
+		case <-deadline:
+			t.Fatal("dial never reached a successful attempt")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	buf := make([]byte, 64)
+	n, err := serverSide.Read(buf)
+	if err != nil {
+		t.Fatalf("read preface: %v", err)
+	}
+	if got := string(buf[:n]); !strings.HasPrefix(got, BackendRoutePreface+"route-ts") {
+		t.Fatalf("preface = %q, want prefix %q", got, BackendRoutePreface+"route-ts")
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("dial attempts = %d, want 3 (two transient failures retried)", attempts)
+	}
+}
+
+func TestBackendDialerTSNetFailsClearlyWhenPeerMissing(t *testing.T) {
+	withFastRoutePolling(t)
+	withFastPeerPolling(t)
+
+	ts := testTailscale(t, statusWithPeers("some-other-agent"))
+	resolver := &tsnetRouteResolver{proxyTarget: "beam-agent-missing.tailnet.ts.net:29443"}
+
+	dialer := NewBackendDialer(ts, types.TailscaleConfig{Enabled: true}, resolver, 300*time.Millisecond)
+	dialer.tsnetDial = func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
+		t.Fatal("dial must not be attempted when the peer is missing from the netmap")
+		return nil, nil
+	}
+
+	_, err := dialer.Dial(context.Background(), types.BackendRouteAddress("route-ts"))
+	if err == nil {
+		t.Fatal("dial succeeded, want netmap visibility error")
+	}
+	if !strings.Contains(err.Error(), "netmap") {
+		t.Fatalf("dial error = %v, want mention of netmap", err)
+	}
+}
+
+func TestBackendDialerTSNetExhaustsBudgetWithLastError(t *testing.T) {
+	withFastRoutePolling(t)
+	withFastPeerPolling(t)
+
+	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
+	resolver := &tsnetRouteResolver{proxyTarget: "beam-agent-machine.tailnet.ts.net:29443"}
+
+	dialer := NewBackendDialer(ts, types.TailscaleConfig{Enabled: true}, resolver, 200*time.Millisecond)
+	dialer.tsnetDial = func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	_, err := dialer.Dial(context.Background(), types.BackendRouteAddress("route-ts"))
+	if err == nil {
+		t.Fatal("dial succeeded, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") || !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Fatalf("dial error = %v, want timeout wrapping the last dial error", err)
+	}
+}
+
 func TestBackendDialerReadyRouteDialsImmediately(t *testing.T) {
 	withFastRoutePolling(t)
 

--- a/pkg/network/backend_dialer_test.go
+++ b/pkg/network/backend_dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,16 +156,15 @@ func TestBackendDialerTSNetRetriesTransientDialFailures(t *testing.T) {
 	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
 	resolver := &tsnetRouteResolver{proxyTarget: "beam-agent-machine.tailnet.ts.net:29443"}
 
-	var attempts int
-	var serverSide net.Conn
+	var attempts atomic.Int32
+	serverSide := make(chan net.Conn, 1)
 	dialer := NewBackendDialer(ts, types.TailscaleConfig{Enabled: true}, resolver, 2*time.Second)
 	dialer.tsnetDial = func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
-		attempts++
-		if attempts < 3 {
+		if attempts.Add(1) < 3 {
 			return nil, context.DeadlineExceeded
 		}
 		client, server := net.Pipe()
-		serverSide = server
+		serverSide <- server
 		return client, nil
 	}
 
@@ -178,18 +178,16 @@ func TestBackendDialerTSNetRetriesTransientDialFailures(t *testing.T) {
 	}()
 
 	// The preface is written synchronously on the pipe; consume it.
-	deadline := time.After(2 * time.Second)
-	for serverSide == nil {
-		select {
-		case err := <-done:
-			t.Fatalf("dial finished early: %v", err)
-		case <-deadline:
-			t.Fatal("dial never reached a successful attempt")
-		case <-time.After(time.Millisecond):
-		}
+	var server net.Conn
+	select {
+	case server = <-serverSide:
+	case err := <-done:
+		t.Fatalf("dial finished early: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("dial never reached a successful attempt")
 	}
 	buf := make([]byte, 64)
-	n, err := serverSide.Read(buf)
+	n, err := server.Read(buf)
 	if err != nil {
 		t.Fatalf("read preface: %v", err)
 	}
@@ -199,8 +197,8 @@ func TestBackendDialerTSNetRetriesTransientDialFailures(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}
-	if attempts != 3 {
-		t.Fatalf("dial attempts = %d, want 3 (two transient failures retried)", attempts)
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("dial attempts = %d, want 3 (two transient failures retried)", got)
 	}
 }
 

--- a/pkg/network/resolve.go
+++ b/pkg/network/resolve.go
@@ -14,7 +14,16 @@ import (
 func ConnectToHost(ctx context.Context, host string, timeout time.Duration, tailscale *Tailscale, tsConfig types.TailscaleConfig) (net.Conn, error) {
 	var conn net.Conn = nil
 
-	if tsConfig.Enabled && strings.Contains(host, tsConfig.HostName) {
+	if tsConfig.Enabled && tailscale != nil && strings.Contains(host, tsConfig.HostName) {
+		// Confirm the peer is in our netmap first; dialing an unknown MagicDNS
+		// name silently falls back to the system resolver and fails with a
+		// misleading NXDOMAIN.
+		if peerHost := tailnetHostFromAddr(host); peerHost != "" {
+			if err := tailscale.WaitForPeer(ctx, peerHost, timeout); err != nil {
+				return nil, err
+			}
+		}
+
 		conn, err := tailscale.DialContextTimeout(ctx, "tcp", host, timeout)
 		if err != nil {
 			return nil, err

--- a/pkg/network/tailscale.go
+++ b/pkg/network/tailscale.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/rs/zerolog/log"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tsnet"
 )
 
@@ -46,12 +48,33 @@ type TailscaleConfig struct {
 	Debug      bool
 }
 
+// Stale-netmap self-healing: when peers the control plane says are connected
+// keep missing from this node's netmap, the tailnet control connection is
+// likely a zombie. After enough misses spread over a window, the tsnet server
+// is recycled (rate-limited) to force a fresh control connection and netmap.
+var (
+	staleNetmapMissThreshold   = 3
+	staleNetmapMissWindow      = time.Minute
+	staleNetmapRestartCooldown = 5 * time.Minute
+	tailnetPeerPollInterval    = 500 * time.Millisecond
+)
+
 type Tailscale struct {
 	server        *tsnet.Server
+	cfg           TailscaleConfig
 	debug         bool
 	initialized   bool
+	served        bool
 	mu            sync.Mutex
 	tailscaleRepo repository.TailscaleRepository
+
+	// statusFunc overrides netmap status lookups in tests.
+	statusFunc func(ctx context.Context) (*ipnstate.Status, error)
+
+	missMu      sync.Mutex
+	missCount   int
+	firstMissAt time.Time
+	lastRestart time.Time
 }
 
 func (t *Tailscale) logF(format string, v ...interface{}) {
@@ -63,42 +86,71 @@ func (t *Tailscale) logF(format string, v ...interface{}) {
 // NewTailscale creates a new Tailscale instance using tsnet
 func newTailscale(cfg TailscaleConfig, tailscaleRepo repository.TailscaleRepository) *Tailscale {
 	ts := &Tailscale{
+		cfg:           cfg,
 		debug:         cfg.Debug,
 		initialized:   false,
 		mu:            sync.Mutex{},
 		tailscaleRepo: tailscaleRepo,
 	}
 
-	ts.server = &tsnet.Server{
-		Dir:        cfg.Dir,
-		Hostname:   cfg.Hostname,
-		AuthKey:    cfg.AuthKey,
-		ControlURL: cfg.ControlURL,
-		Ephemeral:  cfg.Ephemeral,
-		UserLogf:   ts.logF,
-		Logf:       ts.logF,
-	}
-
+	ts.server = ts.buildServer()
 	return ts
+}
+
+func (t *Tailscale) buildServer() *tsnet.Server {
+	return &tsnet.Server{
+		Dir:        t.cfg.Dir,
+		Hostname:   t.cfg.Hostname,
+		AuthKey:    t.cfg.AuthKey,
+		ControlURL: t.cfg.ControlURL,
+		Ephemeral:  t.cfg.Ephemeral,
+		UserLogf:   t.logF,
+		Logf:       t.logF,
+	}
+}
+
+func (t *Tailscale) currentServer() *tsnet.Server {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.server
+}
+
+func (t *Tailscale) ensureUp(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.initialized {
+		return nil
+	}
+	if _, err := t.server.Up(ctx); err != nil {
+		return err
+	}
+	t.initialized = true
+	return nil
 }
 
 // Serve connects to a tailnet and serves a local service
 func (t *Tailscale) Serve(ctx context.Context, service types.InternalService) (net.Listener, error) {
-	log.Info().Str("url", t.server.ControlURL).Msg("connecting to tailnet")
+	server := t.currentServer()
+	log.Info().Str("url", server.ControlURL).Msg("connecting to tailnet")
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	addr := fmt.Sprintf(":%d", service.LocalPort)
-	listener, err := t.server.Listen("tcp", addr)
+	listener, err := server.Listen("tcp", addr)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = t.server.Up(timeoutCtx)
+	_, err = server.Up(timeoutCtx)
 	if err != nil {
 		return nil, err
 	}
+
+	t.mu.Lock()
+	t.served = true
+	t.initialized = true
+	t.mu.Unlock()
 
 	log.Info().Str("addr", addr).Msg("connected to tailnet")
 	return listener, nil
@@ -106,25 +158,155 @@ func (t *Tailscale) Serve(ctx context.Context, service types.InternalService) (n
 
 // Dial attempts to establish a TCP connection to a tailscale service
 func (t *Tailscale) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
-	if !t.initialized {
-		t.mu.Lock()
-
-		_, err := t.server.Up(ctx)
-		if err != nil {
-			t.mu.Unlock()
-			return nil, err
-		}
-
-		t.initialized = true
-		t.mu.Unlock()
+	if err := t.ensureUp(ctx); err != nil {
+		return nil, err
 	}
 
-	conn, err := t.server.Dial(ctx, network, addr)
+	conn, err := t.currentServer().Dial(ctx, network, addr)
 	if err != nil {
 		return nil, err
 	}
 
 	return conn, nil
+}
+
+// WaitForPeer blocks until host is visible in this node's tailnet netmap, or
+// the timeout elapses. Dialing a MagicDNS name for a peer that is missing from
+// the netmap silently falls back to the system resolver and surfaces as a
+// confusing NXDOMAIN ("no such host"); callers should use this to fail with a
+// clear error instead. Repeated misses feed the stale-netmap self-healing.
+func (t *Tailscale) WaitForPeer(ctx context.Context, host string, timeout time.Duration) error {
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	if host == "" {
+		return nil
+	}
+	if _, err := netip.ParseAddr(host); err == nil {
+		// IP targets don't go through MagicDNS; tsnet dials them directly
+		// from the netmap and fails fast on its own.
+		return nil
+	}
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		found, err := t.peerInNetmap(ctx, host)
+		if err == nil && found {
+			t.notePeerSeen()
+			return nil
+		}
+		lastErr = err
+
+		if time.Now().Add(tailnetPeerPollInterval).After(deadline) {
+			t.notePeerMiss(host)
+			if lastErr != nil {
+				return fmt.Errorf("tailnet status unavailable while resolving peer %q: %w", host, lastErr)
+			}
+			return fmt.Errorf("tailnet peer %q is not visible in this node's netmap (peer is offline or the tailnet control connection is stale)", host)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(tailnetPeerPollInterval):
+		}
+	}
+}
+
+func (t *Tailscale) peerInNetmap(ctx context.Context, host string) (bool, error) {
+	status, err := t.netmapStatus(ctx)
+	if err != nil {
+		return false, err
+	}
+	if status == nil {
+		return false, nil
+	}
+	if status.Self != nil && tailnetPeerMatchesHost(status.Self.HostName, status.Self.DNSName, host) {
+		return true, nil
+	}
+	for _, peer := range status.Peer {
+		if peer == nil {
+			continue
+		}
+		if tailnetPeerMatchesHost(peer.HostName, peer.DNSName, host) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (t *Tailscale) netmapStatus(ctx context.Context) (*ipnstate.Status, error) {
+	if t.statusFunc != nil {
+		return t.statusFunc(ctx)
+	}
+	if err := t.ensureUp(ctx); err != nil {
+		return nil, err
+	}
+	client, err := t.currentServer().LocalClient()
+	if err != nil {
+		return nil, err
+	}
+	statusCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	return client.Status(statusCtx)
+}
+
+func tailnetPeerMatchesHost(hostName, dnsName, target string) bool {
+	target = strings.TrimSuffix(target, ".")
+	hostName = strings.TrimSuffix(hostName, ".")
+	dnsName = strings.TrimSuffix(dnsName, ".")
+	return target == hostName || target == dnsName || strings.HasPrefix(dnsName, target+".")
+}
+
+func (t *Tailscale) notePeerSeen() {
+	t.missMu.Lock()
+	defer t.missMu.Unlock()
+	t.missCount = 0
+	t.firstMissAt = time.Time{}
+}
+
+func (t *Tailscale) notePeerMiss(host string) {
+	t.missMu.Lock()
+	now := time.Now()
+	if t.firstMissAt.IsZero() {
+		t.firstMissAt = now
+	}
+	t.missCount++
+	shouldRestart := t.missCount >= staleNetmapMissThreshold &&
+		now.Sub(t.firstMissAt) >= staleNetmapMissWindow &&
+		(t.lastRestart.IsZero() || now.Sub(t.lastRestart) >= staleNetmapRestartCooldown)
+	if shouldRestart {
+		t.lastRestart = now
+		t.missCount = 0
+		t.firstMissAt = time.Time{}
+	}
+	t.missMu.Unlock()
+
+	if shouldRestart {
+		t.restartServer(host)
+	}
+}
+
+// restartServer recycles the tsnet server to force a fresh control connection
+// and netmap. It is only safe for dial-only nodes; nodes serving listeners
+// would drop them.
+func (t *Tailscale) restartServer(host string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.served {
+		log.Warn().
+			Str("missing_peer", host).
+			Msg("tailnet netmap appears stale but this node serves tsnet listeners; skipping tsnet restart")
+		return
+	}
+
+	log.Warn().
+		Str("missing_peer", host).
+		Msg("recycling tsnet server after repeated netmap misses; tailnet control connection may be stale")
+	if t.server != nil {
+		_ = t.server.Close()
+	}
+	t.server = t.buildServer()
+	t.initialized = false
 }
 
 // DialTimeout attempts to establish a TCP connection to a tailscale service with the specified timeout duration
@@ -169,11 +351,11 @@ func (t *Tailscale) GetHostnameForService(serviceName string) (string, error) {
 }
 
 func (t *Tailscale) GetServer() *tsnet.Server {
-	return t.server
+	return t.currentServer()
 }
 
 func (t *Tailscale) ResolveService(serviceName string, timeout time.Duration) (string, error) {
-	client, err := t.server.LocalClient()
+	client, err := t.currentServer().LocalClient()
 	if err != nil {
 		return "", err
 	}
@@ -207,5 +389,5 @@ func (t *Tailscale) ResolveService(serviceName string, timeout time.Duration) (s
 
 // Stops the Tailscale server
 func (t *Tailscale) Close() error {
-	return t.server.Close()
+	return t.currentServer().Close()
 }

--- a/pkg/network/tailscale.go
+++ b/pkg/network/tailscale.go
@@ -59,22 +59,62 @@ var (
 	tailnetPeerPollInterval    = 500 * time.Millisecond
 )
 
+// staleNetmapDetector tracks terminal peer-lookup misses and decides when the
+// tsnet server should be recycled.
+type staleNetmapDetector struct {
+	mu          sync.Mutex
+	misses      int
+	firstMissAt time.Time
+	lastRestart time.Time
+}
+
+func (d *staleNetmapDetector) seen() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.misses = 0
+	d.firstMissAt = time.Time{}
+}
+
+// missed records a failed peer lookup and reports whether the caller should
+// recycle the tsnet server now.
+func (d *staleNetmapDetector) missed(now time.Time) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.firstMissAt.IsZero() {
+		d.firstMissAt = now
+	}
+	d.misses++
+
+	if d.misses < staleNetmapMissThreshold {
+		return false
+	}
+	if now.Sub(d.firstMissAt) < staleNetmapMissWindow {
+		return false
+	}
+	if !d.lastRestart.IsZero() && now.Sub(d.lastRestart) < staleNetmapRestartCooldown {
+		return false
+	}
+
+	d.lastRestart = now
+	d.misses = 0
+	d.firstMissAt = time.Time{}
+	return true
+}
+
 type Tailscale struct {
-	server        *tsnet.Server
+	mu          sync.Mutex // guards server, initialized, served
+	server      *tsnet.Server
+	initialized bool // server has been brought up
+	served      bool // server owns listeners; never recycle it
+
 	cfg           TailscaleConfig
 	debug         bool
-	initialized   bool
-	served        bool
-	mu            sync.Mutex
 	tailscaleRepo repository.TailscaleRepository
+	staleNetmap   staleNetmapDetector
 
 	// statusFunc overrides netmap status lookups in tests.
 	statusFunc func(ctx context.Context) (*ipnstate.Status, error)
-
-	missMu      sync.Mutex
-	missCount   int
-	firstMissAt time.Time
-	lastRestart time.Time
 }
 
 func (t *Tailscale) logF(format string, v ...interface{}) {
@@ -85,16 +125,13 @@ func (t *Tailscale) logF(format string, v ...interface{}) {
 
 // NewTailscale creates a new Tailscale instance using tsnet
 func newTailscale(cfg TailscaleConfig, tailscaleRepo repository.TailscaleRepository) *Tailscale {
-	ts := &Tailscale{
+	t := &Tailscale{
 		cfg:           cfg,
 		debug:         cfg.Debug,
-		initialized:   false,
-		mu:            sync.Mutex{},
 		tailscaleRepo: tailscaleRepo,
 	}
-
-	ts.server = ts.buildServer()
-	return ts
+	t.server = t.buildServer()
+	return t
 }
 
 func (t *Tailscale) buildServer() *tsnet.Server {
@@ -191,25 +228,28 @@ func (t *Tailscale) WaitForPeer(ctx context.Context, host string, timeout time.D
 	for {
 		found, err := t.peerInNetmap(ctx, host)
 		if err == nil && found {
-			t.notePeerSeen()
+			t.staleNetmap.seen()
 			return nil
 		}
 		lastErr = err
 
 		if time.Now().Add(tailnetPeerPollInterval).After(deadline) {
-			t.notePeerMiss(host)
-			if lastErr != nil {
-				return fmt.Errorf("tailnet status unavailable while resolving peer %q: %w", host, lastErr)
-			}
-			return fmt.Errorf("tailnet peer %q is not visible in this node's netmap (peer is offline or the tailnet control connection is stale)", host)
+			break
 		}
-
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-time.After(tailnetPeerPollInterval):
 		}
 	}
+
+	if t.staleNetmap.missed(time.Now()) {
+		t.recycleServer(host)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("tailnet status unavailable while resolving peer %q: %w", host, lastErr)
+	}
+	return fmt.Errorf("tailnet peer %q is not visible in this node's netmap (peer is offline or the tailnet control connection is stale)", host)
 }
 
 func (t *Tailscale) peerInNetmap(ctx context.Context, host string) (bool, error) {
@@ -257,54 +297,23 @@ func tailnetPeerMatchesHost(hostName, dnsName, target string) bool {
 	return target == hostName || target == dnsName || strings.HasPrefix(dnsName, target+".")
 }
 
-func (t *Tailscale) notePeerSeen() {
-	t.missMu.Lock()
-	defer t.missMu.Unlock()
-	t.missCount = 0
-	t.firstMissAt = time.Time{}
-}
-
-func (t *Tailscale) notePeerMiss(host string) {
-	t.missMu.Lock()
-	now := time.Now()
-	if t.firstMissAt.IsZero() {
-		t.firstMissAt = now
-	}
-	t.missCount++
-	shouldRestart := t.missCount >= staleNetmapMissThreshold &&
-		now.Sub(t.firstMissAt) >= staleNetmapMissWindow &&
-		(t.lastRestart.IsZero() || now.Sub(t.lastRestart) >= staleNetmapRestartCooldown)
-	if shouldRestart {
-		t.lastRestart = now
-		t.missCount = 0
-		t.firstMissAt = time.Time{}
-	}
-	t.missMu.Unlock()
-
-	if shouldRestart {
-		t.restartServer(host)
-	}
-}
-
-// restartServer recycles the tsnet server to force a fresh control connection
+// recycleServer replaces the tsnet server to force a fresh control connection
 // and netmap. It is only safe for dial-only nodes; nodes serving listeners
 // would drop them.
-func (t *Tailscale) restartServer(host string) {
+func (t *Tailscale) recycleServer(missingPeer string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.served {
 		log.Warn().
-			Str("missing_peer", host).
+			Str("missing_peer", missingPeer).
 			Msg("tailnet netmap appears stale but this node serves tsnet listeners; skipping tsnet restart")
 		return
 	}
 
 	log.Warn().
-		Str("missing_peer", host).
+		Str("missing_peer", missingPeer).
 		Msg("recycling tsnet server after repeated netmap misses; tailnet control connection may be stale")
-	if t.server != nil {
-		_ = t.server.Close()
-	}
+	_ = t.server.Close()
 	t.server = t.buildServer()
 	t.initialized = false
 }

--- a/pkg/network/tailscale_test.go
+++ b/pkg/network/tailscale_test.go
@@ -1,0 +1,157 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/key"
+)
+
+func statusWithPeers(hosts ...string) *ipnstate.Status {
+	status := &ipnstate.Status{
+		Peer: map[key.NodePublic]*ipnstate.PeerStatus{},
+	}
+	for _, host := range hosts {
+		status.Peer[key.NewNode().Public()] = &ipnstate.PeerStatus{
+			HostName: host,
+			DNSName:  host + ".tailnet.ts.net.",
+		}
+	}
+	return status
+}
+
+func testTailscale(t *testing.T, status *ipnstate.Status) *Tailscale {
+	t.Helper()
+	ts := newTailscale(TailscaleConfig{Hostname: "test-node"}, nil)
+	ts.initialized = true
+	ts.statusFunc = func(ctx context.Context) (*ipnstate.Status, error) {
+		return status, nil
+	}
+	return ts
+}
+
+func withFastPeerPolling(t *testing.T) {
+	t.Helper()
+	prev := tailnetPeerPollInterval
+	tailnetPeerPollInterval = time.Millisecond
+	t.Cleanup(func() { tailnetPeerPollInterval = prev })
+}
+
+func TestWaitForPeerFindsPeerByDNSName(t *testing.T) {
+	withFastPeerPolling(t)
+	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
+
+	if err := ts.WaitForPeer(context.Background(), "beam-agent-machine.tailnet.ts.net", 100*time.Millisecond); err != nil {
+		t.Fatalf("WaitForPeer() error = %v, want nil", err)
+	}
+	if ts.missCount != 0 {
+		t.Fatalf("missCount = %d, want 0", ts.missCount)
+	}
+}
+
+func TestWaitForPeerSkipsIPLiterals(t *testing.T) {
+	withFastPeerPolling(t)
+	// No peers at all: an IP target must not be blocked on netmap visibility.
+	ts := testTailscale(t, statusWithPeers())
+
+	for _, host := range []string{"100.71.206.108", "fd7a:115c:a1e0::3233:ce6d"} {
+		if err := ts.WaitForPeer(context.Background(), host, 10*time.Millisecond); err != nil {
+			t.Fatalf("WaitForPeer(%q) error = %v, want nil for IP literal", host, err)
+		}
+	}
+	if ts.missCount != 0 {
+		t.Fatalf("missCount = %d, want 0 (IP literals must not count as misses)", ts.missCount)
+	}
+}
+
+func TestWaitForPeerMatchesSelf(t *testing.T) {
+	withFastPeerPolling(t)
+	status := statusWithPeers()
+	status.Self = &ipnstate.PeerStatus{HostName: "test-node", DNSName: "test-node.tailnet.ts.net."}
+	ts := testTailscale(t, status)
+
+	if err := ts.WaitForPeer(context.Background(), "test-node.tailnet.ts.net", 50*time.Millisecond); err != nil {
+		t.Fatalf("WaitForPeer() error = %v, want nil", err)
+	}
+}
+
+func TestWaitForPeerMissingPeerReturnsClearError(t *testing.T) {
+	withFastPeerPolling(t)
+	ts := testTailscale(t, statusWithPeers("some-other-node"))
+
+	err := ts.WaitForPeer(context.Background(), "beam-agent-missing.tailnet.ts.net", 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("WaitForPeer() error = nil, want netmap error")
+	}
+	if !strings.Contains(err.Error(), "netmap") {
+		t.Fatalf("WaitForPeer() error = %v, want mention of netmap", err)
+	}
+	if ts.missCount != 1 {
+		t.Fatalf("missCount = %d, want 1", ts.missCount)
+	}
+}
+
+func TestWaitForPeerSuccessResetsMissCount(t *testing.T) {
+	withFastPeerPolling(t)
+	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
+	ts.missCount = 2
+	ts.firstMissAt = time.Now().Add(-time.Minute)
+
+	if err := ts.WaitForPeer(context.Background(), "beam-agent-machine", 50*time.Millisecond); err != nil {
+		t.Fatalf("WaitForPeer() error = %v, want nil", err)
+	}
+	if ts.missCount != 0 || !ts.firstMissAt.IsZero() {
+		t.Fatalf("miss state = (%d, %v), want reset", ts.missCount, ts.firstMissAt)
+	}
+}
+
+func TestRepeatedMissesRecycleServer(t *testing.T) {
+	withFastPeerPolling(t)
+	prevThreshold, prevWindow, prevCooldown := staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown
+	staleNetmapMissThreshold = 3
+	staleNetmapMissWindow = 0
+	staleNetmapRestartCooldown = 0
+	t.Cleanup(func() {
+		staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown = prevThreshold, prevWindow, prevCooldown
+	})
+
+	ts := testTailscale(t, statusWithPeers())
+	originalServer := ts.currentServer()
+
+	for i := 0; i < 3; i++ {
+		_ = ts.WaitForPeer(context.Background(), "beam-agent-missing", time.Millisecond)
+	}
+
+	if ts.currentServer() == originalServer {
+		t.Fatal("server was not recycled after repeated netmap misses")
+	}
+	if ts.initialized {
+		t.Fatal("initialized = true after recycle, want false so the next dial re-ups")
+	}
+}
+
+func TestRepeatedMissesDoNotRecycleServingNode(t *testing.T) {
+	withFastPeerPolling(t)
+	prevThreshold, prevWindow, prevCooldown := staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown
+	staleNetmapMissThreshold = 2
+	staleNetmapMissWindow = 0
+	staleNetmapRestartCooldown = 0
+	t.Cleanup(func() {
+		staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown = prevThreshold, prevWindow, prevCooldown
+	})
+
+	ts := testTailscale(t, statusWithPeers())
+	ts.served = true
+	originalServer := ts.currentServer()
+
+	for i := 0; i < 4; i++ {
+		_ = ts.WaitForPeer(context.Background(), "beam-agent-missing", time.Millisecond)
+	}
+
+	if ts.currentServer() != originalServer {
+		t.Fatal("serving node's tsnet server was recycled, want untouched")
+	}
+}

--- a/pkg/network/tailscale_test.go
+++ b/pkg/network/tailscale_test.go
@@ -47,8 +47,8 @@ func TestWaitForPeerFindsPeerByDNSName(t *testing.T) {
 	if err := ts.WaitForPeer(context.Background(), "beam-agent-machine.tailnet.ts.net", 100*time.Millisecond); err != nil {
 		t.Fatalf("WaitForPeer() error = %v, want nil", err)
 	}
-	if ts.missCount != 0 {
-		t.Fatalf("missCount = %d, want 0", ts.missCount)
+	if ts.staleNetmap.misses != 0 {
+		t.Fatalf("missCount = %d, want 0", ts.staleNetmap.misses)
 	}
 }
 
@@ -62,8 +62,8 @@ func TestWaitForPeerSkipsIPLiterals(t *testing.T) {
 			t.Fatalf("WaitForPeer(%q) error = %v, want nil for IP literal", host, err)
 		}
 	}
-	if ts.missCount != 0 {
-		t.Fatalf("missCount = %d, want 0 (IP literals must not count as misses)", ts.missCount)
+	if ts.staleNetmap.misses != 0 {
+		t.Fatalf("missCount = %d, want 0 (IP literals must not count as misses)", ts.staleNetmap.misses)
 	}
 }
 
@@ -89,22 +89,22 @@ func TestWaitForPeerMissingPeerReturnsClearError(t *testing.T) {
 	if !strings.Contains(err.Error(), "netmap") {
 		t.Fatalf("WaitForPeer() error = %v, want mention of netmap", err)
 	}
-	if ts.missCount != 1 {
-		t.Fatalf("missCount = %d, want 1", ts.missCount)
+	if ts.staleNetmap.misses != 1 {
+		t.Fatalf("missCount = %d, want 1", ts.staleNetmap.misses)
 	}
 }
 
 func TestWaitForPeerSuccessResetsMissCount(t *testing.T) {
 	withFastPeerPolling(t)
 	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
-	ts.missCount = 2
-	ts.firstMissAt = time.Now().Add(-time.Minute)
+	ts.staleNetmap.misses = 2
+	ts.staleNetmap.firstMissAt = time.Now().Add(-time.Minute)
 
 	if err := ts.WaitForPeer(context.Background(), "beam-agent-machine", 50*time.Millisecond); err != nil {
 		t.Fatalf("WaitForPeer() error = %v, want nil", err)
 	}
-	if ts.missCount != 0 || !ts.firstMissAt.IsZero() {
-		t.Fatalf("miss state = (%d, %v), want reset", ts.missCount, ts.firstMissAt)
+	if ts.staleNetmap.misses != 0 || !ts.staleNetmap.firstMissAt.IsZero() {
+		t.Fatalf("miss state = (%d, %v), want reset", ts.staleNetmap.misses, ts.staleNetmap.firstMissAt)
 	}
 }
 

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -64,6 +64,9 @@ type eventMetadata struct {
 	ServiceName string
 	InstanceID  string
 	PoolName    string
+	// Action is the payload-level action (e.g. machine.heartbeat); used for
+	// stream routing decisions, not persisted as a cloud event extension.
+	Action string
 }
 
 func NewEventClientRepo(config types.AppConfig) EventRepository {
@@ -1115,6 +1118,7 @@ func eventMetadataFromData(data interface{}) eventMetadata {
 			MachineID:   d.MachineID,
 			RouteID:     d.RouteID,
 			PoolName:    d.PoolName,
+			Action:      d.Action,
 		}
 	case types.EventStubCacheRequiredContentSchema:
 		return eventMetadata{StubID: d.StubID, WorkspaceID: d.WorkspaceID}

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -466,6 +466,24 @@ func (r *S2EventRepository) GetEventHistory(ctx context.Context, query types.Eve
 		}
 	}
 
+	// The dense compute stream may be empty for workspaces whose events
+	// predate it; fall back to scanning the full workspace stream.
+	if len(response.Events) == 0 && query.WorkspaceID != "" && allComputeEventTypes(query.EventTypes) {
+		workspaceStream := r.workspaceStreamName(query.WorkspaceID)
+		alreadyRead := false
+		for _, streamName := range response.Streams {
+			if streamName == string(workspaceStream) {
+				alreadyRead = true
+				break
+			}
+		}
+		if !alreadyRead {
+			if err := r.readEventHistoryStream(ctx, workspaceStream, query, limit, response); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	sortContainerEventRecords(response.Events)
 	return response, nil
 }
@@ -652,6 +670,10 @@ func (r *S2EventRepository) readContainerStream(ctx context.Context, streamName 
 func (r *S2EventRepository) readEventHistoryStream(ctx context.Context, streamName s2.StreamName, query types.EventQuery, limit uint64, response *types.EventHistoryResponse) error {
 	response.Streams = append(response.Streams, string(streamName))
 
+	if eventHistoryQueryReadsFromTail(query) {
+		return r.readEventHistoryStreamFromTail(ctx, streamName, query, limit, response)
+	}
+
 	var nextSeqNum *uint64
 	if query.SeqNum != nil {
 		seq := *query.SeqNum
@@ -721,6 +743,77 @@ func (r *S2EventRepository) readEventHistoryStream(ctx context.Context, streamNa
 		startTimestamp = nil
 		if len(batch.Records) < int(count) {
 			return nil
+		}
+	}
+	return nil
+}
+
+// eventHistoryQueryReadsFromTail reports whether a history query has no
+// explicit start/end selector, in which case callers want the most recent
+// events rather than the oldest records in the stream.
+func eventHistoryQueryReadsFromTail(query types.EventQuery) bool {
+	return query.SeqNum == nil &&
+		query.StartTime == nil &&
+		query.Timestamp == nil &&
+		query.EndTime == nil &&
+		query.Until == nil
+}
+
+// readEventHistoryStreamFromTail scans the stream newest-first so a limited
+// history read returns the latest matching events instead of the first
+// records ever written to the stream.
+func (r *S2EventRepository) readEventHistoryStreamFromTail(ctx context.Context, streamName s2.StreamName, query types.EventQuery, limit uint64, response *types.EventHistoryResponse) error {
+	tail, err := r.basin.Stream(streamName).CheckTail(ctx)
+	if err != nil {
+		if isS2ReadEmpty(err) {
+			return nil
+		}
+		return fmt.Errorf("check tail for event history s2 stream %q: %w", streamName, err)
+	}
+	if tail.Tail.SeqNum == 0 {
+		return nil
+	}
+
+	chunkSize := uint64(s2EventHistoryReadLimit)
+	if chunkSize == 0 {
+		chunkSize = 1000
+	}
+	scanLimit := uint64(s2EventAggregateScanLimit)
+	if limit > scanLimit {
+		scanLimit = limit
+	}
+
+	var recordsScanned uint64
+	var scannedFromTail uint64
+	for scannedFromTail < tail.Tail.SeqNum && recordsScanned < scanLimit && uint64(len(response.Events)) < limit {
+		tailOffset, count := nextTailReadWindow(scannedFromTail, tail.Tail.SeqNum, chunkSize)
+		tailOffsetValue := int64(tailOffset)
+		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{
+			TailOffset: &tailOffsetValue,
+			Count:      &count,
+		})
+		if err != nil {
+			if isS2ReadEmpty(err) {
+				return nil
+			}
+			return fmt.Errorf("read event history from s2 stream %q: %w", streamName, err)
+		}
+		if len(batch.Records) == 0 {
+			return nil
+		}
+		recordsScanned += uint64(len(batch.Records))
+		scannedFromTail = tailOffset
+
+		for i := len(batch.Records) - 1; i >= 0; i-- {
+			eventRecord, ok := containerEventRecordFromS2(batch.Records[i], query, &types.ContainerEventsResponse{})
+			if !ok || !eventRecordMatchesQuery(eventRecord, query) {
+				continue
+			}
+			augmentContainerEventResponse(&types.ContainerEventsResponse{}, &eventRecord)
+			response.Events = append(response.Events, eventRecord)
+			if uint64(len(response.Events)) >= limit {
+				break
+			}
 		}
 	}
 	return nil
@@ -948,6 +1041,9 @@ func eventRecordMatchesQuery(record types.ContainerEventRecord, query types.Even
 	if query.WorkspaceID != "" && record.WorkspaceID != query.WorkspaceID {
 		return false
 	}
+	if len(query.ExcludeActions) > 0 && eventRecordActionExcluded(record, query.ExcludeActions) {
+		return false
+	}
 	if query.StubID != "" && record.StubID != query.StubID {
 		return false
 	}
@@ -971,6 +1067,26 @@ func eventRecordMatchesQuery(record types.ContainerEventRecord, query types.Even
 		return false
 	}
 	return true
+}
+
+// eventRecordActionExcluded reports whether the record's payload "action"
+// field matches one of the excluded actions.
+func eventRecordActionExcluded(record types.ContainerEventRecord, excludeActions []string) bool {
+	if len(record.Data) == 0 {
+		return false
+	}
+	var payload struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal(record.Data, &payload); err != nil || payload.Action == "" {
+		return false
+	}
+	for _, action := range excludeActions {
+		if strings.TrimSpace(action) == payload.Action {
+			return true
+		}
+	}
+	return false
 }
 
 func s2TimestampMillisToNanos(timestamp uint64) uint64 {
@@ -1099,9 +1215,13 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 	}
 	if isComputeEvent(eventType) && metadata.WorkspaceID != "" {
 		// Workspace stream powers the live workspace SSE; the compute stream keeps
-		// a dense history for fast compute-only history queries.
+		// a dense history for fast compute-only history queries. Heartbeats fire
+		// every few seconds per machine and would drown out lifecycle events in
+		// the history stream, so they only go to the live workspace stream.
 		add(r.workspaceStreamName(metadata.WorkspaceID))
-		add(r.workspaceComputeStreamName(metadata.WorkspaceID))
+		if metadata.Action != types.EventComputeActionMachineHeartbeat {
+			add(r.workspaceComputeStreamName(metadata.WorkspaceID))
+		}
 	}
 	if isTaskEvent(eventType) && metadata.WorkspaceID != "" {
 		add(r.workspaceStreamName(metadata.WorkspaceID))

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -763,21 +763,24 @@ type EventPlatformLogSchema struct {
 }
 
 type EventQuery struct {
-	Limit       uint64     `json:"limit,omitempty"`
-	WorkspaceID string     `json:"workspace_id,omitempty"`
-	StubID      string     `json:"stub_id,omitempty"`
-	AppID       string     `json:"app_id,omitempty"`
-	TaskID      string     `json:"task_id,omitempty"`
-	ContainerID string     `json:"container_id,omitempty"`
-	EventTypes  []string   `json:"event_types,omitempty"`
-	StartTime   *time.Time `json:"start_time,omitempty"`
-	EndTime     *time.Time `json:"end_time,omitempty"`
-	SeqNum      *uint64    `json:"seq_num,omitempty"`
-	Timestamp   *uint64    `json:"timestamp,omitempty"`
-	TailOffset  *int64     `json:"tail_offset,omitempty"`
-	Until       *uint64    `json:"until,omitempty"`
-	WaitSeconds *int32     `json:"wait,omitempty"`
-	Clamp       *bool      `json:"clamp,omitempty"`
+	Limit       uint64   `json:"limit,omitempty"`
+	WorkspaceID string   `json:"workspace_id,omitempty"`
+	StubID      string   `json:"stub_id,omitempty"`
+	AppID       string   `json:"app_id,omitempty"`
+	TaskID      string   `json:"task_id,omitempty"`
+	ContainerID string   `json:"container_id,omitempty"`
+	EventTypes  []string `json:"event_types,omitempty"`
+	// ExcludeActions drops records whose payload "action" field matches; used
+	// to keep dense actions (e.g. machine.heartbeat) from consuming the limit.
+	ExcludeActions []string   `json:"exclude_actions,omitempty"`
+	StartTime      *time.Time `json:"start_time,omitempty"`
+	EndTime        *time.Time `json:"end_time,omitempty"`
+	SeqNum         *uint64    `json:"seq_num,omitempty"`
+	Timestamp      *uint64    `json:"timestamp,omitempty"`
+	TailOffset     *int64     `json:"tail_offset,omitempty"`
+	Until          *uint64    `json:"until,omitempty"`
+	WaitSeconds    *int32     `json:"wait,omitempty"`
+	Clamp          *bool      `json:"clamp,omitempty"`
 }
 
 type LogQuery struct {

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -59,8 +59,18 @@ const (
 	cacheDefaultReconcileLockTTLS       = 300
 	cacheDefaultReconcileMaxStubsCycle  = 256
 	cacheDefaultReconcileMaxItemsCycle  = 32
-	cacheDefaultVolumeReportMinBytes    = 128 * 1024 * 1024
-	cacheReconcileSuccessBackoff        = time.Hour
+	// cacheDefaultReconcileMaxDiskUsagePct pauses proactive materialization
+	// before node-level DiskPressure thresholds can be reached.
+	cacheDefaultReconcileMaxDiskUsagePct = 0.75
+	// cacheReconcileOwnerGracePeriod is how long a key's HRW owner may be
+	// endpoint-less (rolling deploy, pod cycle) before its keys fail over to
+	// the next-ranked host for proactive materialization. Short blips keep
+	// ownership stable so an entire key range isn't duplicated onto peers;
+	// hosts that disappear for good also age out of the ring itself via the
+	// coordinator TTL.
+	cacheReconcileOwnerGracePeriod   = 10 * time.Minute
+	cacheDefaultVolumeReportMinBytes = 128 * 1024 * 1024
+	cacheReconcileSuccessBackoff     = time.Hour
 )
 
 type WorkerCacheManager struct {
@@ -88,6 +98,9 @@ type WorkerCacheManager struct {
 	reconcileFailures     map[string]time.Time
 	reconcileSuccessesMu  sync.Mutex
 	reconcileSuccesses    map[string]time.Time
+	ownerLastLiveMu       sync.Mutex
+	ownerLastLive         map[string]time.Time
+	reconcilePausedAt     time.Time
 	reconcileNow          chan struct{}
 	client                *cache.Client
 	server                *cache.Server
@@ -126,6 +139,7 @@ func NewWorkerCacheManager(ctx context.Context, config types.AppConfig, poolConf
 		originCredsCache:   make(map[string]*originCredentials),
 		reconcileFailures:  make(map[string]time.Time),
 		reconcileSuccesses: make(map[string]time.Time),
+		ownerLastLive:      make(map[string]time.Time),
 		reconcileNow:       make(chan struct{}, 1),
 	}
 }

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -9,6 +9,10 @@ package worker
 //   - WorkerCacheManager reconcile loop: on the node that currently hosts the
 //     cache server, materializes content the local host owns (HRW), except
 //     checkpoints which materialize on every matching accelerator in locality.
+//     Ownership has hysteresis: an owner that is briefly endpoint-less (e.g. a
+//     rolling deploy) keeps its keys; only after a grace period do its keys
+//     fail over to the next-ranked live host. Materialization also pauses
+//     while local disk usage is above the reconciliation watermark.
 //
 // The worker is trustless: all coordinator state (recent stubs, locks) is
 // brokered through the gateway, and all origin credentials are fetched from the
@@ -95,6 +99,16 @@ func (m *WorkerCacheManager) reconcileMaxItemsPerCycle() int {
 		items = cacheDefaultReconcileMaxItemsCycle
 	}
 	return items
+}
+
+// reconcileMaxDiskUsagePct is the local disk usage fraction above which
+// proactive materialization pauses.
+func (m *WorkerCacheManager) reconcileMaxDiskUsagePct() float64 {
+	pct := m.config.Cache.Reconciliation.MaxDiskUsagePct
+	if pct <= 0 || pct > 1 {
+		pct = cacheDefaultReconcileMaxDiskUsagePct
+	}
+	return pct
 }
 
 // cacheContentReporter coalesces required-content reports per (stub, kind) and
@@ -431,6 +445,10 @@ func (m *WorkerCacheManager) reconcileOnce() {
 		return
 	}
 
+	if m.reconcileGatedByDiskUsage(server, localHostID) {
+		return
+	}
+
 	m.pruneReconcileFailures()
 	m.pruneReconcileSuccesses()
 
@@ -495,12 +513,8 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 			if item.CheckpointID != "" {
 				checkpointIDs = append(checkpointIDs, item.CheckpointID)
 			}
-		} else {
-			// Materialize only on the host a read would actually resolve to.
-			primary, err := m.client.PrimaryReadHost(routingKey)
-			if err != nil || primary == nil || primary.HostId != localHostID {
-				continue
-			}
+		} else if !m.localHostOwnsForReconcile(localHostID, routingKey) {
+			continue
 		}
 
 		if m.requiredContentComplete(server, item, routingKey) {
@@ -523,6 +537,89 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 		m.materializeOwnedItem(server, localHostID, stub, item, routingKey)
 	}
 	return checkpointIDs
+}
+
+// reconcileGatedByDiskUsage pauses proactive materialization while local disk
+// usage is above the reconciliation watermark, so reconciliation can never
+// push a node into kubelet DiskPressure territory. Demand-driven reads are
+// unaffected. Transitions are logged once, not every cycle.
+func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, localHostID string) bool {
+	usage := server.UsagePct()
+	if usage > m.reconcileMaxDiskUsagePct() {
+		if m.reconcilePausedAt.IsZero() {
+			m.reconcilePausedAt = time.Now()
+			log.Warn().
+				Str("locality", m.locality).
+				Str("logical_host", localHostID).
+				Float64("disk_usage_pct", usage).
+				Float64("max_disk_usage_pct", m.reconcileMaxDiskUsagePct()).
+				Msg("cache reconciliation paused: disk usage above watermark")
+		}
+		return true
+	}
+
+	if !m.reconcilePausedAt.IsZero() {
+		log.Info().
+			Str("locality", m.locality).
+			Str("logical_host", localHostID).
+			Dur("paused_for", time.Since(m.reconcilePausedAt)).
+			Msg("cache reconciliation resumed: disk usage back below watermark")
+		m.reconcilePausedAt = time.Time{}
+	}
+	return false
+}
+
+// localHostOwnsForReconcile reports whether this host should proactively
+// materialize the given key. The HRW owner keeps its keys while it is live or
+// only briefly endpoint-less (e.g. a rolling deploy: its on-disk content
+// survives the restart, and duplicating its entire key range onto peers is
+// what causes post-deploy materialization storms). Once the owner has been
+// endpoint-less past the grace period, ownership for reconciliation purposes
+// falls through to the next-ranked live host, preserving self-healing when a
+// node is really gone. Hosts that stay gone also age out of the ring itself.
+func (m *WorkerCacheManager) localHostOwnsForReconcile(localHostID, routingKey string) bool {
+	now := time.Now()
+	for _, host := range m.client.RankedReadHosts(routingKey) {
+		switch {
+		case host == nil:
+			continue
+		case host.HasEndpoint():
+			m.ownerSeenLive(host.HostId, now)
+			return host.HostId == localHostID
+		case now.Sub(m.ownerLastLiveAt(host.HostId, now)) < cacheReconcileOwnerGracePeriod:
+			// The owner is endpoint-less but within grace: nobody takes over
+			// its keys yet
+			return host.HostId == localHostID
+		}
+		// Owner endpoint-less past grace: fall through to the next-ranked host
+	}
+	return false
+}
+
+func (m *WorkerCacheManager) ownerSeenLive(hostID string, now time.Time) {
+	m.ownerLastLiveMu.Lock()
+	defer m.ownerLastLiveMu.Unlock()
+	if m.ownerLastLive == nil {
+		m.ownerLastLive = make(map[string]time.Time)
+	}
+	m.ownerLastLive[hostID] = now
+}
+
+// ownerLastLiveAt returns when hostID was last observed with a live endpoint.
+// A host seen for the first time while endpoint-less starts its grace window
+// now, so a freshly-restarted process doesn't immediately treat peers that
+// were down before it started as permanently gone.
+func (m *WorkerCacheManager) ownerLastLiveAt(hostID string, now time.Time) time.Time {
+	m.ownerLastLiveMu.Lock()
+	defer m.ownerLastLiveMu.Unlock()
+	if m.ownerLastLive == nil {
+		m.ownerLastLive = make(map[string]time.Time)
+	}
+	if lastLive, ok := m.ownerLastLive[hostID]; ok {
+		return lastLive
+	}
+	m.ownerLastLive[hostID] = now
+	return now
 }
 
 type reconcileBudget struct {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -353,6 +353,84 @@ func TestReconcileOnceUsesOnlyCurrentLocalityRecentStubs(t *testing.T) {
 	require.Equal(t, []string{"workspace-b|stub-b"}, fake.readKeys)
 }
 
+func TestLocalHostOwnsForReconcileKeepsOwnershipThroughBriefEndpointLoss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := testCacheManagerConfig(t.TempDir()).Cache
+	cfg.Client.NTopHosts = 2
+
+	localServer, err := cache.NewServerWithOptions(ctx, cfg, "test", cache.WithServerMetadataStore(cache.NewMockCacheMetadataStore()), cache.WithServerHostID("local-host"))
+	require.NoError(t, err)
+	localAddr, err := localServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, localServer.Close()) })
+
+	localHost := localServer.Host()
+	require.NotNil(t, localHost)
+	localHost.Addr = localAddr
+	localHost.PrivateAddr = localAddr
+
+	// A peer that is registered in the ring but currently has no live endpoint
+	// (e.g. its pod is mid-restart during a rolling deploy).
+	peerHost := &cache.Host{
+		HostId:      "peer-host",
+		PoolName:    localHost.PoolName,
+		Locality:    "test",
+		NodeID:      "node-peer",
+		CachePathID: "path-peer",
+	}
+	require.False(t, peerHost.HasEndpoint())
+
+	clientCfg := cfg
+	clientCfg.Server.DiskCacheDir = t.TempDir()
+	client, err := cache.NewClientWithHostDirectory(ctx, clientCfg, cache.NewMockCacheMetadataStore(), testHostDirectoryFunc(func(context.Context, string) ([]*cache.Host, error) {
+		return []*cache.Host{localHost, peerHost}, nil
+	}), "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Cleanup()) })
+
+	require.Eventually(t, func() bool {
+		return len(client.RankedReadHosts("probe")) == 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	manager := &WorkerCacheManager{
+		ctx:           ctx,
+		locality:      "test",
+		client:        client,
+		ownerLastLive: make(map[string]time.Time),
+	}
+
+	// Find one key owned by the down peer and one owned by the live local host
+	peerKey, localKey := "", ""
+	for i := 0; i < 256 && (peerKey == "" || localKey == ""); i++ {
+		key := fmt.Sprintf("key-%d", i)
+		ranked := client.RankedReadHosts(key)
+		require.Len(t, ranked, 2)
+		if ranked[0].HostId == peerHost.HostId && peerKey == "" {
+			peerKey = key
+		}
+		if ranked[0].HostId == localHost.HostId && localKey == "" {
+			localKey = key
+		}
+	}
+	require.NotEmpty(t, peerKey)
+	require.NotEmpty(t, localKey)
+
+	// Keys owned by the live local host always reconcile locally
+	require.True(t, manager.localHostOwnsForReconcile(localHost.HostId, localKey))
+
+	// Keys owned by the briefly endpoint-less peer must NOT fail over within
+	// the grace window: its on-disk content survives the restart, and taking
+	// over would duplicate its entire key range.
+	require.False(t, manager.localHostOwnsForReconcile(localHost.HostId, peerKey))
+
+	// Once the peer has been endpoint-less past the grace period, its keys
+	// fail over to the next-ranked live host so the system still self-heals.
+	manager.ownerLastLive[peerHost.HostId] = time.Now().Add(-cacheReconcileOwnerGracePeriod - time.Minute)
+	require.True(t, manager.localHostOwnsForReconcile(localHost.HostId, peerKey))
+}
+
 func TestReconcileStubSkipsRecentlyMaterializedMissingContent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves remote node connectivity and cache behavior: adds explicit Tailscale peer checks with self-healing, LRU disk eviction, and safer cache reconciliation. Stabilizes compute telemetry and event history while reducing dial flakiness and avoiding DiskPressure.

- **New Features**
  - Tailscale dialing hardening in `pkg/network`: wait for peer presence in netmap before dialing (incl. `resolve.go`), retry transient errors with clearer timeouts; auto-recycle `tsnet` on repeated netmap misses; tests added.
  - LRU disk cache eviction in `pkg/cache`: track read recency via marker mtime (throttled touches); evict oldest above `DiskCacheEvictWatermarkPct` (default 0.85) and refresh usage after eviction; tests added.
  - Safer cache reconciliation in `pkg/worker`: pause proactive materialization above `MaxDiskUsagePct` (default 0.75); ownership hysteresis via `RankedReadHosts` so brief endpoint loss doesn’t shift ownership; graceful failover; `RankedReadHosts` exposed in client; tests added.
  - Event history in `pkg/repository`: tail-first scans when no selector, workspace fallback if dense compute stream empty, `exclude_actions` filter; heartbeat events excluded from the dense compute history stream.
  - Shadeform in `pkg/compute`: extend auto-delete grace to 7d, remove spend_threshold; renewals only bump date; tests updated.

- **Bug Fixes**
  - Heartbeat/liveness in `pkg/gateway` and `pkg/compute`: use gateway clock for heartbeats, clamp future agent timestamps, heartbeat timeout to 60s; test tolerances updated.
  - Telemetry in `pkg/agent`: cap health string, only include `peer_count` on full snapshots, and add summarized peer connectivity stats.
  - Control-plane worker list: filter out private-pool agent workers to avoid duplicate/confusing rows.
  - MagicDNS clarity: netmap checks prevent misleading NXDOMAIN when a peer is missing; improved error messages across Tailscale dials.

<sup>Written for commit 38f2e54f210e4a7096da419d7a616416adc474d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

