### PR TITLE
improve sandbox timeline

### DIFF
--- a/pkg/abstractions/endpoint/autoscaler.go
+++ b/pkg/abstractions/endpoint/autoscaler.go
@@ -115,12 +115,17 @@ func recordEndpointScaleDecision(i *endpointInstance, sample *endpointAutoscaler
 	}
 
 	for _, container := range containers {
+		appID := ""
+		if i.Stub.App != nil {
+			appID = i.Stub.App.ExternalId
+		}
 		i.EventRepo.PushContainerEvent(types.EventContainerEventSchema{
 			ID:          types.ContainerEventAutoscalerScaleDecision,
 			ContainerID: container.ContainerId,
 			StubID:      container.StubId,
 			StubType:    string(i.Stub.Type.Kind()),
 			WorkspaceID: container.WorkspaceId,
+			AppID:       appID,
 			Reason:      reason,
 			Source:      types.EventSourceEndpointAutoscaler.String(),
 			Message:     types.EventMessageAutoscalerScaleDecision.String(),

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -320,10 +320,15 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 	if imageId == nil {
 		imageId = &stubConfig.Runtime.ImageId
 	}
+	appId := ""
+	if stub.App != nil {
+		appId = stub.App.ExternalId
+	}
 
 	runRequest := &types.ContainerRequest{
 		ContainerId:       containerId,
 		StubId:            stub.ExternalId,
+		AppId:             appId,
 		Env:               env,
 		Cpu:               stubConfig.Runtime.Cpu,
 		Memory:            stubConfig.Runtime.Memory,

--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -191,7 +191,7 @@ func NewEventGroup(g *echo.Group, backendRepo repository.BackendRepository, cont
 	g.GET("/:workspaceId/stubs/:stubId/containers/:containerId/summary", auth.WithWorkspaceAuth(group.GetContainerEventSummary))
 	g.GET("/:workspaceId/stubs/:stubId/stream", auth.WithWorkspaceAuth(group.StreamStubEvents))
 	g.GET("/:workspaceId/tasks/:taskId/stream", auth.WithWorkspaceAuth(group.StreamTaskEvents))
-	g.GET("/:workspaceId/apps/:appId/stream", auth.WithWorkspaceAuth(group.StreamAppEvents))
+	g.GET("/:workspaceId/apps/:appId/stream", auth.WithWorkspaceAuth(group.StreamAppNamespaceEvents))
 	g.GET("/:workspaceId/history", auth.WithWorkspaceAuth(group.GetEventHistory))
 	g.GET("/:workspaceId/stream", auth.WithWorkspaceAuth(group.StreamWorkspaceEvents))
 	g.POST("/:workspaceId/containers/batch", auth.WithWorkspaceAuth(group.GetContainerEventsBatch))
@@ -405,7 +405,7 @@ func (g *EventGroup) StreamWorkspaceEvents(ctx echo.Context) error {
 	return g.writeEventStream(ctx, stream)
 }
 
-func (g *EventGroup) StreamAppEvents(ctx echo.Context) error {
+func (g *EventGroup) StreamAppNamespaceEvents(ctx echo.Context) error {
 	cc, _ := ctx.(*auth.HttpAuthContext)
 	appID := ctx.Param("appId")
 	if appID == "" {
@@ -424,12 +424,12 @@ func (g *EventGroup) StreamAppEvents(ctx echo.Context) error {
 		return HTTPNotFound()
 	}
 
-	stream, err := g.eventRepo.StreamAppEvents(ctx.Request().Context(), query)
+	stream, err := g.eventRepo.StreamAppNamespaceEvents(ctx.Request().Context(), query)
 	if err != nil {
 		if errors.Is(err, repository.ErrEventReadUnsupported) {
 			return NewHTTPError(http.StatusServiceUnavailable, "Event streams are not configured")
 		}
-		return HTTPInternalServerError("Failed to stream app events")
+		return HTTPInternalServerError("Failed to stream app namespace events")
 	}
 	defer stream.Close()
 

--- a/pkg/api/v1/sandbox_test.go
+++ b/pkg/api/v1/sandbox_test.go
@@ -91,7 +91,34 @@ func TestBuildCreatedBuckets(t *testing.T) {
 	}
 
 	week := buildCreatedBucketsAt(stubs, "last_week", now)
-	if len(week) != 7 {
-		t.Errorf("expected last_week to return 7 day buckets, got %d", len(week))
+	if len(week) != 60 {
+		t.Errorf("expected last_week to return fixed 60 buckets, got %d", len(week))
+	}
+	day := buildCreatedBucketsAt(stubs, "last_day", now)
+	if len(day) != 60 {
+		t.Errorf("expected last_day to return fixed 60 buckets, got %d", len(day))
+	}
+}
+
+func TestBuildSandboxSummaryCreatedBucketsDedupeContainers(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+	base := now.Add(-30 * time.Minute)
+	summaries := []sandboxContainerSummary{
+		{ContainerID: "sandbox-1", CreatedAt: base},
+		{ContainerID: "sandbox-2", CreatedAt: base.Add(10 * time.Second)},
+		{ContainerID: "sandbox-3", CreatedAt: now.Add(-2 * time.Hour)},
+	}
+
+	buckets := buildSandboxSummaryCreatedBucketsAt(summaries, "last_hour", now)
+	if got, want := len(buckets), 60; got != want {
+		t.Fatalf("expected %d buckets, got %d", want, got)
+	}
+
+	total := 0
+	for _, bucket := range buckets {
+		total += bucket.Count
+	}
+	if total != 2 {
+		t.Fatalf("expected in-range bucket counts to sum to 2, got %d", total)
 	}
 }

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -697,16 +697,18 @@ const (
 )
 
 type SandboxRow struct {
-	Id              string    `json:"id"`
-	StubId          string    `json:"stub_id,omitempty"`
-	Name            string    `json:"name"`
-	CreatedAt       time.Time `json:"created_at"`
-	Status          string    `json:"status"`
-	Gpu             string    `json:"gpu,omitempty"`
-	ContainerId     string    `json:"container_id,omitempty"`
-	TimeToStartedMs *int64    `json:"time_to_started_ms,omitempty"`
-	LifetimeMs      *int64    `json:"lifetime_ms,omitempty"`
-	StartedAtMs     *int64    `json:"started_at_ms,omitempty"`
+	Id                  string    `json:"id"`
+	StubId              string    `json:"stub_id,omitempty"`
+	Name                string    `json:"name"`
+	CreatedAt           time.Time `json:"created_at"`
+	Status              string    `json:"status"`
+	Gpu                 string    `json:"gpu,omitempty"`
+	ContainerId         string    `json:"container_id,omitempty"`
+	TimeToStartedMs     *int64    `json:"time_to_started_ms,omitempty"`
+	TimeToInteractiveMs *int64    `json:"time_to_interactive_ms,omitempty"`
+	LifetimeMs          *int64    `json:"lifetime_ms,omitempty"`
+	StartedAtMs         *int64    `json:"started_at_ms,omitempty"`
+	InteractiveAtMs     *int64    `json:"interactive_at_ms,omitempty"`
 }
 
 type SandboxListResponse struct {
@@ -769,13 +771,23 @@ func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 	}
 
 	containersByStub := g.activeContainersByStub(workspaceID)
+	summariesByStubID := indexSandboxContainerSummariesByStubID(
+		g.recentSandboxStatsContainerSummaries(ctx.Request().Context(), workspaceID, ctx.QueryParam("app_id"), page.Data),
+	)
 
 	rows := make([]SandboxRow, 0, limit)
 	for i := range page.Data {
 		if len(rows) >= limit {
 			break
 		}
-		rows = append(rows, g.buildSandboxRows(ctx.Request().Context(), workspaceID, &page.Data[i], containersByStub[page.Data[i].ExternalId], limit-len(rows))...)
+		rows = append(rows, g.buildSandboxRowsWithPreloadedSummaries(
+			ctx.Request().Context(),
+			workspaceID,
+			&page.Data[i],
+			containersByStub[page.Data[i].ExternalId],
+			limit-len(rows),
+			summariesByStubID[page.Data[i].ExternalId],
+		)...)
 	}
 
 	return ctx.JSON(http.StatusOK, SandboxListResponse{Data: rows, Next: page.Next})
@@ -797,7 +809,9 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 
 	containersByStub := g.activeContainersByStub(workspaceID)
 
-	sandboxRows := g.buildSandboxStatsRows(ctx.Request().Context(), workspaceID, ctx.QueryParam("app_id"), stubs, containersByStub)
+	appID := ctx.QueryParam("app_id")
+	summaries := g.recentSandboxStatsContainerSummaries(ctx.Request().Context(), workspaceID, appID, stubs)
+	sandboxRows := g.buildSandboxStatsRowsWithSummaries(ctx.Request().Context(), workspaceID, stubs, containersByStub, summaries)
 
 	statusCounts := map[string]int{
 		SandboxStatusRunning:  0,
@@ -836,7 +850,7 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 		TotalCreated:   total,
 		RatePerSecond:  ratePerSecond,
 		StatusCounts:   statusCounts,
-		CreatedBuckets: buildSandboxRowCreatedBuckets(sandboxRows, ctx.QueryParam("chart_range")),
+		CreatedBuckets: buildSandboxSummaryCreatedBuckets(summaries, ctx.QueryParam("chart_range")),
 	})
 }
 
@@ -909,6 +923,11 @@ func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
 			applyContainerTimeline(&timeline, resp)
 		}
 	}
+	if containerID != "" && (timeline.StartedAt == nil || timeline.EndedAt == nil || timeline.RuntimeMs == nil) {
+		if summary, ok := g.sandboxTimelineSummary(ctx.Request().Context(), workspaceID, stub, containerID); ok {
+			applySandboxSummaryToTimeline(&timeline, summary)
+		}
+	}
 
 	// Compute runtime once we know when the sandbox started.
 	if timeline.StartedAt != nil {
@@ -926,6 +945,53 @@ func (g *StubGroup) GetSandboxTimeline(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, timeline)
+}
+
+func (g *StubGroup) sandboxTimelineSummary(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containerID string) (sandboxContainerSummary, bool) {
+	if stub == nil {
+		return sandboxContainerSummary{}, false
+	}
+
+	appID := ""
+	if stub.App != nil {
+		appID = stub.App.ExternalId
+	}
+
+	summaries := g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, []types.StubWithRelated{*stub})
+	for _, summary := range summaries {
+		if summary.ContainerID == containerID {
+			return summary, true
+		}
+	}
+	return sandboxContainerSummary{}, false
+}
+
+func applySandboxSummaryToTimeline(timeline *SandboxTimeline, summary sandboxContainerSummary) {
+	if timeline == nil {
+		return
+	}
+	if timeline.ContainerId == "" {
+		timeline.ContainerId = summary.ContainerID
+	}
+	if summary.Status != "" {
+		timeline.Status = summary.Status
+	}
+	if !summary.CreatedAt.IsZero() {
+		timeline.CreatedAt = summary.CreatedAt
+	}
+	if timeline.StartedAt == nil && summary.StartedAt != nil {
+		timeline.StartedAt = summary.StartedAt
+	}
+	if timeline.StartupMs == nil && summary.TimeToStartedMs != nil {
+		timeline.StartupMs = summary.TimeToStartedMs
+	}
+	if timeline.RuntimeMs == nil && summary.LifetimeMs != nil {
+		timeline.RuntimeMs = summary.LifetimeMs
+	}
+	if timeline.EndedAt == nil && !isActiveSandboxStatus(timeline.Status) && !summary.LastEventAt.IsZero() {
+		endedAt := summary.LastEventAt.UTC()
+		timeline.EndedAt = &endedAt
+	}
 }
 
 func applyContainerTimeline(timeline *SandboxTimeline, resp *types.ContainerEventsResponse) {
@@ -1003,12 +1069,16 @@ func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]type
 }
 
 func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appID string, stubs []types.StubWithRelated, containersByStub map[string][]types.ContainerState) []SandboxRow {
+	summaries := g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, stubs)
+	return g.buildSandboxStatsRowsWithSummaries(ctx, workspaceID, stubs, containersByStub, summaries)
+}
+
+func (g *StubGroup) buildSandboxStatsRowsWithSummaries(ctx context.Context, workspaceID string, stubs []types.StubWithRelated, containersByStub map[string][]types.ContainerState, summaries []sandboxContainerSummary) []SandboxRow {
 	stubsByID := make(map[string]*types.StubWithRelated, len(stubs))
 	for i := range stubs {
 		stubsByID[stubs[i].ExternalId] = &stubs[i]
 	}
 
-	summaries := g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, stubs)
 	summariesByContainerID := indexSandboxContainerSummaries(summaries)
 	now := time.Now().UTC()
 
