### PR TITLE
fix rt updates in table

### DIFF
--- a/benchmarks/sandbox_parallel.py
+++ b/benchmarks/sandbox_parallel.py
@@ -95,6 +95,7 @@ def parse_args():
     parser.add_argument("--warmup", type=int, default=env_int("BENCH_SANDBOX_WARMUP", 1))
     parser.add_argument("--sandbox-cpu", default=os.getenv("BENCH_SANDBOX_CPU", "0.1"))
     parser.add_argument("--sandbox-memory", default=os.getenv("BENCH_SANDBOX_MEMORY", "192"))
+    parser.add_argument("--sandbox-app-name", default=os.getenv("BENCH_SANDBOX_APP_NAME", "sandbox-parallel-benchmark"))
     parser.add_argument("--sandbox-keep-warm-seconds", type=int, default=env_int("BENCH_SANDBOX_KEEP_WARM_SECONDS", 600))
     parser.add_argument("--sandbox-image-uri", default=os.getenv("BENCH_SANDBOX_IMAGE_URI", os.getenv("BENCH_BOOTSTRAP_IMAGE_URI", "registry.localhost:5000/beta9-bench-alpine:latest")))
     parser.add_argument("--sandbox-exec", default=os.getenv("BENCH_SANDBOX_EXEC", DEFAULT_SANDBOX_EXEC))
