### PR TITLE
Fix sandbox rows by container

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -686,8 +687,11 @@ const (
 	SandboxStatusFailed   = "FAILED"
 )
 
+const sandboxContainerHistoryLimit = 500
+
 type SandboxRow struct {
 	Id              string    `json:"id"`
+	StubId          string    `json:"stub_id,omitempty"`
 	Name            string    `json:"name"`
 	CreatedAt       time.Time `json:"created_at"`
 	Status          string    `json:"status"`
@@ -740,15 +744,14 @@ func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 
 	rows := make([]SandboxRow, 0, len(page.Data))
 	for i := range page.Data {
-		rows = append(rows, g.buildSandboxRow(ctx.Request().Context(), workspaceID, &page.Data[i], containersByStub[page.Data[i].ExternalId]))
+		rows = append(rows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &page.Data[i], containersByStub[page.Data[i].ExternalId])...)
 	}
 
 	return ctx.JSON(http.StatusOK, SandboxListResponse{Data: rows, Next: page.Next})
 }
 
-// GetSandboxStats returns aggregate stats for the sandboxes dashboard. The
-// status counts and concurrency are computed from live container state; the
-// totals and creation histogram come from the sandbox stubs themselves.
+// GetSandboxStats returns aggregate stats for the sandboxes dashboard using the
+// same container-backed rows as ListSandboxes.
 func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 	workspaceID := ctx.Param("workspaceId")
 
@@ -763,6 +766,11 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 
 	containersByStub := g.activeContainersByStub(workspaceID)
 
+	sandboxRows := make([]SandboxRow, 0, len(stubs))
+	for i := range stubs {
+		sandboxRows = append(sandboxRows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &stubs[i], containersByStub[stubs[i].ExternalId])...)
+	}
+
 	statusCounts := map[string]int{
 		SandboxStatusRunning:  0,
 		SandboxStatusPending:  0,
@@ -773,9 +781,9 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 
 	concurrent := 0
 	var earliest, latest time.Time
-	for i := range stubs {
-		stub := &stubs[i]
-		createdAt := stub.CreatedAt.Time
+	for i := range sandboxRows {
+		row := &sandboxRows[i]
+		createdAt := row.CreatedAt
 		if earliest.IsZero() || createdAt.Before(earliest) {
 			earliest = createdAt
 		}
@@ -783,19 +791,13 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 			latest = createdAt
 		}
 
-		// Live states come straight from the container status enum. Sandboxes
-		// without an active container are grouped as stopped here; the list
-		// endpoint refines a subset of those into failed per-row.
-		status := liveSandboxStatus(containersByStub[stub.ExternalId])
-		if status == "" {
-			status = SandboxStatusStopped
-		} else {
+		if isActiveSandboxStatus(row.Status) {
 			concurrent++
 		}
-		statusCounts[status]++
+		statusCounts[row.Status]++
 	}
 
-	total := len(stubs)
+	total := len(sandboxRows)
 	ratePerSecond := 0.0
 	if total > 1 && !earliest.IsZero() && latest.After(earliest) {
 		ratePerSecond = float64(total) / latest.Sub(earliest).Seconds()
@@ -806,7 +808,7 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 		TotalCreated:   total,
 		RatePerSecond:  ratePerSecond,
 		StatusCounts:   statusCounts,
-		CreatedBuckets: buildCreatedBuckets(stubs, ctx.QueryParam("chart_range")),
+		CreatedBuckets: buildSandboxRowCreatedBuckets(sandboxRows, ctx.QueryParam("chart_range")),
 	})
 }
 
