### PR TITLE
fix a couple dashboard latency issues

### DIFF
--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -75,30 +75,44 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		Next: apps.Next,
 	}
 
+	appIDs := make([]string, 0, len(apps.Data))
+	for i := range apps.Data {
+		appIDs = append(appIDs, apps.Data[i].ExternalId)
+	}
+
+	deploymentsByApp, err := a.backendRepo.ListLatestDeploymentsByAppIDs(ctx.Request().Context(), workspace.Id, appIDs)
+	if err != nil {
+		return HTTPBadRequest("Failed to get apps")
+	}
+
+	appIDsWithoutDeployment := make([]string, 0, len(apps.Data))
+	for i := range apps.Data {
+		if _, ok := deploymentsByApp[apps.Data[i].ExternalId]; !ok {
+			appIDsWithoutDeployment = append(appIDsWithoutDeployment, apps.Data[i].ExternalId)
+		}
+	}
+
+	stubsByApp, err := a.backendRepo.ListLatestStubsByAppIDs(ctx.Request().Context(), workspace.Id, appIDsWithoutDeployment)
+	if err != nil {
+		return HTTPBadRequest("Failed to get apps")
+	}
+
 	for i := range apps.Data {
 		appsWithLatest.Data[i].App = apps.Data[i]
 
-		deployments, err := a.backendRepo.ListDeploymentsWithRelated(ctx.Request().Context(), types.DeploymentFilter{AppId: apps.Data[i].ExternalId})
-		if err != nil {
-			return HTTPBadRequest("Failed to get apps")
-		}
-
-		if len(deployments) > 0 {
-			appsWithLatest.Data[i].Deployment = &deployments[0]
+		if deployment, ok := deploymentsByApp[apps.Data[i].ExternalId]; ok {
+			deploymentCopy := deployment
+			appsWithLatest.Data[i].Deployment = &deploymentCopy
 			continue
 		}
 
-		// If the app doesn't have a deployment, we get the latest stub
-		stubs, err := a.backendRepo.ListStubs(ctx.Request().Context(), types.StubFilter{AppId: apps.Data[i].ExternalId})
-		if err != nil {
-			return HTTPBadRequest("Failed to get apps")
-		}
-
-		if stubs == nil || len(stubs) == 0 {
+		stub, ok := stubsByApp[apps.Data[i].ExternalId]
+		if !ok {
 			continue
 		}
 
-		appsWithLatest.Data[i].Stub = &stubs[0]
+		stubCopy := stub
+		appsWithLatest.Data[i].Stub = &stubCopy
 		appsWithLatest.Data[i].Stub.SanitizeConfig()
 	}
 

--- a/pkg/api/v1/app_test.go
+++ b/pkg/api/v1/app_test.go
@@ -39,8 +39,28 @@ func (r *appBackendRepo) ListDeploymentsWithRelated(_ context.Context, filters t
 	return r.deploymentsByApp[filters.AppId], nil
 }
 
+func (r *appBackendRepo) ListLatestDeploymentsByAppIDs(_ context.Context, _ uint, appExternalIDs []string) (map[string]types.DeploymentWithRelated, error) {
+	deployments := map[string]types.DeploymentWithRelated{}
+	for _, appID := range appExternalIDs {
+		if len(r.deploymentsByApp[appID]) > 0 {
+			deployments[appID] = r.deploymentsByApp[appID][0]
+		}
+	}
+	return deployments, nil
+}
+
 func (r *appBackendRepo) ListStubs(_ context.Context, filters types.StubFilter) ([]types.StubWithRelated, error) {
 	return r.stubsByApp[filters.AppId], nil
+}
+
+func (r *appBackendRepo) ListLatestStubsByAppIDs(_ context.Context, _ uint, appExternalIDs []string) (map[string]types.StubWithRelated, error) {
+	stubs := map[string]types.StubWithRelated{}
+	for _, appID := range appExternalIDs {
+		if len(r.stubsByApp[appID]) > 0 {
+			stubs[appID] = r.stubsByApp[appID][0]
+		}
+	}
+	return stubs, nil
 }
 
 func TestListAppWithLatestActivityAllowsAppsWithoutActivity(t *testing.T) {

--- a/pkg/api/v1/container.go
+++ b/pkg/api/v1/container.go
@@ -56,22 +56,27 @@ func (c *ContainerGroup) ListContainersByWorkspaceId(ctx echo.Context) error {
 	}
 
 	containerStatesWithAppId := make([]ContainerStateWithAppId, len(containerStates))
-	stubIdsToAppIds := make(map[string]string)
-	for i, containerState := range containerStates {
-		if appId, ok := stubIdsToAppIds[containerState.StubId]; ok {
-			containerStatesWithAppId[i].AppId = appId
-			containerStatesWithAppId[i].ContainerState = containerState
+	stubIDs := make([]string, 0, len(containerStates))
+	seenStubIDs := map[string]struct{}{}
+	for _, containerState := range containerStates {
+		if containerState.StubId == "" {
 			continue
 		}
-
-		app, err := c.backendRepo.RetrieveAppByStubExternalId(ctx.Request().Context(), containerState.StubId)
-		if err != nil {
-			return HTTPInternalServerError("Failed to get app")
+		if _, ok := seenStubIDs[containerState.StubId]; ok {
+			continue
 		}
+		seenStubIDs[containerState.StubId] = struct{}{}
+		stubIDs = append(stubIDs, containerState.StubId)
+	}
 
-		containerStatesWithAppId[i].AppId = app.ExternalId
+	stubIdsToAppIds, err := c.backendRepo.ListAppIDsByStubExternalIDs(ctx.Request().Context(), workspaceId, stubIDs)
+	if err != nil {
+		return HTTPInternalServerError("Failed to get app")
+	}
+
+	for i, containerState := range containerStates {
 		containerStatesWithAppId[i].ContainerState = containerState
-		stubIdsToAppIds[containerState.StubId] = app.ExternalId
+		containerStatesWithAppId[i].AppId = stubIdsToAppIds[containerState.StubId]
 	}
 
 	return ctx.JSON(http.StatusOK, containerStatesWithAppId)

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -693,6 +693,7 @@ const (
 	maxSandboxListLimit          = 200
 	sandboxContainerHistoryLimit = 500
 	sandboxHistoryEventsPerRow   = 32
+	sandboxStatsHistoryLimit     = 5000
 )
 
 type SandboxRow struct {
@@ -796,10 +797,7 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 
 	containersByStub := g.activeContainersByStub(workspaceID)
 
-	sandboxRows := make([]SandboxRow, 0, len(stubs))
-	for i := range stubs {
-		sandboxRows = append(sandboxRows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &stubs[i], containersByStub[stubs[i].ExternalId], 0)...)
-	}
+	sandboxRows := g.buildSandboxStatsRows(ctx.Request().Context(), workspaceID, ctx.QueryParam("app_id"), stubs, containersByStub)
 
 	statusCounts := map[string]int{
 		SandboxStatusRunning:  0,
@@ -1004,6 +1002,61 @@ func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]type
 	return byStub
 }
 
+func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appID string, stubs []types.StubWithRelated, containersByStub map[string][]types.ContainerState) []SandboxRow {
+	stubsByID := make(map[string]*types.StubWithRelated, len(stubs))
+	for i := range stubs {
+		stubsByID[stubs[i].ExternalId] = &stubs[i]
+	}
+
+	rows := make([]SandboxRow, 0, len(stubs))
+	rowByContainerID := map[string]struct{}{}
+	rowByStubID := map[string]struct{}{}
+	for stubID, containers := range containersByStub {
+		stub, ok := stubsByID[stubID]
+		if !ok {
+			continue
+		}
+		for _, container := range containers {
+			if container.ContainerId == "" {
+				continue
+			}
+			rows = append(rows, g.buildActiveSandboxRow(ctx, workspaceID, stub, container))
+			rowByContainerID[container.ContainerId] = struct{}{}
+			rowByStubID[stubID] = struct{}{}
+		}
+	}
+
+	for _, summary := range g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID) {
+		if _, ok := rowByContainerID[summary.ContainerID]; ok {
+			continue
+		}
+		stubID := summary.StubID
+		if stubID == "" {
+			continue
+		}
+		stub, ok := stubsByID[stubID]
+		if !ok {
+			continue
+		}
+		rows = append(rows, g.buildTerminalSandboxRowFromSummary(stub, summary))
+		rowByContainerID[summary.ContainerID] = struct{}{}
+		rowByStubID[stubID] = struct{}{}
+	}
+
+	for i := range stubs {
+		if _, ok := rowByStubID[stubs[i].ExternalId]; ok {
+			continue
+		}
+		rows = append(rows, g.buildFallbackSandboxRow(ctx, workspaceID, &stubs[i]))
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].CreatedAt.After(rows[j].CreatedAt)
+	})
+
+	return rows
+}
+
 func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState, maxRows int) []SandboxRow {
 	rows := make([]SandboxRow, 0, len(containers)+1)
 	activeContainerIDs := make(map[string]struct{}, len(containers))
@@ -1083,6 +1136,8 @@ func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID strin
 
 type sandboxContainerSummary struct {
 	ContainerID     string
+	StubID          string
+	AppID           string
 	CreatedAt       time.Time
 	LastEventAt     time.Time
 	StartedAt       *time.Time
@@ -1168,6 +1223,23 @@ func (g *StubGroup) recentSandboxContainerSummaries(ctx context.Context, workspa
 	return sandboxContainerSummariesFromHistory(history.Events, maxContainers)
 }
 
+func (g *StubGroup) recentSandboxStatsContainerSummaries(ctx context.Context, workspaceID, appID string) []sandboxContainerSummary {
+	if g.eventRepo == nil {
+		return nil
+	}
+
+	history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		Limit:       sandboxStatsHistoryLimit,
+		EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+	})
+	if err != nil || history == nil {
+		return nil
+	}
+	return sandboxContainerSummariesFromHistory(history.Events, 0)
+}
+
 func sandboxContainerSummariesFromHistory(events []types.ContainerEventRecord, maxContainers int) []sandboxContainerSummary {
 	byContainer := map[string][]types.ContainerEventRecord{}
 	for _, event := range events {
@@ -1198,6 +1270,13 @@ func sandboxContainerSummaryFromEvents(containerID string, events []types.Contai
 
 	var startedAt time.Time
 	for _, event := range events {
+		if summary.StubID == "" {
+			summary.StubID = event.StubID
+		}
+		if summary.AppID == "" {
+			summary.AppID = event.AppID
+		}
+
 		eventTime := containerEventTime(event)
 		if eventTime.IsZero() && event.StoredAtNs > 0 {
 			eventTime = time.Unix(0, int64(event.StoredAtNs)).UTC()

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -687,7 +688,12 @@ const (
 	SandboxStatusFailed   = "FAILED"
 )
 
-const sandboxContainerHistoryLimit = 500
+const (
+	defaultSandboxListLimit      = 50
+	maxSandboxListLimit          = 200
+	sandboxContainerHistoryLimit = 500
+	sandboxHistoryEventsPerRow   = 32
+)
 
 type SandboxRow struct {
 	Id              string    `json:"id"`
@@ -720,11 +726,31 @@ type SandboxStatsResponse struct {
 	CreatedBuckets []SandboxCreatedBucket `json:"created_buckets"`
 }
 
+func sandboxListLimit(ctx echo.Context) (int, error) {
+	raw := ctx.QueryParam("limit")
+	if raw == "" {
+		return defaultSandboxListLimit, nil
+	}
+
+	limit, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil || limit == 0 {
+		return 0, HTTPBadRequest("Invalid sandbox limit")
+	}
+	if limit > maxSandboxListLimit {
+		limit = maxSandboxListLimit
+	}
+	return int(limit), nil
+}
+
 // ListSandboxes returns a cursor-paginated list of sandboxes enriched with live
 // status, GPU, time-to-started, and lifetime. It is scoped to the app when an
 // app_id is provided, otherwise it lists all sandboxes in the workspace.
 func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 	workspaceID := ctx.Param("workspaceId")
+	limit, err := sandboxListLimit(ctx)
+	if err != nil {
+		return err
+	}
 
 	var filters types.StubFilter
 	if err := ctx.Bind(&filters); err != nil {
@@ -734,6 +760,7 @@ func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 	filters.WorkspaceID = workspaceID
 	filters.StubTypes = types.StringSlice{types.StubTypeSandbox}
 	filters.Pagination = true
+	filters.Limit = uint32(limit)
 
 	page, err := g.backendRepo.ListStubsPaginated(ctx.Request().Context(), filters)
 	if err != nil {
@@ -742,9 +769,12 @@ func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 
 	containersByStub := g.activeContainersByStub(workspaceID)
 
-	rows := make([]SandboxRow, 0, len(page.Data))
+	rows := make([]SandboxRow, 0, limit)
 	for i := range page.Data {
-		rows = append(rows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &page.Data[i], containersByStub[page.Data[i].ExternalId])...)
+		if len(rows) >= limit {
+			break
+		}
+		rows = append(rows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &page.Data[i], containersByStub[page.Data[i].ExternalId], limit-len(rows))...)
 	}
 
 	return ctx.JSON(http.StatusOK, SandboxListResponse{Data: rows, Next: page.Next})
@@ -768,7 +798,7 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 
 	sandboxRows := make([]SandboxRow, 0, len(stubs))
 	for i := range stubs {
-		sandboxRows = append(sandboxRows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &stubs[i], containersByStub[stubs[i].ExternalId])...)
+		sandboxRows = append(sandboxRows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &stubs[i], containersByStub[stubs[i].ExternalId], 0)...)
 	}
 
 	statusCounts := map[string]int{
@@ -974,11 +1004,14 @@ func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]type
 	return byStub
 }
 
-func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState) []SandboxRow {
+func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState, maxRows int) []SandboxRow {
 	rows := make([]SandboxRow, 0, len(containers)+1)
 	activeContainerIDs := make(map[string]struct{}, len(containers))
 
 	for i := range containers {
+		if maxRows > 0 && len(rows) >= maxRows {
+			break
+		}
 		if containers[i].ContainerId == "" {
 			continue
 		}
@@ -986,11 +1019,20 @@ func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, st
 		rows = append(rows, g.buildActiveSandboxRow(ctx, workspaceID, stub, containers[i]))
 	}
 
-	for _, containerID := range g.recentSandboxContainerIDs(ctx, workspaceID, stub.ExternalId) {
-		if _, ok := activeContainerIDs[containerID]; ok {
-			continue
+	if maxRows <= 0 || len(rows) < maxRows {
+		remaining := 0
+		if maxRows > 0 {
+			remaining = maxRows - len(rows)
 		}
-		rows = append(rows, g.buildTerminalSandboxRow(ctx, workspaceID, stub, containerID))
+		for _, summary := range g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, remaining) {
+			if _, ok := activeContainerIDs[summary.ContainerID]; ok {
+				continue
+			}
+			if maxRows > 0 && len(rows) >= maxRows {
+				break
+			}
+			rows = append(rows, g.buildTerminalSandboxRowFromSummary(stub, summary))
+		}
 	}
 
 	if len(rows) == 0 {
@@ -1036,27 +1078,35 @@ func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID strin
 		}
 	}
 
-	g.enrichSandboxTimingFromEvents(ctx, workspaceID, stub.ExternalId, &row)
 	return row
 }
 
-func (g *StubGroup) buildTerminalSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containerID string) SandboxRow {
+type sandboxContainerSummary struct {
+	ContainerID     string
+	CreatedAt       time.Time
+	LastEventAt     time.Time
+	StartedAt       *time.Time
+	Status          string
+	TimeToStartedMs *int64
+	LifetimeMs      *int64
+	StartedAtMs     *int64
+}
+
+func (g *StubGroup) buildTerminalSandboxRowFromSummary(stub *types.StubWithRelated, summary sandboxContainerSummary) SandboxRow {
 	row := SandboxRow{
-		Id:          containerID,
-		StubId:      stub.ExternalId,
-		Name:        stub.Name,
-		CreatedAt:   stub.CreatedAt.Time,
-		Status:      SandboxStatusStopped,
-		ContainerId: containerID,
+		Id:              summary.ContainerID,
+		StubId:          stub.ExternalId,
+		Name:            stub.Name,
+		CreatedAt:       stub.CreatedAt.Time,
+		Status:          summary.Status,
+		ContainerId:     summary.ContainerID,
+		TimeToStartedMs: summary.TimeToStartedMs,
+		LifetimeMs:      summary.LifetimeMs,
+		StartedAtMs:     summary.StartedAtMs,
 	}
-
-	resp := g.containerEvents(ctx, workspaceID, stub.ExternalId, containerID)
-	if resp == nil {
-		return row
+	if !summary.CreatedAt.IsZero() {
+		row.CreatedAt = summary.CreatedAt
 	}
-
-	row.Status = terminalStatusFromContainerEvents(resp)
-	applySandboxRowEvents(&row, resp)
 	return row
 }
 
@@ -1075,49 +1125,6 @@ func (g *StubGroup) buildFallbackSandboxRow(ctx context.Context, workspaceID str
 	return row
 }
 
-func (g *StubGroup) enrichSandboxTimingFromEvents(ctx context.Context, workspaceID, stubID string, row *SandboxRow) {
-	resp := g.containerEvents(ctx, workspaceID, stubID, row.ContainerId)
-	if resp == nil {
-		return
-	}
-
-	applySandboxRowEvents(row, resp)
-}
-
-func applySandboxRowEvents(row *SandboxRow, resp *types.ContainerEventsResponse) {
-	if createdAt := firstContainerEventTime(resp.Events); !createdAt.IsZero() {
-		row.CreatedAt = createdAt
-	}
-	if v, ok := resp.Summary["container_request_to_running_ms"]; ok && v > 0 {
-		value := v
-		row.TimeToStartedMs = &value
-	}
-
-	timeline := SandboxTimeline{
-		ContainerId: row.ContainerId,
-		Status:      row.Status,
-		CreatedAt:   row.CreatedAt,
-	}
-	applyContainerTimeline(&timeline, resp)
-
-	if timeline.StartedAt != nil {
-		startedAtMs := timeline.StartedAt.UnixMilli()
-		row.StartedAtMs = &startedAtMs
-	}
-
-	end := timeline.EndedAt
-	if end == nil && row.Status == SandboxStatusRunning {
-		now := time.Now().UTC()
-		end = &now
-	}
-	if timeline.StartedAt != nil && end != nil {
-		lifetime := end.Sub(*timeline.StartedAt).Milliseconds()
-		if lifetime >= 0 {
-			row.LifetimeMs = &lifetime
-		}
-	}
-}
-
 func (g *StubGroup) containerEvents(ctx context.Context, workspaceID, stubID, containerID string) *types.ContainerEventsResponse {
 	if g.eventRepo == nil || containerID == "" {
 		return nil
@@ -1133,46 +1140,116 @@ func (g *StubGroup) containerEvents(ctx context.Context, workspaceID, stubID, co
 	return resp
 }
 
-func (g *StubGroup) recentSandboxContainerIDs(ctx context.Context, workspaceID, stubID string) []string {
+func (g *StubGroup) recentSandboxContainerSummaries(ctx context.Context, workspaceID, stubID string, maxContainers int) []sandboxContainerSummary {
 	if g.eventRepo == nil {
 		return nil
+	}
+
+	limit := uint64(sandboxContainerHistoryLimit)
+	if maxContainers > 0 {
+		limit = uint64(maxContainers * sandboxHistoryEventsPerRow)
+		if limit < uint64(maxContainers) {
+			limit = uint64(maxContainers)
+		}
+		if limit > sandboxContainerHistoryLimit {
+			limit = sandboxContainerHistoryLimit
+		}
 	}
 
 	history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
 		WorkspaceID: workspaceID,
 		StubID:      stubID,
-		Limit:       sandboxContainerHistoryLimit,
+		Limit:       limit,
 		EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
 	})
 	if err != nil || history == nil {
 		return nil
 	}
-	return sandboxContainerIDsFromHistory(history.Events)
+	return sandboxContainerSummariesFromHistory(history.Events, maxContainers)
 }
 
-func sandboxContainerIDsFromHistory(events []types.ContainerEventRecord) []string {
-	lastSeen := map[string]time.Time{}
+func sandboxContainerSummariesFromHistory(events []types.ContainerEventRecord, maxContainers int) []sandboxContainerSummary {
+	byContainer := map[string][]types.ContainerEventRecord{}
 	for _, event := range events {
 		if event.ContainerID == "" {
 			continue
 		}
-		t := containerEventTime(event)
-		if t.IsZero() {
-			t = time.Unix(0, int64(event.StoredAtNs)).UTC()
+		byContainer[event.ContainerID] = append(byContainer[event.ContainerID], event)
+	}
+
+	summaries := make([]sandboxContainerSummary, 0, len(byContainer))
+	for containerID, containerEvents := range byContainer {
+		summaries = append(summaries, sandboxContainerSummaryFromEvents(containerID, containerEvents))
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		return summaries[i].LastEventAt.After(summaries[j].LastEventAt)
+	})
+	if maxContainers > 0 && len(summaries) > maxContainers {
+		summaries = summaries[:maxContainers]
+	}
+	return summaries
+}
+
+func sandboxContainerSummaryFromEvents(containerID string, events []types.ContainerEventRecord) sandboxContainerSummary {
+	summary := sandboxContainerSummary{
+		ContainerID: containerID,
+		Status:      SandboxStatusStopped,
+	}
+
+	var startedAt time.Time
+	for _, event := range events {
+		eventTime := containerEventTime(event)
+		if eventTime.IsZero() && event.StoredAtNs > 0 {
+			eventTime = time.Unix(0, int64(event.StoredAtNs)).UTC()
 		}
-		if current, ok := lastSeen[event.ContainerID]; !ok || t.After(current) {
-			lastSeen[event.ContainerID] = t
+		if !eventTime.IsZero() {
+			if summary.CreatedAt.IsZero() || eventTime.Before(summary.CreatedAt) {
+				summary.CreatedAt = eventTime
+			}
+			if eventTime.After(summary.LastEventAt) {
+				summary.LastEventAt = eventTime
+			}
+		}
+
+		if event.Type == types.EventContainerLifecycle && event.EventID == string(types.ContainerLifecycleStartup) {
+			switch {
+			case !event.EndTime.IsZero():
+				startedAt = event.EndTime.UTC()
+			case !event.StartTime.IsZero() && event.DurationMs > 0:
+				startedAt = event.StartTime.Add(time.Duration(event.DurationMs) * time.Millisecond).UTC()
+			case !event.StartTime.IsZero():
+				startedAt = event.StartTime.UTC()
+			}
+		}
+
+		signal := strings.ToLower(strings.Join([]string{event.EventID, event.Reason, event.Message}, " "))
+		if strings.Contains(signal, "oom") || strings.Contains(signal, "fail") || strings.Contains(signal, "error") {
+			summary.Status = SandboxStatusFailed
 		}
 	}
 
-	ids := make([]string, 0, len(lastSeen))
-	for containerID := range lastSeen {
-		ids = append(ids, containerID)
+	if !startedAt.IsZero() {
+		startedAt = startedAt.UTC()
+		summary.StartedAt = &startedAt
+		startedAtMs := startedAt.UnixMilli()
+		summary.StartedAtMs = &startedAtMs
+
+		if !summary.CreatedAt.IsZero() {
+			timeToStarted := startedAt.Sub(summary.CreatedAt).Milliseconds()
+			if timeToStarted >= 0 {
+				summary.TimeToStartedMs = &timeToStarted
+			}
+		}
+
+		if !summary.LastEventAt.IsZero() {
+			lifetime := summary.LastEventAt.Sub(startedAt).Milliseconds()
+			if lifetime >= 0 {
+				summary.LifetimeMs = &lifetime
+			}
+		}
 	}
-	sort.SliceStable(ids, func(i, j int) bool {
-		return lastSeen[ids[i]].After(lastSeen[ids[j]])
-	})
-	return ids
+
+	return summary
 }
 
 func firstContainerEventTime(events []types.ContainerEventRecord) time.Time {

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -102,36 +102,21 @@ func TestBuildSandboxRowsReturnsOneRowPerRecentContainer(t *testing.T) {
 		CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
 	}}
 
-	containerEvents := func(containerID string, startedAt time.Time) *types.ContainerEventsResponse {
-		endedAt := startedAt.Add(250 * time.Millisecond)
-		return &types.ContainerEventsResponse{
-			ContainerID: containerID,
-			WorkspaceID: "workspace",
-			StubID:      "sandbox-stub",
-			Summary: map[string]int64{
-				"container_request_to_running_ms": 44,
-			},
-			Events: []types.ContainerEventRecord{
-				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: containerID, WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: startedAt},
-				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: containerID, WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: endedAt},
-			},
-		}
-	}
-
 	group := &StubGroup{eventRepo: &sandboxRowsEventRepo{
 		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
-			{ContainerID: "sandbox-stub-11111111", Timestamp: base.Add(1 * time.Second)},
-			{ContainerID: "sandbox-stub-22222222", Timestamp: base.Add(2 * time.Second)},
-			{ContainerID: "sandbox-stub-33333333", Timestamp: base.Add(3 * time.Second)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1 * time.Second)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(1 * time.Second), EndTime: base.Add(1044 * time.Millisecond)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1250 * time.Millisecond)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2 * time.Second)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(2 * time.Second), EndTime: base.Add(2044 * time.Millisecond)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2250 * time.Millisecond)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3 * time.Second)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(3 * time.Second), EndTime: base.Add(3044 * time.Millisecond)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3250 * time.Millisecond)},
 		}},