@@ -1066,6 +1136,11 @@ func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appI
 }
 
 func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState, maxRows int) []SandboxRow {
+	summaries := g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, maxRows)
+	return g.buildSandboxRowsWithPreloadedSummaries(ctx, workspaceID, stub, containers, maxRows, summaries)
+}
+
+func (g *StubGroup) buildSandboxRowsWithPreloadedSummaries(ctx context.Context, workspaceID string, stub *types.StubWithRelated, containers []types.ContainerState, maxRows int, summaries []sandboxContainerSummary) []SandboxRow {
 	rows := make([]SandboxRow, 0, len(containers)+1)
 	activeContainerIDs := make(map[string]struct{}, len(containers))
 	activeRowsNeedSummary := false
@@ -1098,7 +1173,9 @@ func (g *StubGroup) buildSandboxRows(ctx context.Context, workspaceID string, st
 			}
 		}
 
-		summaries := g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, summaryLimit)
+		if summaries == nil {
+			summaries = g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, summaryLimit)
+		}
 		summariesByContainerID := indexSandboxContainerSummaries(summaries)
 		now := time.Now().UTC()
 		for i := range rows {
@@ -1152,11 +1229,13 @@ func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID strin
 	if container.StartedAt > 0 && container.ScheduledAt > 0 && container.StartedAt >= container.ScheduledAt {
 		tts := (container.StartedAt - container.ScheduledAt) * 1000
 		row.TimeToStartedMs = &tts
+		row.TimeToInteractiveMs = &tts
 	}
 
 	if isActiveSandboxStatus(row.Status) && container.StartedAt > 0 {
 		startedAtMs := container.StartedAt * 1000
 		row.StartedAtMs = &startedAtMs
+		row.InteractiveAtMs = &startedAtMs
 
 		lifetime := (time.Now().Unix() - container.StartedAt) * 1000
 		if lifetime >= 0 {
@@ -1168,29 +1247,34 @@ func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID strin
 }
 
 type sandboxContainerSummary struct {
-	ContainerID     string
-	StubID          string
-	AppID           string
-	CreatedAt       time.Time
-	LastEventAt     time.Time
-	StartedAt       *time.Time
-	Status          string
-	TimeToStartedMs *int64
-	LifetimeMs      *int64
-	StartedAtMs     *int64
+	ContainerID         string
+	StubID              string
+	AppID               string
+	CreatedAt           time.Time
+	LastEventAt         time.Time
+	StartedAt           *time.Time
+	InteractiveAt       *time.Time
+	Status              string
+	TimeToStartedMs     *int64
+	TimeToInteractiveMs *int64
+	LifetimeMs          *int64
+	StartedAtMs         *int64
+	InteractiveAtMs     *int64
 }
 
 func (g *StubGroup) buildTerminalSandboxRowFromSummary(stub *types.StubWithRelated, summary sandboxContainerSummary) SandboxRow {
 	row := SandboxRow{
-		Id:              summary.ContainerID,
-		StubId:          stub.ExternalId,
-		Name:            stub.Name,
-		CreatedAt:       stub.CreatedAt.Time,
-		Status:          summary.Status,
-		ContainerId:     summary.ContainerID,
-		TimeToStartedMs: summary.TimeToStartedMs,
-		LifetimeMs:      summary.LifetimeMs,
-		StartedAtMs:     summary.StartedAtMs,
+		Id:                  summary.ContainerID,
+		StubId:              stub.ExternalId,
+		Name:                stub.Name,
+		CreatedAt:           stub.CreatedAt.Time,
+		Status:              summary.Status,
+		ContainerId:         summary.ContainerID,
+		TimeToStartedMs:     summary.TimeToStartedMs,
+		TimeToInteractiveMs: summary.TimeToInteractiveMs,
+		LifetimeMs:          summary.LifetimeMs,
+		StartedAtMs:         summary.StartedAtMs,
+		InteractiveAtMs:     summary.InteractiveAtMs,
 	}
 	if !summary.CreatedAt.IsZero() {
 		row.CreatedAt = summary.CreatedAt
@@ -1207,6 +1291,17 @@ func indexSandboxContainerSummaries(summaries []sandboxContainerSummary) map[str
 		byContainerID[summary.ContainerID] = summary
 	}
 	return byContainerID
+}
+
+func indexSandboxContainerSummariesByStubID(summaries []sandboxContainerSummary) map[string][]sandboxContainerSummary {
+	byStubID := make(map[string][]sandboxContainerSummary, len(summaries))
+	for _, summary := range summaries {
+		if summary.StubID == "" {
+			continue
+		}
+		byStubID[summary.StubID] = append(byStubID[summary.StubID], summary)
+	}
+	return byStubID
 }
 
 func sandboxContainerStateNeedsSummary(container types.ContainerState) bool {
@@ -1232,8 +1327,14 @@ func applySandboxSummaryToActiveRow(row *SandboxRow, summary sandboxContainerSum
 	if row.TimeToStartedMs == nil && summary.TimeToStartedMs != nil {
 		row.TimeToStartedMs = summary.TimeToStartedMs
 	}
+	if row.TimeToInteractiveMs == nil && summary.TimeToInteractiveMs != nil {
+		row.TimeToInteractiveMs = summary.TimeToInteractiveMs
+	}
 	if row.StartedAtMs == nil && summary.StartedAtMs != nil {
 		row.StartedAtMs = summary.StartedAtMs
+	}
+	if row.InteractiveAtMs == nil && summary.InteractiveAtMs != nil {
+		row.InteractiveAtMs = summary.InteractiveAtMs
 	}
 
 	var startedAt *time.Time
@@ -1249,6 +1350,27 @@ func applySandboxSummaryToActiveRow(row *SandboxRow, summary sandboxContainerSum
 		if timeToStarted >= 0 {
 			row.TimeToStartedMs = &timeToStarted
 		}
+	}
+
+	var interactiveAt *time.Time
+	if summary.InteractiveAt != nil {
+		interactiveAt = summary.InteractiveAt
+	} else if row.InteractiveAtMs != nil {
+		t := time.UnixMilli(*row.InteractiveAtMs).UTC()
+		interactiveAt = &t
+	} else {
+		interactiveAt = startedAt
+	}
+
+	if row.TimeToInteractiveMs == nil && interactiveAt != nil && !row.CreatedAt.IsZero() {
+		timeToInteractive := interactiveAt.Sub(row.CreatedAt).Milliseconds()
+		if timeToInteractive >= 0 {
+			row.TimeToInteractiveMs = &timeToInteractive
+		}
+	}
+	if row.InteractiveAtMs == nil && interactiveAt != nil {
+		interactiveAtMs := interactiveAt.UnixMilli()
+		row.InteractiveAtMs = &interactiveAtMs
 	}
 
 	if row.LifetimeMs == nil && isActiveSandboxStatus(row.Status) && startedAt != nil {
@@ -1273,6 +1395,7 @@ func (g *StubGroup) buildFallbackSandboxRow(ctx context.Context, workspaceID str
 	status, timeToStarted, containerID := g.deriveTerminalSandbox(ctx, workspaceID, stub.ExternalId)
 	row.Status = status
 	row.TimeToStartedMs = timeToStarted
+	row.TimeToInteractiveMs = timeToStarted
 	row.ContainerId = containerID
 	return row
 }
@@ -1325,28 +1448,34 @@ func (g *StubGroup) recentSandboxStatsContainerSummaries(ctx context.Context, wo
 		return nil
 	}
 
+	events := make([]types.ContainerEventRecord, 0, sandboxStatsHistoryLimit)
 	if appID != "" {
-		events := make([]types.ContainerEventRecord, 0)
-		limitPerStub := sandboxStatsHistoryLimit
-		if len(stubs) > 1 {
-			limitPerStub = sandboxStatsHistoryLimit / len(stubs)
-			if limitPerStub < sandboxContainerHistoryLimit {
-				limitPerStub = sandboxContainerHistoryLimit
-			}
-		}
-
-		for i := range stubs {
-			history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
-				WorkspaceID: workspaceID,
-				StubID:      stubs[i].ExternalId,
-				Limit:       uint64(limitPerStub),
-				EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
-			})
-			if err != nil || history == nil {
-				continue
-			}
+		history, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
+			WorkspaceID: workspaceID,
+			AppID:       appID,
+			Limit:       sandboxStatsHistoryLimit,
+			EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+		})
+		if err == nil && history != nil {
 			events = append(events, history.Events...)
 		}
+
+		legacyLimit := uint64(len(stubs) * sandboxHistoryEventsPerRow)
+		if legacyLimit == 0 || legacyLimit > sandboxStatsHistoryLimit {
+			legacyLimit = sandboxStatsHistoryLimit
+		}
+		if legacyLimit < sandboxContainerHistoryLimit {
+			legacyLimit = sandboxContainerHistoryLimit
+		}
+		legacy, err := g.eventRepo.GetEventHistory(ctx, types.EventQuery{
+			WorkspaceID: workspaceID,
+			Limit:       legacyLimit,
+			EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+		})
+		if err == nil && legacy != nil {
+			events = append(events, legacySandboxEventsForApp(legacy.Events, stubs)...)
+		}
+
 		return sandboxContainerSummariesFromHistory(events, 0)
 	}
 
@@ -1360,6 +1489,31 @@ func (g *StubGroup) recentSandboxStatsContainerSummaries(ctx context.Context, wo
 		return nil
 	}
 	return sandboxContainerSummariesFromHistory(history.Events, 0)
+}
+
+func legacySandboxEventsForApp(events []types.ContainerEventRecord, stubs []types.StubWithRelated) []types.ContainerEventRecord {
+	if len(events) == 0 || len(stubs) == 0 {
+		return nil
+	}
+
+	stubIDs := make(map[string]struct{}, len(stubs))
+	for i := range stubs {
+		if stubs[i].ExternalId != "" {
+			stubIDs[stubs[i].ExternalId] = struct{}{}
+		}
+	}
+
+	filtered := make([]types.ContainerEventRecord, 0, len(events))
+	for _, event := range events {
+		if event.AppID != "" {
+			continue
+		}
+		if _, ok := stubIDs[event.StubID]; !ok {
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+	return filtered
 }
 
 func sandboxContainerSummariesFromHistory(events []types.ContainerEventRecord, maxContainers int) []sandboxContainerSummary {
@@ -1390,7 +1544,10 @@ func sandboxContainerSummaryFromEvents(containerID string, events []types.Contai
 		Status:      SandboxStatusStopped,
 	}
 
+	var earliestEventAt time.Time
+	var createdAt time.Time
 	var startedAt time.Time
+	var interactiveAt time.Time
 	for _, event := range events {
 		if summary.StubID == "" {
 			summary.StubID = event.StubID
@@ -1404,22 +1561,31 @@ func sandboxContainerSummaryFromEvents(containerID string, events []types.Contai
 			eventTime = time.Unix(0, int64(event.StoredAtNs)).UTC()
 		}
 		if !eventTime.IsZero() {
-			if summary.CreatedAt.IsZero() || eventTime.Before(summary.CreatedAt) {
-				summary.CreatedAt = eventTime
+			if earliestEventAt.IsZero() || eventTime.Before(earliestEventAt) {
+				earliestEventAt = eventTime
 			}
 			if eventTime.After(summary.LastEventAt) {
 				summary.LastEventAt = eventTime
 			}
 		}
 
+		if event.Type == types.EventContainerLifecycle && event.EventID == string(types.ContainerLifecycleSchedulerQueuePush) {
+			if !eventTime.IsZero() && (createdAt.IsZero() || eventTime.Before(createdAt)) {
+				createdAt = eventTime
+			}
+		}
+
 		if event.Type == types.EventContainerLifecycle && event.EventID == string(types.ContainerLifecycleStartup) {
-			switch {
-			case !event.EndTime.IsZero():
-				startedAt = event.EndTime.UTC()
-			case !event.StartTime.IsZero() && event.DurationMs > 0:
-				startedAt = event.StartTime.Add(time.Duration(event.DurationMs) * time.Millisecond).UTC()
-			case !event.StartTime.IsZero():
-				startedAt = event.StartTime.UTC()
+			candidate := lifecycleCompletionTime(event)
+			if !candidate.IsZero() && (startedAt.IsZero() || candidate.Before(startedAt)) {
+				startedAt = candidate
+			}
+		}
+
+		if event.Type == types.EventContainerLifecycle && event.EventID == string(types.ContainerLifecycleSandboxProcessManagerReady) {
+			candidate := lifecycleCompletionTime(event)
+			if !candidate.IsZero() && (interactiveAt.IsZero() || candidate.Before(interactiveAt)) {
+				interactiveAt = candidate
 			}
 		}
 
@@ -1427,6 +1593,13 @@ func sandboxContainerSummaryFromEvents(containerID string, events []types.Contai
 		if strings.Contains(signal, "oom") || strings.Contains(signal, "fail") || strings.Contains(signal, "error") {
 			summary.Status = SandboxStatusFailed
 		}
+	}
+
+	if createdAt.IsZero() {
+		createdAt = earliestEventAt
+	}
+	if !createdAt.IsZero() {
+		summary.CreatedAt = createdAt.UTC()
 	}
 
 	if !startedAt.IsZero() {
@@ -1450,7 +1623,39 @@ func sandboxContainerSummaryFromEvents(containerID string, events []types.Contai
 		}
 	}
 
+	if interactiveAt.IsZero() {
+		interactiveAt = startedAt
+	}
+	if !interactiveAt.IsZero() {
+		interactiveAt = interactiveAt.UTC()
+		summary.InteractiveAt = &interactiveAt
+		interactiveAtMs := interactiveAt.UnixMilli()
+		summary.InteractiveAtMs = &interactiveAtMs
+
+		if !summary.CreatedAt.IsZero() {
+			timeToInteractive := interactiveAt.Sub(summary.CreatedAt).Milliseconds()
+			if timeToInteractive >= 0 {
+				summary.TimeToInteractiveMs = &timeToInteractive
+			}
+		}
+	}
+
 	return summary
+}
+
+func lifecycleCompletionTime(event types.ContainerEventRecord) time.Time {
+	switch {
+	case !event.EndTime.IsZero():
+		return event.EndTime.UTC()
+	case !event.StartTime.IsZero() && event.DurationMs > 0:
+		return event.StartTime.Add(time.Duration(event.DurationMs) * time.Millisecond).UTC()
+	case !event.Timestamp.IsZero():
+		return event.Timestamp.UTC()
+	case !event.StartTime.IsZero():
+		return event.StartTime.UTC()
+	default:
+		return time.Time{}
+	}
 }
 
 func firstContainerEventTime(events []types.ContainerEventRecord) time.Time {
@@ -1586,19 +1791,22 @@ type sandboxChartRange struct {
 
 func sandboxCreatedChartRange(value string, now time.Time) sandboxChartRange {
 	now = now.UTC()
+	rangeDuration := time.Hour
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "last_week", "week", "7d":
-		end := now.Truncate(24 * time.Hour).Add(24 * time.Hour)
-		return sandboxChartRange{start: end.Add(-7 * 24 * time.Hour), bucketSize: 24 * time.Hour, count: 7}
+		rangeDuration = 7 * 24 * time.Hour
 	case "last_day", "day", "24h":
-		end := now.Truncate(time.Hour).Add(time.Hour)
-		return sandboxChartRange{start: end.Add(-24 * time.Hour), bucketSize: time.Hour, count: 24}
+		rangeDuration = 24 * time.Hour
 	case "last_hour", "hour", "1h", "":
 		fallthrough
 	default:
-		end := now.Truncate(time.Minute).Add(time.Minute)
-		return sandboxChartRange{start: end.Add(-60 * time.Minute), bucketSize: time.Minute, count: 60}
+		rangeDuration = time.Hour
 	}
+
+	const bucketCount = 60
+	bucketSize := rangeDuration / bucketCount
+	end := now.Truncate(bucketSize).Add(bucketSize)
+	return sandboxChartRange{start: end.Add(-rangeDuration), bucketSize: bucketSize, count: bucketCount}
 }
 
 // buildCreatedBuckets groups sandbox creation timestamps into fixed time buckets
@@ -1646,6 +1854,37 @@ func buildSandboxRowCreatedBucketsAt(rows []SandboxRow, rangeValue string, now t
 	end := r.start.Add(time.Duration(r.count) * r.bucketSize)
 	for i := range rows {
 		t := rows[i].CreatedAt.UTC()
+		if t.Before(r.start) || !t.Before(end) {
+			continue
+		}
+
+		idx := int(t.Sub(r.start) / r.bucketSize)
+		if idx >= 0 && idx < len(buckets) {
+			buckets[idx].Count++
+		}
+	}
+
+	return buckets
+}
+
+func buildSandboxSummaryCreatedBuckets(summaries []sandboxContainerSummary, rangeValue string) []SandboxCreatedBucket {
+	return buildSandboxSummaryCreatedBucketsAt(summaries, rangeValue, time.Now())
+}
+
+func buildSandboxSummaryCreatedBucketsAt(summaries []sandboxContainerSummary, rangeValue string, now time.Time) []SandboxCreatedBucket {
+	r := sandboxCreatedChartRange(rangeValue, now)
+	buckets := make([]SandboxCreatedBucket, r.count)
+	for i := range buckets {
+		buckets[i] = SandboxCreatedBucket{Timestamp: r.start.Add(time.Duration(i) * r.bucketSize)}
+	}
+
+	end := r.start.Add(time.Duration(r.count) * r.bucketSize)
+	for _, summary := range summaries {
+		if summary.ContainerID == "" || summary.CreatedAt.IsZero() {
+			continue
+		}
+
+		t := summary.CreatedAt.UTC()
 		if t.Before(r.start) || !t.Before(end) {
 			continue
 		}

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -274,7 +274,7 @@ func TestBuildSandboxRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 	}
 }
 
-func TestBuildSandboxStatsRowsUsesAppHistoryForAppScopedStats(t *testing.T) {
+func TestBuildSandboxStatsRowsUsesAppHistoryForAppNamespaceStats(t *testing.T) {
 	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
 	stubs := []types.StubWithRelated{{
 		Stub: types.Stub{
@@ -301,7 +301,7 @@ func TestBuildSandboxStatsRowsUsesAppHistoryForAppScopedStats(t *testing.T) {
 		t.Fatalf("expected %d sandbox stats rows, got %d", want, got)
 	}
 	if got := len(eventRepo.queries); got != 2 {
-		t.Fatalf("expected one app-scoped history query and one legacy fallback query, got %d", got)
+		t.Fatalf("expected one app namespace history query and one legacy fallback query, got %d", got)
 	}
 	query := eventRepo.queries[0]
 	if query.AppID != "app-1" {

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -145,6 +145,9 @@ func TestBuildSandboxRowsReturnsOneRowPerRecentContainer(t *testing.T) {
 		if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 44 {
 			t.Fatalf("row %d time_to_started_ms = %v, want 44", i, row.TimeToStartedMs)
 		}
+		if row.TimeToInteractiveMs == nil || *row.TimeToInteractiveMs != 44 {
+			t.Fatalf("row %d time_to_interactive_ms = %v, want 44", i, row.TimeToInteractiveMs)
+		}
 	}
 }
 
@@ -229,6 +232,7 @@ func TestBuildSandboxRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
 			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base},
 			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(1500 * time.Millisecond)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSandboxProcessManagerReady), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(1500 * time.Millisecond), EndTime: base.Add(2500 * time.Millisecond)},
 		}},
 	}
 	group := &StubGroup{eventRepo: eventRepo}
@@ -254,16 +258,23 @@ func TestBuildSandboxRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 	if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 1500 {
 		t.Fatalf("time_to_started_ms = %v, want 1500", row.TimeToStartedMs)
 	}
+	if row.TimeToInteractiveMs == nil || *row.TimeToInteractiveMs != 2500 {
+		t.Fatalf("time_to_interactive_ms = %v, want 2500", row.TimeToInteractiveMs)
+	}
 	wantStartedAtMs := base.Add(1500 * time.Millisecond).UnixMilli()
 	if row.StartedAtMs == nil || *row.StartedAtMs != wantStartedAtMs {
 		t.Fatalf("started_at_ms = %v, want %d", row.StartedAtMs, wantStartedAtMs)
+	}
+	wantInteractiveAtMs := base.Add(2500 * time.Millisecond).UnixMilli()
+	if row.InteractiveAtMs == nil || *row.InteractiveAtMs != wantInteractiveAtMs {
+		t.Fatalf("interactive_at_ms = %v, want %d", row.InteractiveAtMs, wantInteractiveAtMs)
 	}
 	if row.LifetimeMs == nil || *row.LifetimeMs <= 0 {
 		t.Fatalf("lifetime_ms = %v, want a positive running lifetime", row.LifetimeMs)
 	}
 }
 
-func TestBuildSandboxStatsRowsUsesStubHistoryForAppScopedStats(t *testing.T) {
+func TestBuildSandboxStatsRowsUsesAppHistoryForAppScopedStats(t *testing.T) {
 	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
 	stubs := []types.StubWithRelated{{
 		Stub: types.Stub{
@@ -274,16 +285,14 @@ func TestBuildSandboxStatsRowsUsesStubHistoryForAppScopedStats(t *testing.T) {
 	}}
 
 	eventRepo := &sandboxRowsEventRepo{
-		historiesByStub: map[string]*types.EventHistoryResponse{
-			"sandbox-stub": {Events: []types.ContainerEventRecord{
-				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1 * time.Second)},
-				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(1250 * time.Millisecond)},
-				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2 * time.Second)},
-				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(2250 * time.Millisecond)},
-				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3 * time.Second)},
-				{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(3250 * time.Millisecond)},
-			}},
-		},
+		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(1 * time.Second)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(1250 * time.Millisecond)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(2 * time.Second)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(2250 * time.Millisecond)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(3 * time.Second)},
+			{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-33333333", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(3250 * time.Millisecond)},
+		}},
 	}
 	group := &StubGroup{eventRepo: eventRepo}
 
@@ -291,15 +300,19 @@ func TestBuildSandboxStatsRowsUsesStubHistoryForAppScopedStats(t *testing.T) {
 	if got, want := len(rows), 3; got != want {
 		t.Fatalf("expected %d sandbox stats rows, got %d", want, got)
 	}
-	if got := len(eventRepo.queries); got != 1 {
-		t.Fatalf("expected one stub-scoped history query, got %d", got)
+	if got := len(eventRepo.queries); got != 2 {
+		t.Fatalf("expected one app-scoped history query and one legacy fallback query, got %d", got)
 	}
 	query := eventRepo.queries[0]
-	if query.StubID != "sandbox-stub" {
-		t.Fatalf("history query stub_id = %q, want sandbox-stub", query.StubID)
+	if query.AppID != "app-1" {
+		t.Fatalf("history query app_id = %q, want app-1", query.AppID)
 	}
-	if query.AppID != "" {
-		t.Fatalf("history query app_id = %q, want empty because DB app scope already selected the stub", query.AppID)
+	if query.StubID != "" {
+		t.Fatalf("history query stub_id = %q, want empty", query.StubID)
+	}
+	query = eventRepo.queries[1]
+	if query.AppID != "" || query.StubID != "" {
+		t.Fatalf("legacy query app_id/stub_id = %q/%q, want empty", query.AppID, query.StubID)
 	}
 }
 
@@ -313,12 +326,11 @@ func TestBuildSandboxStatsRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 		},
 	}}
 	eventRepo := &sandboxRowsEventRepo{
-		historiesByStub: map[string]*types.EventHistoryResponse{
-			"sandbox-stub": {Events: []types.ContainerEventRecord{
-				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base},
-				{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(1500 * time.Millisecond)},
-			}},
-		},
+		history: &types.EventHistoryResponse{Events: []types.ContainerEventRecord{
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(1500 * time.Millisecond)},
+			{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSandboxProcessManagerReady), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(1500 * time.Millisecond), EndTime: base.Add(2500 * time.Millisecond)},
+		}},
 	}
 	group := &StubGroup{eventRepo: eventRepo}
 
