### PR TITLE
Add audited sandbox process log metadata

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -264,9 +264,9 @@ EOT
 RUN apt-get install -y ripgrep wget
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.5/goproc-0.1.5-linux-arm64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
+      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.6/goproc-0.1.6-linux-arm64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
     elif [ "$TARGETARCH" = "amd64" ]; then \
-      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.5/goproc-0.1.5-linux-amd64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
+      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.6/goproc-0.1.6-linux-amd64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
     else \
       echo "Unsupported architecture: $TARGETARCH" && exit 1 ; \
     fi

--- a/go.mod
+++ b/go.mod
@@ -94,8 +94,6 @@ require (
 	tailscale.com v1.72.1
 )
 
-replace github.com/beam-cloud/goproc => /Users/luke/beam/goproc
-
 require (
 	cloud.google.com/go v0.112.1 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
 	github.com/beam-cloud/clip v0.0.0-20260612152219-fc12eb359a11
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
-	github.com/beam-cloud/goproc v0.1.5
+	github.com/beam-cloud/goproc v0.1.6
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
 	github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -93,6 +93,8 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	tailscale.com v1.72.1
 )
+
+replace github.com/beam-cloud/goproc => /Users/luke/beam/goproc
 
 require (
 	cloud.google.com/go v0.112.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/beam-cloud/gofuse v0.0.0-20260524202825-ee695e692747 h1:OZJmeUHKMeeje
 github.com/beam-cloud/gofuse v0.0.0-20260524202825-ee695e692747/go.mod h1:JYi9iIxdYNgxmMgLwtSHO/hmVnP2kfX1oc+mtx+XWLA=
 github.com/beam-cloud/goproc v0.1.5 h1:FDldQgLn5AbfEJ4Ais70xxmbQhfl2Cmx1IqupJYF11M=
 github.com/beam-cloud/goproc v0.1.5/go.mod h1:eis19sZHSHNCmj8PjiRCdHwp3kkc31wdW3hrynKZq8k=
+github.com/beam-cloud/goproc v0.1.6 h1:cAMoYSY6j3fgpyiJm9mZMmkJIMF2MBAgSNMlWtWHrQw=
+github.com/beam-cloud/goproc v0.1.6/go.mod h1:eis19sZHSHNCmj8PjiRCdHwp3kkc31wdW3hrynKZq8k=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324/go.mod h1:pBb6ZWEw7rhALuBZTGZxT3p+Sd5b8jsvP5EPEsM8T/Q=
 github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8 h1:lc3G6/sHW4e5/XPHO2w2Ni43fbu42nojS/uX45Ws6Ck=

--- a/pkg/api/v1/logs.go
+++ b/pkg/api/v1/logs.go
@@ -120,6 +120,10 @@ func writeLogStream(ctx echo.Context, stream repository.EventStream) error {
 			AppID:       record.AppID,
 			MachineID:   record.MachineID,
 			WorkerID:    record.WorkerID,
+			PID:         record.PID,
+			ProcessArgs: record.ProcessArgs,
+			ProcessCwd:  record.ProcessCwd,
+			ProcessSeq:  record.ProcessSeq,
 		}
 		payload, err := json.Marshal(logRecord)
 		if err != nil {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -269,7 +269,7 @@ type EventRepository interface {
 	PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema)
 	PushContainerEvent(event types.EventContainerEventSchema)
 	PushContainerLogEvent(entry types.EventContainerLogSchema)
-	PushContainerLogEventSync(entry types.EventContainerLogSchema) error
+	PushContainerLogEventQueued(entry types.EventContainerLogSchema) error
 	PushPlatformLogEvent(entry types.EventPlatformLogSchema)
 	PushContainerRequestEvent(workerID string, request *types.ContainerRequest, eventID types.ContainerEventID, opts types.ContainerEventOptions)
 	PushContainerRequestLifecycle(workerID string, request *types.ContainerRequest, lifecycleID types.ContainerLifecycleID, startedAt time.Time, duration time.Duration, success bool, opts types.ContainerLifecycleOptions)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -269,6 +269,7 @@ type EventRepository interface {
 	PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema)
 	PushContainerEvent(event types.EventContainerEventSchema)
 	PushContainerLogEvent(entry types.EventContainerLogSchema)
+	PushContainerLogEventSync(entry types.EventContainerLogSchema) error
 	PushPlatformLogEvent(entry types.EventPlatformLogSchema)
 	PushContainerRequestEvent(workerID string, request *types.ContainerRequest, eventID types.ContainerEventID, opts types.ContainerEventOptions)
 	PushContainerRequestLifecycle(workerID string, request *types.ContainerRequest, lifecycleID types.ContainerLifecycleID, startedAt time.Time, duration time.Duration, success bool, opts types.ContainerLifecycleOptions)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -321,7 +321,7 @@ func (r *EventClientRepo) PushContainerLogEvent(entry types.EventContainerLogSch
 	r.pushEvent(types.EventContainerLog, types.EventContainerLogSchemaVersion, entry)
 }
 
-func (r *EventClientRepo) PushContainerLogEventSync(entry types.EventContainerLogSchema) error {
+func (r *EventClientRepo) PushContainerLogEventQueued(entry types.EventContainerLogSchema) error {
 	if entry.Line == "" {
 		return nil
 	}
@@ -339,12 +339,6 @@ func (r *EventClientRepo) PushContainerLogEventSync(entry types.EventContainerLo
 
 	var errs []error
 	for _, sink := range r.storageSinks {
-		if syncSink, ok := sink.(syncEventSink); ok {
-			if err := syncSink.PushEventSync(event); err != nil {
-				errs = append(errs, err)
-			}
-			continue
-		}
 		if err := sink.PushEvent(event); err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -50,7 +50,10 @@ type EventClientRepo struct {
 	streamer      eventStreamer
 }
 
-var ErrEventReadUnsupported = errors.New("event read unsupported")
+var (
+	ErrEventReadUnsupported  = errors.New("event read unsupported")
+	ErrEventWriteUnsupported = errors.New("event write unsupported")
+)
 
 type eventMetadata struct {
 	ContainerID string
@@ -316,6 +319,37 @@ func (r *EventClientRepo) PushContainerLogEvent(entry types.EventContainerLogSch
 	}
 
 	r.pushEvent(types.EventContainerLog, types.EventContainerLogSchemaVersion, entry)
+}
+
+func (r *EventClientRepo) PushContainerLogEventSync(entry types.EventContainerLogSchema) error {
+	if entry.Line == "" {
+		return nil
+	}
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now().UTC()
+	}
+	if len(r.storageSinks) == 0 {
+		return ErrEventWriteUnsupported
+	}
+
+	event, err := r.createEventObject(types.EventContainerLog, types.EventContainerLogSchemaVersion, entry)
+	if err != nil {
+		return fmt.Errorf("create container log event: %w", err)
+	}
+
+	var errs []error
+	for _, sink := range r.storageSinks {
+		if syncSink, ok := sink.(syncEventSink); ok {
+			if err := syncSink.PushEventSync(event); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		if err := sink.PushEvent(event); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (r *EventClientRepo) PushPlatformLogEvent(entry types.EventPlatformLogSchema) {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -264,6 +264,10 @@ func (r *ScopedS2EventRepository) appendEventBatch(events []cloudevents.Event) e
 	return errors.Join(streamErrs...)
 }
 
+func (r *ScopedS2EventRepository) PushEventSync(event cloudevents.Event) error {
+	return r.appendEventBatch([]cloudevents.Event{event})
+}
+
 func (r *ScopedS2EventRepository) targetForStream(streamName s2.StreamName) *scopedS2EventTarget {
 	stream := strings.Trim(string(streamName), "/")
 	for i := range r.targets {
@@ -1818,6 +1822,10 @@ func augmentContainerEventResponse(response *types.ContainerEventsResponse, reco
 		record.WorkerID = entry.WorkerID
 		record.Stream = entry.Stream
 		record.Line = entry.Line
+		record.PID = entry.PID
+		record.ProcessArgs = entry.ProcessArgs
+		record.ProcessCwd = entry.ProcessCwd
+		record.ProcessSeq = entry.ProcessSeq
 		if response.WorkspaceID == "" {
 			response.WorkspaceID = entry.WorkspaceID
 		}

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -405,6 +405,10 @@ func logRecordFromS2(record s2.SequencedRecord) (types.LogRecord, bool) {
 		WorkspaceID: firstNonEmpty(entry.WorkspaceID, eventRecord.WorkspaceID),
 		AppID:       firstNonEmpty(entry.AppID, eventRecord.AppID),
 		WorkerID:    firstNonEmpty(entry.WorkerID, eventRecord.WorkerID),
+		PID:         entry.PID,
+		ProcessArgs: entry.ProcessArgs,
+		ProcessCwd:  entry.ProcessCwd,
+		ProcessSeq:  entry.ProcessSeq,
 	}, true
 }
 
@@ -575,6 +579,10 @@ func containerEventRecordFromLogRecord(record types.LogRecord) types.ContainerEv
 		AppID:       record.AppID,
 		MachineID:   record.MachineID,
 		WorkerID:    record.WorkerID,
+		PID:         record.PID,
+		ProcessArgs: record.ProcessArgs,
+		ProcessCwd:  record.ProcessCwd,
+		ProcessSeq:  record.ProcessSeq,
 	}
 }
 

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -539,6 +539,10 @@ func TestLogRecordFromS2ExtractsLineFromEventData(t *testing.T) {
 		WorkerID:    "worker-1",
 		Stream:      "stdout",
 		Line:        "Starting gunicorn 22.0.0",
+		PID:         123,
+		ProcessArgs: []string{"python3", "-c", "print('hi')"},
+		ProcessCwd:  "/workspace",
+		ProcessSeq:  7,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -563,6 +567,18 @@ func TestLogRecordFromS2ExtractsLineFromEventData(t *testing.T) {
 	}
 	if got, want := logRecord.TaskID, "task-123"; got != want {
 		t.Fatalf("unexpected task id: got %q want %q", got, want)
+	}
+	if got, want := logRecord.PID, int32(123); got != want {
+		t.Fatalf("unexpected pid: got %d want %d", got, want)
+	}
+	if got, want := logRecord.ProcessArgs, []string{"python3", "-c", "print('hi')"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected process args: got %#v want %#v", got, want)
+	}
+	if got, want := logRecord.ProcessCwd, "/workspace"; got != want {
+		t.Fatalf("unexpected process cwd: got %q want %q", got, want)
+	}
+	if got, want := logRecord.ProcessSeq, uint64(7); got != want {
+		t.Fatalf("unexpected process seq: got %d want %d", got, want)
 	}
 	if !logRecord.Timestamp.Equal(logAt) {
 		t.Fatalf("unexpected timestamp: got %s want %s", logRecord.Timestamp, logAt)

--- a/pkg/repository/events_test.go
+++ b/pkg/repository/events_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -19,6 +20,10 @@ type captureEventSink struct {
 func (s *captureEventSink) PushEvent(event cloudevents.Event) error {
 	s.events = append(s.events, event)
 	return nil
+}
+
+func (s *captureEventSink) PushEventSync(event cloudevents.Event) error {
+	return s.PushEvent(event)
 }
 
 func TestEventHTTPSinkDeliversCloudEvent(t *testing.T) {
@@ -402,6 +407,66 @@ func TestPushContainerLogSkipsCallbackSinks(t *testing.T) {
 	}
 	if got := len(callbackSink.events); got != 0 {
 		t.Fatalf("expected log event to skip callbacks, got %d callback events", got)
+	}
+}
+
+func TestPushContainerLogEventSyncOptionalAuditFields(t *testing.T) {
+	storageSink := &captureEventSink{}
+	repo := &EventClientRepo{storageSinks: []eventSink{storageSink}}
+
+	err := repo.PushContainerLogEventSync(types.EventContainerLogSchema{
+		ContainerID: "container-1",
+		WorkspaceID: "workspace-1",
+		StubID:      "stub-1",
+		Stream:      types.EventLogStreamStdout,
+		Line:        "hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(storageSink.events), 1; got != want {
+		t.Fatalf("unexpected storage event count: got %d want %d", got, want)
+	}
+
+	raw := storageSink.events[0].Data()
+	if json.Valid(raw) {
+		var payload map[string]interface{}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := payload["pid"]; ok {
+			t.Fatal("expected pid to be omitted for ordinary log")
+		}
+		if _, ok := payload["process_args"]; ok {
+			t.Fatal("expected process_args to be omitted for ordinary log")
+		}
+	}
+
+	err = repo.PushContainerLogEventSync(types.EventContainerLogSchema{
+		ContainerID: "container-1",
+		WorkspaceID: "workspace-1",
+		StubID:      "stub-1",
+		Stream:      types.EventLogStreamStderr,
+		Line:        "boom",
+		PID:         123,
+		ProcessArgs: []string{"python3", "-c", "print('hi')"},
+		ProcessCwd:  "/workspace",
+		ProcessSeq:  7,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var event types.EventContainerLogSchema
+	if err := json.Unmarshal(storageSink.events[1].Data(), &event); err != nil {
+		t.Fatal(err)
+	}
+	if event.PID != 123 || event.ProcessSeq != 7 || event.ProcessCwd != "/workspace" {
+		t.Fatalf("unexpected audit fields: %+v", event)
+	}
+	if got, want := event.ProcessArgs, []string{"python3", "-c", "print('hi')"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected process args: got %#v want %#v", got, want)
 	}
 }
 

--- a/pkg/repository/events_test.go
+++ b/pkg/repository/events_test.go
@@ -410,11 +410,11 @@ func TestPushContainerLogSkipsCallbackSinks(t *testing.T) {
 	}
 }
 
-func TestPushContainerLogEventSyncOptionalAuditFields(t *testing.T) {
+func TestPushContainerLogEventQueuedOptionalProcessFields(t *testing.T) {
 	storageSink := &captureEventSink{}
 	repo := &EventClientRepo{storageSinks: []eventSink{storageSink}}
 
-	err := repo.PushContainerLogEventSync(types.EventContainerLogSchema{
+	err := repo.PushContainerLogEventQueued(types.EventContainerLogSchema{
 		ContainerID: "container-1",
 		WorkspaceID: "workspace-1",
 		StubID:      "stub-1",
@@ -443,7 +443,7 @@ func TestPushContainerLogEventSyncOptionalAuditFields(t *testing.T) {
 		}
 	}
 
-	err = repo.PushContainerLogEventSync(types.EventContainerLogSchema{
+	err = repo.PushContainerLogEventQueued(types.EventContainerLogSchema{
 		ContainerID: "container-1",
 		WorkspaceID: "workspace-1",
 		StubID:      "stub-1",
@@ -463,7 +463,7 @@ func TestPushContainerLogEventSyncOptionalAuditFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	if event.PID != 123 || event.ProcessSeq != 7 || event.ProcessCwd != "/workspace" {
-		t.Fatalf("unexpected audit fields: %+v", event)
+		t.Fatalf("unexpected process fields: %+v", event)
 	}
 	if got, want := event.ProcessArgs, []string{"python3", "-c", "print('hi')"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected process args: got %#v want %#v", got, want)

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -747,6 +747,10 @@ type EventContainerLogSchema struct {
 	WorkerID    string    `json:"worker_id,omitempty"`
 	Stream      string    `json:"stream,omitempty"`
 	Line        string    `json:"line"`
+	PID         int32     `json:"pid,omitempty"`
+	ProcessArgs []string  `json:"process_args,omitempty"`
+	ProcessCwd  string    `json:"process_cwd,omitempty"`
+	ProcessSeq  uint64    `json:"process_seq,omitempty"`
 }
 
 var EventPlatformLogSchemaVersion = "1.0"
@@ -835,6 +839,10 @@ type LogRecord struct {
 	AppID       string    `json:"app_id,omitempty"`
 	MachineID   string    `json:"machine_id,omitempty"`
 	WorkerID    string    `json:"worker_id,omitempty"`
+	PID         int32     `json:"pid,omitempty"`
+	ProcessArgs []string  `json:"process_args,omitempty"`
+	ProcessCwd  string    `json:"process_cwd,omitempty"`
+	ProcessSeq  uint64    `json:"process_seq,omitempty"`
 }
 
 type LogsResponse struct {
@@ -912,6 +920,10 @@ type ContainerEventRecord struct {
 	AppID       string            `json:"app_id,omitempty"`
 	MachineID   string            `json:"machine_id,omitempty"`
 	WorkerID    string            `json:"worker_id,omitempty"`
+	PID         int32             `json:"pid,omitempty"`
+	ProcessArgs []string          `json:"process_args,omitempty"`
+	ProcessCwd  string            `json:"process_cwd,omitempty"`
+	ProcessSeq  uint64            `json:"process_seq,omitempty"`
 }
 
 type ContainerEventsResponse struct {

--- a/pkg/worker/container_server.go
+++ b/pkg/worker/container_server.go
@@ -46,8 +46,8 @@ const (
 )
 
 // ContainerRuntimeServer is a runtime-agnostic container server that works with any OCI runtime
-type auditedLogEventRepository interface {
-	PushContainerLogEventSync(entry types.EventContainerLogSchema) error
+type processLogEventRepository interface {
+	PushContainerLogEventQueued(entry types.EventContainerLogSchema) error
 }
 
 type ContainerRuntimeServer struct {
@@ -58,7 +58,7 @@ type ContainerRuntimeServer struct {
 	containerNetworkManager ContainerNetwork
 	imageClient             *ImageClient
 	runtime                 runtime.Runtime // The worker's configured runtime (from pool config)
-	eventRepo               auditedLogEventRepository
+	eventRepo               processLogEventRepository
 	workerID                string
 	port                    int
 	podAddr                 string
@@ -642,7 +642,7 @@ func (s *ContainerRuntimeServer) handleSandboxExec(ctx context.Context, in *pb.C
 }
 
 func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, containerId string, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
-	pid, err := s.execAuditedSandboxProcess(ctx, containerId, instance, cmd, cwd, env)
+	pid, err := s.streamSandboxProcessExec(ctx, containerId, instance, cmd, cwd, env)
 	if err == nil || !isProcessManagerDialFailure(err) {
 		return pid, err
 	}
@@ -662,7 +662,7 @@ func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, contain
 	case <-timer.C:
 	}
 
-	retryPID, retryErr := s.execAuditedSandboxProcess(ctx, containerId, instance, cmd, cwd, env)
+	retryPID, retryErr := s.streamSandboxProcessExec(ctx, containerId, instance, cmd, cwd, env)
 	if retryErr != nil {
 		return -1, fmt.Errorf("%w; retry failed: %v", err, retryErr)
 	}
@@ -670,7 +670,7 @@ func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, contain
 	return retryPID, nil
 }
 
-func (s *ContainerRuntimeServer) execAuditedSandboxProcess(ctx context.Context, containerId string, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
+func (s *ContainerRuntimeServer) streamSandboxProcessExec(ctx context.Context, containerId string, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
 	if s.eventRepo == nil {
 		return -1, repository.ErrEventWriteUnsupported
 	}
@@ -682,7 +682,7 @@ func (s *ContainerRuntimeServer) execAuditedSandboxProcess(ctx context.Context, 
 		return -1, err
 	}
 
-	stream, err := client.AuditedExec(streamCtx, cmd, cwd, env, false)
+	stream, err := client.StreamExec(streamCtx, cmd, cwd, env, false)
 	if err != nil {
 		cancel()
 		_ = client.Cleanup()
@@ -693,7 +693,7 @@ func (s *ContainerRuntimeServer) execAuditedSandboxProcess(ctx context.Context, 
 	errCh := make(chan error, 1)
 	started := &atomic.Bool{}
 
-	go s.handleAuditedSandboxExecStream(stream, cancel, client.Cleanup, containerId, instance, cmd, cwd, pidCh, errCh, started)
+	go s.handleSandboxExecStream(stream, cancel, client.Cleanup, containerId, instance, cmd, cwd, pidCh, errCh, started)
 
 	select {
 	case pid := <-pidCh:
@@ -707,8 +707,8 @@ func (s *ContainerRuntimeServer) execAuditedSandboxProcess(ctx context.Context, 
 	}
 }
 
-func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
-	stream goprocpb.GoProc_AuditedExecClient,
+func (s *ContainerRuntimeServer) handleSandboxExecStream(
+	stream goprocpb.GoProc_StreamExecClient,
 	cancel context.CancelFunc,
 	cleanup func() error,
 	containerId string,
@@ -722,7 +722,7 @@ func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
 	defer cancel()
 	defer func() {
 		if err := cleanup(); err != nil {
-			log.Debug().Err(err).Str("container_id", containerId).Msg("failed to cleanup audited sandbox process manager client")
+			log.Debug().Err(err).Str("container_id", containerId).Msg("failed to cleanup sandbox process manager client")
 		}
 	}()
 
@@ -739,13 +739,13 @@ func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
 	for {
 		resp, err := stream.Recv()
 		if err == io.EOF {
-			sendStartErr(errors.New("audited sandbox exec stream closed before process start"))
+			sendStartErr(errors.New("sandbox exec stream closed before process start"))
 			return
 		}
 		if err != nil {
 			sendStartErr(err)
 			if started.Load() {
-				log.Warn().Err(err).Str("container_id", containerId).Msg("audited sandbox exec stream failed")
+				log.Warn().Err(err).Str("container_id", containerId).Msg("sandbox exec stream failed")
 			}
 			return
 		}
@@ -758,13 +758,13 @@ func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
 		}
 
 		if chunk := resp.GetChunk(); chunk != nil {
-			persistErr := s.persistAuditedSandboxLog(instance, chunk, cmd, cwd)
-			ack := &goprocpb.AuditLogAck{Seq: chunk.Seq, Ok: persistErr == nil}
+			persistErr := s.persistSandboxProcessLog(instance, chunk, cmd, cwd)
+			ack := &goprocpb.ProcessLogAck{Seq: chunk.Seq, Ok: persistErr == nil}
 			if persistErr != nil {
 				ack.ErrorMsg = persistErr.Error()
 			}
-			sendErr := stream.Send(&goprocpb.AuditedExecRequest{
-				Message: &goprocpb.AuditedExecRequest_Ack{Ack: ack},
+			sendErr := stream.Send(&goprocpb.StreamExecRequest{
+				Message: &goprocpb.StreamExecRequest_Ack{Ack: ack},
 			})
 			if persistErr != nil {
 				log.Error().
@@ -773,13 +773,13 @@ func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
 					Int32("pid", chunk.Pid).
 					Uint64("seq", chunk.Seq).
 					Str("stream", chunk.Stream).
-					Msg("failed to persist audited sandbox process log")
+					Msg("failed to persist sandbox process log")
 				return
 			}
 			if sendErr != nil {
 				sendStartErr(sendErr)
 				if started.Load() {
-					log.Warn().Err(sendErr).Str("container_id", containerId).Msg("failed to ack audited sandbox process log")
+					log.Warn().Err(sendErr).Str("container_id", containerId).Msg("failed to ack sandbox process log")
 				}
 				return
 			}
@@ -790,7 +790,7 @@ func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
 			if !started.Load() {
 				msg := event.ErrorMsg
 				if msg == "" {
-					msg = "audited sandbox process exited before start acknowledgement"
+					msg = "sandbox process exited before start acknowledgement"
 				}
 				sendStartErr(errors.New(msg))
 			}
@@ -799,12 +799,12 @@ func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
 	}
 }
 
-func (s *ContainerRuntimeServer) persistAuditedSandboxLog(instance *ContainerInstance, chunk *goprocpb.AuditLogChunk, cmd []string, cwd string) error {
+func (s *ContainerRuntimeServer) persistSandboxProcessLog(instance *ContainerInstance, chunk *goprocpb.ProcessLogChunk, cmd []string, cwd string) error {
 	if s.eventRepo == nil {
 		return repository.ErrEventWriteUnsupported
 	}
 	if instance == nil || instance.Request == nil {
-		return errors.New("container request not available for audited sandbox log")
+		return errors.New("container request not available for sandbox process log")
 	}
 	if len(chunk.Data) == 0 {
 		return nil
@@ -826,7 +826,7 @@ func (s *ContainerRuntimeServer) persistAuditedSandboxLog(instance *ContainerIns
 		ProcessCwd:  cwd,
 		ProcessSeq:  chunk.Seq,
 	}
-	if err := s.eventRepo.PushContainerLogEventSync(entry); err != nil {
+	if err := s.eventRepo.PushContainerLogEventQueued(entry); err != nil {
 		return err
 	}
 

--- a/pkg/worker/container_server.go
+++ b/pkg/worker/container_server.go
@@ -17,15 +17,18 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
+	goprocpb "github.com/beam-cloud/goproc/proto"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	common "github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/runtime"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
@@ -43,6 +46,10 @@ const (
 )
 
 // ContainerRuntimeServer is a runtime-agnostic container server that works with any OCI runtime
+type auditedLogEventRepository interface {
+	PushContainerLogEventSync(entry types.EventContainerLogSchema) error
+}
+
 type ContainerRuntimeServer struct {
 	baseConfigSpec specs.Spec
 	pb.UnimplementedContainerServiceServer
@@ -51,6 +58,8 @@ type ContainerRuntimeServer struct {
 	containerNetworkManager ContainerNetwork
 	imageClient             *ImageClient
 	runtime                 runtime.Runtime // The worker's configured runtime (from pool config)
+	eventRepo               auditedLogEventRepository
+	workerID                string
 	port                    int
 	podAddr                 string
 	backendRoute            backendRouteFunc
@@ -69,6 +78,8 @@ type ContainerRuntimeServerOpts struct {
 	ImageClient             *ImageClient
 	ContainerRepoClient     pb.ContainerRepositoryServiceClient
 	ContainerNetworkManager ContainerNetwork
+	EventRepo               repository.EventRepository
+	WorkerID                string
 	BackendRoute            backendRouteFunc
 	CreateCheckpoint        func(ctx context.Context, opts *CreateCheckpointOpts) error
 }
@@ -93,6 +104,8 @@ func NewContainerRuntimeServer(opts *ContainerRuntimeServerOpts) (*ContainerRunt
 		imageClient:             opts.ImageClient,
 		containerRepoClient:     opts.ContainerRepoClient,
 		containerNetworkManager: opts.ContainerNetworkManager,
+		eventRepo:               opts.EventRepo,
+		workerID:                opts.WorkerID,
 		backendRoute:            opts.BackendRoute,
 		createCheckpoint:        opts.CreateCheckpoint,
 	}, nil
@@ -629,7 +642,7 @@ func (s *ContainerRuntimeServer) handleSandboxExec(ctx context.Context, in *pb.C
 }
 
 func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, containerId string, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
-	pid, err := execSandboxProcess(ctx, instance, cmd, cwd, env)
+	pid, err := s.execAuditedSandboxProcess(ctx, containerId, instance, cmd, cwd, env)
 	if err == nil || !isProcessManagerDialFailure(err) {
 		return pid, err
 	}
@@ -649,7 +662,7 @@ func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, contain
 	case <-timer.C:
 	}
 
-	retryPID, retryErr := execSandboxProcess(ctx, instance, cmd, cwd, env)
+	retryPID, retryErr := s.execAuditedSandboxProcess(ctx, containerId, instance, cmd, cwd, env)
 	if retryErr != nil {
 		return -1, fmt.Errorf("%w; retry failed: %v", err, retryErr)
 	}
@@ -657,14 +670,170 @@ func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, contain
 	return retryPID, nil
 }
 
-func execSandboxProcess(ctx context.Context, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
-	client, err := newProcessManagerClient(ctx, instance)
+func (s *ContainerRuntimeServer) execAuditedSandboxProcess(ctx context.Context, containerId string, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
+	if s.eventRepo == nil {
+		return -1, repository.ErrEventWriteUnsupported
+	}
+
+	streamCtx, cancel := context.WithCancel(context.Background())
+	client, err := newProcessManagerClient(streamCtx, instance)
 	if err != nil {
+		cancel()
 		return -1, err
 	}
-	defer client.Cleanup()
 
-	return client.Exec(cmd, cwd, env, false)
+	stream, err := client.AuditedExec(streamCtx, cmd, cwd, env, false)
+	if err != nil {
+		cancel()
+		_ = client.Cleanup()
+		return -1, err
+	}
+
+	pidCh := make(chan int, 1)
+	errCh := make(chan error, 1)
+	started := &atomic.Bool{}
+
+	go s.handleAuditedSandboxExecStream(stream, cancel, client.Cleanup, containerId, instance, cmd, cwd, pidCh, errCh, started)
+
+	select {
+	case pid := <-pidCh:
+		return pid, nil
+	case err := <-errCh:
+		cancel()
+		return -1, err
+	case <-ctx.Done():
+		cancel()
+		return -1, ctx.Err()
+	}
+}
+
+func (s *ContainerRuntimeServer) handleAuditedSandboxExecStream(
+	stream goprocpb.GoProc_AuditedExecClient,
+	cancel context.CancelFunc,
+	cleanup func() error,
+	containerId string,
+	instance *ContainerInstance,
+	cmd []string,
+	cwd string,
+	pidCh chan<- int,
+	errCh chan<- error,
+	started *atomic.Bool,
+) {
+	defer cancel()
+	defer func() {
+		if err := cleanup(); err != nil {
+			log.Debug().Err(err).Str("container_id", containerId).Msg("failed to cleanup audited sandbox process manager client")
+		}
+	}()
+
+	sendStartErr := func(err error) {
+		if err == nil || started.Load() {
+			return
+		}
+		select {
+		case errCh <- err:
+		default:
+		}
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			sendStartErr(errors.New("audited sandbox exec stream closed before process start"))
+			return
+		}
+		if err != nil {
+			sendStartErr(err)
+			if started.Load() {
+				log.Warn().Err(err).Str("container_id", containerId).Msg("audited sandbox exec stream failed")
+			}
+			return
+		}
+
+		if event := resp.GetStarted(); event != nil {
+			if started.CompareAndSwap(false, true) {
+				pidCh <- int(event.Pid)
+			}
+			continue
+		}
+
+		if chunk := resp.GetChunk(); chunk != nil {
+			persistErr := s.persistAuditedSandboxLog(instance, chunk, cmd, cwd)
+			ack := &goprocpb.AuditLogAck{Seq: chunk.Seq, Ok: persistErr == nil}
+			if persistErr != nil {
+				ack.ErrorMsg = persistErr.Error()
+			}
+			sendErr := stream.Send(&goprocpb.AuditedExecRequest{
+				Message: &goprocpb.AuditedExecRequest_Ack{Ack: ack},
+			})
+			if persistErr != nil {
+				log.Error().
+					Err(persistErr).
+					Str("container_id", containerId).
+					Int32("pid", chunk.Pid).
+					Uint64("seq", chunk.Seq).
+					Str("stream", chunk.Stream).
+					Msg("failed to persist audited sandbox process log")
+				return
+			}
+			if sendErr != nil {
+				sendStartErr(sendErr)
+				if started.Load() {
+					log.Warn().Err(sendErr).Str("container_id", containerId).Msg("failed to ack audited sandbox process log")
+				}
+				return
+			}
+			continue
+		}
+
+		if event := resp.GetExited(); event != nil {
+			if !started.Load() {
+				msg := event.ErrorMsg
+				if msg == "" {
+					msg = "audited sandbox process exited before start acknowledgement"
+				}
+				sendStartErr(errors.New(msg))
+			}
+			return
+		}
+	}
+}
+
+func (s *ContainerRuntimeServer) persistAuditedSandboxLog(instance *ContainerInstance, chunk *goprocpb.AuditLogChunk, cmd []string, cwd string) error {
+	if s.eventRepo == nil {
+		return repository.ErrEventWriteUnsupported
+	}
+	if instance == nil || instance.Request == nil {
+		return errors.New("container request not available for audited sandbox log")
+	}
+	if len(chunk.Data) == 0 {
+		return nil
+	}
+
+	request := instance.Request
+	entry := types.EventContainerLogSchema{
+		Timestamp:   time.Now().UTC(),
+		ContainerID: request.ContainerId,
+		StubID:      request.StubId,
+		StubType:    string(request.Stub.Type.Kind()),
+		WorkspaceID: request.WorkspaceId,
+		AppID:       request.AppId,
+		WorkerID:    s.workerID,
+		Stream:      chunk.Stream,
+		Line:        string(chunk.Data),
+		PID:         chunk.Pid,
+		ProcessArgs: append([]string(nil), cmd...),
+		ProcessCwd:  cwd,
+		ProcessSeq:  chunk.Seq,
+	}
+	if err := s.eventRepo.PushContainerLogEventSync(entry); err != nil {
+		return err
+	}
+
+	if instance.LogBuffer != nil {
+		_ = instance.LogBuffer.Write(chunk.Data)
+	}
+	return nil
 }
 
 func isProcessManagerDialFailure(err error) bool {

--- a/pkg/worker/container_server_test.go
+++ b/pkg/worker/container_server_test.go
@@ -183,22 +183,22 @@ func TestContainerSandboxStatusRequiresProcessManagerForPid(t *testing.T) {
 	require.Contains(t, resp.ErrorMsg, "process manager")
 }
 
-func TestAuditedSandboxExecStreamPersistsChunkBeforeAck(t *testing.T) {
-	repo := &fakeAuditedLogRepo{}
+func TestSandboxExecStreamPersistsChunkBeforeAck(t *testing.T) {
+	repo := &fakeProcessLogRepo{}
 	server := &ContainerRuntimeServer{
 		eventRepo: repo,
 		workerID:  "worker-1",
 	}
-	instance := auditedSandboxTestInstance("sandbox-test")
-	stream := newFakeAuditedExecStream(
-		&goprocpb.AuditedExecResponse{
-			Message: &goprocpb.AuditedExecResponse_Started{
+	instance := sandboxExecTestInstance("sandbox-test")
+	stream := newFakeStreamExecStream(
+		&goprocpb.StreamExecResponse{
+			Message: &goprocpb.StreamExecResponse_Started{
 				Started: &goprocpb.ExecProcessStarted{Pid: 123},
 			},
 		},
-		&goprocpb.AuditedExecResponse{
-			Message: &goprocpb.AuditedExecResponse_Chunk{
-				Chunk: &goprocpb.AuditLogChunk{
+		&goprocpb.StreamExecResponse{
+			Message: &goprocpb.StreamExecResponse_Chunk{
+				Chunk: &goprocpb.ProcessLogChunk{
 					Pid:    123,
 					Stream: types.EventLogStreamStdout,
 					Seq:    7,
@@ -211,16 +211,16 @@ func TestAuditedSandboxExecStreamPersistsChunkBeforeAck(t *testing.T) {
 	pidCh := make(chan int, 1)
 	errCh := make(chan error, 1)
 	started := &atomic.Bool{}
-	go server.handleAuditedSandboxExecStream(stream, func() {}, func() error { return nil }, instance.Id, instance, []string{"python3", "-c", "print('hi')"}, "/workspace", pidCh, errCh, started)
+	go server.handleSandboxExecStream(stream, func() {}, func() error { return nil }, instance.Id, instance, []string{"python3", "-c", "print('hi')"}, "/workspace", pidCh, errCh, started)
 
 	require.Equal(t, 123, <-pidCh)
 
-	var ack *goprocpb.AuditLogAck
+	var ack *goprocpb.ProcessLogAck
 	select {
 	case req := <-stream.sent:
 		ack = req.GetAck()
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for audit ack")
+		t.Fatal("timed out waiting for log ack")
 	}
 	require.NotNil(t, ack)
 	require.True(t, ack.Ok)
@@ -241,22 +241,22 @@ func TestAuditedSandboxExecStreamPersistsChunkBeforeAck(t *testing.T) {
 	require.Equal(t, uint64(7), entry.ProcessSeq)
 }
 
-func TestAuditedSandboxExecStreamNacksPersistFailure(t *testing.T) {
-	repo := &fakeAuditedLogRepo{err: errors.New("s2 unavailable")}
+func TestSandboxExecStreamNacksPersistFailure(t *testing.T) {
+	repo := &fakeProcessLogRepo{err: errors.New("s2 unavailable")}
 	server := &ContainerRuntimeServer{
 		eventRepo: repo,
 		workerID:  "worker-1",
 	}
-	instance := auditedSandboxTestInstance("sandbox-test")
-	stream := newFakeAuditedExecStream(
-		&goprocpb.AuditedExecResponse{
-			Message: &goprocpb.AuditedExecResponse_Started{
+	instance := sandboxExecTestInstance("sandbox-test")
+	stream := newFakeStreamExecStream(
+		&goprocpb.StreamExecResponse{
+			Message: &goprocpb.StreamExecResponse_Started{
 				Started: &goprocpb.ExecProcessStarted{Pid: 123},
 			},
 		},
-		&goprocpb.AuditedExecResponse{
-			Message: &goprocpb.AuditedExecResponse_Chunk{
-				Chunk: &goprocpb.AuditLogChunk{
+		&goprocpb.StreamExecResponse{
+			Message: &goprocpb.StreamExecResponse_Chunk{
+				Chunk: &goprocpb.ProcessLogChunk{
 					Pid:    123,
 					Stream: types.EventLogStreamStderr,
 					Seq:    9,
@@ -269,16 +269,16 @@ func TestAuditedSandboxExecStreamNacksPersistFailure(t *testing.T) {
 	pidCh := make(chan int, 1)
 	errCh := make(chan error, 1)
 	started := &atomic.Bool{}
-	go server.handleAuditedSandboxExecStream(stream, func() {}, func() error { return nil }, instance.Id, instance, []string{"python3"}, "", pidCh, errCh, started)
+	go server.handleSandboxExecStream(stream, func() {}, func() error { return nil }, instance.Id, instance, []string{"python3"}, "", pidCh, errCh, started)
 
 	require.Equal(t, 123, <-pidCh)
 
-	var ack *goprocpb.AuditLogAck
+	var ack *goprocpb.ProcessLogAck
 	select {
 	case req := <-stream.sent:
 		ack = req.GetAck()
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for audit nack")
+		t.Fatal("timed out waiting for log nack")
 	}
 	require.NotNil(t, ack)
 	require.False(t, ack.Ok)
@@ -286,12 +286,12 @@ func TestAuditedSandboxExecStreamNacksPersistFailure(t *testing.T) {
 	require.Contains(t, ack.ErrorMsg, "s2 unavailable")
 }
 
-type fakeAuditedLogRepo struct {
+type fakeProcessLogRepo struct {
 	entries []types.EventContainerLogSchema
 	err     error
 }
 
-func (r *fakeAuditedLogRepo) PushContainerLogEventSync(entry types.EventContainerLogSchema) error {
+func (r *fakeProcessLogRepo) PushContainerLogEventQueued(entry types.EventContainerLogSchema) error {
 	if r.err != nil {
 		return r.err
 	}
@@ -299,16 +299,16 @@ func (r *fakeAuditedLogRepo) PushContainerLogEventSync(entry types.EventContaine
 	return nil
 }
 
-type fakeAuditedExecStream struct {
+type fakeStreamExecStream struct {
 	grpc.ClientStream
-	recv chan *goprocpb.AuditedExecResponse
-	sent chan *goprocpb.AuditedExecRequest
+	recv chan *goprocpb.StreamExecResponse
+	sent chan *goprocpb.StreamExecRequest
 }
 
-func newFakeAuditedExecStream(responses ...*goprocpb.AuditedExecResponse) *fakeAuditedExecStream {
-	stream := &fakeAuditedExecStream{
-		recv: make(chan *goprocpb.AuditedExecResponse, len(responses)),
-		sent: make(chan *goprocpb.AuditedExecRequest, len(responses)),
+func newFakeStreamExecStream(responses ...*goprocpb.StreamExecResponse) *fakeStreamExecStream {
+	stream := &fakeStreamExecStream{
+		recv: make(chan *goprocpb.StreamExecResponse, len(responses)),
+		sent: make(chan *goprocpb.StreamExecRequest, len(responses)),
 	}
 	for _, response := range responses {
 		stream.recv <- response
@@ -317,12 +317,12 @@ func newFakeAuditedExecStream(responses ...*goprocpb.AuditedExecResponse) *fakeA
 	return stream
 }
 
-func (s *fakeAuditedExecStream) Send(req *goprocpb.AuditedExecRequest) error {
+func (s *fakeStreamExecStream) Send(req *goprocpb.StreamExecRequest) error {
 	s.sent <- req
 	return nil
 }
 
-func (s *fakeAuditedExecStream) Recv() (*goprocpb.AuditedExecResponse, error) {
+func (s *fakeStreamExecStream) Recv() (*goprocpb.StreamExecResponse, error) {
 	resp, ok := <-s.recv
 	if !ok {
 		return nil, io.EOF
@@ -330,7 +330,7 @@ func (s *fakeAuditedExecStream) Recv() (*goprocpb.AuditedExecResponse, error) {
 	return resp, nil
 }
 
-func auditedSandboxTestInstance(containerId string) *ContainerInstance {
+func sandboxExecTestInstance(containerId string) *ContainerInstance {
 	return &ContainerInstance{
 		Id:        containerId,
 		LogBuffer: common.NewLogBuffer(),

--- a/pkg/worker/container_server_test.go
+++ b/pkg/worker/container_server_test.go
@@ -2,7 +2,9 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,8 +13,10 @@ import (
 	betaruntime "github.com/beam-cloud/beta9/pkg/runtime"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
+	goprocpb "github.com/beam-cloud/goproc/proto"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func TestWaitForSandboxProcessManagerDoesNotProceedBeforeReadySignal(t *testing.T) {
@@ -177,6 +181,169 @@ func TestContainerSandboxStatusRequiresProcessManagerForPid(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, resp.Ok)
 	require.Contains(t, resp.ErrorMsg, "process manager")
+}
+
+func TestAuditedSandboxExecStreamPersistsChunkBeforeAck(t *testing.T) {
+	repo := &fakeAuditedLogRepo{}
+	server := &ContainerRuntimeServer{
+		eventRepo: repo,
+		workerID:  "worker-1",
+	}
+	instance := auditedSandboxTestInstance("sandbox-test")
+	stream := newFakeAuditedExecStream(
+		&goprocpb.AuditedExecResponse{
+			Message: &goprocpb.AuditedExecResponse_Started{
+				Started: &goprocpb.ExecProcessStarted{Pid: 123},
+			},
+		},
+		&goprocpb.AuditedExecResponse{
+			Message: &goprocpb.AuditedExecResponse_Chunk{
+				Chunk: &goprocpb.AuditLogChunk{
+					Pid:    123,
+					Stream: types.EventLogStreamStdout,
+					Seq:    7,
+					Data:   []byte("hello from sandbox\n"),
+				},
+			},
+		},
+	)
+
+	pidCh := make(chan int, 1)
+	errCh := make(chan error, 1)
+	started := &atomic.Bool{}
+	go server.handleAuditedSandboxExecStream(stream, func() {}, func() error { return nil }, instance.Id, instance, []string{"python3", "-c", "print('hi')"}, "/workspace", pidCh, errCh, started)
+
+	require.Equal(t, 123, <-pidCh)
+
+	var ack *goprocpb.AuditLogAck
+	select {
+	case req := <-stream.sent:
+		ack = req.GetAck()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for audit ack")
+	}
+	require.NotNil(t, ack)
+	require.True(t, ack.Ok)
+	require.Equal(t, uint64(7), ack.Seq)
+
+	require.Len(t, repo.entries, 1)
+	entry := repo.entries[0]
+	require.Equal(t, "sandbox-test", entry.ContainerID)
+	require.Equal(t, "stub-1", entry.StubID)
+	require.Equal(t, "workspace-1", entry.WorkspaceID)
+	require.Equal(t, "app-1", entry.AppID)
+	require.Equal(t, "worker-1", entry.WorkerID)
+	require.Equal(t, types.EventLogStreamStdout, entry.Stream)
+	require.Equal(t, "hello from sandbox\n", entry.Line)
+	require.Equal(t, int32(123), entry.PID)
+	require.Equal(t, []string{"python3", "-c", "print('hi')"}, entry.ProcessArgs)
+	require.Equal(t, "/workspace", entry.ProcessCwd)
+	require.Equal(t, uint64(7), entry.ProcessSeq)
+}
+
+func TestAuditedSandboxExecStreamNacksPersistFailure(t *testing.T) {
+	repo := &fakeAuditedLogRepo{err: errors.New("s2 unavailable")}
+	server := &ContainerRuntimeServer{
+		eventRepo: repo,
+		workerID:  "worker-1",
+	}
+	instance := auditedSandboxTestInstance("sandbox-test")
+	stream := newFakeAuditedExecStream(
+		&goprocpb.AuditedExecResponse{
+			Message: &goprocpb.AuditedExecResponse_Started{
+				Started: &goprocpb.ExecProcessStarted{Pid: 123},
+			},
+		},
+		&goprocpb.AuditedExecResponse{
+			Message: &goprocpb.AuditedExecResponse_Chunk{
+				Chunk: &goprocpb.AuditLogChunk{
+					Pid:    123,
+					Stream: types.EventLogStreamStderr,
+					Seq:    9,
+					Data:   []byte("boom"),
+				},
+			},
+		},
+	)
+
+	pidCh := make(chan int, 1)
+	errCh := make(chan error, 1)
+	started := &atomic.Bool{}
+	go server.handleAuditedSandboxExecStream(stream, func() {}, func() error { return nil }, instance.Id, instance, []string{"python3"}, "", pidCh, errCh, started)
+
+	require.Equal(t, 123, <-pidCh)
+
+	var ack *goprocpb.AuditLogAck
+	select {
+	case req := <-stream.sent:
+		ack = req.GetAck()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for audit nack")
+	}
+	require.NotNil(t, ack)
+	require.False(t, ack.Ok)
+	require.Equal(t, uint64(9), ack.Seq)
+	require.Contains(t, ack.ErrorMsg, "s2 unavailable")
+}
+
+type fakeAuditedLogRepo struct {
+	entries []types.EventContainerLogSchema
+	err     error
+}
+
+func (r *fakeAuditedLogRepo) PushContainerLogEventSync(entry types.EventContainerLogSchema) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.entries = append(r.entries, entry)
+	return nil
+}
+
+type fakeAuditedExecStream struct {
+	grpc.ClientStream
+	recv chan *goprocpb.AuditedExecResponse
+	sent chan *goprocpb.AuditedExecRequest
+}
+
+func newFakeAuditedExecStream(responses ...*goprocpb.AuditedExecResponse) *fakeAuditedExecStream {
+	stream := &fakeAuditedExecStream{
+		recv: make(chan *goprocpb.AuditedExecResponse, len(responses)),
+		sent: make(chan *goprocpb.AuditedExecRequest, len(responses)),
+	}
+	for _, response := range responses {
+		stream.recv <- response
+	}
+	close(stream.recv)
+	return stream
+}
+
+func (s *fakeAuditedExecStream) Send(req *goprocpb.AuditedExecRequest) error {
+	s.sent <- req
+	return nil
+}
+
+func (s *fakeAuditedExecStream) Recv() (*goprocpb.AuditedExecResponse, error) {
+	resp, ok := <-s.recv
+	if !ok {
+		return nil, io.EOF
+	}
+	return resp, nil
+}
+
+func auditedSandboxTestInstance(containerId string) *ContainerInstance {
+	return &ContainerInstance{
+		Id:        containerId,
+		LogBuffer: common.NewLogBuffer(),
+		Request: &types.ContainerRequest{
+			ContainerId: containerId,
+			StubId:      "stub-1",
+			WorkspaceId: "workspace-1",
+			AppId:       "app-1",
+			Stub: types.StubWithRelated{
+				Stub: types.Stub{Type: types.StubType(types.StubTypeSandbox)},
+			},
+		},
+	}
 }
 
 func TestWritableContainerAddressMapHandlesNilMap(t *testing.T) {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -393,6 +393,8 @@ func NewWorker() (*Worker, error) {
 		ImageClient:             imageClient,
 		ContainerRepoClient:     containerRepoClient,
 		ContainerNetworkManager: containerNetworkManager,
+		EventRepo:               eventRepo,
+		WorkerID:                workerId,
 		BackendRoute:            worker.backendRouteFor,
 		CreateCheckpoint:        worker.createCheckpoint,
 	})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Capture and persist streamed sandbox process logs with PID, args, cwd, and sequence, and surface them in logs/events APIs. Each chunk is written to storage before we ack the sandbox process.

- **New Features**
  - Added `pid`, `process_args`, `process_cwd`, and `process_seq` to container log events, realtime events, and the log stream API.
  - Added `PushContainerLogEventQueued` and S2 `PushEventSync` to persist log chunks before ack; introduced `ErrEventWriteUnsupported`.
  - Worker streams sandbox process logs via `goproc`, writes them with `WorkerID`, cmd, and cwd, and acks only on success (nacks on failure).

- **Dependencies**
  - Updated `github.com/beam-cloud/goproc` and the `goproc` binary to v0.1.6.

<sup>Written for commit f2bd967080503869abdb0deae59ad4144ffc1e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

