### PR TITLE
Fill sandbox timing fields from lifecycle history

### DIFF
--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -1008,6 +1008,10 @@ func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appI
 		stubsByID[stubs[i].ExternalId] = &stubs[i]
 	}
 
+	summaries := g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, stubs)
+	summariesByContainerID := indexSandboxContainerSummaries(summaries)
+	now := time.Now().UTC()
+
 	rows := make([]SandboxRow, 0, len(stubs))
 	rowByContainerID := map[string]struct{}{}
 	rowByStubID := map[string]struct{}{}
@@ -1020,13 +1024,17 @@ func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appI
 			if container.ContainerId == "" {
 				continue
 			}
-			rows = append(rows, g.buildActiveSandboxRow(ctx, workspaceID, stub, container))
+			row := g.buildActiveSandboxRow(ctx, workspaceID, stub, container)
+			if summary, ok := summariesByContainerID[container.ContainerId]; ok {
+				applySandboxSummaryToActiveRow(&row, summary, now)
+			}
+			rows = append(rows, row)
 			rowByContainerID[container.ContainerId] = struct{}{}
 			rowByStubID[stubID] = struct{}{}
 		}
 	}
 
-	for _, summary := range g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, stubs) {
+	for _, summary := range summaries {
 		if _, ok := rowByContainerID[summary.ContainerID]; ok {
 			continue
 		}
@@ -1060,6 +1068,7 @@ func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appI
 func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState, maxRows int) []SandboxRow {
 	rows := make([]SandboxRow, 0, len(containers)+1)
 	activeContainerIDs := make(map[string]struct{}, len(containers))
+	activeRowsNeedSummary := false
 
 	for i := range containers {
 		if maxRows > 0 && len(rows) >= maxRows {
@@ -1069,15 +1078,39 @@ func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, st
 			continue
 		}
 		activeContainerIDs[containers[i].ContainerId] = struct{}{}
+		if sandboxContainerStateNeedsSummary(containers[i]) {
+			activeRowsNeedSummary = true
+		}
 		rows = append(rows, g.buildActiveSandboxRow(ctx, workspaceID, stub, containers[i]))
 	}
 
-	if maxRows <= 0 || len(rows) < maxRows {
+	if activeRowsNeedSummary || maxRows <= 0 || len(rows) < maxRows {
 		remaining := 0
 		if maxRows > 0 {
 			remaining = maxRows - len(rows)
 		}
-		for _, summary := range g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, remaining) {
+
+		summaryLimit := remaining
+		if activeRowsNeedSummary && maxRows > 0 {
+			summaryLimit = maxRows
+			if len(activeContainerIDs) > summaryLimit {
+				summaryLimit = len(activeContainerIDs)
+			}
+		}
+
+		summaries := g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, summaryLimit)
+		summariesByContainerID := indexSandboxContainerSummaries(summaries)
+		now := time.Now().UTC()
+		for i := range rows {
+			if rows[i].ContainerId == "" {
+				continue
+			}
+			if summary, ok := summariesByContainerID[rows[i].ContainerId]; ok {
+				applySandboxSummaryToActiveRow(&rows[i], summary, now)
+			}
+		}
+
+		for _, summary := range summaries {
 			if _, ok := activeContainerIDs[summary.ContainerID]; ok {
 				continue
 			}
@@ -1121,7 +1154,7 @@ func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID strin
 		row.TimeToStartedMs = &tts
 	}
 
-	if container.Status == types.ContainerStatusRunning && container.StartedAt > 0 {
+	if isActiveSandboxStatus(row.Status) && container.StartedAt > 0 {
 		startedAtMs := container.StartedAt * 1000
 		row.StartedAtMs = &startedAtMs
 
@@ -1163,6 +1196,70 @@ func (g *StubGroup) buildTerminalSandboxRowFromSummary(stub *types.StubWithRelat
 		row.CreatedAt = summary.CreatedAt
 	}
 	return row
+}
+
+func indexSandboxContainerSummaries(summaries []sandboxContainerSummary) map[string]sandboxContainerSummary {
+	byContainerID := make(map[string]sandboxContainerSummary, len(summaries))
+	for _, summary := range summaries {
+		if summary.ContainerID == "" {
+			continue
+		}
+		byContainerID[summary.ContainerID] = summary
+	}
+	return byContainerID
+}
+
+func sandboxContainerStateNeedsSummary(container types.ContainerState) bool {
+	if container.ContainerId == "" {
+		return false
+	}
+	if container.ScheduledAt <= 0 {
+		return true
+	}
+	if isActiveSandboxStatus(string(container.Status)) && container.StartedAt <= 0 {
+		return true
+	}
+	return container.StartedAt > 0 && container.ScheduledAt > 0 && container.StartedAt < container.ScheduledAt
+}
+
+func applySandboxSummaryToActiveRow(row *SandboxRow, summary sandboxContainerSummary, now time.Time) {
+	if row == nil {
+		return
+	}
+	if !summary.CreatedAt.IsZero() {
+		row.CreatedAt = summary.CreatedAt
+	}
+	if row.TimeToStartedMs == nil && summary.TimeToStartedMs != nil {
+		row.TimeToStartedMs = summary.TimeToStartedMs
+	}
+	if row.StartedAtMs == nil && summary.StartedAtMs != nil {
+		row.StartedAtMs = summary.StartedAtMs
+	}
+
+	var startedAt *time.Time
+	if summary.StartedAt != nil {
+		startedAt = summary.StartedAt
+	} else if row.StartedAtMs != nil {
+		t := time.UnixMilli(*row.StartedAtMs).UTC()
+		startedAt = &t
+	}
+
+	if row.TimeToStartedMs == nil && startedAt != nil && !row.CreatedAt.IsZero() {
+		timeToStarted := startedAt.Sub(row.CreatedAt).Milliseconds()
+		if timeToStarted >= 0 {
+			row.TimeToStartedMs = &timeToStarted
+		}
+	}
+
+	if row.LifetimeMs == nil && isActiveSandboxStatus(row.Status) && startedAt != nil {
+		if now.IsZero() {
+			now = time.Now().UTC()
+		}
+		lifetime := now.Sub(*startedAt).Milliseconds()
+		if lifetime >= 0 {
+			row.LifetimeMs = &lifetime
+		}
+	}
 }
 
 func (g *StubGroup) buildFallbackSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated) SandboxRow {

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -217,6 +217,52 @@ func TestBuildSandboxRowsReturnsEveryActiveContainer(t *testing.T) {
 	}
 }
 
+func TestBuildSandboxRowsEnrichesActiveTimingFromHistory(t *testing.T) {
+	base := time.Now().Add(-2 * time.Minute).UTC().Truncate(time.Millisecond)
+	stub := &types.StubWithRelated{Stub: types.Stub{
+		ExternalId: "sandbox-stub",
+		Name:       "sandbox",
+		CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+	}}
+
+	eventRepo := &sandboxRowsEventRepo{
+		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(1500 * time.Millisecond)},
+		}},
+	}
+	group := &StubGroup{eventRepo: eventRepo}
+
+	rows := group.buildSandboxRows(context.Background(), "workspace", stub, []types.ContainerState{
+		{
+			ContainerId: "sandbox-stub-11111111",
+			StubId:      "sandbox-stub",
+			Status:      types.ContainerStatusRunning,
+		},
+	}, 1)
+	if got, want := len(rows), 1; got != want {
+		t.Fatalf("expected %d sandbox rows, got %d", want, got)
+	}
+	if got := len(eventRepo.queries); got != 1 {
+		t.Fatalf("expected active row timing to query history despite full page, got %d queries", got)
+	}
+
+	row := rows[0]
+	if !row.CreatedAt.Equal(base) {
+		t.Fatalf("created_at = %s, want lifecycle created_at %s", row.CreatedAt, base)
+	}
+	if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 1500 {
+		t.Fatalf("time_to_started_ms = %v, want 1500", row.TimeToStartedMs)
+	}
+	wantStartedAtMs := base.Add(1500 * time.Millisecond).UnixMilli()
+	if row.StartedAtMs == nil || *row.StartedAtMs != wantStartedAtMs {
+		t.Fatalf("started_at_ms = %v, want %d", row.StartedAtMs, wantStartedAtMs)
+	}
+	if row.LifetimeMs == nil || *row.LifetimeMs <= 0 {
+		t.Fatalf("lifetime_ms = %v, want a positive running lifetime", row.LifetimeMs)
+	}
+}
+
 func TestBuildSandboxStatsRowsUsesStubHistoryForAppScopedStats(t *testing.T) {
 	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
 	stubs := []types.StubWithRelated{{
@@ -254,6 +300,51 @@ func TestBuildSandboxStatsRowsUsesStubHistoryForAppScopedStats(t *testing.T) {
 	}
 	if query.AppID != "" {
 		t.Fatalf("history query app_id = %q, want empty because DB app scope already selected the stub", query.AppID)
+	}
+}
+
+func TestBuildSandboxStatsRowsEnrichesActiveTimingFromHistory(t *testing.T) {
+	base := time.Now().Add(-2 * time.Minute).UTC().Truncate(time.Millisecond)
+	stubs := []types.StubWithRelated{{
+		Stub: types.Stub{
+			ExternalId: "sandbox-stub",
+			Name:       "sandbox",
+			CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+		},
+	}}
+	eventRepo := &sandboxRowsEventRepo{
+		historiesByStub: map[string]*types.EventHistoryResponse{
+			"sandbox-stub": {Events: []types.ContainerEventRecord{
+				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base},
+				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(1500 * time.Millisecond)},
+			}},
+		},
+	}
+	group := &StubGroup{eventRepo: eventRepo}
+
+	rows := group.buildSandboxStatsRows(context.Background(), "workspace", "app-1", stubs, map[string][]types.ContainerState{
+		"sandbox-stub": {
+			{
+				ContainerId: "sandbox-stub-11111111",
+				StubId:      "sandbox-stub",
+				Status:      types.ContainerStatusRunning,
+			},
+		},
+	})
+	if got, want := len(rows), 1; got != want {
+		t.Fatalf("expected %d sandbox stats rows, got %d", want, got)
+	}
+
+	row := rows[0]
+	if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 1500 {
+		t.Fatalf("time_to_started_ms = %v, want 1500", row.TimeToStartedMs)
+	}
+	wantStartedAtMs := base.Add(1500 * time.Millisecond).UnixMilli()
+	if row.StartedAtMs == nil || *row.StartedAtMs != wantStartedAtMs {
+		t.Fatalf("started_at_ms = %v, want %d", row.StartedAtMs, wantStartedAtMs)
+	}
+	if row.LifetimeMs == nil || *row.LifetimeMs <= 0 {
+		t.Fatalf("lifetime_ms = %v, want a positive running lifetime", row.LifetimeMs)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fill sandbox timing fields for active containers from lifecycle history so `created_at`, `started_at_ms`, `time_to_started_ms`, and `lifetime_ms` are accurate. Applies to both sandbox list and stats, including when the page is full.

- **Bug Fixes**
  - Backfill missing or inconsistent timing for active containers using recent lifecycle summaries (list and stats paths).
  - Compute `lifetime_ms` from start time to now; only update fields when missing.
  - Query and index summaries by container ID once per request; enrich active rows even on full pages.
  - Added focused tests in `pkg/api/v1/stub_test.go` to validate enrichment and query behavior.

<sup>Written for commit 666901f18c4d20b2126c5db21927c6dbc6aaeeb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