-		containers: map[string]*types.ContainerEventsResponse{
-			"sandbox-stub-11111111": containerEvents("sandbox-stub-11111111", base.Add(1*time.Second)),
-			"sandbox-stub-22222222": containerEvents("sandbox-stub-22222222", base.Add(2*time.Second)),
-			"sandbox-stub-33333333": containerEvents("sandbox-stub-33333333", base.Add(3*time.Second)),
-		},
 	}}
 
-	rows := group.buildSandboxRows(context.Background(), "workspace", stub, nil)
+	rows := group.buildSandboxRows(context.Background(), "workspace", stub, nil, 0)
 	if got, want := len(rows), 3; got != want {
 		t.Fatalf("expected %d sandbox rows, got %d", want, got)
 	}
@@ -154,6 +139,31 @@ func TestBuildSandboxRowsReturnsOneRowPerRecentContainer(t *testing.T) {
 		if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 44 {
 			t.Fatalf("row %d time_to_started_ms = %v, want 44", i, row.TimeToStartedMs)
 		}
+	}
+}
+
+func TestBuildSandboxRowsAppliesMaxRows(t *testing.T) {
+	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
+	stub := &types.StubWithRelated{Stub: types.Stub{
+		ExternalId: "sandbox-stub",
+		Name:       "sandbox",
+		CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+	}}
+
+	group := &StubGroup{eventRepo: &sandboxRowsEventRepo{
+		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1 * time.Second)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2 * time.Second)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3 * time.Second)},
+		}},
+	}}
+
+	rows := group.buildSandboxRows(context.Background(), "workspace", stub, nil, 2)
+	if got, want := len(rows), 2; got != want {
+		t.Fatalf("expected %d sandbox rows, got %d", want, got)
+	}
+	if rows[0].ContainerId != "sandbox-stub-33333333" || rows[1].ContainerId != "sandbox-stub-22222222" {
+		t.Fatalf("unexpected limited rows: %#v", rows)
 	}
 }
 