@@ -827,6 +829,7 @@ type SandboxTimeline struct {
 func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
 	workspaceID := ctx.Param("workspaceId")
 	stubID := ctx.Param("stubId")
+	requestedContainerID := ctx.QueryParam("container_id")
 
 	stub, err := g.backendRepo.GetStubByExternalId(ctx.Request().Context(), stubID)
 	if err != nil {
@@ -843,6 +846,9 @@ func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
 		activeContainers, _ = g.containerRepo.GetActiveContainersByStubId(stubID)
 	}
 	active := mostRelevantContainer(activeContainers)
+	if requestedContainerID != "" {
+		active = matchingContainer(activeContainers, requestedContainerID)
+	}
 
 	containerID := ""
 	if active != nil {
@@ -852,6 +858,8 @@ func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
 			startedAt := time.Unix(active.StartedAt, 0).UTC()
 			timeline.StartedAt = &startedAt
 		}
+	} else if requestedContainerID != "" {
+		containerID = requestedContainerID
 	} else {
 		status, _, terminalContainerID := g.deriveTerminalSandbox(ctx.Request().Context(), workspaceID, stubID)
 		timeline.Status = status
@@ -864,6 +872,12 @@ func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
 			WorkspaceID: workspaceID,
 			StubID:      stubID,
 		}); err == nil && resp != nil {
+			if createdAt := firstContainerEventTime(resp.Events); !createdAt.IsZero() {
+				timeline.CreatedAt = createdAt
+			}
+			if active == nil && requestedContainerID != "" {
+				timeline.Status = terminalStatusFromContainerEvents(resp)
+			}
 			applyContainerTimeline(&timeline, resp)
 		}
 	}
@@ -960,35 +974,98 @@ func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]type
 	return byStub
 }
 