@@ -278,7 +279,7 @@ def prepare_sandbox_runtime(args):
     Image, Sandbox, sandbox_stub_type = import_sdk()
     image = Image.from_registry(args.sandbox_image_uri)
     sandbox = Sandbox(
-        name="sandbox-parallel-benchmark",
+        name=args.sandbox_app_name,
         image=image,
         cpu=parse_sdk_cpu(args.sandbox_cpu),
         memory=parse_sdk_memory(args.sandbox_memory),
@@ -814,6 +815,7 @@ def main():
             "warmup": args.warmup,
             "sandboxCpu": args.sandbox_cpu,
             "sandboxMemory": args.sandbox_memory,
+            "sandboxAppName": args.sandbox_app_name,
             "sandboxKeepWarmSeconds": args.sandbox_keep_warm_seconds,
             "sandboxImageUri": args.sandbox_image_uri,
             "sandboxExec": args.sandbox_exec,

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -689,11 +689,13 @@ const (
 )
 
 const (
-	defaultSandboxListLimit      = 50
-	maxSandboxListLimit          = 200
-	sandboxContainerHistoryLimit = 500
-	sandboxHistoryEventsPerRow   = 32
-	sandboxStatsHistoryLimit     = 5000
+	defaultSandboxListLimit       = 50
+	maxSandboxListLimit           = 200
+	sandboxContainerHistoryLimit  = 500
+	sandboxHistoryEventsPerRow    = 32
+	sandboxStatsHistoryLimit      = 5000
+	sandboxStatsFallbackStubLimit = 25
+	sandboxTimingHydrationLimit   = 50
 )
 
 type SandboxRow struct {
@@ -811,6 +813,7 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 
 	appID := ctx.QueryParam("app_id")
 	summaries := g.recentSandboxStatsContainerSummaries(ctx.Request().Context(), workspaceID, appID, stubs)
+	summaries = g.hydrateSandboxStatsSummaries(ctx.Request().Context(), workspaceID, appID, stubs, summaries)
 	sandboxRows := g.buildSandboxStatsRowsWithSummaries(ctx.Request().Context(), workspaceID, stubs, containersByStub, summaries)
 
 	statusCounts := map[string]int{
@@ -1070,6 +1073,7 @@ func (g *StubGroup) activeContainersByStub(workspaceID string) map[string][]type
 
 func (g *StubGroup) buildSandboxStatsRows(ctx context.Context, workspaceID, appID string, stubs []types.StubWithRelated, containersByStub map[string][]types.ContainerState) []SandboxRow {
 	summaries := g.recentSandboxStatsContainerSummaries(ctx, workspaceID, appID, stubs)
+	summaries = g.hydrateSandboxStatsSummaries(ctx, workspaceID, appID, stubs, summaries)
 	return g.buildSandboxStatsRowsWithSummaries(ctx, workspaceID, stubs, containersByStub, summaries)
 }
 
@@ -1096,7 +1100,7 @@ func (g *StubGroup) buildSandboxStatsRowsWithSummaries(ctx context.Context, work
 			}
 			row := g.buildActiveSandboxRow(ctx, workspaceID, stub, container)
 			if summary, ok := summariesByContainerID[container.ContainerId]; ok {
-				applySandboxSummaryToActiveRow(&row, summary, now)
+				applySandboxSummaryToRow(&row, summary, now)
 			}
 			rows = append(rows, row)
 			rowByContainerID[container.ContainerId] = struct{}{}
@@ -1183,7 +1187,7 @@ func (g *StubGroup) buildSandboxRowsWithPreloadedSummaries(ctx context.Context, 
 				continue
 			}
 			if summary, ok := summariesByContainerID[rows[i].ContainerId]; ok {
-				applySandboxSummaryToActiveRow(&rows[i], summary, now)
+				applySandboxSummaryToRow(&rows[i], summary, now)
 			}
 		}
 
@@ -1201,6 +1205,8 @@ func (g *StubGroup) buildSandboxRowsWithPreloadedSummaries(ctx context.Context, 
 	if len(rows) == 0 {
 		rows = append(rows, g.buildFallbackSandboxRow(ctx, workspaceID, stub))
 	}
+
+	g.hydrateSandboxRowTimings(ctx, workspaceID, rows, maxRows)
 
 	sort.SliceStable(rows, func(i, j int) bool {
 		return rows[i].CreatedAt.After(rows[j].CreatedAt)
@@ -1317,7 +1323,7 @@ func sandboxContainerStateNeedsSummary(container types.ContainerState) bool {
 	return container.StartedAt > 0 && container.ScheduledAt > 0 && container.StartedAt < container.ScheduledAt
 }
 
-func applySandboxSummaryToActiveRow(row *SandboxRow, summary sandboxContainerSummary, now time.Time) {
+func applySandboxSummaryToRow(row *SandboxRow, summary sandboxContainerSummary, now time.Time) {
 	if row == nil {
 		return
 	}
@@ -1373,7 +1379,7 @@ func applySandboxSummaryToActiveRow(row *SandboxRow, summary sandboxContainerSum
 		row.InteractiveAtMs = &interactiveAtMs
 	}
 
-	if row.LifetimeMs == nil && isActiveSandboxStatus(row.Status) && startedAt != nil {
+	if isActiveSandboxStatus(row.Status) && startedAt != nil {
 		if now.IsZero() {
 			now = time.Now().UTC()
 		}
@@ -1381,7 +1387,72 @@ func applySandboxSummaryToActiveRow(row *SandboxRow, summary sandboxContainerSum
 		if lifetime >= 0 {
 			row.LifetimeMs = &lifetime
 		}
+	} else if row.LifetimeMs == nil && summary.LifetimeMs != nil {
+		row.LifetimeMs = summary.LifetimeMs
 	}
+}
+
+func sandboxRowNeedsTimingHydration(row SandboxRow) bool {
+	if row.ContainerId == "" || row.StubId == "" {
+		return false
+	}
+	return row.TimeToStartedMs == nil ||
+		row.TimeToInteractiveMs == nil ||
+		row.StartedAtMs == nil ||
+		row.InteractiveAtMs == nil ||
+		row.LifetimeMs == nil
+}
+
+func (g *StubGroup) hydrateSandboxRowTimings(ctx context.Context, workspaceID string, rows []SandboxRow, maxRows int) {
+	if g.eventRepo == nil || len(rows) == 0 {
+		return
+	}
+
+	limit := maxRows
+	if limit <= 0 || limit > sandboxTimingHydrationLimit {
+		limit = sandboxTimingHydrationLimit
+	}
+
+	now := time.Now().UTC()
+	for i := range rows {
+		if limit <= 0 {
+			return
+		}
+		if !sandboxRowNeedsTimingHydration(rows[i]) {
+			continue
+		}
+
+		summary, ok := g.canonicalSandboxContainerSummary(ctx, workspaceID, rows[i].StubId, rows[i].ContainerId)
+		if !ok {
+			limit--
+			continue
+		}
+
+		applySandboxSummaryToRow(&rows[i], summary, now)
+		limit--
+	}
+}
+
+func (g *StubGroup) canonicalSandboxContainerSummary(ctx context.Context, workspaceID, stubID, containerID string) (sandboxContainerSummary, bool) {
+	if g.eventRepo == nil || containerID == "" {
+		return sandboxContainerSummary{}, false
+	}
+
+	resp, err := g.eventRepo.GetContainerEvents(ctx, containerID, types.EventQuery{
+		WorkspaceID: workspaceID,
+		StubID:      stubID,
+		Limit:       sandboxContainerHistoryLimit,
+		EventTypes:  []string{types.EventContainerLifecycle, types.EventContainerEvent},
+	})
+	if err != nil || resp == nil || len(resp.Events) == 0 {
+		return sandboxContainerSummary{}, false
+	}
+
+	summary := sandboxContainerSummaryFromEvents(containerID, resp.Events)
+	if summary.StubID == "" {
+		summary.StubID = stubID
+	}
+	return summary, true
 }
 
 func (g *StubGroup) buildFallbackSandboxRow(ctx context.Context, workspaceID string, stub *types.StubWithRelated) SandboxRow {
@@ -1489,6 +1560,53 @@ func (g *StubGroup) recentSandboxStatsContainerSummaries(ctx context.Context, wo
 		return nil
 	}
 	return sandboxContainerSummariesFromHistory(history.Events, 0)
+}
+
+func (g *StubGroup) hydrateSandboxStatsSummaries(ctx context.Context, workspaceID, appID string, stubs []types.StubWithRelated, summaries []sandboxContainerSummary) []sandboxContainerSummary {
+	if g.eventRepo == nil || appID == "" || len(stubs) == 0 {
+		return summaries
+	}
+
+	byContainerID := indexSandboxContainerSummaries(summaries)
+	for _, stub := range recentSandboxStatsFallbackStubs(stubs, sandboxStatsFallbackStubLimit) {
+		for _, summary := range g.recentSandboxContainerSummaries(ctx, workspaceID, stub.ExternalId, 0) {
+			if summary.ContainerID == "" {
+				continue
+			}
+			if summary.AppID != "" && summary.AppID != appID {
+				continue
+			}
+			if summary.StubID == "" {
+				summary.StubID = stub.ExternalId
+			}
+			if _, ok := byContainerID[summary.ContainerID]; ok {
+				continue
+			}
+
+			summaries = append(summaries, summary)
+			byContainerID[summary.ContainerID] = summary
+		}
+	}
+
+	sort.SliceStable(summaries, func(i, j int) bool {
+		return summaries[i].LastEventAt.After(summaries[j].LastEventAt)
+	})
+	return summaries
+}
+
+func recentSandboxStatsFallbackStubs(stubs []types.StubWithRelated, limit int) []types.StubWithRelated {
+	if limit <= 0 || len(stubs) == 0 {
+		return nil
+	}
+
+	candidates := append([]types.StubWithRelated(nil), stubs...)
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].CreatedAt.Time.After(candidates[j].CreatedAt.Time)
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	return candidates
 }
 
 func legacySandboxEventsForApp(events []types.ContainerEventRecord, stubs []types.StubWithRelated) []types.ContainerEventRecord {

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -24,10 +24,11 @@ import (
 
 type sandboxRowsEventRepo struct {
 	repository.EventRepository
-	history         *types.EventHistoryResponse
-	historiesByStub map[string]*types.EventHistoryResponse
-	containers      map[string]*types.ContainerEventsResponse
-	queries         []types.EventQuery
+	history          *types.EventHistoryResponse
+	historiesByStub  map[string]*types.EventHistoryResponse
+	containers       map[string]*types.ContainerEventsResponse
+	queries          []types.EventQuery
+	containerQueries []types.EventQuery
 }
 
 func (r *sandboxRowsEventRepo) GetEventHistory(_ context.Context, query types.EventQuery) (*types.EventHistoryResponse, error) {
@@ -38,7 +39,9 @@ func (r *sandboxRowsEventRepo) GetEventHistory(_ context.Context, query types.Ev
 	return r.history, nil
 }
 
-func (r *sandboxRowsEventRepo) GetContainerEvents(_ context.Context, containerID string, _ types.EventQuery) (*types.ContainerEventsResponse, error) {
+func (r *sandboxRowsEventRepo) GetContainerEvents(_ context.Context, containerID string, query types.EventQuery) (*types.ContainerEventsResponse, error) {
+	query.ContainerID = containerID
+	r.containerQueries = append(r.containerQueries, query)
 	return r.containers[containerID], nil
 }
 
@@ -300,8 +303,8 @@ func TestBuildSandboxStatsRowsUsesAppHistoryForAppNamespaceStats(t *testing.T) {
 	if got, want := len(rows), 3; got != want {
 		t.Fatalf("expected %d sandbox stats rows, got %d", want, got)
 	}
-	if got := len(eventRepo.queries); got != 2 {
-		t.Fatalf("expected one app namespace history query and one legacy fallback query, got %d", got)
+	if got := len(eventRepo.queries); got != 3 {
+		t.Fatalf("expected app, legacy, and bounded stub fallback history queries, got %d", got)
 	}
 	query := eventRepo.queries[0]
 	if query.AppID != "app-1" {
@@ -313,6 +316,63 @@ func TestBuildSandboxStatsRowsUsesAppHistoryForAppNamespaceStats(t *testing.T) {
 	query = eventRepo.queries[1]
 	if query.AppID != "" || query.StubID != "" {
 		t.Fatalf("legacy query app_id/stub_id = %q/%q, want empty", query.AppID, query.StubID)
+	}
+	query = eventRepo.queries[2]
+	if query.AppID != "" || query.StubID != "sandbox-stub" {
+		t.Fatalf("stub fallback query app_id/stub_id = %q/%q, want empty/sandbox-stub", query.AppID, query.StubID)
+	}
+}
+
+func TestBuildSandboxStatsRowsMergesStubFallbackForPartialAppHistory(t *testing.T) {
+	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
+	stubs := []types.StubWithRelated{{
+		Stub: types.Stub{
+			ExternalId: "sandbox-stub",
+			Name:       "sandbox",
+			CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+		},
+	}}
+
+	appHistory := []types.ContainerEventRecord{
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(900 * time.Millisecond)},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSandboxProcessManagerReady), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(900 * time.Millisecond), EndTime: base.Add(1200 * time.Millisecond)},
+		{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(2 * time.Second)},
+	}
+	stubHistory := append([]types.ContainerEventRecord{}, appHistory...)
+	stubHistory = append(stubHistory,
+		types.ContainerEventRecord{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(10 * time.Second)},
+		types.ContainerEventRecord{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(10*time.Second + 100*time.Millisecond), EndTime: base.Add(11 * time.Second)},
+		types.ContainerEventRecord{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSandboxProcessManagerReady), ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", StartTime: base.Add(11 * time.Second), EndTime: base.Add(12 * time.Second)},
+		types.ContainerEventRecord{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-22222222", WorkspaceID: "workspace", StubID: "sandbox-stub", Timestamp: base.Add(13 * time.Second)},
+	)
+
+	eventRepo := &sandboxRowsEventRepo{
+		history: &types.EventHistoryResponse{Events: appHistory},
+		historiesByStub: map[string]*types.EventHistoryResponse{
+			"sandbox-stub": {Events: stubHistory},
+		},
+	}
+	group := &StubGroup{eventRepo: eventRepo}
+
+	rows := group.buildSandboxStatsRows(context.Background(), "workspace", "app-1", stubs, nil)
+	if got, want := len(rows), 2; got != want {
+		t.Fatalf("expected %d sandbox stats rows, got %d", want, got)
+	}
+
+	rowsByContainer := map[string]SandboxRow{}
+	for _, row := range rows {
+		rowsByContainer[row.ContainerId] = row
+	}
+	if _, ok := rowsByContainer["sandbox-stub-11111111"]; !ok {
+		t.Fatalf("missing app-history row: %#v", rows)
+	}
+	fallback := rowsByContainer["sandbox-stub-22222222"]
+	if fallback.TimeToInteractiveMs == nil || *fallback.TimeToInteractiveMs != 2000 {
+		t.Fatalf("fallback time_to_interactive_ms = %v, want 2000", fallback.TimeToInteractiveMs)
+	}
+	if fallback.LifetimeMs == nil || *fallback.LifetimeMs != 2000 {
+		t.Fatalf("fallback lifetime_ms = %v, want 2000", fallback.LifetimeMs)
 	}
 }
 
@@ -364,6 +424,82 @@ func TestBuildSandboxStatsRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 	}
 	if row.LifetimeMs == nil || *row.LifetimeMs <= 0 {
 		t.Fatalf("lifetime_ms = %v, want a positive running lifetime", row.LifetimeMs)
+	}
+}
+
+func TestBuildSandboxRowsHydratesMissingTimingFromContainerStream(t *testing.T) {
+	base := time.Date(2026, 6, 16, 20, 1, 0, 0, time.UTC)
+	stub := types.StubWithRelated{
+		Stub: types.Stub{
+			ExternalId: "sandbox-stub",
+			Name:       "sandbox",
+			CreatedAt:  types.Time{Time: base.Add(-time.Hour)},
+		},
+	}
+
+	containerID := "sandbox-stub-22222222"
+	historyEvents := []types.ContainerEventRecord{
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(100 * time.Millisecond), EndTime: base.Add(1500 * time.Millisecond)},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSandboxProcessManagerReady), ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(1500 * time.Millisecond), EndTime: base.Add(2500 * time.Millisecond)},
+		{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: "sandbox-stub-11111111", WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(3 * time.Second)},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: containerID, WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(10 * time.Second)},
+		{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: containerID, WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(13 * time.Second)},
+	}
+	canonicalEvents := []types.ContainerEventRecord{
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSchedulerQueuePush), ContainerID: containerID, WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(10 * time.Second)},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleStartup), ContainerID: containerID, WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(10*time.Second + 100*time.Millisecond), EndTime: base.Add(11 * time.Second)},
+		{Type: types.EventContainerLifecycle, EventID: string(types.ContainerLifecycleSandboxProcessManagerReady), ContainerID: containerID, WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", StartTime: base.Add(11 * time.Second), EndTime: base.Add(12 * time.Second)},
+		{Type: types.EventContainerEvent, EventID: "runtime.exited", ContainerID: containerID, WorkspaceID: "workspace", AppID: "app-1", StubID: "sandbox-stub", Timestamp: base.Add(13 * time.Second)},
+	}
+
+	eventRepo := &sandboxRowsEventRepo{
+		containers: map[string]*types.ContainerEventsResponse{
+			containerID: {ContainerID: containerID, Events: canonicalEvents},
+		},
+	}
+	group := &StubGroup{eventRepo: eventRepo}
+
+	rows := group.buildSandboxRowsWithPreloadedSummaries(
+		context.Background(),
+		"workspace",
+		&stub,
+		nil,
+		50,
+		sandboxContainerSummariesFromHistory(historyEvents, 0),
+	)
+	if got, want := len(rows), 2; got != want {
+		t.Fatalf("expected %d sandbox rows, got %d", want, got)
+	}
+
+	var hydrated *SandboxRow
+	for i := range rows {
+		if rows[i].ContainerId == containerID {
+			hydrated = &rows[i]
+			break
+		}
+	}
+	if hydrated == nil {
+		t.Fatalf("expected row for %s, got %#v", containerID, rows)
+	}
+	if hydrated.TimeToStartedMs == nil || *hydrated.TimeToStartedMs != 1000 {
+		t.Fatalf("time_to_started_ms = %v, want 1000", hydrated.TimeToStartedMs)
+	}
+	if hydrated.TimeToInteractiveMs == nil || *hydrated.TimeToInteractiveMs != 2000 {
+		t.Fatalf("time_to_interactive_ms = %v, want 2000", hydrated.TimeToInteractiveMs)
+	}
+	if hydrated.LifetimeMs == nil || *hydrated.LifetimeMs != 2000 {
+		t.Fatalf("lifetime_ms = %v, want 2000", hydrated.LifetimeMs)
+	}
+	if got := len(eventRepo.containerQueries); got != 1 {
+		t.Fatalf("expected one canonical container lookup, got %d", got)
+	}
+	query := eventRepo.containerQueries[0]
+	if query.ContainerID != containerID || query.StubID != "sandbox-stub" || query.WorkspaceID != "workspace" {
+		t.Fatalf("unexpected container lookup query: %#v", query)
+	}
+	if query.Limit != sandboxContainerHistoryLimit {
+		t.Fatalf("container lookup limit = %d, want %d", query.Limit, sandboxContainerHistoryLimit)
 	}
 }
 

--- a/sdk/src/beta9/abstractions/sandbox.py
+++ b/sdk/src/beta9/abstractions/sandbox.py
@@ -91,7 +91,7 @@ class Sandbox(Pod):
         authorized (bool):
             Whether the sandbox should be authorized for external access. Default is False.
         name (str):
-            The name of the Sandbox app. Default is none, which means you must provide it during deployment.
+            Assign the sandbox to an app namespace. If the app does not exist, it will be created with the given name.
         volumes (List[Union[Volume, CloudBucket]]):
             The volumes and/or cloud buckets to mount into the Sandbox container. Default is an empty list.
         secrets (List[str]):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes real-time timing in the sandbox table by backfilling missing metrics from canonical container events and recent history. Ensures time-to-started, time-to-interactive, and lifetime are accurate for both active and completed containers.

- **Bug Fixes**
  - Hydrates missing timing fields from container event streams; bounded by `sandboxTimingHydrationLimit`.
  - Merges recent stub history into app stats to cover partial app history; bounded by `sandboxStatsFallbackStubLimit`.
  - Applies timing to active and inactive rows; respects stored lifetime for completed runs.
  - Caps container history lookups at `sandboxContainerHistoryLimit` and de-dupes by container.
  - Bench: adds `--sandbox-app-name` to set the sandbox app namespace.
  - SDK: clarifies `Sandbox.name` assigns the sandbox to an app namespace.

<sup>Written for commit 56c25ee98181ed41fb567b2e070fc4f729fedb7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