@@ -180,7 +190,7 @@ func TestBuildSandboxRowsReturnsEveryActiveContainer(t *testing.T) {
 			Status:      types.ContainerStatusPending,
 			ScheduledAt: base.Add(3 * time.Second).Unix(),
 		},
-	})
+	}, 0)
 	if got, want := len(rows), 2; got != want {
 		t.Fatalf("expected %d sandbox rows, got %d", want, got)
 	}

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1707,7 +1707,7 @@ func (c *PostgresBackendRepository) ListStubsPaginated(ctx context.Context, filt
 			SortOrder:       "DESC",
 			SortColumn:      "created_at",
 			SortQueryPrefix: "s",
-			PageSize:        10,
+			PageSize:        int(filters.Limit),
 		},
 		filters.Cursor,
 	)

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1408,7 +1408,7 @@ func (c *PostgresBackendRepository) ListLatestDeploymentsWithRelatedPaginated(ct
 			SortOrder:       "DESC",
 			SortColumn:      "created_at",
 			SortQueryPrefix: "d",
-			PageSize:        10,
+			PageSize:        int(filters.Limit),
 		},
 		filters.Cursor,
 	)
@@ -1610,6 +1610,44 @@ func (c *PostgresBackendRepository) ListDeploymentsWithRelated(ctx context.Conte
 	return deployments, nil
 }
 
