### PR TITLE
fix sandbox metrics chart

### DIFF
--- a/pkg/api/v1/metrics.go
+++ b/pkg/api/v1/metrics.go
@@ -123,6 +123,7 @@ func (g *MetricsGroup) GetWorkspaceMetricTimeseries(ctx echo.Context) error {
 	response, err := g.eventRepo.GetWorkspaceMetricsTimeseries(ctx.Request().Context(), types.EventQuery{
 		WorkspaceID: workspaceID,
 		StubType:    ctx.QueryParam("stub_type"),
+		AppID:       ctx.QueryParam("app_id"),
 		EventTypes:  []string{types.EventContainerMetrics},
 	}, start.UTC(), end.UTC(), interval)
 	if err != nil {

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -1235,13 +1235,11 @@ func (g *StubGroup) buildActiveSandboxRow(ctx context.Context, workspaceID strin
 	if container.StartedAt > 0 && container.ScheduledAt > 0 && container.StartedAt >= container.ScheduledAt {
 		tts := (container.StartedAt - container.ScheduledAt) * 1000
 		row.TimeToStartedMs = &tts
-		row.TimeToInteractiveMs = &tts
 	}
 
 	if isActiveSandboxStatus(row.Status) && container.StartedAt > 0 {
 		startedAtMs := container.StartedAt * 1000
 		row.StartedAtMs = &startedAtMs
-		row.InteractiveAtMs = &startedAtMs
 
 		lifetime := (time.Now().Unix() - container.StartedAt) * 1000
 		if lifetime >= 0 {
@@ -1314,10 +1312,10 @@ func sandboxContainerStateNeedsSummary(container types.ContainerState) bool {
 	if container.ContainerId == "" {
 		return false
 	}
-	if container.ScheduledAt <= 0 {
+	if isActiveSandboxStatus(string(container.Status)) {
 		return true
 	}
-	if isActiveSandboxStatus(string(container.Status)) && container.StartedAt <= 0 {
+	if container.ScheduledAt <= 0 {
 		return true
 	}
 	return container.StartedAt > 0 && container.ScheduledAt > 0 && container.StartedAt < container.ScheduledAt
@@ -1330,16 +1328,16 @@ func applySandboxSummaryToRow(row *SandboxRow, summary sandboxContainerSummary, 
 	if !summary.CreatedAt.IsZero() {
 		row.CreatedAt = summary.CreatedAt
 	}
-	if row.TimeToStartedMs == nil && summary.TimeToStartedMs != nil {
+	if summary.TimeToStartedMs != nil {
 		row.TimeToStartedMs = summary.TimeToStartedMs
 	}
-	if row.TimeToInteractiveMs == nil && summary.TimeToInteractiveMs != nil {
+	if summary.TimeToInteractiveMs != nil {
 		row.TimeToInteractiveMs = summary.TimeToInteractiveMs
 	}
-	if row.StartedAtMs == nil && summary.StartedAtMs != nil {
+	if summary.StartedAtMs != nil {
 		row.StartedAtMs = summary.StartedAtMs
 	}
-	if row.InteractiveAtMs == nil && summary.InteractiveAtMs != nil {
+	if summary.InteractiveAtMs != nil {
 		row.InteractiveAtMs = summary.InteractiveAtMs
 	}
 

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -245,6 +245,8 @@ func TestBuildSandboxRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 			ContainerId: "sandbox-stub-11111111",
 			StubId:      "sandbox-stub",
 			Status:      types.ContainerStatusRunning,
+			ScheduledAt: base.Unix(),
+			StartedAt:   base.Add(time.Second).Unix(),
 		},
 	}, 1)
 	if got, want := len(rows), 1; got != want {
@@ -400,6 +402,8 @@ func TestBuildSandboxStatsRowsEnrichesActiveTimingFromHistory(t *testing.T) {
 				ContainerId: "sandbox-stub-11111111",
 				StubId:      "sandbox-stub",
 				Status:      types.ContainerStatusRunning,
+				ScheduledAt: base.Unix(),
+				StartedAt:   base.Add(time.Second).Unix(),
 			},
 		},
 	})

--- a/pkg/repository/events.go
+++ b/pkg/repository/events.go
@@ -826,6 +826,7 @@ func (r *EventClientRepo) PushContainerResourceMetricsEvent(workerID string, req
 			WorkspaceID:      request.WorkspaceId,
 			StubID:           request.StubId,
 			StubType:         string(request.Stub.Type.Kind()),
+			AppID:            request.AppId,
 			CPU:              request.Cpu,
 			GPUCount:         request.GpuCount,
 			ContainerMetrics: metrics,
@@ -1123,7 +1124,7 @@ func firstNonEmpty(values ...string) string {
 func eventMetadataFromData(data interface{}) eventMetadata {
 	switch d := data.(type) {
 	case types.EventContainerMetricsSchema:
-		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID}
+		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID, AppID: d.AppID}
 	case types.EventContainerLifecycleSchema:
 		return eventMetadata{ContainerID: d.ContainerID, StubID: d.StubID, TaskID: d.TaskID, WorkerID: d.WorkerID, WorkspaceID: d.WorkspaceID, AppID: d.AppID}
 	case types.EventContainerEventSchema:

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -1891,6 +1891,7 @@ func augmentContainerEventResponse(response *types.ContainerEventsResponse, reco
 		record.StubID = metrics.StubID
 		record.StubType = metrics.StubType
 		record.WorkspaceID = metrics.WorkspaceID
+		record.AppID = metrics.AppID
 		record.WorkerID = metrics.WorkerID
 		if response.WorkspaceID == "" {
 			response.WorkspaceID = metrics.WorkspaceID

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -121,7 +121,7 @@ func (r *S2EventRepository) GetStubMetricsTimeseries(ctx context.Context, query 
 		return response, nil
 	}
 
-	return r.getMetricsTimeseries(ctx, r.stubStreamName(query.WorkspaceID, query.StubID), start, end, interval, query.StubType)
+	return r.getMetricsTimeseries(ctx, r.stubStreamName(query.WorkspaceID, query.StubID), start, end, interval, query)
 }
 
 func (r *S2EventRepository) GetWorkspaceMetricsTimeseries(ctx context.Context, query types.EventQuery, start time.Time, end time.Time, interval string) (*types.MetricsTimeseriesResponse, error) {
@@ -130,10 +130,10 @@ func (r *S2EventRepository) GetWorkspaceMetricsTimeseries(ctx context.Context, q
 		return response, nil
 	}
 
-	return r.getMetricsTimeseries(ctx, r.workspaceStreamName(query.WorkspaceID), start, end, interval, query.StubType)
+	return r.getMetricsTimeseries(ctx, r.workspaceStreamName(query.WorkspaceID), start, end, interval, query)
 }
 
-func (r *S2EventRepository) getMetricsTimeseries(ctx context.Context, streamName s2.StreamName, start time.Time, end time.Time, interval string, stubTypeFilter string) (*types.MetricsTimeseriesResponse, error) {
+func (r *S2EventRepository) getMetricsTimeseries(ctx context.Context, streamName s2.StreamName, start time.Time, end time.Time, interval string, query types.EventQuery) (*types.MetricsTimeseriesResponse, error) {
 	response := &types.MetricsTimeseriesResponse{}
 	buckets := map[int64]*metricsBucketAccumulator{}
 	seqNum := uint64(0)
@@ -166,7 +166,10 @@ func (r *S2EventRepository) getMetricsTimeseries(ctx context.Context, streamName
 			if !ok {
 				continue
 			}
-			if stubTypeFilter != "" && types.StubType(metrics.StubType).Kind() != stubTypeFilter {
+			if !metricsRecordMatchesQuery(record, metrics, query) {
+				continue
+			}
+			if query.StubType != "" && types.StubType(metrics.StubType).Kind() != query.StubType {
 				continue
 			}
 			if eventTime.Before(start) || !eventTime.Before(end) {
@@ -603,6 +606,21 @@ func containerMetricsFromS2(record s2.SequencedRecord) (types.EventContainerMetr
 		envelope.Time = time.UnixMilli(int64(record.Timestamp)).UTC()
 	}
 	return envelope.Data, envelope.Time, true
+}
+
+func metricsRecordMatchesQuery(record s2.SequencedRecord, metrics types.EventContainerMetricsSchema, query types.EventQuery) bool {
+	if query.AppID == "" {
+		return true
+	}
+
+	headerAppID, hasAppIDHeader := s2RecordHeader(record, "app_id")
+	if hasAppIDHeader && headerAppID != query.AppID {
+		return false
+	}
+	if !hasAppIDHeader && metrics.AppID != query.AppID {
+		return false
+	}
+	return metrics.AppID == "" || metrics.AppID == query.AppID
 }
 
 func metricsBucketKey(t time.Time, interval string) int64 {

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -864,6 +864,35 @@ func TestLogRecordHeadersSkipDemultiplexesByTaskHeader(t *testing.T) {
 	}
 }
 
+func TestMetricsRecordMatchesAppScopedQuery(t *testing.T) {
+	query := types.EventQuery{AppID: "app-1"}
+	matchingPayload := types.EventContainerMetricsSchema{AppID: "app-1"}
+	otherPayload := types.EventContainerMetricsSchema{AppID: "app-2"}
+
+	if !metricsRecordMatchesQuery(s2.SequencedRecord{}, matchingPayload, query) {
+		t.Fatal("expected matching payload app id to pass")
+	}
+	if metricsRecordMatchesQuery(s2.SequencedRecord{}, types.EventContainerMetricsSchema{}, query) {
+		t.Fatal("expected app-scoped query to reject records without app id")
+	}
+	if metricsRecordMatchesQuery(s2.SequencedRecord{}, otherPayload, query) {
+		t.Fatal("expected mismatched payload app id to be rejected")
+	}
+
+	matchingHeader := s2.SequencedRecord{Headers: []s2.Header{s2.NewHeader("app_id", "app-1")}}
+	if !metricsRecordMatchesQuery(matchingHeader, types.EventContainerMetricsSchema{}, query) {
+		t.Fatal("expected matching app header to pass legacy payload")
+	}
+	if metricsRecordMatchesQuery(matchingHeader, otherPayload, query) {
+		t.Fatal("expected mismatched payload to reject even with a matching header")
+	}
+
+	otherHeader := s2.SequencedRecord{Headers: []s2.Header{s2.NewHeader("app_id", "app-2")}}
+	if metricsRecordMatchesQuery(otherHeader, matchingPayload, query) {
+		t.Fatal("expected mismatched app header to be rejected")
+	}
+}
+
 func TestTaskEventSchemaIncludesStubTypeAndDeploymentContext(t *testing.T) {
 	version := uint(7)
 	deploymentID := "deployment-123"

--- a/pkg/repository/events_test.go
+++ b/pkg/repository/events_test.go
@@ -294,6 +294,7 @@ func TestPushContainerResourceMetricsEventIncludesReservedResources(t *testing.T
 		ContainerId: "container-1",
 		StubId:      "stub-1",
 		WorkspaceId: "workspace-1",
+		AppId:       "app-1",
 		Cpu:         2500,
 		GpuCount:    2,
 		Stub: types.StubWithRelated{
@@ -318,6 +319,12 @@ func TestPushContainerResourceMetricsEventIncludesReservedResources(t *testing.T
 	}
 	if got, want := event.GPUCount, request.GpuCount; got != want {
 		t.Fatalf("unexpected gpu count: got %d want %d", got, want)
+	}
+	if got, want := event.AppID, request.AppId; got != want {
+		t.Fatalf("unexpected app id: got %q want %q", got, want)
+	}
+	if got, want := sink.events[0].Extensions()["appid"], request.AppId; got != want {
+		t.Fatalf("unexpected app extension: got %q want %q", got, want)
 	}
 }
 

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -134,6 +134,7 @@ type EventContainerMetricsSchema struct {
 	WorkspaceID      string                    `json:"workspace_id"`
 	StubID           string                    `json:"stub_id"`
 	StubType         string                    `json:"stub_type,omitempty"`
+	AppID            string                    `json:"app_id,omitempty"`
 	CPU              int64                     `json:"cpu,omitempty"`
 	GPUCount         uint32                    `json:"gpu_count,omitempty"`
 	ContainerMetrics EventContainerMetricsData `json:"metrics"`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the sandbox metrics chart by scoping resource metrics to the selected app and correctly populating active sandbox timing.

- **Bug Fixes**
  - Add app-scoped filtering to metrics timeseries: read `app_id` from the API, pass it in `EventQuery`, and filter S2 records by header or payload so charts only include the selected app.
  - Include `AppID` in `EventContainerMetricsSchema` and propagate through repositories and CloudEvents extensions to enable accurate matching.
  - Correct active sandbox timing: stop defaulting `TimeToInteractiveMs`/`InteractiveAtMs` to started time, allow history summary to override fields, and adjust summary-needed logic. Tests added for app scoping and timing enrichment.

<sup>Written for commit bef27051e93c6e9da6807b2d646d6a20723ab3cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

