### PR TITLE
Fix app sandbox stats history

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -1026,7 +1026,7 @@ func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appI
 		}
 	}
 
-	for _, summary := range g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID) {
+	for _, summary := range g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, stubs) {
 		if _, ok := rowByContainerID[summary.ContainerID]; ok {
 			continue
 		}
@@ -1223,9 +1223,34 @@ func (g *StubGroup) recentSandboxContainerSummaries(ctx context.Context, workspa
 	return sandboxContainerSummariesFromHistory(history.Events, maxContainers)
 }
 
-func (g *StubGroup) recentSandboxStatsContainerSummaries(ctx context.Context, workspaceID, appID string) []sandboxContainerSummary {
+func (g *StubGroup) recentSandboxStatsContainerSummaries(ctx context.Context, workspaceID, appID string, stubs []types.StubWithRelated) []sandboxContainerSummary {
 	if g.eventRepo == nil {
 		return nil
+	}
+
+	if appID != "" {
+		events := make([]types.ContainerEventRecord, 0)
+		limitPerStub := sandboxStatsHistoryLimit
+		if len(stubs) > 1 {
+			limitPerStub = sandboxStatsHistoryLimit / len(stubs)
+			if limitPerStub < sandboxContainerHistoryLimit {
+				limitPerStub = sandboxContainerHistoryLimit
+			}
+		}
+
+		for i := range stubs {
+			history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
+				WorkspaceID: workspaceID,
+				StubID:      stubs[i].ExternalId,
+				Limit:       uint64(limitPerStub),
+				EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+			})
+			if err != nil || history == nil {
+				continue
+			}
+			events = append(events, history.Events...)
+		}
+		return sandboxContainerSummariesFromHistory(events, 0)
 	}
 
 	history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -24,11 +24,17 @@ import (
 
 type sandboxRowsEventRepo struct {
 	repository.EventRepository
-	history    *types.EventHistoryResponse
-	containers map[string]*types.ContainerEventsResponse
+	history         *types.EventHistoryResponse
+	historiesByStub map[string]*types.EventHistoryResponse
+	containers      map[string]*types.ContainerEventsResponse
+	queries         []types.EventQuery
 }
 
-func (r *sandboxRowsEventRepo) GetEventHistory(context.Context, types.EventQuery) (*types.EventHistoryResponse, error) {
+func (r *sandboxRowsEventRepo) GetEventHistory(_ context.Context, query types.EventQuery) (*types.EventHistoryResponse, error) {
+	r.queries = append(r.queries, query)
+	if r.historiesByStub != nil && query.StubID != "" {
+		return r.historiesByStub[query.StubID], nil
+	}
 	return r.history, nil
 }
 
@@ -208,6 +214,46 @@ func TestBuildSandboxRowsReturnsEveryActiveContainer(t *testing.T) {
 	}
 	if rows[1].Status != SandboxStatusRunning {
 		t.Fatalf("running row status = %q, want %q", rows[1].Status, SandboxStatusRunning)
+	}
+}
+
+func TestBuildSandboxStatsRowsUsesStubHistoryForAppScopedStats(t *testing.T) {
+	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
+	stubs := []types.StubWithRelated{{
+		Stub: types.Stub{
+			ExternalId: "sandbox-stub",
+			Name:       "sandbox",
+			CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+		},
+	}}
+
+	eventRepo := &sandboxRowsEventRepo{
+		historiesByStub: map[string]*types.EventHistoryResponse{
+			"sandbox-stub": {Events: []types.ContainerEventRecord{
+				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1 * time.Second)},
+				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1250 * time.Millisecond)},
+				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2 * time.Second)},
+				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2250 * time.Millisecond)},
+				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3 * time.Second)},
+				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3250 * time.Millisecond)},
+			}},
+		},
+	}
+	group := &StubGroup{eventRepo: eventRepo}
+
+	rows := group.buildSandboxStatsRows(context.Background(), "workspace", "app-1", stubs, nil)
+	if got, want := len(rows), 3; got != want {
+		t.Fatalf("expected %d sandbox stats rows, got %d", want, got)
+	}
+	if got := len(eventRepo.queries); got != 1 {
+		t.Fatalf("expected one stub-scoped history query, got %d", got)
+	}
+	query := eventRepo.queries[0]
+	if query.StubID != "sandbox-stub" {
+		t.Fatalf("history query stub_id = %q, want sandbox-stub", query.StubID)
+	}
+	if query.AppID != "" {
+		t.Fatalf("history query app_id = %q, want empty because DB app scope already selected the stub", query.AppID)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes app-scoped sandbox stats by using stub-scoped event history when viewing an app. This shows all recent container runs and prevents missing stats.

- **Bug Fixes**
  - For app views, query event history per stub (`StubID`) and merge events instead of using `AppID`.
  - Distribute `sandboxStatsHistoryLimit` across stubs with a minimum of `sandboxContainerHistoryLimit`.
  - Pass stubs into `recentSandboxStatsContainerSummaries(...)` and update tests to assert stub-scoped queries and correct row counts.

<sup>Written for commit 9cbbd938338dc310d721e3bd0dd3a8906cc339f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

