### PR TITLE
scope sandbox list

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -715,9 +715,9 @@ type SandboxStatsResponse struct {
 	CreatedBuckets []SandboxCreatedBucket `json:"created_buckets"`
 }
 
-// ListSandboxes returns a cursor-paginated list of sandboxes for the workspace,
-// enriched with live status, GPU, time-to-started, and lifetime. The list is
-// workspace-scoped (not app-scoped) so SDK-created sandboxes always appear.
+// ListSandboxes returns a cursor-paginated list of sandboxes enriched with live
+// status, GPU, time-to-started, and lifetime. It is scoped to the app when an
+// app_id is provided, otherwise it lists all sandboxes in the workspace.
 func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 	workspaceID := ctx.Param("workspaceId")
 
@@ -754,6 +754,7 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 	stubs, err := g.backendRepo.ListStubs(ctx.Request().Context(), types.StubFilter{
 		WorkspaceID: workspaceID,
 		StubTypes:   types.StringSlice{types.StubTypeSandbox},
+		AppId:       ctx.QueryParam("app_id"),
 	})
 	if err != nil {
 		return HTTPInternalServerError("Failed to list sandboxes")

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -695,6 +695,7 @@ type SandboxRow struct {
 	ContainerId     string    `json:"container_id,omitempty"`
 	TimeToStartedMs *int64    `json:"time_to_started_ms,omitempty"`
 	LifetimeMs      *int64    `json:"lifetime_ms,omitempty"`
+	StartedAtMs     *int64    `json:"started_at_ms,omitempty"`
 }
 
 type SandboxListResponse struct {
@@ -848,6 +849,9 @@ func (g *StubGroup) buildSandboxRow(ctx context.Context, workspaceID string, stu
 		}
 
 		if active.Status == types.ContainerStatusRunning && active.StartedAt > 0 {
+			startedAtMs := active.StartedAt * 1000
+			row.StartedAtMs = &startedAtMs
+
 			lifetime := (time.Now().Unix() - active.StartedAt) * 1000
 			if lifetime >= 0 {
 				row.LifetimeMs = &lifetime

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -41,8 +41,9 @@ func NewStubGroup(g *echo.Group, backendRepo repository.BackendRepository, conta
 		eventRepo:     eventRepo,
 	}
 
-	g.GET("/:workspaceId/sandboxes", auth.WithWorkspaceAuth(group.ListSandboxes))             // Lists sandboxes (enriched with live container state) for a workspace
-	g.GET("/:workspaceId/sandboxes/stats", auth.WithWorkspaceAuth(group.GetSandboxStats))     // Aggregated sandbox stats for the sandboxes dashboard
+	g.GET("/:workspaceId/sandboxes", auth.WithWorkspaceAuth(group.ListSandboxes))                       // Lists sandboxes (enriched with live container state) for a workspace
+	g.GET("/:workspaceId/sandboxes/stats", auth.WithWorkspaceAuth(group.GetSandboxStats))               // Aggregated sandbox stats for the sandboxes dashboard
+	g.GET("/:workspaceId/sandboxes/:stubId/timeline", auth.WithWorkspaceAuth(group.GetSandboxTimeline)) // Startup/lifecycle timeline for a single sandbox
 	g.GET("/:workspaceId", auth.WithWorkspaceAuth(group.ListStubsByWorkspaceId))              // Allows workspace admins to list stubs specific to their workspace
 	g.GET("/:workspaceId/:stubId", auth.WithWorkspaceAuth(group.RetrieveStub))                // Allows workspace admins to retrieve a specific stub
 	g.GET("", auth.WithClusterAdminAuth(group.ListStubs))                                     // Allows cluster admins to list all stubs
@@ -808,6 +809,135 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 		StatusCounts:   statusCounts,
 		CreatedBuckets: buildCreatedBuckets(stubs),
 	})
+}
+
+type SandboxTimeline struct {
+	ContainerId  string     `json:"container_id,omitempty"`
+	Status       string     `json:"status"`
+	CreatedAt    time.Time  `json:"created_at"`
+	ScheduledAt  *time.Time `json:"scheduled_at,omitempty"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
+	SchedulingMs *int64     `json:"scheduling_ms,omitempty"`
+	StartupMs    *int64     `json:"startup_ms,omitempty"`
+	RuntimeMs    *int64     `json:"runtime_ms,omitempty"`
+}
+
+// GetSandboxTimeline returns a Created -> Scheduled -> Started -> Ended timeline
+// for a single sandbox, derived from S2 container lifecycle/scheduling events.
+func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
+	workspaceID := ctx.Param("workspaceId")
+	stubID := ctx.Param("stubId")
+
+	stub, err := g.backendRepo.GetStubByExternalId(ctx.Request().Context(), stubID)
+	if err != nil {
+		return HTTPInternalServerError("Failed to retrieve sandbox")
+	}
+	if stub == nil || stub.Workspace.ExternalId != workspaceID {
+		return HTTPNotFound()
+	}
+
+	timeline := SandboxTimeline{CreatedAt: stub.CreatedAt.Time, Status: SandboxStatusStopped}
+
+	var activeContainers []types.ContainerState
+	if g.containerRepo != nil {
+		activeContainers, _ = g.containerRepo.GetActiveContainersByStubId(stubID)
+	}
+	active := mostRelevantContainer(activeContainers)
+
+	containerID := ""
+	if active != nil {
+		containerID = active.ContainerId
+		timeline.Status = string(active.Status)
+		if active.StartedAt > 0 {
+			startedAt := time.Unix(active.StartedAt, 0).UTC()
+			timeline.StartedAt = &startedAt
+		}
+	} else {
+		status, _, terminalContainerID := g.deriveTerminalSandbox(ctx.Request().Context(), workspaceID, stubID)
+		timeline.Status = status
+		containerID = terminalContainerID
+	}
+	timeline.ContainerId = containerID
+
+	if containerID != "" && g.eventRepo != nil {
+		if resp, err := g.eventRepo.GetContainerEvents(ctx.Request().Context(), containerID, types.EventQuery{
+			WorkspaceID: workspaceID,
+			StubID:      stubID,
+		}); err == nil && resp != nil {
+			applyContainerTimeline(&timeline, resp)
+		}
+	}
+
+	// Compute runtime once we know when the sandbox started.
+	if timeline.StartedAt != nil {
+		end := timeline.EndedAt
+		if end == nil && isActiveSandboxStatus(timeline.Status) {
+			now := time.Now().UTC()
+			end = &now
+		}
+		if end != nil {
+			runtime := end.Sub(*timeline.StartedAt).Milliseconds()
+			if runtime >= 0 {
+				timeline.RuntimeMs = &runtime
+			}
+		}
+	}
+
+	return ctx.JSON(http.StatusOK, timeline)
+}
+
+func applyContainerTimeline(timeline *SandboxTimeline, resp *types.ContainerEventsResponse) {
+	created := timeline.CreatedAt
+
+	if scheduling, ok := resp.Summary["scheduler_queue_to_worker_receive_ms"]; ok && scheduling >= 0 {
+		value := scheduling
+		timeline.SchedulingMs = &value
+		scheduledAt := created.Add(time.Duration(scheduling) * time.Millisecond)
+		timeline.ScheduledAt = &scheduledAt
+	}
+
+	if total, ok := resp.Summary["container_request_to_running_ms"]; ok && total > 0 {
+		// Prefer the event-derived start only when the live container state did
+		// not already give us an authoritative started timestamp.
+		if timeline.StartedAt == nil {
+			startedAt := created.Add(time.Duration(total) * time.Millisecond)
+			timeline.StartedAt = &startedAt
+		}
+		if timeline.SchedulingMs != nil {
+			startup := total - *timeline.SchedulingMs
+			if startup >= 0 {
+				timeline.StartupMs = &startup
+			}
+		}
+	}
+
+	// The terminal timestamp is the latest observed event for the container.
+	if !isActiveSandboxStatus(timeline.Status) {
+		var latest time.Time
+		for _, event := range resp.Events {
+			candidate := event.Timestamp
+			if candidate.IsZero() {
+				candidate = event.EndTime
+			}
+			if candidate.After(latest) {
+				latest = candidate
+			}
+		}
+		if !latest.IsZero() {
+			endedAt := latest.UTC()
+			timeline.EndedAt = &endedAt
+		}
+	}
+}
+
+func isActiveSandboxStatus(status string) bool {
+	switch status {
+	case SandboxStatusRunning, SandboxStatusPending, SandboxStatusStopping:
+		return true
+	default:
+		return false
+	}
 }
 
 func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]types.ContainerState {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optional app scoping to sandbox list/stats, add `started_at_ms` in rows, and expose a sandbox timeline endpoint. `GET /:workspaceId/sandboxes/:stubId/timeline` returns Created/Scheduled/Started/Ended and durations; lists/stats are app-scoped when `app_id` is set, else workspace-wide.

<sup>Written for commit a9a8bffa346d140a8ff20cabca28f3a026ede98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