-func (g *StubGroup) buildSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState) SandboxRow {
+func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState) []SandboxRow {
+	rows := make([]SandboxRow, 0, len(containers)+1)
+	activeContainerIDs := make(map[string]struct{}, len(containers))
+
+	for i := range containers {
+		if containers[i].ContainerId == "" {
+			continue
+		}
+		activeContainerIDs[containers[i].ContainerId] = struct{}{}
+		rows = append(rows, g.buildActiveSandboxRow(ctx, workspaceID, stub, containers[i]))
+	}
+
+	for _, containerID := range g.recentSandboxContainerIDs(ctx, workspaceID, stub.ExternalId) {
+		if _, ok := activeContainerIDs[containerID]; ok {
+			continue
+		}
+		rows = append(rows, g.buildTerminalSandboxRow(ctx, workspaceID, stub, containerID))
+	}
+
+	if len(rows) == 0 {
+		rows = append(rows, g.buildFallbackSandboxRow(ctx, workspaceID, stub))
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].CreatedAt.After(rows[j].CreatedAt)
+	})
+
+	return rows
+}
+
+func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated, container types.ContainerState) SandboxRow {
 	row := SandboxRow{
 		Id:        stub.ExternalId,
+		StubId:    stub.ExternalId,
 		Name:      stub.Name,
 		CreatedAt: stub.CreatedAt.Time,
 	}
 
-	if active := mostRelevantContainer(containers); active != nil {
-		row.ContainerId = active.ContainerId
-		row.Gpu = active.Gpu
-		row.Status = string(active.Status)
+	row.Id = container.ContainerId
+	row.ContainerId = container.ContainerId
+	row.Gpu = container.Gpu
+	row.Status = string(container.Status)
 
-		if active.StartedAt > 0 && active.ScheduledAt > 0 && active.StartedAt >= active.ScheduledAt {
-			tts := (active.StartedAt - active.ScheduledAt) * 1000
-			row.TimeToStartedMs = &tts
+	if container.ScheduledAt > 0 {
+		row.CreatedAt = time.Unix(container.ScheduledAt, 0).UTC()
+	}
+
+	if container.StartedAt > 0 && container.ScheduledAt > 0 && container.StartedAt >= container.ScheduledAt {
+		tts := (container.StartedAt - container.ScheduledAt) * 1000
+		row.TimeToStartedMs = &tts
+	}
+
+	if container.Status == types.ContainerStatusRunning && container.StartedAt > 0 {
+		startedAtMs := container.StartedAt * 1000
+		row.StartedAtMs = &startedAtMs
+
+		lifetime := (time.Now().Unix() - container.StartedAt) * 1000
+		if lifetime >= 0 {
+			row.LifetimeMs = &lifetime
 		}
+	}
 
-		if active.Status == types.ContainerStatusRunning && active.StartedAt > 0 {
-			startedAtMs := active.StartedAt * 1000
-			row.StartedAtMs = &startedAtMs
+	g.enrichSandboxTimingFromEvents(ctx, workspaceID, stub.ExternalId, &row)
+	return row
+}
 
-			lifetime := (time.Now().Unix() - active.StartedAt) * 1000
-			if lifetime >= 0 {
-				row.LifetimeMs = &lifetime
-			}
-		}
+func (g *StubGroup) buildTerminalSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containerID string) SandboxRow {
+	row := SandboxRow{
+		Id:          containerID,
+		StubId:      stub.ExternalId,
+		Name:        stub.Name,
+		CreatedAt:   stub.CreatedAt.Time,
+		Status:      SandboxStatusStopped,
+		ContainerId: containerID,
+	}
 
-		g.enrichSandboxTimingFromEvents(ctx, workspaceID, stub.ExternalId, &row)
+	resp := g.containerEvents(ctx, workspaceID, stub.ExternalId, containerID)
+	if resp == nil {
 		return row
+	}
+
+	row.Status = terminalStatusFromContainerEvents(resp)
+	applySandboxRowEvents(&row, resp)
+	return row
+}
+
+func (g *StubGroup) buildFallbackSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated) SandboxRow {
+	row := SandboxRow{
+		Id:        stub.ExternalId,
+		StubId:    stub.ExternalId,
+		Name:      stub.Name,
+		CreatedAt: stub.CreatedAt.Time,
 	}
 
 	status, timeToStarted, containerID := g.deriveTerminalSandbox(ctx, workspaceID, stub.ExternalId)
@@ -999,22 +1076,130 @@ func (g *StubGroup) buildSandboxRow(ctx context.Context, workspaceID string, stu
 }
 
 func (g *StubGroup) enrichSandboxTimingFromEvents(ctx context.Context, workspaceID, stubID string, row *SandboxRow) {
-	if g.eventRepo == nil || row.ContainerId == "" {
+	resp := g.containerEvents(ctx, workspaceID, stubID, row.ContainerId)
+	if resp == nil {
 		return
 	}
 
-	resp, err := g.eventRepo.GetContainerEvents(ctx, row.ContainerId, types.EventQuery{
-		WorkspaceID: workspaceID,
-		StubID:      stubID,
-	})
-	if err != nil || resp == nil {
-		return
-	}
+	applySandboxRowEvents(row, resp)
+}
 
+func applySandboxRowEvents(row *SandboxRow, resp *types.ContainerEventsResponse) {
+	if createdAt := firstContainerEventTime(resp.Events); !createdAt.IsZero() {
+		row.CreatedAt = createdAt
+	}
 	if v, ok := resp.Summary["container_request_to_running_ms"]; ok && v > 0 {
 		value := v
 		row.TimeToStartedMs = &value
 	}
+
+	timeline := SandboxTimeline{
+		ContainerId: row.ContainerId,
+		Status:      row.Status,
+		CreatedAt:   row.CreatedAt,
+	}
+	applyContainerTimeline(&timeline, resp)
+
+	if timeline.StartedAt != nil {
+		startedAtMs := timeline.StartedAt.UnixMilli()
+		row.StartedAtMs = &startedAtMs
+	}
+
+	end := timeline.EndedAt
+	if end == nil && row.Status == SandboxStatusRunning {
+		now := time.Now().UTC()
+		end = &now
+	}
+	if timeline.StartedAt != nil && end != nil {
+		lifetime := end.Sub(*timeline.StartedAt).Milliseconds()
+		if lifetime >= 0 {
+			row.LifetimeMs = &lifetime
+		}
+	}
+}
+
+func (g *StubGroup) containerEvents(ctx context.Context, workspaceID, stubID, containerID string) *types.ContainerEventsResponse {
+	if g.eventRepo == nil || containerID == "" {
+		return nil
+	}
+
+	resp, err := g.eventRepo.GetContainerEvents(ctx, containerID, types.EventQuery{
+		WorkspaceID: workspaceID,
+		StubID:      stubID,
+	})
+	if err != nil || resp == nil {
+		return nil
+	}
+	return resp
+}
+
+func (g *StubGroup) recentSandboxContainerIDs(ctx context.Context, workspaceID, stubID string) []string {
+	if g.eventRepo == nil {
+		return nil
+	}
+
+	history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
+		WorkspaceID: workspaceID,
+		StubID:      stubID,
+		Limit:       sandboxContainerHistoryLimit,
+		EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+	})
+	if err != nil || history == nil {
+		return nil
+	}
+	return sandboxContainerIDsFromHistory(history.Events)
+}
+
+func sandboxContainerIDsFromHistory(events []types.ContainerEventRecord) []string {
+	lastSeen := map[string]time.Time{}
+	for _, event := range events {
+		if event.ContainerID == "" {
+			continue
+		}
+		t := containerEventTime(event)
+		if t.IsZero() {
+			t = time.Unix(0, int64(event.StoredAtNs)).UTC()
+		}
+		if current, ok := lastSeen[event.ContainerID]; !ok || t.After(current) {
+			lastSeen[event.ContainerID] = t
+		}
+	}
+
+	ids := make([]string, 0, len(lastSeen))
+	for containerID := range lastSeen {
+		ids = append(ids, containerID)
+	}
+	sort.SliceStable(ids, func(i, j int) bool {
+		return lastSeen[ids[i]].After(lastSeen[ids[j]])
+	})
+	return ids
+}
+
+func firstContainerEventTime(events []types.ContainerEventRecord) time.Time {
+	var first time.Time
+	for _, event := range events {
+		t := containerEventTime(event)
+		if t.IsZero() {
+			continue
+		}
+		if first.IsZero() || t.Before(first) {
+			first = t
+		}
+	}
+	return first.UTC()
+}
+
+func containerEventTime(event types.ContainerEventRecord) time.Time {
+	if !event.Timestamp.IsZero() {
+		return event.Timestamp.UTC()
+	}
+	if !event.StartTime.IsZero() {
+		return event.StartTime.UTC()
+	}
+	if !event.EndTime.IsZero() {
+		return event.EndTime.UTC()
+	}
+	return time.Time{}
 }
 
 // deriveTerminalSandbox performs a best-effort lookup against the event store to