@@ -339,9 +351,16 @@ func TestBuildSandboxStatsRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 	if row.TimeToStartedMs == nil || *row.TimeToStartedMs != 1500 {
 		t.Fatalf("time_to_started_ms = %v, want 1500", row.TimeToStartedMs)
 	}
+	if row.TimeToInteractiveMs == nil || *row.TimeToInteractiveMs != 2500 {
+		t.Fatalf("time_to_interactive_ms = %v, want 2500", row.TimeToInteractiveMs)
+	}
 	wantStartedAtMs := base.Add(1500 * time.Millisecond).UnixMilli()
 	if row.StartedAtMs == nil || *row.StartedAtMs != wantStartedAtMs {
 		t.Fatalf("started_at_ms = %v, want %d", row.StartedAtMs, wantStartedAtMs)
+	}
+	wantInteractiveAtMs := base.Add(2500 * time.Millisecond).UnixMilli()
+	if row.InteractiveAtMs == nil || *row.InteractiveAtMs != wantInteractiveAtMs {
+		t.Fatalf("interactive_at_ms = %v, want %d", row.InteractiveAtMs, wantInteractiveAtMs)
 	}
 	if row.LifetimeMs == nil || *row.LifetimeMs <= 0 {
 		t.Fatalf("lifetime_ms = %v, want a positive running lifetime", row.LifetimeMs)

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -266,7 +266,7 @@ type EventRepository interface {
 	StreamStubEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	StreamTaskEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	StreamWorkspaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
-	StreamAppEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
+	StreamAppNamespaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	StreamLogs(ctx context.Context, query types.LogQuery) (EventStream, error)
 	PushContainerResourceMetricsEvent(workerID string, request *types.ContainerRequest, metrics types.EventContainerMetricsData)
 	PushContainerLifecycleEvent(lifecycle types.EventContainerLifecycleSchema)

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -370,6 +370,7 @@ func (r *EventClientRepo) PushContainerRequestEvent(workerID string, request *ty
 		StubType:    string(request.Stub.Type.Kind()),
 		TaskID:      taskID,
 		WorkspaceID: request.WorkspaceId,
+		AppID:       request.AppId,
 		WorkerID:    workerID,
 		CPU:         request.Cpu,
 		GPUCount:    request.GpuCount,
@@ -400,6 +401,7 @@ func (r *EventClientRepo) PushContainerRequestLifecycle(workerID string, request
 		StubType:    string(request.Stub.Type.Kind()),
 		TaskID:      firstNonEmpty(opts.TaskID, taskIDFromRequestEnv(request)),
 		WorkspaceID: request.WorkspaceId,
+		AppID:       request.AppId,
 		WorkerID:    workerID,
 		Success:     &success,
 		Source:      opts.Source.String(),
@@ -419,6 +421,7 @@ func (r *EventClientRepo) PushContainerTaskEvent(task *types.TaskWithRelated, ev
 		StubType:    string(task.Stub.Type.Kind()),
 		TaskID:      task.ExternalId,
 		WorkspaceID: task.Workspace.ExternalId,
+		AppID:       task.App.ExternalId,
 		Reason:      opts.Reason,
 		Source:      opts.Source.String(),
 		Message:     opts.Message.String(),
@@ -469,6 +472,7 @@ func (r *EventClientRepo) PushContainerTaskLifecycle(task *types.TaskWithRelated
 		StubType:    string(task.Stub.Type.Kind()),
 		TaskID:      firstNonEmpty(opts.TaskID, task.ExternalId),
 		WorkspaceID: task.Workspace.ExternalId,
+		AppID:       task.App.ExternalId,
 		Success:     &success,
 		Source:      opts.Source.String(),
 		Attrs:       attrs,
@@ -574,6 +578,7 @@ func (r *EventClientRepo) PushContainerRunnerEvent(workerID string, request *typ
 			StubType:    firstNonEmpty(event.StubType, string(request.Stub.Type.Kind())),
 			TaskID:      firstNonEmpty(event.TaskID, taskIDFromRequestEnv(request)),
 			WorkspaceID: request.WorkspaceId,
+			AppID:       request.AppId,
 			WorkerID:    workerID,
 			Success:     &success,
 			Source:      types.EventSourceRunnerStdout.String(),
@@ -597,6 +602,7 @@ func (r *EventClientRepo) PushContainerRunnerEvent(workerID string, request *typ
 			StubType:    firstNonEmpty(event.StubType, string(request.Stub.Type.Kind())),
 			TaskID:      firstNonEmpty(event.TaskID, taskIDFromRequestEnv(request)),
 			WorkspaceID: request.WorkspaceId,
+			AppID:       request.AppId,
 			WorkerID:    workerID,
 			Source:      types.EventSourceRunnerStdout.String(),
 			Message:     event.Message,
@@ -1119,9 +1125,9 @@ func eventMetadataFromData(data interface{}) eventMetadata {
 	case types.EventContainerMetricsSchema:
 		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID}
 	case types.EventContainerLifecycleSchema:
-		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, TaskID: d.TaskID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID}
+		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, TaskID: d.TaskID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID, AppID: d.AppID}
 	case types.EventContainerEventSchema:
-		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, TaskID: d.TaskID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID}
+		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, TaskID: d.TaskID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID, AppID: d.AppID}
 	case types.EventContainerLogSchema:
 		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, TaskID: d.TaskID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID, AppID: d.AppID}
 	case types.EventPlatformLogSchema:

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -39,7 +39,7 @@ type eventStreamer interface {
 	StreamStubEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	StreamTaskEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	StreamWorkspaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
-	StreamAppEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
+	StreamAppNamespaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error)
 	StreamLogs(ctx context.Context, query types.LogQuery) (EventStream, error)
 }
 
@@ -261,11 +261,11 @@ func (r *EventClientRepo) StreamWorkspaceEvents(ctx context.Context, query types
 	return r.streamer.StreamWorkspaceEvents(ctx, query)
 }
 
-func (r *EventClientRepo) StreamAppEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
+func (r *EventClientRepo) StreamAppNamespaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
 	if r.streamer == nil {
 		return nil, ErrEventReadUnsupported
 	}
-	return r.streamer.StreamAppEvents(ctx, query)
+	return r.streamer.StreamAppNamespaceEvents(ctx, query)
 }
 
 func (r *EventClientRepo) StreamLogs(ctx context.Context, query types.LogQuery) (EventStream, error) {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -1811,6 +1811,7 @@ func augmentContainerEventResponse(response *types.ContainerEventsResponse, reco
 		record.StubType = lifecycle.StubType
 		record.TaskID = lifecycle.TaskID
 		record.WorkspaceID = lifecycle.WorkspaceID
+		record.AppID = firstNonEmpty(lifecycle.AppID, record.AppID)
 		record.WorkerID = lifecycle.WorkerID
 		if response.WorkspaceID == "" {
 			response.WorkspaceID = lifecycle.WorkspaceID
@@ -1835,6 +1836,7 @@ func augmentContainerEventResponse(response *types.ContainerEventsResponse, reco
 		record.StubType = event.StubType
 		record.TaskID = event.TaskID
 		record.WorkspaceID = event.WorkspaceID
+		record.AppID = firstNonEmpty(event.AppID, record.AppID)
 		record.WorkerID = event.WorkerID
 		if response.WorkspaceID == "" {
 			response.WorkspaceID = event.WorkspaceID

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -280,10 +280,7 @@ func (r *ScopedS2EventRepository) targetForStream(streamName s2.StreamName) *sco
 }
 
 func appendScopedS2Records(basin *s2.BasinClient, streamName s2.StreamName, records []s2.AppendRecord) error {
-	ctx, cancel := s2EventWriteContext()
-	defer cancel()
-	_, err := basin.Stream(streamName).Append(ctx, &s2.AppendInput{Records: records})
-	return err
+	return appendS2RecordsForWrite(basin, streamName, records)
 }
 
 func (r *S2EventRepository) PushEvent(event cloudevents.Event) error {
@@ -1259,10 +1256,29 @@ func s2TimestampMillisToNanos(timestamp uint64) uint64 {
 }
 
 func (r *S2EventRepository) appendRecordsForWrite(streamName s2.StreamName, records []s2.AppendRecord) error {
-	ctx, cancel := s2EventWriteContext()
-	defer cancel()
-	_, err := r.basin.Stream(streamName).Append(ctx, &s2.AppendInput{Records: records})
-	return err
+	return appendS2RecordsForWrite(r.basin, streamName, records)
+}
+
+func appendS2RecordsForWrite(basin *s2.BasinClient, streamName s2.StreamName, records []s2.AppendRecord) error {
+	appendRecords := func() error {
+		ctx, cancel := s2EventWriteContext()
+		defer cancel()
+		_, err := basin.Stream(streamName).Append(ctx, &s2.AppendInput{Records: records})
+		return err
+	}
+
+	err := appendRecords()
+	if !isS2StreamNotFound(err) {
+		return err
+	}
+
+	ensureCtx, ensureCancel := s2EventWriteContext()
+	defer ensureCancel()
+	if _, ensureErr := basin.Streams.Ensure(ensureCtx, s2.EnsureStreamArgs{Stream: streamName}); ensureErr != nil {
+		return fmt.Errorf("ensure missing s2 stream %q: %w; append: %v", streamName, ensureErr, err)
+	}
+
+	return appendRecords()
 }
 
 func s2EventWriteContext() (context.Context, context.CancelFunc) {

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -485,9 +485,8 @@ func (r *S2EventRepository) GetEventHistory(ctx context.Context, query types.Eve
 		}
 	}
 
-	// App-scoped container lifecycle/event records were originally available
-	// through the workspace stream. Keep that path as a fallback so app
-	// dashboards can read older sandbox/container history without per-stub scans.
+	// App namespace container lifecycle/event records were originally available
+	// through the workspace stream. Keep that fallback for older sandbox history.
 	if len(response.Events) == 0 && query.AppID != "" && query.WorkspaceID != "" && allWorkspaceContainerRealtimeEventTypes(query.EventTypes) {
 		workspaceStream := r.workspaceStreamName(query.WorkspaceID)
 		if !responseReadStream(response.Streams, workspaceStream) {
@@ -583,12 +582,12 @@ func (r *S2EventRepository) StreamWorkspaceEvents(ctx context.Context, query typ
 	return r.streamEvents(ctx, streamName, "", query)
 }
 
-func (r *S2EventRepository) StreamAppEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
+func (r *S2EventRepository) StreamAppNamespaceEvents(ctx context.Context, query types.EventQuery) (EventStream, error) {
 	if query.WorkspaceID == "" || query.AppID == "" {
-		return nil, fmt.Errorf("workspace id and app id are required to stream app events")
+		return nil, fmt.Errorf("workspace id and app id are required to stream app namespace events")
 	}
 
-	streamName := r.appStreamName(query.WorkspaceID, query.AppID)
+	streamName := r.appNamespaceStreamName(query.WorkspaceID, query.AppID)
 	return r.streamEvents(ctx, streamName, "", query)
 }
 
@@ -643,7 +642,7 @@ func (r *S2EventRepository) resolveEventHistoryStreams(ctx context.Context, quer
 	case query.TaskID != "":
 		return addKnown(r.legacyTaskStreamName(query.TaskID))
 	case query.AppID != "" && query.WorkspaceID != "":
-		return addKnown(r.appStreamName(query.WorkspaceID, query.AppID))
+		return addKnown(r.appNamespaceStreamName(query.WorkspaceID, query.AppID))
 	case query.StubID != "" && query.WorkspaceID != "":
 		return addKnown(r.stubStreamName(query.WorkspaceID, query.StubID))
 	case query.WorkspaceID != "" && allComputeEventTypes(query.EventTypes):
@@ -1361,15 +1360,7 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 
 	streams := []s2.StreamName{}
 	add := func(stream s2.StreamName) {
-		if stream == "" {
-			return
-		}
-		for _, existing := range streams {
-			if existing == stream {
-				return
-			}
-		}
-		streams = append(streams, stream)
+		streams = appendUniqueS2Stream(streams, stream)
 	}
 
 	add(r.streamNameForEvent(eventType, metadata))
@@ -1388,7 +1379,7 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 	if isWorkspaceContainerRealtimeEvent(eventType) && metadata.WorkspaceID != "" {
 		add(r.workspaceStreamName(metadata.WorkspaceID))
 		if metadata.AppID != "" {
-			add(r.appStreamName(metadata.WorkspaceID, metadata.AppID))
+			add(r.appNamespaceStreamName(metadata.WorkspaceID, metadata.AppID))
 		}
 	}
 	if isComputeEvent(eventType) && metadata.WorkspaceID != "" {
@@ -1404,7 +1395,7 @@ func (r *S2EventRepository) streamNamesForEvent(eventType string, metadata event
 	if isTaskEvent(eventType) && metadata.WorkspaceID != "" {
 		add(r.workspaceStreamName(metadata.WorkspaceID))
 		if metadata.AppID != "" {
-			add(r.appStreamName(metadata.WorkspaceID, metadata.AppID))
+			add(r.appNamespaceStreamName(metadata.WorkspaceID, metadata.AppID))
 		}
 	}
 	return streams
@@ -1424,6 +1415,18 @@ func isWorkspaceContainerRealtimeEvent(eventType string) bool {
 		eventType == types.EventContainerLifecycle
 }
 
+func appendUniqueS2Stream(streams []s2.StreamName, stream s2.StreamName) []s2.StreamName {
+	if stream == "" {
+		return streams
+	}
+	for _, existing := range streams {
+		if existing == stream {
+			return streams
+		}
+	}
+	return append(streams, stream)
+}
+
 func isComputeEvent(eventType string) bool {
 	return strings.HasPrefix(eventType, "compute.")
 }
@@ -1439,7 +1442,7 @@ func (r *S2EventRepository) primaryLogStreamName(metadata eventMetadata) s2.Stre
 	case metadata.StubID != "" && metadata.WorkspaceID != "":
 		return r.stubLogStreamName(metadata.WorkspaceID, metadata.StubID)
 	case metadata.AppID != "" && metadata.WorkspaceID != "":
-		return r.appLogStreamName(metadata.WorkspaceID, metadata.AppID)
+		return r.appNamespaceLogStreamName(metadata.WorkspaceID, metadata.AppID)
 	case metadata.WorkspaceID != "":
 		return r.workspaceLogStreamName(metadata.WorkspaceID)
 	default:
@@ -1450,20 +1453,14 @@ func (r *S2EventRepository) primaryLogStreamName(metadata eventMetadata) s2.Stre
 func (r *S2EventRepository) logStreamNamesForEvent(metadata eventMetadata) []s2.StreamName {
 	streams := []s2.StreamName{}
 	add := func(stream s2.StreamName) {
-		if stream == "" {
-			return
-		}
-		for _, existing := range streams {
-			if existing == stream {
-				return
-			}
-		}
-		streams = append(streams, stream)
+		streams = appendUniqueS2Stream(streams, stream)
 	}
 
 	if metadata.WorkspaceID == "" {
 		return streams
 	}
+	// Container/stub streams are the canonical lookup path for individual logs.
+	// App namespace logs are a secondary dashboard index across those containers.
 	if metadata.ContainerID != "" && metadata.StubID != "" {
 		add(r.containerLogStreamName(metadata.WorkspaceID, metadata.StubID, metadata.ContainerID))
 	}
@@ -1480,7 +1477,7 @@ func (r *S2EventRepository) logStreamNamesForEvent(metadata eventMetadata) []s2.
 		add(r.stubTaskStreamName(metadata.WorkspaceID, metadata.StubID))
 	}
 	if metadata.AppID != "" {
-		add(r.appLogStreamName(metadata.WorkspaceID, metadata.AppID))
+		add(r.appNamespaceLogStreamName(metadata.WorkspaceID, metadata.AppID))
 	}
 	add(r.workspaceLogStreamName(metadata.WorkspaceID))
 	return streams
@@ -1566,7 +1563,7 @@ func (r *S2EventRepository) stubStreamName(workspaceID, stubID string) s2.Stream
 	return s2.StreamName(fmt.Sprintf("%s/workspaces/%s/stubs/%s", r.streamPrefix, eventStreamPart(workspaceID), eventStreamPart(stubID)))
 }
 
-func (r *S2EventRepository) appStreamName(workspaceID, appID string) s2.StreamName {
+func (r *S2EventRepository) appNamespaceStreamName(workspaceID, appID string) s2.StreamName {
 	return s2.StreamName(fmt.Sprintf("%s/workspaces/%s/apps/%s", r.streamPrefix, eventStreamPart(workspaceID), eventStreamPart(appID)))
 }
 
@@ -1710,7 +1707,7 @@ func (r *S2EventRepository) legacyTaskLogStreamName(workspaceID, taskID string) 
 	return s2.StreamName(fmt.Sprintf("%s/logs/workspaces/%s/tasks/%s", r.streamPrefix, eventStreamPart(workspaceID), eventStreamPart(taskID)))
 }
 
-func (r *S2EventRepository) appLogStreamName(workspaceID, appID string) s2.StreamName {
+func (r *S2EventRepository) appNamespaceLogStreamName(workspaceID, appID string) s2.StreamName {
 	return s2.StreamName(fmt.Sprintf("%s/logs/workspaces/%s/apps/%s", r.streamPrefix, eventStreamPart(workspaceID), eventStreamPart(appID)))
 }
 

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -238,7 +238,7 @@ func (r *S2EventRepository) resolveLogStreams(query types.LogQuery) ([]s2.Stream
 	case query.StubID != "" && query.WorkspaceID != "":
 		return addKnown(r.stubLogStreamName(query.WorkspaceID, query.StubID))
 	case query.AppID != "" && query.WorkspaceID != "":
-		return addKnown(r.appLogStreamName(query.WorkspaceID, query.AppID))
+		return addKnown(r.appNamespaceLogStreamName(query.WorkspaceID, query.AppID))
 	case query.WorkspaceID != "":
 		return addKnown(r.workspaceLogStreamName(query.WorkspaceID))
 	default:

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -52,7 +52,7 @@ func TestS2ContainerEventsAlsoUseStubAggregateStream(t *testing.T) {
 	}
 }
 
-func TestS2AppScopedContainerEventsUseAppAggregateStream(t *testing.T) {
+func TestS2AppNamespaceContainerEventsUseAppNamespaceStream(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 
 	streams := repo.streamNamesForEvent(types.EventContainerLifecycle, eventMetadata{
@@ -310,7 +310,7 @@ func TestS2StubEventsAlsoUseWorkspaceAggregateStream(t *testing.T) {
 	}
 }
 
-func TestS2ContainerLogsUseDifferentiatedLogStreams(t *testing.T) {
+func TestS2ContainerLogsUseContainerStubLookupBeforeAppNamespaceIndex(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 
 	streams := repo.streamNamesForEvent(types.EventContainerLog, eventMetadata{
@@ -637,7 +637,7 @@ func TestTaskLogQueryRequiresTaskTaggedLogs(t *testing.T) {
 	}
 }
 
-func TestS2TaskEventsUseWorkspaceAndAppAggregateStreams(t *testing.T) {
+func TestS2TaskEventsUseWorkspaceAndAppNamespaceStreams(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 
 	streams := repo.streamNamesForEvent(types.EventTaskCreated, eventMetadata{

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -1072,6 +1072,7 @@ func TestEventMetadataExtensionsRoundTrip(t *testing.T) {
 		ContainerID: "container-1",
 		WorkspaceID: "workspace-1",
 		StubID:      "stub-1",
+		AppID:       "app-1",
 		TaskID:      "task-1",
 		WorkerID:    "worker-1",
 	})
@@ -1083,6 +1084,7 @@ func TestEventMetadataExtensionsRoundTrip(t *testing.T) {
 	if metadata.ContainerID != "container-1" ||
 		metadata.WorkspaceID != "workspace-1" ||
 		metadata.StubID != "stub-1" ||
+		metadata.AppID != "app-1" ||
 		metadata.TaskID != "task-1" ||
 		metadata.WorkerID != "worker-1" {
 		t.Fatalf("metadata did not round trip: %#v", metadata)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -499,6 +499,7 @@ func (s *Scheduler) recordContainerLifecycle(request *types.ContainerRequest, li
 		StubType:    string(request.Stub.Type.Kind()),
 		TaskID:      taskIDFromRequestEnv(request.Env),
 		WorkspaceID: request.WorkspaceId,
+		AppID:       request.AppId,
 		Success:     &success,
 		Source:      types.EventSourceScheduler.String(),
 		Attrs:       attrs,

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -708,6 +708,7 @@ type EventContainerLifecycleSchema struct {
 	StubType    string               `json:"stub_type,omitempty"`
 	TaskID      string               `json:"task_id,omitempty"`
 	WorkspaceID string               `json:"workspace_id,omitempty"`
+	AppID       string               `json:"app_id,omitempty"`
 	WorkerID    string               `json:"worker_id,omitempty"`
 	Success     *bool                `json:"success,omitempty"`
 	Source      string               `json:"source,omitempty"`
@@ -725,6 +726,7 @@ type EventContainerEventSchema struct {
 	StubType    string            `json:"stub_type,omitempty"`
 	TaskID      string            `json:"task_id,omitempty"`
 	WorkspaceID string            `json:"workspace_id,omitempty"`
+	AppID       string            `json:"app_id,omitempty"`
 	WorkerID    string            `json:"worker_id,omitempty"`
 	CPU         int64             `json:"cpu,omitempty"`
 	GPUCount    uint32            `json:"gpu_count,omitempty"`

--- a/pkg/worker/container_events.go
+++ b/pkg/worker/container_events.go
@@ -47,6 +47,9 @@ func populateContainerEventFromRequest(event *types.EventContainerEventSchema, r
 	if event.WorkspaceID == "" {
 		event.WorkspaceID = request.WorkspaceId
 	}
+	if event.AppID == "" {
+		event.AppID = request.AppId
+	}
 	if event.TaskID == "" {
 		event.TaskID = taskIDFromEnv(request.Env)
 	}
@@ -70,6 +73,9 @@ func populateContainerLifecycleFromRequest(lifecycle *types.EventContainerLifecy
 	}
 	if lifecycle.WorkspaceID == "" {
 		lifecycle.WorkspaceID = request.WorkspaceId
+	}
+	if lifecycle.AppID == "" {
+		lifecycle.AppID = request.AppId
 	}
 	if lifecycle.TaskID == "" {
 		lifecycle.TaskID = taskIDFromEnv(request.Env)

--- a/pkg/worker/image_events.go
+++ b/pkg/worker/image_events.go
@@ -472,6 +472,7 @@ func (c *ImageClient) pushClipReadAggregate(aggregate *clipReadAggregate, flushR
 		StubType:    string(request.Stub.Type.Kind()),
 		TaskID:      taskIDFromEnv(request.Env),
 		WorkspaceID: request.WorkspaceId,
+		AppID:       request.AppId,
 		WorkerID:    c.workerId,
 		Success:     &success,
 		Source:      types.EventSourceClipFUSE.String(),

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -1213,6 +1213,7 @@ func (m *ContainerNetworkManager) recordNetworkLifecycle(request *types.Containe
 		StubType:    string(request.Stub.Type.Kind()),
 		TaskID:      taskIDFromContainerRequestEnv(request.Env),
 		WorkspaceID: request.WorkspaceId,
+		AppID:       request.AppId,
 		WorkerID:    m.workerId,
 		Success:     &success,
 		Source:      types.EventSourceWorkerNetwork.String(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the sandbox timeline and stats with richer container summaries, interactive timing, and reliable app‑namespace history. Charts use 60 fixed buckets, and S2 writes auto-create missing streams for more resilient metrics and logs.

- **New Features**
  - Interactive timing: added `time_to_interactive_ms` and `interactive_at_ms` on sandbox rows from lifecycle events (process manager ready), defaulting to start time when needed.
  - Timeline fallback: backfills start/end/runtime from recent container summaries when streams are incomplete; `created_at` derives from queue push or the earliest event.
  - App namespace streams: AppID is propagated across autoscaler, scheduler, worker, and repository; event and log streaming use app‑namespace streams on the same `/apps/:appId/stream` route.

- **Bug Fixes**
  - Created charts: fixed 60 buckets for hour/day/week; counts built from container summaries to avoid double counting; tests cover bucket count and de‑dupe.
  - Fewer redundant event queries by preloading/indexing per‑stub summaries in list and stats.
  - S2: on append, auto‑ensure missing streams; log routing prefers container/stub streams with app‑namespace as a secondary index.

<sup>Written for commit 034f8920d6516b3397add7fdf87a369651e10912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