+type latestDeploymentByAppRow struct {
+	types.DeploymentWithRelated
+	AppExternalID string `db:"app_external_id"`
+}
+
+func (c *PostgresBackendRepository) ListLatestDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]types.DeploymentWithRelated, error) {
+	deploymentsByApp := make(map[string]types.DeploymentWithRelated, len(appExternalIDs))
+	if workspaceID == 0 || len(appExternalIDs) == 0 {
+		return deploymentsByApp, nil
+	}
+
+	query := `
+		SELECT DISTINCT ON (a.external_id)
+			a.external_id AS app_external_id,
+			d.id, d.external_id, d.name, d.active, d.subdomain, d.workspace_id, d.stub_id, d.stub_type, d.version, d.created_at, d.updated_at, d.deleted_at, d.app_id,
+			w.external_id AS "workspace.external_id", w.name AS "workspace.name", w.created_at AS "workspace.created_at", w.updated_at AS "workspace.updated_at",
+			s.external_id AS "stub.external_id", s.name AS "stub.name", s.config AS "stub.config", s.type AS "stub.type", s.created_at AS "stub.created_at", s.updated_at AS "stub.updated_at",
+			a.id AS "app.id", a.external_id AS "app.external_id", a.name AS "app.name", a.description AS "app.description", a.workspace_id AS "app.workspace_id", a.created_at AS "app.created_at", a.updated_at AS "app.updated_at", a.deleted_at AS "app.deleted_at"
+		FROM app a
+		JOIN deployment d ON d.app_id = a.id AND d.deleted_at IS NULL
+		JOIN workspace w ON d.workspace_id = w.id
+		JOIN stub s ON d.stub_id = s.id
+		WHERE a.workspace_id = $1
+		  AND a.deleted_at IS NULL
+		  AND a.external_id = ANY($2)
+		ORDER BY a.external_id, d.created_at DESC, d.id DESC;
+	`
+
+	var rows []latestDeploymentByAppRow
+	if err := c.client.SelectContext(ctx, &rows, query, workspaceID, pq.Array(appExternalIDs)); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		deploymentsByApp[row.AppExternalID] = row.DeploymentWithRelated
+	}
+	return deploymentsByApp, nil
+}
+
 func (c *PostgresBackendRepository) ListDeploymentsPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error) {
 	qb := c.listDeploymentsQueryBuilder(filters)
 
@@ -1695,6 +1733,73 @@ func (c *PostgresBackendRepository) ListStubs(ctx context.Context, filters types
 	}
 
 	return stubs, nil
+}
+
+type latestStubByAppRow struct {
+	types.StubWithRelated
+	AppExternalID string `db:"app_external_id"`
+}
+
+func (c *PostgresBackendRepository) ListLatestStubsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]types.StubWithRelated, error) {
+	stubsByApp := make(map[string]types.StubWithRelated, len(appExternalIDs))
+	if workspaceID == 0 || len(appExternalIDs) == 0 {
+		return stubsByApp, nil
+	}
+
+	query := `
+		SELECT DISTINCT ON (a.external_id)
+			a.external_id AS app_external_id,
+			s.*,
+			w.external_id AS "workspace.external_id", w.name AS "workspace.name", w.created_at AS "workspace.created_at", w.updated_at AS "workspace.updated_at",
+			a.id AS "app.id", a.external_id AS "app.external_id", a.name AS "app.name", a.description AS "app.description", a.workspace_id AS "app.workspace_id", a.created_at AS "app.created_at", a.updated_at AS "app.updated_at", a.deleted_at AS "app.deleted_at"
+		FROM app a
+		JOIN stub s ON s.app_id = a.id
+		JOIN workspace w ON s.workspace_id = w.id
+		WHERE a.workspace_id = $1
+		  AND a.deleted_at IS NULL
+		  AND a.external_id = ANY($2)
+		ORDER BY a.external_id, s.created_at DESC, s.id DESC;
+	`
+
+	var rows []latestStubByAppRow
+	if err := c.client.SelectContext(ctx, &rows, query, workspaceID, pq.Array(appExternalIDs)); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		stubsByApp[row.AppExternalID] = row.StubWithRelated
+	}
+	return stubsByApp, nil
+}
+
+type stubAppIDRow struct {
+	StubExternalID string `db:"stub_external_id"`
+	AppExternalID  string `db:"app_external_id"`
+}
+
+func (c *PostgresBackendRepository) ListAppIDsByStubExternalIDs(ctx context.Context, workspaceID string, stubExternalIDs []string) (map[string]string, error) {
+	appIDsByStub := make(map[string]string, len(stubExternalIDs))
+	if workspaceID == "" || len(stubExternalIDs) == 0 {
+		return appIDsByStub, nil
+	}
+
+	query := `
+		SELECT s.external_id AS stub_external_id, a.external_id AS app_external_id
+		FROM stub s
+		JOIN workspace w ON s.workspace_id = w.id
+		JOIN app a ON s.app_id = a.id
+		WHERE w.external_id = $1
+		  AND s.external_id = ANY($2)
+		  AND a.deleted_at IS NULL;
+	`
+
+	var rows []stubAppIDRow
+	if err := c.client.SelectContext(ctx, &rows, query, workspaceID, pq.Array(stubExternalIDs)); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		appIDsByStub[row.StubExternalID] = row.AppExternalID
+	}
+	return appIDsByStub, nil
 }
 
 func (c *PostgresBackendRepository) ListStubsPaginated(ctx context.Context, filters types.StubFilter) (common.CursorPaginationInfo[types.StubWithRelated], error) {
@@ -2335,7 +2440,7 @@ func (r *PostgresBackendRepository) ListAppsPaginated(ctx context.Context, works
 			SortOrder:       "DESC",
 			SortColumn:      "updated_at",
 			SortQueryPrefix: "a",
-			PageSize:        10,
+			PageSize:        int(filters.Limit),
 		},
 		filters.Cursor,
 	)

