### PR TITLE
fix: container port proxy for ipv6/ipv4 cross compat

### DIFF
--- a/pkg/worker/container_network.go
+++ b/pkg/worker/container_network.go
@@ -52,33 +52,6 @@ type agentContainerNetwork struct {
 	*localContainerNetwork
 }
 
-func (m *agentContainerNetwork) ContainerPortAddress(containerId string, binding PortBinding) (string, error) {
-	info, err := m.getContainerNetworkInfo(containerId)
-	if err != nil {
-		return "", err
-	}
-	if info.ContainerIp == "" {
-		return "", fmt.Errorf("container %s has no bridge IP", containerId)
-	}
-	return joinHostPort(info.ContainerIp, binding.ContainerPort), nil
-}
-
-func (m *agentContainerNetwork) ContainerPortAddressMap(containerId string, bindings []PortBinding) (map[int32]string, error) {
-	info, err := m.getContainerNetworkInfo(containerId)
-	if err != nil {
-		return nil, err
-	}
-	if info.ContainerIp == "" {
-		return nil, fmt.Errorf("container %s has no bridge IP", containerId)
-	}
-
-	addressMap := make(map[int32]string, len(bindings))
-	for _, binding := range bindings {
-		addressMap[int32(binding.ContainerPort)] = joinHostPort(info.ContainerIp, binding.ContainerPort)
-	}
-	return addressMap, nil
-}
-
 func joinHostPort(host string, port int) string {
 	host = strings.TrimSpace(host)
 	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {

--- a/pkg/worker/container_network.go
+++ b/pkg/worker/container_network.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -32,7 +33,7 @@ func (m *localContainerNetwork) ContainerPortAddress(_ string, binding PortBindi
 	if m.podAddr == "" {
 		return "", fmt.Errorf("pod address is empty")
 	}
-	return net.JoinHostPort(m.podAddr, strconv.Itoa(binding.HostPort)), nil
+	return joinHostPort(m.podAddr, binding.HostPort), nil
 }
 
 func (m *localContainerNetwork) ContainerPortAddressMap(containerId string, bindings []PortBinding) (map[int32]string, error) {
@@ -59,7 +60,7 @@ func (m *agentContainerNetwork) ContainerPortAddress(containerId string, binding
 	if info.ContainerIp == "" {
 		return "", fmt.Errorf("container %s has no bridge IP", containerId)
 	}
-	return net.JoinHostPort(info.ContainerIp, strconv.Itoa(binding.ContainerPort)), nil
+	return joinHostPort(info.ContainerIp, binding.ContainerPort), nil
 }
 
 func (m *agentContainerNetwork) ContainerPortAddressMap(containerId string, bindings []PortBinding) (map[int32]string, error) {
@@ -73,12 +74,24 @@ func (m *agentContainerNetwork) ContainerPortAddressMap(containerId string, bind
 
 	addressMap := make(map[int32]string, len(bindings))
 	for _, binding := range bindings {
-		addressMap[int32(binding.ContainerPort)] = net.JoinHostPort(info.ContainerIp, strconv.Itoa(binding.ContainerPort))
+		addressMap[int32(binding.ContainerPort)] = joinHostPort(info.ContainerIp, binding.ContainerPort)
 	}
 	return addressMap, nil
 }
 
+func joinHostPort(host string, port int) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		unwrapped := strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+		if net.ParseIP(unwrapped) != nil {
+			host = unwrapped
+		}
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 func newContainerNetwork(base *ContainerNetworkManager, podAddr string, persistent bool, machineID, transport string) ContainerNetwork {
+	base.podAddr = podAddr
 	local := &localContainerNetwork{
 		ContainerNetworkManager: base,
 		podAddr:                 podAddr,

--- a/pkg/worker/container_network_test.go
+++ b/pkg/worker/container_network_test.go
@@ -46,7 +46,7 @@ func TestNewContainerNetworkFormatsBracketedIPv6PodAddress(t *testing.T) {
 	}, addressMap)
 }
 
-func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testing.T) {
+func TestNewContainerNetworkUsesExposedHostPortForPersistentMachine(t *testing.T) {
 	containerID := "container-one"
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
 	containerInstances.Set(containerID, &ContainerInstance{
@@ -61,7 +61,7 @@ func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testi
 
 	address, err := network.ContainerPortAddress(containerID, PortBinding{HostPort: 32000, ContainerPort: 8001})
 	require.NoError(t, err)
-	require.Equal(t, "192.168.0.44:8001", address)
+	require.Equal(t, "127.0.0.1:32000", address)
 
 	addressMap, err := network.ContainerPortAddressMap(containerID, []PortBinding{
 		{HostPort: 32000, ContainerPort: 8001},
@@ -69,12 +69,12 @@ func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testi
 	})
 	require.NoError(t, err)
 	require.Equal(t, map[int32]string{
-		8001: "192.168.0.44:8001",
-		2222: "192.168.0.44:2222",
+		8001: "127.0.0.1:32000",
+		2222: "127.0.0.1:32001",
 	}, addressMap)
 }
 
-func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
+func TestNewContainerNetworkFormatsPersistentIPv6HostAddress(t *testing.T) {
 	containerID := "container-one"
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
 	containerInstances.Set(containerID, &ContainerInstance{
@@ -82,11 +82,11 @@ func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
 		ContainerIp: "fd00:abcd::3f",
 	})
 
-	network := newContainerNetwork(&ContainerNetworkManager{containerInstances: containerInstances}, "127.0.0.1", true, "machine-one", "tsnet_restricted")
+	network := newContainerNetwork(&ContainerNetworkManager{containerInstances: containerInstances}, "[::1]", true, "machine-one", "tsnet_restricted")
 
 	address, err := network.ContainerPortAddress(containerID, PortBinding{HostPort: 32000, ContainerPort: 8001})
 	require.NoError(t, err)
-	require.Equal(t, "[fd00:abcd::3f]:8001", address)
+	require.Equal(t, "[::1]:32000", address)
 
 	addressMap, err := network.ContainerPortAddressMap(containerID, []PortBinding{
 		{HostPort: 32000, ContainerPort: 8001},
@@ -94,7 +94,7 @@ func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, map[int32]string{
-		8001: "[fd00:abcd::3f]:8001",
-		2222: "[fd00:abcd::3f]:2222",
+		8001: "[::1]:32000",
+		2222: "[::1]:32001",
 	}, addressMap)
 }

--- a/pkg/worker/container_network_test.go
+++ b/pkg/worker/container_network_test.go
@@ -28,6 +28,24 @@ func TestNewContainerNetworkUsesLocalImplementationByDefault(t *testing.T) {
 	}, addressMap)
 }
 
+func TestNewContainerNetworkFormatsBracketedIPv6PodAddress(t *testing.T) {
+	network := newContainerNetwork(&ContainerNetworkManager{}, "[2600:1f18:37a4:c02::7286]", false, "", "")
+
+	address, err := network.ContainerPortAddress("container-one", PortBinding{HostPort: 32000, ContainerPort: 8001})
+	require.NoError(t, err)
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:32000", address)
+
+	addressMap, err := network.ContainerPortAddressMap("container-one", []PortBinding{
+		{HostPort: 32000, ContainerPort: 8001},
+		{HostPort: 32001, ContainerPort: 2222},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[int32]string{
+		8001: "[2600:1f18:37a4:c02::7286]:32000",
+		2222: "[2600:1f18:37a4:c02::7286]:32001",
+	}, addressMap)
+}
+
 func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testing.T) {
 	containerID := "container-one"
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
@@ -53,5 +71,30 @@ func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testi
 	require.Equal(t, map[int32]string{
 		8001: "192.168.0.44:8001",
 		2222: "192.168.0.44:2222",
+	}, addressMap)
+}
+
+func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
+	containerID := "container-one"
+	containerInstances := common.NewSafeMap[*ContainerInstance]()
+	containerInstances.Set(containerID, &ContainerInstance{
+		Id:          containerID,
+		ContainerIp: "fd00:abcd::3f",
+	})
+
+	network := newContainerNetwork(&ContainerNetworkManager{containerInstances: containerInstances}, "127.0.0.1", true, "machine-one", "tsnet_restricted")
+
+	address, err := network.ContainerPortAddress(containerID, PortBinding{HostPort: 32000, ContainerPort: 8001})
+	require.NoError(t, err)
+	require.Equal(t, "[fd00:abcd::3f]:8001", address)
+
+	addressMap, err := network.ContainerPortAddressMap(containerID, []PortBinding{
+		{HostPort: 32000, ContainerPort: 8001},
+		{HostPort: 32001, ContainerPort: 2222},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[int32]string{
+		8001: "[fd00:abcd::3f]:8001",
+		2222: "[fd00:abcd::3f]:2222",
 	}, addressMap)
 }

--- a/pkg/worker/container_port_proxy.go
+++ b/pkg/worker/container_port_proxy.go
@@ -1,0 +1,349 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	containerPortProxyReadyPollInterval = 100 * time.Millisecond
+	containerPortProxyDialTimeout       = 250 * time.Millisecond
+	containerPortProxyConnectTimeout    = 2 * time.Second
+)
+
+type containerPortExposure struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	containerID   string
+	hostPort      int
+	containerPort int
+	proxyMu       sync.Mutex
+	proxy         *containerPortProxy
+}
+
+type containerPortProxy struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	containerID   string
+	hostPort      int
+	containerPort int
+	listenNetwork string
+	listenAddress string
+	targets       []string
+	ready         chan struct{}
+	readyOnce     sync.Once
+	listenerMu    sync.Mutex
+	listener      net.Listener
+}
+
+func newContainerPortExposure(parent context.Context, containerID string, binding PortBinding) *containerPortExposure {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &containerPortExposure{
+		ctx:           ctx,
+		cancel:        cancel,
+		containerID:   containerID,
+		hostPort:      binding.HostPort,
+		containerPort: binding.ContainerPort,
+	}
+}
+
+func (e *containerPortExposure) startProxy(family addressFamily, targets []string) {
+	if len(targets) == 0 || e.ctx.Err() != nil {
+		return
+	}
+
+	proxy := newContainerPortProxy(e.ctx, e.containerID, PortBinding{
+		HostPort:      e.hostPort,
+		ContainerPort: e.containerPort,
+	}, family, targets)
+
+	e.proxyMu.Lock()
+	if e.ctx.Err() != nil {
+		e.proxyMu.Unlock()
+		proxy.close()
+		return
+	}
+	e.proxy = proxy
+	e.proxyMu.Unlock()
+
+	go proxy.run()
+}
+
+func (e *containerPortExposure) close() {
+	e.cancel()
+	e.proxyMu.Lock()
+	proxy := e.proxy
+	e.proxy = nil
+	e.proxyMu.Unlock()
+	if proxy != nil {
+		proxy.close()
+	}
+}
+
+func newContainerPortProxy(parent context.Context, containerID string, binding PortBinding, family addressFamily, targets []string) *containerPortProxy {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	listenNetwork, listenAddress := containerPortProxyListenConfig(binding.HostPort, family)
+	return &containerPortProxy{
+		ctx:           ctx,
+		cancel:        cancel,
+		containerID:   containerID,
+		hostPort:      binding.HostPort,
+		containerPort: binding.ContainerPort,
+		listenNetwork: listenNetwork,
+		listenAddress: listenAddress,
+		targets:       append([]string(nil), targets...),
+		ready:         make(chan struct{}),
+	}
+}
+
+type addressFamily int
+
+const (
+	addressFamilyUnknown addressFamily = iota
+	addressFamilyIPv4
+	addressFamilyIPv6
+)
+
+func addressFamilyForHost(host string) addressFamily {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return addressFamilyUnknown
+	}
+	if ip.To4() != nil {
+		return addressFamilyIPv4
+	}
+	return addressFamilyIPv6
+}
+
+func containerPortTargets(info *containerNetworkInfo, containerPort int, family addressFamily) (native, fallback string) {
+	if info == nil {
+		return "", ""
+	}
+
+	port := strconv.Itoa(containerPort)
+	ipv4 := ""
+	if info.ContainerIp != "" {
+		ipv4 = net.JoinHostPort(info.ContainerIp, port)
+	}
+	ipv6 := ""
+	if info.ContainerIpv6 != "" {
+		ipv6 = net.JoinHostPort(info.ContainerIpv6, port)
+	}
+
+	switch family {
+	case addressFamilyIPv6:
+		return ipv6, ipv4
+	case addressFamilyIPv4:
+		return ipv4, ipv6
+	default:
+		return ipv4, ipv6
+	}
+}
+
+func containerPortProxyListenConfig(hostPort int, family addressFamily) (network, address string) {
+	port := strconv.Itoa(hostPort)
+	switch family {
+	case addressFamilyIPv6:
+		return "tcp6", net.JoinHostPort("::", port)
+	case addressFamilyIPv4:
+		return "tcp4", net.JoinHostPort("0.0.0.0", port)
+	default:
+		return "tcp", net.JoinHostPort("", port)
+	}
+}
+
+func (p *containerPortProxy) run() {
+	if err := p.waitForBackend(); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.Debug().
+				Err(err).
+				Str("container_id", p.containerID).
+				Int("host_port", p.hostPort).
+				Int("container_port", p.containerPort).
+				Msg("container port proxy stopped before backend became reachable")
+		}
+		return
+	}
+
+	listener, err := net.Listen(p.listenNetwork, p.listenAddress)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("container_id", p.containerID).
+			Int("host_port", p.hostPort).
+			Int("container_port", p.containerPort).
+			Str("listen_network", p.listenNetwork).
+			Str("listen_address", p.listenAddress).
+			Msg("failed to start container port proxy")
+		return
+	}
+
+	p.listenerMu.Lock()
+	p.listener = listener
+	p.listenerMu.Unlock()
+	p.readyOnce.Do(func() { close(p.ready) })
+	log.Debug().
+		Str("container_id", p.containerID).
+		Int("host_port", p.hostPort).
+		Int("container_port", p.containerPort).
+		Str("listen_network", p.listenNetwork).
+		Str("listen_address", p.listenAddress).
+		Strs("targets", p.targets).
+		Msg("container port proxy started")
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case <-p.ctx.Done():
+				return
+			default:
+				log.Debug().
+					Err(err).
+					Str("container_id", p.containerID).
+					Int("host_port", p.hostPort).
+					Msg("container port proxy accept failed")
+				return
+			}
+		}
+		go p.handle(conn)
+	}
+}
+
+func containerPortTargetReachable(ctx context.Context, target string, timeout time.Duration) bool {
+	if target == "" {
+		return false
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", target)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func (p *containerPortProxy) waitForBackend() error {
+	ticker := time.NewTicker(containerPortProxyReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		conn, err := p.dialBackend(containerPortProxyDialTimeout)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		select {
+		case <-p.ctx.Done():
+			return p.ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *containerPortProxy) handle(client net.Conn) {
+	defer client.Close()
+
+	backend, err := p.dialBackend(containerPortProxyConnectTimeout)
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Str("container_id", p.containerID).
+			Int("host_port", p.hostPort).
+			Int("container_port", p.containerPort).
+			Msg("container port proxy backend dial failed")
+		return
+	}
+	defer backend.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go proxyConnHalf(&wg, backend, client)
+	go proxyConnHalf(&wg, client, backend)
+	wg.Wait()
+}
+
+func proxyConnHalf(wg *sync.WaitGroup, dst, src net.Conn) {
+	defer wg.Done()
+	_, _ = io.Copy(dst, src)
+	if tcp, ok := dst.(*net.TCPConn); ok {
+		_ = tcp.CloseWrite()
+	}
+}
+
+func (p *containerPortProxy) dialBackend(timeout time.Duration) (net.Conn, error) {
+	if len(p.targets) == 0 {
+		return nil, fmt.Errorf("container port proxy has no backend targets")
+	}
+
+	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	defer cancel()
+
+	type dialResult struct {
+		target string
+		conn   net.Conn
+		err    error
+	}
+
+	results := make(chan dialResult, len(p.targets))
+	for _, target := range p.targets {
+		target := target
+		go func() {
+			dialer := &net.Dialer{}
+			conn, err := dialer.DialContext(ctx, "tcp", target)
+			select {
+			case results <- dialResult{target: target, conn: conn, err: err}:
+			case <-ctx.Done():
+				if conn != nil {
+					_ = conn.Close()
+				}
+			}
+		}()
+	}
+
+	var errs []error
+	for range p.targets {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Join(append(errs, ctx.Err())...)
+		case result := <-results:
+			if result.err == nil {
+				cancel()
+				return result.conn, nil
+			}
+			errs = append(errs, fmt.Errorf("%s: %w", result.target, result.err))
+		}
+	}
+	return nil, errors.Join(errs...)
+}
+
+func (p *containerPortProxy) close() {
+	p.cancel()
+	p.listenerMu.Lock()
+	if p.listener != nil {
+		_ = p.listener.Close()
+		p.listener = nil
+	}
+	p.listenerMu.Unlock()
+}

--- a/pkg/worker/container_port_proxy_test.go
+++ b/pkg/worker/container_port_proxy_test.go
@@ -1,0 +1,183 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerPortTargetsPreferNativeFamily(t *testing.T) {
+	info := &containerNetworkInfo{
+		ContainerIp:   "192.168.0.63",
+		ContainerIpv6: "fd00:abcd::3f",
+	}
+
+	native, fallback := containerPortTargets(info, 8781, addressFamilyIPv6)
+	require.Equal(t, "[fd00:abcd::3f]:8781", native)
+	require.Equal(t, "192.168.0.63:8781", fallback)
+
+	native, fallback = containerPortTargets(info, 8781, addressFamilyIPv4)
+	require.Equal(t, "192.168.0.63:8781", native)
+	require.Equal(t, "[fd00:abcd::3f]:8781", fallback)
+}
+
+func TestAddressFamilyForHostHandlesBracketedIPv6(t *testing.T) {
+	require.Equal(t, addressFamilyIPv6, addressFamilyForHost("[2600:1f18:37a4:c02::7286]"))
+	require.Equal(t, addressFamilyIPv4, addressFamilyForHost("10.42.0.34"))
+	require.Equal(t, addressFamilyUnknown, addressFamilyForHost("worker.local"))
+}
+
+func TestContainerPortProxyListenConfigUsesAdvertisedFamily(t *testing.T) {
+	network, address := containerPortProxyListenConfig(8781, addressFamilyIPv6)
+	require.Equal(t, "tcp6", network)
+	require.Equal(t, "[::]:8781", address)
+
+	network, address = containerPortProxyListenConfig(8781, addressFamilyIPv4)
+	require.Equal(t, "tcp4", network)
+	require.Equal(t, "0.0.0.0:8781", address)
+
+	network, address = containerPortProxyListenConfig(8781, addressFamilyUnknown)
+	require.Equal(t, "tcp", network)
+	require.Equal(t, ":8781", address)
+}
+
+func TestContainerPortProxyFallsBackToReachableBackendFamily(t *testing.T) {
+	backend := startLineServer(t, "tcp4", "127.0.0.1:0", "proxy-ok\n")
+	hostPort := freeTCPPortForNetwork(t, "tcp4", "127.0.0.1:0")
+	unusedIPv6Port, err := getRandomFreePort()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	proxy := newContainerPortProxy(ctx, "container-one", PortBinding{
+		HostPort:      hostPort,
+		ContainerPort: 8781,
+	}, addressFamilyIPv4, []string{
+		net.JoinHostPort("::1", fmt.Sprintf("%d", unusedIPv6Port)),
+		backend.Addr().String(),
+	})
+	defer proxy.close()
+	go proxy.run()
+
+	select {
+	case <-proxy.ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for port proxy to become ready")
+	}
+
+	conn, err := net.DialTimeout("tcp4", net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", hostPort)), time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("ping\n"))
+	require.NoError(t, err)
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "proxy-ok\n", line)
+}
+
+func TestContainerPortProxyAcceptsIPv6ForIPv4Backend(t *testing.T) {
+	backend := startLineServer(t, "tcp4", "127.0.0.1:0", "ipv6-to-ipv4-ok\n")
+	hostPort := freeTCPPortForNetwork(t, "tcp6", "[::1]:0")
+
+	proxy := startTestPortProxy(t, hostPort, addressFamilyIPv6, []string{backend.Addr().String()})
+	defer proxy.close()
+
+	line := dialLineServer(t, "tcp6", net.JoinHostPort("::1", fmt.Sprintf("%d", hostPort)))
+	require.Equal(t, "ipv6-to-ipv4-ok\n", line)
+}
+
+func TestContainerPortProxyAcceptsIPv4ForIPv6Backend(t *testing.T) {
+	backend := startLineServer(t, "tcp6", "[::1]:0", "ipv4-to-ipv6-ok\n")
+	hostPort := freeTCPPortForNetwork(t, "tcp4", "127.0.0.1:0")
+
+	proxy := startTestPortProxy(t, hostPort, addressFamilyIPv4, []string{backend.Addr().String()})
+	defer proxy.close()
+
+	line := dialLineServer(t, "tcp4", net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", hostPort)))
+	require.Equal(t, "ipv4-to-ipv6-ok\n", line)
+}
+
+func startTestPortProxy(t *testing.T, hostPort int, family addressFamily, targets []string) *containerPortProxy {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	proxy := newContainerPortProxy(ctx, "container-one", PortBinding{
+		HostPort:      hostPort,
+		ContainerPort: 8781,
+	}, family, targets)
+	go proxy.run()
+
+	select {
+	case <-proxy.ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for port proxy to become ready")
+	}
+	return proxy
+}
+
+func startLineServer(t *testing.T, network, address, response string) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen(network, address)
+	if err != nil && network == "tcp6" {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				if _, err := bufio.NewReader(conn).ReadString('\n'); err != nil {
+					return
+				}
+				_, _ = conn.Write([]byte(response))
+			}()
+		}
+	}()
+
+	return listener
+}
+
+func freeTCPPortForNetwork(t *testing.T, network, address string) int {
+	t.Helper()
+
+	listener, err := net.Listen(network, address)
+	if err != nil && network == "tcp6" {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+	defer listener.Close()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func dialLineServer(t *testing.T, network, address string) string {
+	t.Helper()
+
+	conn, err := net.DialTimeout(network, address, time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("ping\n"))
+	require.NoError(t, err)
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+	return line
+}

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -524,7 +524,7 @@ func (s *Worker) publishContainerAddresses(ctx context.Context, request *types.C
 
 	containerId := request.ContainerId
 	if len(bindings) > 0 {
-		containerAddr := fmt.Sprintf("%s:%d", s.podAddr, bindings[0].HostPort)
+		containerAddr := joinHostPort(s.podAddr, bindings[0].HostPort)
 		phaseStart := time.Now()
 		_, err := handleGRPCResponse(s.containerRepoClient.SetContainerAddress(context.Background(), &pb.SetContainerAddressRequest{
 			ContainerId: containerId,
@@ -540,7 +540,7 @@ func (s *Worker) publishContainerAddresses(ctx context.Context, request *types.C
 
 	addressMap := make(map[int32]string, len(bindings))
 	for _, binding := range bindings {
-		addressMap[int32(binding.ContainerPort)] = fmt.Sprintf("%s:%d", s.podAddr, binding.HostPort)
+		addressMap[int32(binding.ContainerPort)] = joinHostPort(s.podAddr, binding.HostPort)
 	}
 	s.cacheContainerAddressMap(containerId, addressMap)
 

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -260,6 +260,32 @@ func TestRegisterContainerPortsKeepsLocalAddressBehavior(t *testing.T) {
 	require.Equal(t, "10.0.0.2:30002", instance.ContainerAddressMap[2222])
 }
 
+func TestPublishContainerAddressesFormatsBracketedIPv6PodAddress(t *testing.T) {
+	containerID := "container-ipv6"
+	repoClient := &fakeContainerRepoClient{}
+	worker := &Worker{
+		containerRepoClient: repoClient,
+		containerInstances:  common.NewSafeMap[*ContainerInstance](),
+		podAddr:             "[2600:1f18:37a4:c02::7286]",
+	}
+	worker.containerInstances.Set(containerID, &ContainerInstance{})
+
+	err := worker.publishContainerAddresses(context.Background(), &types.ContainerRequest{
+		ContainerId: containerID,
+	}, []PortBinding{
+		{HostPort: 30001, ContainerPort: 8001},
+		{HostPort: 30002, ContainerPort: 2222},
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, repoClient.lastSetAddress)
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:30001", repoClient.lastSetAddress.Address)
+
+	require.NotNil(t, repoClient.lastSetAddressMap)
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:30001", repoClient.lastSetAddressMap.AddressMap[8001])
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:30002", repoClient.lastSetAddressMap.AddressMap[2222])
+}
+
 func TestPublishContainerAddressesSkipsAgentWorkers(t *testing.T) {
 	repoClient := &fakeContainerRepoClient{}
 	worker := &Worker{

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -70,9 +70,11 @@ type ContainerNetworkManager struct {
 	containerRepoClient pb.ContainerRepositoryServiceClient
 	eventRepo           repo.EventRepository
 	networkPrefix       string
+	podAddr             string
 	bridgeMu            sync.Mutex
 	ipMu                sync.Mutex
 	iptablesMu          sync.Mutex
+	portExposureMu      sync.Mutex
 	containerLocksMu    sync.Mutex
 	containerLocks      sync.Map
 	config              types.AppConfig
@@ -88,6 +90,7 @@ type ContainerNetworkManager struct {
 	slotMu              sync.Mutex
 	freeSlots           []*containerNetworkSlot
 	containerSlots      map[string]*containerNetworkSlot
+	portExposures       map[int]*containerPortExposure
 	totalSlots          int
 	slotFillRunning     bool
 	slotPoolClosed      bool
@@ -752,6 +755,8 @@ func (m *ContainerNetworkManager) deleteNetworkSlotResources(slotID string) {
 }
 
 func (m *ContainerNetworkManager) Close() error {
+	m.stopAllPortExposures()
+
 	slots := m.drainFreeNetworkSlots()
 	ctx, cancel := context.WithTimeout(context.Background(), workerShutdownRPCTimeout)
 	defer cancel()
@@ -2094,6 +2099,8 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 	unlockContainer := m.lockContainerNetwork(containerId)
 	defer unlockContainer()
 
+	m.stopContainerPortExposures(containerId)
+
 	if slot := m.containerNetworkSlot(containerId); slot != nil {
 		return m.tearDownPreallocatedNetworkSlot(containerId, slot)
 	}
@@ -2301,11 +2308,8 @@ func (m *ContainerNetworkManager) ExposePorts(containerId string, bindings []Por
 		return err
 	}
 
-	m.iptablesMu.Lock()
-	defer m.iptablesMu.Unlock()
-
 	for _, binding := range bindings {
-		if err := m.exposePortLocked(info, binding.HostPort, binding.ContainerPort); err != nil {
+		if err := m.startContainerPortExposure(containerId, info, binding); err != nil {
 			return err
 		}
 	}
@@ -2313,38 +2317,126 @@ func (m *ContainerNetworkManager) ExposePorts(containerId string, bindings []Por
 	return nil
 }
 
-func (m *ContainerNetworkManager) exposePortLocked(info *containerNetworkInfo, hostPort, containerPort int) error {
-	// Insert NAT PREROUTING rule at the top of the chain
-	// IPv4
-	err := m.ipt.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", info.ContainerIp, containerPort), "-m", "comment", "--comment", info.Comment)
-	if err != nil {
-		return err
+func (m *ContainerNetworkManager) startContainerPortExposure(containerId string, info *containerNetworkInfo, binding PortBinding) error {
+	family := addressFamilyForHost(m.podAddr)
+	native, fallback := containerPortTargets(info, binding.ContainerPort, family)
+	if native == "" && fallback == "" {
+		return fmt.Errorf("container %s has no network targets for port %d", containerId, binding.ContainerPort)
 	}
 
-	// IPv6
-	if m.ipt6 != nil && info.ContainerIpv6 != "" {
-		err = m.ipt6.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("[%s]:%d", info.ContainerIpv6, containerPort), "-m", "comment", "--comment", info.Comment)
-		if err != nil {
-			return err
+	exposure := newContainerPortExposure(m.ctx, containerId, binding)
+
+	m.portExposureMu.Lock()
+	if m.portExposures == nil {
+		m.portExposures = map[int]*containerPortExposure{}
+	}
+	if existing := m.portExposures[binding.HostPort]; existing != nil {
+		m.portExposureMu.Unlock()
+		if existing.containerID == containerId && existing.containerPort == binding.ContainerPort {
+			return nil
 		}
+		return fmt.Errorf("host port %d is already proxied for container %s port %d", binding.HostPort, existing.containerID, existing.containerPort)
 	}
+	m.portExposures[binding.HostPort] = exposure
+	m.portExposureMu.Unlock()
 
-	// Add FORWARD rule for the DNAT'd traffic
-	// IPv4
-	err = m.ipt.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIp, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment)
-	if err != nil {
-		return err
-	}
-
-	// IPv6
-	if m.ipt6 != nil && info.ContainerIpv6 != "" {
-		err = m.ipt6.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIpv6, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment)
-		if err != nil {
-			return err
-		}
-	}
-
+	go m.runContainerPortExposure(exposure, info, binding, family, native, fallback)
 	return nil
+}
+
+func (m *ContainerNetworkManager) runContainerPortExposure(exposure *containerPortExposure, info *containerNetworkInfo, binding PortBinding, family addressFamily, native, fallback string) {
+	ticker := time.NewTicker(containerPortProxyReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		nativeReady := containerPortTargetReachable(exposure.ctx, native, containerPortProxyDialTimeout)
+		fallbackReady := containerPortTargetReachable(exposure.ctx, fallback, containerPortProxyDialTimeout)
+		if nativeReady || (family == addressFamilyUnknown && fallbackReady) {
+			if err := m.exposePortDNAT(exposure.ctx, info, binding.HostPort, binding.ContainerPort, family); err != nil {
+				log.Warn().
+					Err(err).
+					Str("container_id", exposure.containerID).
+					Int("host_port", binding.HostPort).
+					Int("container_port", binding.ContainerPort).
+					Msg("failed to expose container port with kernel forwarding")
+			}
+			return
+		}
+		if fallbackReady {
+			exposure.startProxy(family, []string{fallback})
+			return
+		}
+
+		select {
+		case <-exposure.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *ContainerNetworkManager) exposePortDNAT(ctx context.Context, info *containerNetworkInfo, hostPort, containerPort int, family addressFamily) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	m.iptablesMu.Lock()
+	defer m.iptablesMu.Unlock()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return m.exposePortDNATLocked(info, hostPort, containerPort, family)
+}
+
+func (m *ContainerNetworkManager) exposePortDNATLocked(info *containerNetworkInfo, hostPort, containerPort int, family addressFamily) error {
+	if family != addressFamilyIPv6 {
+		if err := m.ipt.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", info.ContainerIp, containerPort), "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+		if err := m.ipt.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIp, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+	}
+	if family != addressFamilyIPv4 && m.ipt6 != nil && info.ContainerIpv6 != "" {
+		if err := m.ipt6.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("[%s]:%d", info.ContainerIpv6, containerPort), "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+		if err := m.ipt6.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIpv6, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ContainerNetworkManager) stopContainerPortExposures(containerId string) {
+	var exposures []*containerPortExposure
+
+	m.portExposureMu.Lock()
+	for hostPort, exposure := range m.portExposures {
+		if exposure.containerID != containerId {
+			continue
+		}
+		delete(m.portExposures, hostPort)
+		exposures = append(exposures, exposure)
+	}
+	m.portExposureMu.Unlock()
+
+	for _, exposure := range exposures {
+		exposure.close()
+	}
+}
+
+func (m *ContainerNetworkManager) stopAllPortExposures() {
+	m.portExposureMu.Lock()
+	exposures := make([]*containerPortExposure, 0, len(m.portExposures))
+	for hostPort, exposure := range m.portExposures {
+		delete(m.portExposures, hostPort)
+		exposures = append(exposures, exposure)
+	}
+	m.portExposureMu.Unlock()
+
+	for _, exposure := range exposures {
+		exposure.close()
+	}
 }
 
 func (m *ContainerNetworkManager) UpdateNetworkPermissions(containerId string, request *types.ContainerRequest) error {

--- a/sdk/tests/test_sandbox_log_streaming_integration.py
+++ b/sdk/tests/test_sandbox_log_streaming_integration.py
@@ -2,12 +2,21 @@ import os
 import queue
 import threading
 import time
+import urllib.request
 
 import pytest
 
 from beta9 import Image, Sandbox
+from beta9.abstractions import base as base_module
 from beta9.abstractions.base import unset_channel
 from beta9.config import set_settings
+
+
+def _close_global_channel():
+    channel = getattr(base_module, "_channel", None)
+    if channel is not None:
+        channel.close()
+    unset_channel()
 
 
 def _configure_local_gateway(monkeypatch, tmp_path):
@@ -29,7 +38,31 @@ def _configure_local_gateway(monkeypatch, tmp_path):
         monkeypatch.delenv("BETA9_TOKEN", raising=False)
 
     set_settings()
-    unset_channel()
+    _close_global_channel()
+
+
+def _wait_public_url_contains(url, *values):
+    token = os.environ.get("BETA9_TOKEN")
+    deadline = time.monotonic() + 90
+    last_error = None
+    last_body = ""
+
+    while time.monotonic() < deadline:
+        try:
+            request = urllib.request.Request(url)
+            if token:
+                request.add_header("Authorization", f"Bearer {token}")
+            with urllib.request.urlopen(request, timeout=5) as response:
+                last_body = response.read().decode()
+            if all(value in last_body for value in values):
+                return last_body
+        except Exception as exc:
+            last_error = exc
+        time.sleep(0.5)
+
+    raise AssertionError(
+        f"timed out waiting for {url} to contain {values}: body={last_body!r} error={last_error!r}"
+    )
 
 
 def test_python_sdk_sandbox_log_streaming_live(monkeypatch, tmp_path):
@@ -100,3 +133,64 @@ def test_python_sdk_sandbox_log_streaming_live(monkeypatch, tmp_path):
         assert "py-log-out" in combined and "py-log-err" in combined
     finally:
         instance.terminate()
+        _close_global_channel()
+
+
+def test_python_sdk_sandbox_expose_port_listener_families(monkeypatch, tmp_path):
+    _configure_local_gateway(monkeypatch, tmp_path)
+
+    pool = os.environ.get("BETA9_INTEGRATION_POOL")
+    kwargs = {"pool": pool} if pool else {}
+    sandbox = Sandbox(
+        name="python-sdk-listener-families",
+        image=Image(python_version="python3.11"),
+        keep_warm_seconds=300,
+        ports=[8092, 8093],
+        **kwargs,
+    )
+    instance = sandbox.create()
+    servers = []
+    try:
+        instance.fs.create_directory("/workspace/py-sdk")
+        local_file = tmp_path / "file.txt"
+        local_file.write_text("python-sdk-listener-ok\n")
+        instance.fs.upload_file(str(local_file), "/workspace/py-sdk/file.txt")
+
+        servers.append(
+            instance.process.exec(
+                "python3",
+                "-m",
+                "http.server",
+                "8092",
+                "--bind",
+                "0.0.0.0",
+                "--directory",
+                "/workspace/py-sdk",
+            )
+        )
+        servers.append(
+            instance.process.exec(
+                "python3",
+                "-m",
+                "http.server",
+                "8093",
+                "--bind",
+                "::",
+                "--directory",
+                "/workspace/py-sdk",
+            )
+        )
+
+        ipv4_url = instance.expose_port(8092)
+        _wait_public_url_contains(f"{ipv4_url}/file.txt", "python-sdk-listener-ok")
+
+        ipv6_url = instance.expose_port(8093)
+        _wait_public_url_contains(f"{ipv6_url}/file.txt", "python-sdk-listener-ok")
+    finally:
+        for server in servers:
+            try:
+                server.kill()
+            except Exception:
+                pass
+        instance.terminate()
+        _close_global_channel()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds IPv6/IPv4 cross-compatible container port exposure with a user-space TCP proxy fallback and correct IPv6 address formatting. Containers now remain reachable via the advertised family, with automatic fallback when families don’t match.

- **New Features**
  - Added a lightweight TCP port proxy that bridges IPv4↔IPv6 when needed and prefers the native family, falling back to any reachable backend.
  - Exposure flow now tries kernel DNAT first; if the backend family isn’t reachable, it starts the proxy on the appropriate listener (`tcp4`, `tcp6`, or `tcp`) based on the pod address.
  - Per-port lifecycle management with cleanup on container teardown and worker shutdown; includes unit and integration tests validating cross-family access and bracketed IPv6 behavior.

- **Bug Fixes**
  - Use the exposed host port for persistent machines (`127.0.0.1` or `[::1]`) instead of the container bridge IP.
  - Correctly format IPv6 addresses (supports pre-bracketed input) when publishing container addresses and building host:port strings.

<sup>Written for commit 86ae1a00d01aa591b608e61f32802be9493dc58b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

