### PR TITLE
improve sandbox realtime metrics

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -39,12 +39,6 @@ func RunJoin(ctx context.Context, opts types.AgentJoinOptions) error {
 		fmt.Fprintf(opts.Stderr, "failed to save agent state: %v\n", err)
 	}
 
-	statusf(opts.Stdout, "Connected to pool %q", res.PoolName)
-	statusf(opts.Stdout, "Registered machine %q", res.MachineID)
-	if !res.Schedulable && len(res.Preflight) > 0 {
-		statusf(opts.Stdout, "Machine is not schedulable: %s", preflightFailureSummary(res.Preflight))
-	}
-	verbosef(opts.Stdout, "transport=%s executor=%s fallback=%s\n", res.Bootstrap.Transport, res.Bootstrap.Executor, res.Bootstrap.Fallback)
 	grpcClient, grpcConn, err := newGatewayGRPCClient(opts.GatewayURL, res.Bootstrap.GatewayGRPCHost, res.Bootstrap.GatewayGRPCPort, res.Bootstrap.GatewayGRPCTLS)
 	if err != nil {
 		return fmt.Errorf("gateway grpc client: %w", err)
@@ -53,24 +47,33 @@ func RunJoin(ctx context.Context, opts types.AgentJoinOptions) error {
 
 	telemetry := newAgentTelemetry(grpcClient, res.AgentToken, res.Bootstrap, opts.Stderr)
 	go telemetry.run(ctx)
-	agentLogs := telemetry.teeLogWriter(opts.Stderr, types.AgentTelemetrySourceAgent, "", types.EventLogStreamStderr)
-	defer agentLogs.Close()
+	agentStdout := telemetry.teeLogWriter(opts.Stdout, types.AgentTelemetrySourceAgent, "", types.EventLogStreamStdout)
+	defer agentStdout.Close()
+	agentStderr := telemetry.teeLogWriter(opts.Stderr, types.AgentTelemetrySourceAgent, "", types.EventLogStreamStderr)
+	defer agentStderr.Close()
 
-	workers := newWorkerRuntimeManager(res.Bootstrap, opts, opts.Stdout, opts.Stderr, agentLogs, telemetry)
+	statusf(agentStdout, "Connected to pool %q", res.PoolName)
+	statusf(agentStdout, "Registered machine %q", res.MachineID)
+	if !res.Schedulable && len(res.Preflight) > 0 {
+		statusf(agentStdout, "Machine is not schedulable: %s", preflightFailureSummary(res.Preflight))
+	}
+	verbosef(agentStdout, "transport=%s executor=%s fallback=%s\n", res.Bootstrap.Transport, res.Bootstrap.Executor, res.Bootstrap.Fallback)
+
+	workers := newWorkerRuntimeManager(res.Bootstrap, opts, opts.Stdout, opts.Stderr, agentStdout, agentStderr, telemetry)
 	telemetry.setStatsProvider(workers.stats)
 	defer workers.stopAll()
 
-	registryForwarder, err := startLocalRegistryForwarder(ctx, agentLogs)
+	registryForwarder, err := startLocalRegistryForwarder(ctx, agentStderr)
 	if err != nil {
-		fmt.Fprintf(agentLogs, "local registry forwarder disabled: %v\n", err)
+		fmt.Fprintf(agentStderr, "local registry forwarder disabled: %v\n", err)
 	} else if registryForwarder != nil {
 		defer registryForwarder.Close()
 	}
 
 	transport := normalizeTransport(firstNonEmpty(opts.TransportOverride, res.Bootstrap.Transport))
-	if err := runRouteProxy(ctx, grpcClient, res.AgentToken, transport, workers, telemetry, opts.Stdout, agentLogs); err != nil {
+	if err := runRouteProxy(ctx, grpcClient, res.AgentToken, transport, workers, telemetry, agentStdout, agentStderr); err != nil {
 		if agentInterrupted(ctx, err) {
-			statusf(opts.Stdout, "Disconnecting machine %q", res.MachineID)
+			statusf(agentStdout, "Disconnecting machine %q", res.MachineID)
 			return ErrInterrupted
 		}
 		return fmt.Errorf("route proxy stopped: %w", err)

--- a/pkg/agent/service/service_test.go
+++ b/pkg/agent/service/service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 )
 
-func TestSystemdInstallWritesUnitAndRestartsService(t *testing.T) {
+func TestSystemdInstallWritesUnitAndStartsService(t *testing.T) {
 	tmp := t.TempDir()
 	runner := &fakeRunner{}
 	manager := Systemd{
@@ -63,7 +63,7 @@ func TestSystemdInstallWritesUnitAndRestartsService(t *testing.T) {
 	if got, want := strings.Join(runner.commands, "\n"), strings.Join([]string{
 		types.AgentSystemctlCommand + " daemon-reload",
 		types.AgentSystemctlCommand + " enable " + types.DefaultAgentServiceName + types.AgentServiceUnitExtension,
-		types.AgentSystemctlCommand + " restart " + types.DefaultAgentServiceName + types.AgentServiceUnitExtension,
+		types.AgentSystemctlCommand + " start " + types.DefaultAgentServiceName + types.AgentServiceUnitExtension,
 	}, "\n"); got != want {
 		t.Fatalf("unexpected commands:\ngot:\n%s\nwant:\n%s", got, want)
 	}

--- a/pkg/agent/service/systemd.go
+++ b/pkg/agent/service/systemd.go
@@ -55,7 +55,7 @@ func (m Systemd) Install(ctx context.Context, spec Spec) error {
 	for _, args := range [][]string{
 		{"daemon-reload"},
 		{"enable", spec.Name + types.AgentServiceUnitExtension},
-		{"restart", spec.Name + types.AgentServiceUnitExtension},
+		{"start", spec.Name + types.AgentServiceUnitExtension},
 	} {
 		if err := runner.Run(ctx, types.AgentSystemctlCommand, args...); err != nil {
 			return fmt.Errorf("%s %s: %w", types.AgentSystemctlCommand, strings.Join(args, " "), err)

--- a/pkg/agent/worker_runtime.go
+++ b/pkg/agent/worker_runtime.go
@@ -21,8 +21,8 @@ type workerRuntimeManager struct {
 	mu          sync.Mutex
 	supervisors map[string]*workerRuntimeSupervisor
 	noticeOnce  sync.Once
-	stdout      io.Writer
-	stderr      io.Writer
+	statusOut   io.Writer
+	statusErr   io.Writer
 	telemetry   *agentTelemetry
 }
 
@@ -36,20 +36,25 @@ type workerContainerRuntime struct {
 	opts      types.AgentJoinOptions
 	stdout    io.Writer
 	stderr    io.Writer
+	statusOut io.Writer
+	statusErr io.Writer
 	telemetry *agentTelemetry
 	imageMu   sync.Mutex
 	images    map[string]string
 }
 
-func newWorkerRuntimeManager(bootstrap bootstrapConfig, opts types.AgentJoinOptions, stdout, stderr, agentLogs io.Writer, telemetry *agentTelemetry) *workerRuntimeManager {
+func newWorkerRuntimeManager(bootstrap bootstrapConfig, opts types.AgentJoinOptions, stdout, stderr, statusOut, statusErr io.Writer, telemetry *agentTelemetry) *workerRuntimeManager {
 	if stdout == nil {
 		stdout = io.Discard
 	}
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	if agentLogs == nil {
-		agentLogs = stderr
+	if statusOut == nil {
+		statusOut = stdout
+	}
+	if statusErr == nil {
+		statusErr = stderr
 	}
 	return &workerRuntimeManager{
 		executor: bootstrap.Executor,
@@ -58,11 +63,13 @@ func newWorkerRuntimeManager(bootstrap bootstrapConfig, opts types.AgentJoinOpti
 			opts:      opts,
 			stdout:    stdout,
 			stderr:    stderr,
+			statusOut: statusOut,
+			statusErr: statusErr,
 			telemetry: telemetry,
 			images:    map[string]string{},
 		},
-		stdout:      stdout,
-		stderr:      agentLogs,
+		statusOut:   statusOut,
+		statusErr:   statusErr,
 		telemetry:   telemetry,
 		supervisors: map[string]*workerRuntimeSupervisor{},
 	}
@@ -76,7 +83,7 @@ func (m *workerRuntimeManager) reconcile(ctx context.Context, slots []*pb.AgentW
 	if m.executor != types.DefaultAgentWorkerContainerMode {
 		if len(slots) > 0 {
 			m.noticeOnce.Do(func() {
-				fmt.Fprintf(m.stderr, "agent executor %q does not start worker containers; desired slots are ignored\n", m.executor)
+				fmt.Fprintf(m.statusErr, "agent executor %q does not start worker containers; desired slots are ignored\n", m.executor)
 			})
 		}
 		m.stopAll()
@@ -119,7 +126,7 @@ func (m *workerRuntimeManager) ensureSlot(ctx context.Context, slot *pb.AgentWor
 
 	slotCtx, cancel := context.WithCancel(ctx)
 	m.supervisors[slot.WorkerId] = &workerRuntimeSupervisor{slot: cloneAgentWorkerSlot(slot), cancel: cancel}
-	statusf(m.stdout, "Preparing worker %q", slot.WorkerId)
+	statusf(m.statusOut, "Preparing worker %q", slot.WorkerId)
 	go m.superviseSlot(slotCtx, slot)
 }
 
@@ -133,7 +140,7 @@ func (m *workerRuntimeManager) superviseSlot(ctx context.Context, slot *pb.Agent
 		if err == nil {
 			err = fmt.Errorf("worker exited")
 		}
-		fmt.Fprintf(m.stderr, "worker slot %s exited: %v\n", slot.WorkerId, err)
+		fmt.Fprintf(m.statusErr, "worker slot %s exited: %v\n", slot.WorkerId, err)
 
 		select {
 		case <-ctx.Done():
@@ -180,14 +187,14 @@ func (r *workerContainerRuntime) run(ctx context.Context, slot *pb.AgentWorkerSl
 	}
 
 	if err := removeOtherManagedWorkerContainers(name, slot); err != nil {
-		fmt.Fprintf(r.stderr, "failed to clean stale worker containers: %v\n", err)
+		fmt.Fprintf(r.statusErr, "failed to clean stale worker containers: %v\n", err)
 	}
 	if err := removeManagedWorkerContainer(name, slot); err != nil {
 		return err
 	}
 	defer func() {
 		if err := removeManagedWorkerContainer(name, slot); err != nil {
-			fmt.Fprintf(r.stderr, "failed to remove worker container %s: %v\n", name, err)
+			fmt.Fprintf(r.statusErr, "failed to remove worker container %s: %v\n", name, err)
 		}
 	}()
 
@@ -211,7 +218,7 @@ func (r *workerContainerRuntime) run(ctx context.Context, slot *pb.AgentWorkerSl
 	)
 
 	done := make(chan error, 1)
-	statusf(r.stdout, "Starting worker %q", slot.WorkerId)
+	statusf(r.statusOut, "Starting worker %q", slot.WorkerId)
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -237,12 +244,12 @@ func (r *workerContainerRuntime) pullImage(ctx context.Context, image string) (s
 	}
 	r.imageMu.Unlock()
 
-	statusf(r.stdout, "Pulling worker image %q", image)
-	imageID, err := pullDockerImage(ctx, image, r.stdout)
+	statusf(r.statusOut, "Pulling worker image %q", image)
+	imageID, err := pullDockerImage(ctx, image, r.statusOut)
 	if err != nil {
 		return "", err
 	}
-	statusf(r.stdout, "Worker image ready")
+	statusf(r.statusOut, "Worker image ready")
 
 	r.imageMu.Lock()
 	r.images[key] = imageID

--- a/pkg/api/v1/metrics.go
+++ b/pkg/api/v1/metrics.go
@@ -122,6 +122,7 @@ func (g *MetricsGroup) GetWorkspaceMetricTimeseries(ctx echo.Context) error {
 
 	response, err := g.eventRepo.GetWorkspaceMetricsTimeseries(ctx.Request().Context(), types.EventQuery{
 		WorkspaceID: workspaceID,
+		StubType:    ctx.QueryParam("stub_type"),
 		EventTypes:  []string{types.EventContainerMetrics},
 	}, start.UTC(), end.UTC(), interval)
 	if err != nil {

--- a/pkg/api/v1/sandbox_test.go
+++ b/pkg/api/v1/sandbox_test.go
@@ -1,0 +1,96 @@
+package apiv1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestMostRelevantContainerPrefersRunning(t *testing.T) {
+	containers := []types.ContainerState{
+		{ContainerId: "a", Status: types.ContainerStatusStopping},
+		{ContainerId: "b", Status: types.ContainerStatusPending},
+		{ContainerId: "c", Status: types.ContainerStatusRunning},
+	}
+
+	best := mostRelevantContainer(containers)
+	if best == nil || best.ContainerId != "c" {
+		t.Fatalf("expected running container 'c', got %+v", best)
+	}
+
+	if mostRelevantContainer(nil) != nil {
+		t.Fatalf("expected nil for empty container list")
+	}
+}
+
+func TestLiveSandboxStatus(t *testing.T) {
+	cases := []struct {
+		status types.ContainerStatus
+		want   string
+	}{
+		{types.ContainerStatusRunning, SandboxStatusRunning},
+		{types.ContainerStatusPending, SandboxStatusPending},
+		{types.ContainerStatusStopping, SandboxStatusStopping},
+	}
+
+	for _, c := range cases {
+		got := liveSandboxStatus([]types.ContainerState{{Status: c.status}})
+		if got != c.want {
+			t.Errorf("liveSandboxStatus(%s) = %s, want %s", c.status, got, c.want)
+		}
+	}
+
+	if got := liveSandboxStatus(nil); got != "" {
+		t.Errorf("liveSandboxStatus(nil) = %q, want empty", got)
+	}
+}
+
+func TestTerminalStatusFromContainerEvents(t *testing.T) {
+	failed := terminalStatusFromContainerEvents(&types.ContainerEventsResponse{RootCauseEvent: "runtime.oom_killed"})
+	if failed != SandboxStatusFailed {
+		t.Errorf("expected FAILED for oom, got %s", failed)
+	}
+
+	failed = terminalStatusFromContainerEvents(&types.ContainerEventsResponse{StopReason: "container failed to start"})
+	if failed != SandboxStatusFailed {
+		t.Errorf("expected FAILED for failure reason, got %s", failed)
+	}
+
+	stopped := terminalStatusFromContainerEvents(&types.ContainerEventsResponse{Status: "stopped", RootCauseEvent: "scheduler.stop_requested"})
+	if stopped != SandboxStatusStopped {
+		t.Errorf("expected STOPPED for clean stop, got %s", stopped)
+	}
+}
+
+func TestBuildCreatedBuckets(t *testing.T) {
+	if got := buildCreatedBuckets(nil); len(got) != 0 {
+		t.Fatalf("expected empty buckets for no stubs, got %d", len(got))
+	}
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	stubs := []types.StubWithRelated{
+		{Stub: types.Stub{CreatedAt: types.Time{Time: base}}},
+		{Stub: types.Stub{CreatedAt: types.Time{Time: base.Add(1 * time.Hour)}}},
+		{Stub: types.Stub{CreatedAt: types.Time{Time: base.Add(2 * time.Hour)}}},
+	}
+
+	buckets := buildCreatedBuckets(stubs)
+	if len(buckets) == 0 {
+		t.Fatalf("expected non-empty buckets")
+	}
+
+	total := 0
+	for _, bucket := range buckets {
+		total += bucket.Count
+	}
+	if total != len(stubs) {
+		t.Errorf("expected bucket counts to sum to %d, got %d", len(stubs), total)
+	}
+
+	// Single timestamp should collapse to one bucket.
+	single := buildCreatedBuckets([]types.StubWithRelated{{Stub: types.Stub{CreatedAt: types.Time{Time: base}}}})
+	if len(single) != 1 || single[0].Count != 1 {
+		t.Errorf("expected single bucket with count 1, got %+v", single)
+	}
+}

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/clients"
@@ -24,19 +26,23 @@ import (
 )
 
 type StubGroup struct {
-	routerGroup *echo.Group
-	config      types.AppConfig
-	backendRepo repository.BackendRepository
-	eventRepo   repository.EventRepository
+	routerGroup   *echo.Group
+	config        types.AppConfig
+	backendRepo   repository.BackendRepository
+	containerRepo repository.ContainerRepository
+	eventRepo     repository.EventRepository
 }
 
-func NewStubGroup(g *echo.Group, backendRepo repository.BackendRepository, eventRepo repository.EventRepository, config types.AppConfig) *StubGroup {
+func NewStubGroup(g *echo.Group, backendRepo repository.BackendRepository, containerRepo repository.ContainerRepository, eventRepo repository.EventRepository, config types.AppConfig) *StubGroup {
 	group := &StubGroup{routerGroup: g,
-		backendRepo: backendRepo,
-		config:      config,
-		eventRepo:   eventRepo,
+		backendRepo:   backendRepo,
+		containerRepo: containerRepo,
+		config:        config,
+		eventRepo:     eventRepo,
 	}
 
+	g.GET("/:workspaceId/sandboxes", auth.WithWorkspaceAuth(group.ListSandboxes))             // Lists sandboxes (enriched with live container state) for a workspace
+	g.GET("/:workspaceId/sandboxes/stats", auth.WithWorkspaceAuth(group.GetSandboxStats))     // Aggregated sandbox stats for the sandboxes dashboard
 	g.GET("/:workspaceId", auth.WithWorkspaceAuth(group.ListStubsByWorkspaceId))              // Allows workspace admins to list stubs specific to their workspace
 	g.GET("/:workspaceId/:stubId", auth.WithWorkspaceAuth(group.RetrieveStub))                // Allows workspace admins to retrieve a specific stub
 	g.GET("", auth.WithClusterAdminAuth(group.ListStubs))                                     // Allows cluster admins to list all stubs
@@ -666,4 +672,341 @@ func (g *StubGroup) updateConfigField(config *types.StubConfigV1, fieldPath stri
 	}
 
 	return nil
+}
+
+// Sandbox status values surfaced to the dashboard. The live states reuse the
+// canonical container status enum (types.ContainerStatus) so the dashboard
+// filters line up with actual container states; the terminal states cover
+// sandboxes that no longer have an active container.
+const (
+	SandboxStatusPending  = string(types.ContainerStatusPending)  // "PENDING"
+	SandboxStatusRunning  = string(types.ContainerStatusRunning)  // "RUNNING"
+	SandboxStatusStopping = string(types.ContainerStatusStopping) // "STOPPING"
+	SandboxStatusStopped  = "STOPPED"
+	SandboxStatusFailed   = "FAILED"
+)
+
+type SandboxRow struct {
+	Id              string    `json:"id"`
+	Name            string    `json:"name"`
+	CreatedAt       time.Time `json:"created_at"`
+	Status          string    `json:"status"`
+	Gpu             string    `json:"gpu,omitempty"`
+	ContainerId     string    `json:"container_id,omitempty"`
+	TimeToStartedMs *int64    `json:"time_to_started_ms,omitempty"`
+	LifetimeMs      *int64    `json:"lifetime_ms,omitempty"`
+}
+
+type SandboxListResponse struct {
+	Data []SandboxRow `json:"data"`
+	Next string       `json:"next"`
+}
+
+type SandboxCreatedBucket struct {
+	Timestamp time.Time `json:"timestamp"`
+	Count     int       `json:"count"`
+}
+
+type SandboxStatsResponse struct {
+	Concurrent     int                    `json:"concurrent"`
+	TotalCreated   int                    `json:"total_created"`
+	RatePerSecond  float64                `json:"rate_per_second"`
+	StatusCounts   map[string]int         `json:"status_counts"`
+	CreatedBuckets []SandboxCreatedBucket `json:"created_buckets"`
+}
+
+// ListSandboxes returns a cursor-paginated list of sandboxes for the workspace,
+// enriched with live status, GPU, time-to-started, and lifetime. The list is
+// workspace-scoped (not app-scoped) so SDK-created sandboxes always appear.
+func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
+	workspaceID := ctx.Param("workspaceId")
+
+	var filters types.StubFilter
+	if err := ctx.Bind(&filters); err != nil {
+		return HTTPBadRequest("Failed to decode query parameters")
+	}
+
+	filters.WorkspaceID = workspaceID
+	filters.StubTypes = types.StringSlice{types.StubTypeSandbox}
+	filters.Pagination = true
+
+	page, err := g.backendRepo.ListStubsPaginated(ctx.Request().Context(), filters)
+	if err != nil {
+		return HTTPInternalServerError("Failed to list sandboxes")
+	}
+
+	containersByStub := g.activeContainersByStub(workspaceID)
+
+	rows := make([]SandboxRow, 0, len(page.Data))
+	for i := range page.Data {
+		rows = append(rows, g.buildSandboxRow(ctx.Request().Context(), workspaceID, &page.Data[i], containersByStub[page.Data[i].ExternalId]))
+	}
+
+	return ctx.JSON(http.StatusOK, SandboxListResponse{Data: rows, Next: page.Next})
+}
+
+// GetSandboxStats returns aggregate stats for the sandboxes dashboard. The
+// status counts and concurrency are computed from live container state; the
+// totals and creation histogram come from the sandbox stubs themselves.
+func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
+	workspaceID := ctx.Param("workspaceId")
+
+	stubs, err := g.backendRepo.ListStubs(ctx.Request().Context(), types.StubFilter{
+		WorkspaceID: workspaceID,
+		StubTypes:   types.StringSlice{types.StubTypeSandbox},
+	})
+	if err != nil {
+		return HTTPInternalServerError("Failed to list sandboxes")
+	}
+
+	containersByStub := g.activeContainersByStub(workspaceID)
+
+	statusCounts := map[string]int{
+		SandboxStatusRunning:  0,
+		SandboxStatusPending:  0,
+		SandboxStatusStopping: 0,
+		SandboxStatusStopped:  0,
+		SandboxStatusFailed:   0,
+	}
+
+	concurrent := 0
+	var earliest, latest time.Time
+	for i := range stubs {
+		stub := &stubs[i]
+		createdAt := stub.CreatedAt.Time
+		if earliest.IsZero() || createdAt.Before(earliest) {
+			earliest = createdAt
+		}
+		if latest.IsZero() || createdAt.After(latest) {
+			latest = createdAt
+		}
+
+		// Live states come straight from the container status enum. Sandboxes
+		// without an active container are grouped as stopped here; the list
+		// endpoint refines a subset of those into failed per-row.
+		status := liveSandboxStatus(containersByStub[stub.ExternalId])
+		if status == "" {
+			status = SandboxStatusStopped
+		} else {
+			concurrent++
+		}
+		statusCounts[status]++
+	}
+
+	total := len(stubs)
+	ratePerSecond := 0.0
+	if total > 1 && !earliest.IsZero() && latest.After(earliest) {
+		ratePerSecond = float64(total) / latest.Sub(earliest).Seconds()
+	}
+
+	return ctx.JSON(http.StatusOK, SandboxStatsResponse{
+		Concurrent:     concurrent,
+		TotalCreated:   total,
+		RatePerSecond:  ratePerSecond,
+		StatusCounts:   statusCounts,
+		CreatedBuckets: buildCreatedBuckets(stubs),
+	})
+}
+
+func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]types.ContainerState {
+	byStub := map[string][]types.ContainerState{}
+	if g.containerRepo == nil {
+		return byStub
+	}
+
+	containers, err := g.containerRepo.GetActiveContainersByWorkspaceId(workspaceID)
+	if err != nil {
+		return byStub
+	}
+
+	for _, container := range containers {
+		if !strings.HasPrefix(container.ContainerId, types.StubTypeSandbox+"-") {
+			continue
+		}
+		byStub[container.StubId] = append(byStub[container.StubId], container)
+	}
+
+	return byStub
+}
+
+func (g *StubGroup) buildSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState) SandboxRow {
+	row := SandboxRow{
+		Id:        stub.ExternalId,
+		Name:      stub.Name,
+		CreatedAt: stub.CreatedAt.Time,
+	}
+
+	if active := mostRelevantContainer(containers); active != nil {
+		row.ContainerId = active.ContainerId
+		row.Gpu = active.Gpu
+		row.Status = string(active.Status)
+
+		if active.StartedAt > 0 && active.ScheduledAt > 0 && active.StartedAt >= active.ScheduledAt {
+			tts := (active.StartedAt - active.ScheduledAt) * 1000
+			row.TimeToStartedMs = &tts
+		}
+
+		if active.Status == types.ContainerStatusRunning && active.StartedAt > 0 {
+			lifetime := (time.Now().Unix() - active.StartedAt) * 1000
+			if lifetime >= 0 {
+				row.LifetimeMs = &lifetime
+			}
+		}
+
+		return row
+	}
+
+	status, timeToStarted, containerID := g.deriveTerminalSandbox(ctx, workspaceID, stub.ExternalId)
+	row.Status = status
+	row.TimeToStartedMs = timeToStarted
+	row.ContainerId = containerID
+	return row
+}
+
+// deriveTerminalSandbox performs a best-effort lookup against the event store to
+// classify a sandbox that no longer has an active container. It never fails the
+// request: on any error it falls back to TERMINATED.
+func (g *StubGroup) deriveTerminalSandbox(ctx context.Context, workspaceID, stubID string) (string, *int64, string) {
+	if g.eventRepo == nil {
+		return SandboxStatusStopped, nil, ""
+	}
+
+	history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
+		WorkspaceID: workspaceID,
+		StubID:      stubID,
+		Limit:       200,
+		EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+	})
+	if err != nil || history == nil || len(history.Events) == 0 {
+		return SandboxStatusStopped, nil, ""
+	}
+
+	containerID := ""
+	for i := len(history.Events) - 1; i >= 0; i-- {
+		if history.Events[i].ContainerID != "" {
+			containerID = history.Events[i].ContainerID
+			break
+		}
+	}
+	if containerID == "" {
+		return SandboxStatusStopped, nil, ""
+	}
+
+	resp, err := g.eventRepo.GetContainerEvents(ctx, containerID, types.EventQuery{
+		WorkspaceID: workspaceID,
+		StubID:      stubID,
+	})
+	if err != nil || resp == nil {
+		return SandboxStatusStopped, nil, containerID
+	}
+
+	var timeToStarted *int64
+	if v, ok := resp.Summary["container_request_to_running_ms"]; ok && v > 0 {
+		value := v
+		timeToStarted = &value
+	}
+
+	return terminalStatusFromContainerEvents(resp), timeToStarted, containerID
+}
+
+func terminalStatusFromContainerEvents(resp *types.ContainerEventsResponse) string {
+	signal := strings.ToLower(strings.Join([]string{resp.RootCauseEvent, resp.StopReason, resp.Status}, " "))
+	if strings.Contains(signal, "oom") || strings.Contains(signal, "fail") || strings.Contains(signal, "error") {
+		return SandboxStatusFailed
+	}
+	return SandboxStatusStopped
+}
+
+// liveSandboxStatus returns the canonical container status string for the
+// sandbox's active container, or "" when no active container exists.
+func liveSandboxStatus(containers []types.ContainerState) string {
+	active := mostRelevantContainer(containers)
+	if active == nil {
+		return ""
+	}
+	return string(active.Status)
+}
+
+// mostRelevantContainer picks the container that best represents the sandbox's
+// current state, preferring running over pending over stopping.
+func mostRelevantContainer(containers []types.ContainerState) *types.ContainerState {
+	rank := func(status types.ContainerStatus) int {
+		switch status {
+		case types.ContainerStatusRunning:
+			return 3
+		case types.ContainerStatusPending:
+			return 2
+		case types.ContainerStatusStopping:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	var best *types.ContainerState
+	for i := range containers {
+		if best == nil || rank(containers[i].Status) > rank(best.Status) {
+			best = &containers[i]
+		}
+	}
+	return best
+}
+
+// buildCreatedBuckets groups sandbox creation timestamps into evenly spaced
+// buckets spanning the observed time range, suitable for the "Sandboxes created"
+// chart.
+func buildCreatedBuckets(stubs []types.StubWithRelated) []SandboxCreatedBucket {
+	if len(stubs) == 0 {
+		return []SandboxCreatedBucket{}
+	}
+
+	times := make([]time.Time, 0, len(stubs))
+	var earliest, latest time.Time
+	for i := range stubs {
+		t := stubs[i].CreatedAt.Time
+		if t.IsZero() {
+			continue
+		}
+		times = append(times, t)
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+		}
+		if latest.IsZero() || t.After(latest) {
+			latest = t
+		}
+	}
+
+	if len(times) == 0 {
+		return []SandboxCreatedBucket{}
+	}
+
+	const bucketCount = 48
+	span := latest.Sub(earliest)
+	if span <= 0 {
+		return []SandboxCreatedBucket{{Timestamp: earliest, Count: len(times)}}
+	}
+
+	bucketSize := span / time.Duration(bucketCount)
+	if bucketSize <= 0 {
+		bucketSize = time.Minute
+	}
+
+	buckets := make([]SandboxCreatedBucket, bucketCount)
+	for i := range buckets {
+		buckets[i] = SandboxCreatedBucket{Timestamp: earliest.Add(time.Duration(i) * bucketSize)}
+	}
+
+	for _, t := range times {
+		idx := int(t.Sub(earliest) / bucketSize)
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= bucketCount {
+			idx = bucketCount - 1
+		}
+		buckets[idx].Count++
+	}
+
+	sort.SliceStable(buckets, func(i, j int) bool { return buckets[i].Timestamp.Before(buckets[j].Timestamp) })
+	return buckets
 }

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -39,6 +39,7 @@ func NewStubGroupForTest() *StubGroup {
 	return NewStubGroup(
 		e.Group("/stubs"),
 		backendRepo,
+		nil,
 		repository.NewEventClientRepo(config),
 		config,
 	)
@@ -63,6 +64,7 @@ func NewStubGroupWithMockForTest() (*StubGroup, sqlmock.Sqlmock, *echo.Echo) {
 	stubGroup := NewStubGroup(
 		e.Group("/stubs"),
 		backendRepo,
+		nil,
 		repository.NewEventClientRepo(config),
 		config,
 	)

--- a/pkg/compute/state.go
+++ b/pkg/compute/state.go
@@ -119,6 +119,10 @@ type PreflightCheckState struct {
 // disabling the machine's worker and flickering its status.
 const AgentHeartbeatTimeout = 60 * time.Second
 
+// agentHeartbeatFutureTolerance allows small clock differences between
+// gateway pods writing heartbeats and gateway pods evaluating liveness.
+const agentHeartbeatFutureTolerance = 5 * time.Second
+
 func AgentMachineStatus(state *AgentTokenState, now time.Time) string {
 	if AgentMachineConnected(state, now) {
 		return types.AgentMachineStatusSchedulable
@@ -144,7 +148,7 @@ func AgentMachineConnected(state *AgentTokenState, now time.Time) bool {
 		now = time.Now()
 	}
 	if lastSeen.After(now) {
-		return false
+		return lastSeen.Sub(now) <= agentHeartbeatFutureTolerance
 	}
 	return now.Sub(lastSeen) <= AgentHeartbeatTimeout
 }

--- a/pkg/compute/state_test.go
+++ b/pkg/compute/state_test.go
@@ -28,15 +28,28 @@ func TestAgentWorkerSlotStateDoesNotSerializeWorkerToken(t *testing.T) {
 	}
 }
 
-func TestAgentMachineConnectedRejectsFutureHeartbeat(t *testing.T) {
+func TestAgentMachineConnectedAllowsSmallFutureHeartbeatSkew(t *testing.T) {
 	now := time.Now().UTC()
 	state := &AgentTokenState{
 		Schedulable:     true,
 		LastJoinAt:      now.Add(-time.Minute),
-		LastHeartbeatAt: now.Add(time.Minute),
+		LastHeartbeatAt: now.Add(agentHeartbeatFutureTolerance - time.Millisecond),
+	}
+
+	if !AgentMachineConnected(state, now) {
+		t.Fatal("small future heartbeat skew was treated as disconnected")
+	}
+}
+
+func TestAgentMachineConnectedRejectsDistantFutureHeartbeat(t *testing.T) {
+	now := time.Now().UTC()
+	state := &AgentTokenState{
+		Schedulable:     true,
+		LastJoinAt:      now.Add(-time.Minute),
+		LastHeartbeatAt: now.Add(agentHeartbeatFutureTolerance + time.Second),
 	}
 
 	if AgentMachineConnected(state, now) {
-		t.Fatal("future heartbeat was treated as connected")
+		t.Fatal("distant future heartbeat was treated as connected")
 	}
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -234,7 +234,7 @@ func (g *Gateway) initHttp() error {
 	apiv1.NewLogGroup(g.baseRouteGroup.Group("/logs", authMiddleware), g.BackendRepo, g.ContainerRepo, repository.NewComputeRedisRepository(g.RedisClient), g.EventRepo)
 	apiv1.NewMetricsGroup(g.baseRouteGroup.Group("/metrics", authMiddleware), g.BackendRepo, g.EventRepo)
 	apiv1.NewContainerGroup(g.baseRouteGroup.Group("/container", authMiddleware), g.BackendRepo, g.ContainerRepo, *g.Scheduler, g.Config)
-	apiv1.NewStubGroup(g.baseRouteGroup.Group("/stub", authMiddleware), g.BackendRepo, g.EventRepo, g.Config)
+	apiv1.NewStubGroup(g.baseRouteGroup.Group("/stub", authMiddleware), g.BackendRepo, g.ContainerRepo, g.EventRepo, g.Config)
 	apiv1.NewConcurrencyLimitGroup(g.baseRouteGroup.Group("/concurrency-limit", authMiddleware), g.BackendRepo, g.WorkspaceRepo)
 	apiv1.NewDeploymentGroup(g.baseRouteGroup.Group("/deployment", authMiddleware), g.BackendRepo, g.ContainerRepo, *g.Scheduler, g.RedisClient, g.Config)
 	apiv1.NewAppGroup(g.baseRouteGroup.Group("/app", authMiddleware), g.BackendRepo, g.Config, g.ContainerRepo, *g.Scheduler, g.RedisClient)

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -98,6 +98,45 @@ func TestPrivatePoolReadsAreWorkspaceScoped(t *testing.T) {
 	}
 }
 
+func TestListPrivatePoolsReadyMachineCountUsesAgentConnection(t *testing.T) {
+	now := time.Now().UTC()
+	ctx := testAuthContext("workspace-1", "viewer-token")
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{Name: "private-pool", Status: "active"},
+			},
+		},
+		machines: map[string][]*model.AgentTokenState{
+			fakeComputeKey("workspace-1", "private-pool"): {
+				{
+					WorkspaceID:     "workspace-1",
+					PoolName:        "private-pool",
+					MachineID:       "machine-1",
+					Schedulable:     true,
+					LastJoinAt:      now.Add(-time.Minute),
+					LastHeartbeatAt: now,
+				},
+			},
+		},
+	}
+	service := &Service{computeRepo: repo}
+
+	pools, err := service.ListPrivatePools(ctx, &pb.ListPrivatePoolsRequest{})
+	if err != nil {
+		t.Fatalf("ListPrivatePools() error = %v", err)
+	}
+	if !pools.Ok {
+		t.Fatalf("ListPrivatePools() not ok: %s", pools.ErrMsg)
+	}
+	if got, want := len(pools.Pools), 1; got != want {
+		t.Fatalf("pool count = %d, want %d", got, want)
+	}
+	if got, want := pools.Pools[0].ReadyMachineCount, uint32(1); got != want {
+		t.Fatalf("ready machine count = %d, want %d", got, want)
+	}
+}
+
 func TestCreatePoolConflictsWithWorkspacePoolOwnedByAnotherToken(t *testing.T) {
 	ctx := testAuthContext("workspace-1", "viewer-token")
 	repo := &fakeComputeRepo{
@@ -1119,7 +1158,7 @@ func TestRecordAgentDisconnectDisablesStaleHeartbeat(t *testing.T) {
 		PoolName:        "pool-1",
 		MachineID:       "machine-1",
 		Schedulable:     true,
-		LastJoinAt:      now.Add(-time.Minute),
+		LastJoinAt:      now.Add(-model.AgentHeartbeatTimeout - 2*time.Second),
 		LastHeartbeatAt: now.Add(-model.AgentHeartbeatTimeout - time.Second),
 	}
 	workerID := model.AgentMachineWorkerID(machine.MachineID)
@@ -1612,6 +1651,113 @@ func TestReconcileManagedComputeDoesNotTerminateOnBillingError(t *testing.T) {
 	}
 	if state.Reservations[0].TerminatingReason != "" {
 		t.Fatalf("billing error set terminating reason = %q", state.Reservations[0].TerminatingReason)
+	}
+}
+
+func TestReconcileManagedComputeKeepsSameSecondHeartbeatConnected(t *testing.T) {
+	reconcileAt := time.Date(2026, 6, 13, 17, 19, 47, 700*int(time.Millisecond), time.UTC)
+	heartbeatAt := reconcileAt.Truncate(time.Second).Add(650 * time.Millisecond)
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "pool-1",
+	}
+	machine := &model.AgentTokenState{
+		WorkspaceID:     "workspace-1",
+		PoolName:        "pool-1",
+		MachineID:       "machine-1",
+		Executor:        types.DefaultAgentWorkerContainerMode,
+		Schedulable:     true,
+		LastJoinAt:      reconcileAt.Add(-time.Minute),
+		LastHeartbeatAt: heartbeatAt,
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{
+			Id:        workerID,
+			Status:    types.WorkerStatusAvailable,
+			MachineId: machine.MachineID,
+			PoolName:  machine.PoolName,
+		},
+	}
+	service := &Service{
+		computeRepo: &fakeComputeRepo{
+			pools: map[string][]*model.PoolState{"workspace-1": {state}},
+			machines: map[string][]*model.AgentTokenState{
+				fakeComputeKey("workspace-1", "pool-1"): {machine},
+			},
+		},
+		workerRepo: workerRepo,
+	}
+
+	if err := service.reconcileManagedComputeAt(context.Background(), reconcileAt); err != nil {
+		t.Fatalf("reconcileManagedComputeAt() error = %v", err)
+	}
+	if got, want := workerRepo.worker.Status, types.WorkerStatusAvailable; got != want {
+		t.Fatalf("worker status = %q, want %q", got, want)
+	}
+	if got := workerRepo.status; got != "" {
+		t.Fatalf("worker status update = %q, want none", got)
+	}
+}
+
+func TestReconcileManagedComputeUsesFreshTimePerPool(t *testing.T) {
+	firstPoolTime := time.Date(2026, 6, 13, 17, 19, 47, 0, time.UTC)
+	secondPoolTime := firstPoolTime.Add(70 * time.Second)
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "live-pool",
+	}
+	machine := &model.AgentTokenState{
+		WorkspaceID:     "workspace-1",
+		PoolName:        "live-pool",
+		MachineID:       "machine-1",
+		Executor:        types.DefaultAgentWorkerContainerMode,
+		Schedulable:     true,
+		LastJoinAt:      firstPoolTime.Add(-time.Minute),
+		LastHeartbeatAt: secondPoolTime.Add(-5 * time.Second),
+	}
+	workerID := model.AgentMachineWorkerID(machine.MachineID)
+	workerRepo := &fakeWorkerRepo{
+		worker: &types.Worker{
+			Id:        workerID,
+			Status:    types.WorkerStatusAvailable,
+			MachineId: machine.MachineID,
+			PoolName:  machine.PoolName,
+		},
+	}
+	service := &Service{
+		computeRepo: &fakeComputeRepo{
+			pools: map[string][]*model.PoolState{
+				"workspace-1": {
+					{WorkspaceID: "workspace-1", Name: "slow-pool"},
+					state,
+				},
+			},
+			machines: map[string][]*model.AgentTokenState{
+				fakeComputeKey("workspace-1", "live-pool"): {machine},
+			},
+		},
+		workerRepo: workerRepo,
+	}
+	clockCalls := 0
+
+	if err := service.reconcileManagedComputeWithClock(context.Background(), func() time.Time {
+		clockCalls++
+		if clockCalls == 1 {
+			return firstPoolTime
+		}
+		return secondPoolTime
+	}); err != nil {
+		t.Fatalf("reconcileManagedComputeWithClock() error = %v", err)
+	}
+	if got, want := workerRepo.worker.Status, types.WorkerStatusAvailable; got != want {
+		t.Fatalf("worker status = %q, want %q", got, want)
+	}
+	if got := workerRepo.status; got != "" {
+		t.Fatalf("worker status update = %q, want none", got)
+	}
+	if got, want := clockCalls, 2; got != want {
+		t.Fatalf("clock calls = %d, want %d", got, want)
 	}
 }
 

--- a/pkg/gateway/services/compute/pools.go
+++ b/pkg/gateway/services/compute/pools.go
@@ -42,7 +42,6 @@ func (s *Service) ListPrivatePools(ctx context.Context, in *pb.ListPrivatePoolsR
 			return &pb.ListPrivatePoolsResponse{Ok: false, ErrMsg: err.Error()}, nil
 		}
 		pool := s.privatePoolStateToProtoWithMachines(state, machines)
-		pool.ReadyMachineCount = s.readyAgentMachineCount(machines)
 		out = append(out, pool)
 	}
 	return &pb.ListPrivatePoolsResponse{Ok: true, Pools: out}, nil
@@ -341,15 +340,4 @@ func (s *Service) privateMachineForDelete(ctx context.Context, authInfo *auth.Au
 		return nil, true, err
 	}
 	return machine, true, nil
-}
-
-func (s *Service) readyAgentMachineCount(machines []*model.AgentTokenState) uint32 {
-	ready := uint32(0)
-	now := time.Now()
-	for _, machine := range machines {
-		if agentMachineStatus(machine, s.agentMachineStatusWorker(machine), now) == types.MachineStatusAvailable {
-			ready++
-		}
-	}
-	return ready
 }

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -41,6 +41,18 @@ func (s *Service) runReconciler(ctx context.Context) {
 }
 
 func (s *Service) ReconcileManagedCompute(ctx context.Context) error {
+	return s.reconcileManagedComputeWithClock(ctx, func() time.Time {
+		return time.Now().UTC()
+	})
+}
+
+func (s *Service) reconcileManagedComputeAt(ctx context.Context, now time.Time) error {
+	return s.reconcileManagedComputeWithClock(ctx, func() time.Time {
+		return now
+	})
+}
+
+func (s *Service) reconcileManagedComputeWithClock(ctx context.Context, nowFunc func() time.Time) error {
 	if s == nil || s.computeRepo == nil {
 		return nil
 	}
@@ -48,11 +60,13 @@ func (s *Service) ReconcileManagedCompute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Second-aligned windows keep retried usage reports deduplicable.
-	now := time.Now().UTC().Truncate(time.Second)
 	for _, state := range states {
 		if state == nil || state.WorkspaceID == "" || state.Name == "" {
 			continue
+		}
+		now := time.Now().UTC()
+		if nowFunc != nil {
+			now = nowFunc().UTC()
 		}
 		if err := s.reconcilePoolLocked(ctx, state.WorkspaceID, state.Name, now); err != nil {
 			log.Warn().
@@ -79,8 +93,12 @@ func (s *Service) reconcilePoolLocked(ctx context.Context, workspaceID, poolName
 
 func (s *Service) reconcilePool(ctx context.Context, workspaceID string, state *model.PoolState, now time.Time) error {
 	changed := false
-	if s.poolNeedsManagedBilling(state, now) {
-		changed = s.reconcileBilling(ctx, workspaceID, state, now) || changed
+	// Second-aligned billing windows keep retried usage reports deduplicable,
+	// but liveness checks below need the exact timestamp. A same-second
+	// heartbeat can otherwise look like it came from the future.
+	billingNow := now.Truncate(time.Second)
+	if s.poolNeedsManagedBilling(state, billingNow) {
+		changed = s.reconcileBilling(ctx, workspaceID, state, billingNow) || changed
 	}
 
 	vendors := s.computeVendors()

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -121,7 +121,7 @@ func (r *S2EventRepository) GetStubMetricsTimeseries(ctx context.Context, query 
 		return response, nil
 	}
 
-	return r.getMetricsTimeseries(ctx, r.stubStreamName(query.WorkspaceID, query.StubID), start, end, interval)
+	return r.getMetricsTimeseries(ctx, r.stubStreamName(query.WorkspaceID, query.StubID), start, end, interval, query.StubType)
 }
 
 func (r *S2EventRepository) GetWorkspaceMetricsTimeseries(ctx context.Context, query types.EventQuery, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error) {
@@ -130,10 +130,10 @@ func (r *S2EventRepository) GetWorkspaceMetricsTimeseries(ctx context.Context, q
 		return response, nil
 	}
 
-	return r.getMetricsTimeseries(ctx, r.workspaceStreamName(query.WorkspaceID), start, end, interval)
+	return r.getMetricsTimeseries(ctx, r.workspaceStreamName(query.WorkspaceID), start, end, interval, query.StubType)
 }
 
-func (r *S2EventRepository) getMetricsTimeseries(ctx context.Context, streamName s2.StreamName, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error) {
+func (r *S2EventRepository) getMetricsTimeseries(ctx context.Context, streamName s2.StreamName, start time.Time, end time.Time, interval string, stubTypeFilter string) (*types.MetricsTimeseriesResponse, error) {
 	response := &types.MetricsTimeseriesResponse{}
 	buckets := map[int64]*metricsBucketAccumulator{}
 	seqNum := uint64(0)
@@ -164,6 +164,9 @@ func (r *S2EventRepository) getMetricsTimeseries(ctx context.Context, streamName
 		for _, record := range batch.Records {
 			metrics, eventTime, ok := containerMetricsFromS2(record)
 			if !ok {
+				continue
+			}
+			if stubTypeFilter != "" && types.StubType(metrics.StubType).Kind() != stubTypeFilter {
 				continue
 			}
 			if eventTime.Before(start) || !eventTime.Before(end) {

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -766,6 +766,7 @@ type EventQuery struct {
 	Limit       uint64   `json:"limit,omitempty"`
 	WorkspaceID string   `json:"workspace_id,omitempty"`
 	StubID      string   `json:"stub_id,omitempty"`
+	StubType    string   `json:"stub_type,omitempty"`
 	AppID       string   `json:"app_id,omitempty"`
 	TaskID      string   `json:"task_id,omitempty"`
 	ContainerID string   `json:"container_id,omitempty"`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves sandbox real-time metrics and dashboard accuracy with new live sandbox APIs and tighter liveness handling. Adds precise status/GPU/time-to-started/lifetime data, reduces flapping, and supports `stub_type` filtering for metrics.

- **New Features**
  - Added `GET /stub/:workspaceId/sandboxes` and `GET /stub/:workspaceId/sandboxes/stats`.
  - Each sandbox row includes `status`, `gpu`, `container_id`, `time_to_started_ms`, `lifetime_ms`.
  - Live status comes from active containers; terminal state inferred from event history (`STOPPED` or `FAILED`).
  - Added creation histogram buckets and a `rate_per_second` metric.
  - Workspace metric timeseries accept `?stub_type=` to filter events; gateway passes `ContainerRepository` into the `stub` group.

- **Bug Fixes**
  - Treat small future heartbeats (<= 5s) as connected to avoid flapping; use per-pool current time for liveness and second-aligned time only for billing.
  - Ready machine counts and reconciler decisions use agent connection, not stale timestamps.
  - Split agent telemetry into stdout/stderr; worker runtime logs use dedicated status streams.
  - Systemd install uses `start` instead of `restart` to avoid unnecessary restarts.

<sup>Written for commit a45e3a2cc4ba1f48ef20f04b9c4000d5d85e411b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