--- a/pkg/repository/backend_postgres_migrations/040_add_dashboard_query_indexes.go
+++ b/pkg/repository/backend_postgres_migrations/040_add_dashboard_query_indexes.go
@@ -1,0 +1,63 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(upAddDashboardQueryIndexes, downAddDashboardQueryIndexes)
+}
+
+func upAddDashboardQueryIndexes(ctx context.Context, db *sql.DB) error {
+	statements := []string{
+		`CREATE EXTENSION IF NOT EXISTS pg_trgm;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_app_workspace_active_updated_id ON app (workspace_id, updated_at DESC, id DESC) WHERE deleted_at IS NULL;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_app_workspace_external_id_active ON app (workspace_id, external_id) WHERE deleted_at IS NULL;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_app_workspace_name_trgm_active ON app USING gin (LOWER(name) gin_trgm_ops) WHERE deleted_at IS NULL;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stub_app_created_id ON stub (app_id, created_at DESC, id DESC);`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stub_app_type_created_id ON stub (app_id, type, created_at DESC, id DESC);`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_deployment_app_active_created_id ON deployment (app_id, created_at DESC, id DESC) WHERE deleted_at IS NULL;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_deployment_workspace_active_created_id ON deployment (workspace_id, created_at DESC, id DESC) WHERE deleted_at IS NULL;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_deployment_stub_active ON deployment (stub_id) WHERE deleted_at IS NULL;`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_workspace_created_id ON task (workspace_id, created_at DESC, id DESC);`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_external_workspace_created_id ON task (external_workspace_id, created_at DESC, id DESC);`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_stub_created_id ON task (stub_id, created_at DESC, id DESC);`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_container_id ON task (container_id);`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_token_workspace_created_id ON token (workspace_id, created_at DESC, id DESC);`,
+	}
+
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downAddDashboardQueryIndexes(ctx context.Context, db *sql.DB) error {
+	statements := []string{
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_token_workspace_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_task_container_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_task_stub_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_task_external_workspace_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_task_workspace_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_deployment_stub_active;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_deployment_workspace_active_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_deployment_app_active_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_stub_app_type_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_stub_app_created_id;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_app_workspace_name_trgm_active;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_app_workspace_external_id_active;`,
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_app_workspace_active_updated_id;`,
+	}
+
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -166,6 +166,7 @@ type BackendRepository interface {
 	DeleteVolume(ctx context.Context, workspaceId uint, name string) error
 	ListVolumesWithRelated(ctx context.Context, workspaceId uint) ([]types.VolumeWithRelated, error)
 	ListDeploymentsWithRelated(ctx context.Context, filters types.DeploymentFilter) ([]types.DeploymentWithRelated, error)
+	ListLatestDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]types.DeploymentWithRelated, error)
 	ListLatestDeploymentsWithRelatedPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
 	ListDeploymentsPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
 	GetLatestDeploymentByName(ctx context.Context, workspaceId uint, name string, stubType string, filterDeleted bool) (*types.DeploymentWithRelated, error)
@@ -177,6 +178,8 @@ type BackendRepository interface {
 	UpdateDeployment(ctx context.Context, deployment types.Deployment) (*types.Deployment, error)
 	DeleteDeployment(ctx context.Context, deployment types.Deployment) error
 	ListStubs(ctx context.Context, filters types.StubFilter) ([]types.StubWithRelated, error)
+	ListLatestStubsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]types.StubWithRelated, error)
+	ListAppIDsByStubExternalIDs(ctx context.Context, workspaceID string, stubExternalIDs []string) (map[string]string, error)
 	ListStubsPaginated(ctx context.Context, filters types.StubFilter) (common.CursorPaginationInfo[types.StubWithRelated], error)
 	GetConcurrencyLimit(ctx context.Context, concurrenyLimitId uint) (*types.ConcurrencyLimit, error)
 	GetConcurrencyLimitByWorkspaceId(ctx context.Context, workspaceId string) (*types.ConcurrencyLimit, error)

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -488,6 +488,18 @@ func (r *S2EventRepository) GetEventHistory(ctx context.Context, query types.Eve
 		}
 	}
 
+	// App-scoped container lifecycle/event records were originally available
+	// through the workspace stream. Keep that path as a fallback so app
+	// dashboards can read older sandbox/container history without per-stub scans.
+	if len(response.Events) == 0 && query.AppID != "" && query.WorkspaceID != "" && allWorkspaceContainerRealtimeEventTypes(query.EventTypes) {
+		workspaceStream := r.workspaceStreamName(query.WorkspaceID)
+		if !responseReadStream(response.Streams, workspaceStream) {
+			if err := r.readEventHistoryStream(ctx, workspaceStream, query, limit, response); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	// Tasks that predate the multiplexed stub task stream only have records
 	// in the legacy per-task stream.
 	if len(response.Events) == 0 && query.TaskID != "" {
@@ -654,6 +666,21 @@ func allComputeEventTypes(eventTypes []string) bool {
 	}
 	for _, eventType := range eventTypes {
 		if !strings.HasPrefix(strings.TrimSpace(eventType), "compute.") {
+			return false
+		}
+	}
+	return true
+}
+
+func allWorkspaceContainerRealtimeEventTypes(eventTypes []string) bool {
+	if len(eventTypes) == 0 {
+		return false
+	}
+	for _, eventType := range eventTypes {
+		eventType = strings.TrimSpace(eventType)
+		if eventType != types.EventContainerMetrics &&
+			eventType != types.EventContainerEvent &&
+			eventType != types.EventContainerLifecycle {
 			return false
 		}
 	}
@@ -1050,6 +1077,11 @@ func eventRecordHeadersSkip(record s2.SequencedRecord, query types.EventQuery) b
 			return true
 		}
 	}
+	if query.AppID != "" {
+		if appID, ok := s2RecordHeader(record, "app_id"); ok && appID != query.AppID {
+			return true
+		}
+	}
 	return false
 }
 
@@ -1339,6 +1371,9 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 	}
 	if isWorkspaceContainerRealtimeEvent(eventType) && metadata.WorkspaceID != "" {
 		add(r.workspaceStreamName(metadata.WorkspaceID))
+		if metadata.AppID != "" {
+			add(r.appStreamName(metadata.WorkspaceID, metadata.AppID))
+		}
 	}
 	if isComputeEvent(eventType) && metadata.WorkspaceID != "" {
 		// Workspace stream powers the live workspace SSE; the compute stream keeps

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -52,6 +52,33 @@ func TestS2ContainerEventsAlsoUseStubAggregateStream(t *testing.T) {
 	}
 }
 
+func TestS2AppScopedContainerEventsUseAppAggregateStream(t *testing.T) {
+	repo := &S2EventRepository{streamPrefix: "events"}
+
+	streams := repo.streamNamesForEvent(types.EventContainerLifecycle, eventMetadata{
+		WorkspaceID: "workspace-123",
+		StubID:      "stub-456",
+		AppID:       "app-789",
+		ContainerID: "container-abc",
+	})
+
+	want := []s2.StreamName{
+		"events/workspaces/workspace-123/stubs/stub-456/containers/container-abc",
+		"events/workspaces/workspace-123/containers/container-abc",
+		"events/workspaces/workspace-123/stubs/stub-456",
+		"events/workspaces/workspace-123",
+		"events/workspaces/workspace-123/apps/app-789",
+	}
+	if len(streams) != len(want) {
+		t.Fatalf("unexpected stream count: got %d want %d: %#v", len(streams), len(want), streams)
+	}
+	for i := range want {
+		if streams[i] != want[i] {
+			t.Fatalf("unexpected stream at %d: got %q want %q", i, streams[i], want[i])
+		}
+	}
+}
+
 func TestResolveContainerStreamsUsesExactStreamWithoutExistenceList(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 

--- a/pkg/types/filters.go
+++ b/pkg/types/filters.go
@@ -78,6 +78,7 @@ type StubFilter struct {
 type AppFilter struct {
 	Name   string `query:"name"`
 	Cursor string `query:"cursor"`
+	Limit  uint32 `query:"limit"`
 }
 
 type StubGetURLFilter struct {

--- a/pkg/types/filters.go
+++ b/pkg/types/filters.go
@@ -72,6 +72,7 @@ type StubFilter struct {
 	Cursor      string      `query:"cursor"`
 	Pagination  bool        `query:"pagination"`
 	AppId       string      `query:"app_id"`
+	Limit       uint32      `query:"limit"`
 }
 
 type AppFilter struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce dashboard API latency by batching queries and optimizing event history reads, noticeably speeding up app lists, container state, and sandbox pages. Adds DB indexes and a `limit` control to cut response times and lower DB load.

- **New Features**
  - `limit` query param for the sandboxes API (default 50, max 200).
  - App-scoped container lifecycle/event streams with workspace fallback for faster sandbox stats.

- **Migration**
  - Adds new Postgres indexes for apps, stubs, deployments, tasks, and tokens. Run DB migrations.

<sup>Written for commit 48488ff78ba69fc674328360efcd7cf1a85f42d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