@@ -1106,6 +1291,15 @@ func mostRelevantContainer(containers []types.ContainerState) *types.ContainerSt
 	return best
 }
 
+func matchingContainer(containers []types.ContainerState, containerID string) *types.ContainerState {
+	for i := range containers {
+		if containers[i].ContainerId == containerID {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
 type sandboxChartRange struct {
 	start      time.Time
 	bucketSize time.Duration
@@ -1137,6 +1331,10 @@ func buildCreatedBuckets(stubs []types.StubWithRelated, rangeValue string) []San
 	return buildCreatedBucketsAt(stubs, rangeValue, time.Now())
 }
 
+func buildSandboxRowCreatedBuckets(rows []SandboxRow, rangeValue string) []SandboxCreatedBucket {
+	return buildSandboxRowCreatedBucketsAt(rows, rangeValue, time.Now())
+}
+
 func buildCreatedBucketsAt(stubs []types.StubWithRelated, rangeValue string, now time.Time) []SandboxCreatedBucket {
 	r := sandboxCreatedChartRange(rangeValue, now)
 	buckets := make([]SandboxCreatedBucket, r.count)
@@ -1147,6 +1345,29 @@ func buildCreatedBucketsAt(stubs []types.StubWithRelated, rangeValue string, now
 	end := r.start.Add(time.Duration(r.count) * r.bucketSize)
 	for i := range stubs {
 		t := stubs[i].CreatedAt.Time.UTC()
+		if t.Before(r.start) || !t.Before(end) {
+			continue
+		}
+
+		idx := int(t.Sub(r.start) / r.bucketSize)
+		if idx >= 0 && idx < len(buckets) {
+			buckets[idx].Count++
+		}
+	}
+
+	return buckets
+}
+
+func buildSandboxRowCreatedBucketsAt(rows []SandboxRow, rangeValue string, now time.Time) []SandboxCreatedBucket {
+	r := sandboxCreatedChartRange(rangeValue, now)
+	buckets := make([]SandboxCreatedBucket, r.count)
+	for i := range buckets {
+		buckets[i] = SandboxCreatedBucket{Timestamp: r.start.Add(time.Duration(i) * r.bucketSize)}
+	}
+
+	end := r.start.Add(time.Duration(r.count) * r.bucketSize)
+	for i := range rows {
+		t := rows[i].CreatedAt.UTC()
 		if t.Before(r.start) || !t.Before(end) {
 			continue
 		}

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -1,6 +1,7 @@
 package apiv1
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -20,6 +21,20 @@ import (
 	"github.com/labstack/echo/v4"
 	"k8s.io/utils/ptr"
 )
+
+type sandboxRowsEventRepo struct {
+	repository.EventRepository
+	history    *types.EventHistoryResponse
+	containers map[string]*types.ContainerEventsResponse
+}
+
+func (r *sandboxRowsEventRepo) GetEventHistory(context.Context, types.EventQuery) (*types.EventHistoryResponse, error) {
+	return r.history, nil
+}
+
+func (r *sandboxRowsEventRepo) GetContainerEvents(_ context.Context, containerID string, _ types.EventQuery) (*types.ContainerEventsResponse, error) {
+	return r.containers[containerID], nil
+}
 
 func NewStubGroupForTest() *StubGroup {
 	backendRepo, _ := repository.NewBackendPostgresRepositoryForTest()
@@ -76,6 +91,113 @@ func generateDefaultStubWithConfig() *types.Stub {
 	return &types.Stub{
 		Name:   "Test Stub",
 		Config: `{"runtime":{"cpu":1000,"gpu":"","gpu_count":0,"memory":1000,"image_id":"","gpus":[]},"handler":"","on_start":"","on_deploy":"","on_deploy_stub_id":"","python_version":"python3","keep_warm_seconds":600,"max_pending_tasks":100,"callback_url":"","task_policy":{"max_retries":3,"timeout":3600,"expires":"0001-01-01T00:00:00Z","ttl":0},"workers":1,"concurrent_requests":1,"authorized":false,"volumes":null,"autoscaler":{"type":"queue_depth","max_containers":1,"tasks_per_container":1,"min_containers":0},"extra":{},"checkpoint_enabled":false,"work_dir":"","entry_point":["sleep 100"],"ports":[]}`,
+	}
+}
+
+func TestBuildSandboxRowsReturnsOneRowPerRecentContainer(t *testing.T) {
+	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
+	stub := &types.StubWithRelated{Stub: types.Stub{
+		ExternalId: "sandbox-stub",
+		Name:       "sandbox",
+		CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+	}}
+
+	containerEvents := func(containerID string, startedAt time.Time) *types.ContainerEventsResponse {
+		endedAt := startedAt.Add(250 * time.Millisecond)
+		return &types.ContainerEventsResponse{
+			ContainerID: containerID,
+			WorkspaceID: "workspace",
+			StubID:      "sandbox-stub",
+			Summary: map[string]int64{
+				"container_request_to_running_ms": 44,
+			},
+			Events: []types.ContainerEventRecord{
+				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: containerID, WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: startedAt},
+				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: containerID, WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: endedAt},
+			},
+		}
+	}
+
+	group := &StubGroup{eventRepo: &sandboxRowsEventRepo{
+		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
+			{ContainerID: "sandbox-stub-11111111", Timestamp: base.Add(1 * time.Second)},
+			{ContainerID: "sandbox-stub-22222222", Timestamp: base.Add(2 * time.Second)},
+			{ContainerID: "sandbox-stub-33333333", Timestamp: base.Add(3 * time.Second)},
+		}},
+		containers: map[string]*types.ContainerEventsResponse{
+			"sandbox-stub-11111111": containerEvents("sandbox-stub-11111111", base.Add(1*time.Second)),
+			"sandbox-stub-22222222": containerEvents("sandbox-stub-22222222", base.Add(2*time.Second)),
+			"sandbox-stub-33333333": containerEvents("sandbox-stub-33333333", base.Add(3*time.Second)),
+		},
+	}}
+
+	rows := group.buildSandboxRows(context.Background(), "workspace", stub, nil)
+	if got, want := len(rows), 3; got != want {
+		t.Fatalf("expected %d sandbox rows, got %d", want, got)
+	}
+
+	expectedContainerIDs := []string{"sandbox-stub-33333333", "sandbox-stub-22222222", "sandbox-stub-11111111"}
+	for i, expectedContainerID := range expectedContainerIDs {
+		row := rows[i]
+		if row.Id != expectedContainerID {
+			t.Fatalf("row %d id = %q, want container id %q", i, row.Id, expectedContainerID)
+		}
+		if row.StubId != "sandbox-stub" {
+			t.Fatalf("row %d stub_id = %q, want stub id", i, row.StubId)
+		}
+		if row.ContainerId != expectedContainerID {
+			t.Fatalf("row %d container_id = %q, want %q", i, row.ContainerId, expectedContainerID)
+		}
+		if row.Status != SandboxStatusStopped {
+			t.Fatalf("row %d status = %q, want %q", i, row.Status, SandboxStatusStopped)
+		}
+		if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 44 {
+			t.Fatalf("row %d time_to_started_ms = %v, want 44", i, row.TimeToStartedMs)
+		}
+	}
+}
+
+func TestBuildSandboxRowsReturnsEveryActiveContainer(t *testing.T) {
+	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
+	stub := &types.StubWithRelated{Stub: types.Stub{
+		ExternalId: "sandbox-stub",
+		Name:       "sandbox",
+		CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+	}}
+
+	group := &StubGroup{}
+	rows := group.buildSandboxRows(context.Background(), "workspace", stub, []types.ContainerState{
+		{
+			ContainerId: "sandbox-stub-11111111",
+			StubId:      "sandbox-stub",
+			Status:      types.ContainerStatusRunning,
+			ScheduledAt: base.Add(1 * time.Second).Unix(),
+			StartedAt:   base.Add(2 * time.Second).Unix(),
+		},
+		{
+			ContainerId: "sandbox-stub-22222222",
+			StubId:      "sandbox-stub",
+			Status:      types.ContainerStatusPending,
+			ScheduledAt: base.Add(3 * time.Second).Unix(),
+		},
+	})
+	if got, want := len(rows), 2; got != want {
+		t.Fatalf("expected %d sandbox rows, got %d", want, got)
+	}
+	if rows[0].ContainerId != "sandbox-stub-22222222" || rows[1].ContainerId != "sandbox-stub-11111111" {
+		t.Fatalf("unexpected container ordering: %#v", rows)
+	}
+	if rows[0].Id != rows[0].ContainerId || rows[1].Id != rows[1].ContainerId {
+		t.Fatalf("expected active sandbox ids to match container ids: %#v", rows)
+	}
+	if rows[0].StubId != "sandbox-stub" || rows[1].StubId != "sandbox-stub" {
+		t.Fatalf("expected active sandbox stub ids to be preserved: %#v", rows)
+	}
+	if rows[0].Status != SandboxStatusPending {
+		t.Fatalf("pending row status = %q, want %q", rows[0].Status, SandboxStatusPending)
+	}
+	if rows[1].Status != SandboxStatusRunning {
+		t.Fatalf("running row status = %q, want %q", rows[1].Status, SandboxStatusRunning)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return sandbox rows by container instead of by stub to fix missing/ambiguous states and align dashboard stats and charts. Adds `stub_id` to rows and supports container-specific timelines.

- **New Features**
  - `ListSandboxes` returns one row per active or recent container, sorted newest first.
  - Stats and creation histogram are computed from the same container-backed rows.
  - `GetSandboxTimeline` accepts `container_id` to view a specific run; times come from container events.

- **Migration**
  - Row `id` is now the container ID for container-backed rows; use `stub_id` for grouping by sandbox.
  - API may return multiple rows for a single sandbox.
  - Update UI links and queries to pass `container_id` when drilling into a specific run.

<sup>Written for commit 1f8faaf40b2f41bf99862d0f2337a5ba1c790a36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

