### PR TITLE
Fix sandbox runtime ipv6 binding and routing

### DIFF
--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -24,6 +24,21 @@ const (
 	sandboxStatusMetadataTimeout       = 500 * time.Millisecond
 )
 
+func sandboxKillFailureMessage(resp *pb.ContainerSandboxKillResponse) string {
+	if resp != nil && resp.ErrorMsg != "" {
+		return resp.ErrorMsg
+	}
+	return "Failed to kill sandbox process"
+}
+
+func sandboxAuthInfoFromContext(ctx context.Context) (*auth.AuthInfo, bool) {
+	authInfo, ok := auth.AuthInfoFromContext(ctx)
+	if !ok || authInfo == nil || authInfo.Token == nil || authInfo.Workspace == nil {
+		return nil, false
+	}
+	return authInfo, true
+}
+
 func (s *GenericPodService) SandboxExec(ctx context.Context, in *pb.PodSandboxExecRequest) (*pb.PodSandboxExecResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 	cacheKey := sandboxClientCacheKey(in.ContainerId, authInfo.Token.Key)
@@ -269,7 +284,14 @@ func (s *GenericPodService) SandboxStderr(ctx context.Context, in *pb.PodSandbox
 }
 
 func (s *GenericPodService) SandboxKill(ctx context.Context, in *pb.PodSandboxKillRequest) (*pb.PodSandboxKillResponse, error) {
-	authInfo, _ := auth.AuthInfoFromContext(ctx)
+	if in == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing sandbox kill request")
+	}
+
+	authInfo, ok := sandboxAuthInfoFromContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "invalid or missing token")
+	}
 
 	client, _, err := s.getClient(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
 	if err != nil {
@@ -283,14 +305,21 @@ func (s *GenericPodService) SandboxKill(ctx context.Context, in *pb.PodSandboxKi
 	if err != nil {
 		return &pb.PodSandboxKillResponse{
 			Ok:       false,
-			ErrorMsg: resp.ErrorMsg,
+			ErrorMsg: sandboxKillFailureMessage(resp),
+		}, nil
+	}
+
+	if resp == nil {
+		return &pb.PodSandboxKillResponse{
+			Ok:       false,
+			ErrorMsg: sandboxKillFailureMessage(resp),
 		}, nil
 	}
 
 	if !resp.Ok {
 		return &pb.PodSandboxKillResponse{
 			Ok:       false,
-			ErrorMsg: resp.ErrorMsg,
+			ErrorMsg: sandboxKillFailureMessage(resp),
 		}, nil
 	}
 

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -1,10 +1,14 @@
 package pod
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestSandboxConnectErrorMessageDoesNotLeakDetails(t *testing.T) {
@@ -34,5 +38,40 @@ func TestPodRunnableStubOnlyAllowsPodAndSandboxKinds(t *testing.T) {
 				t.Fatalf("podRunnableStub(%q) = %t, want %t", tt.stubType, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSandboxKillFailureMessageHandlesNilResponse(t *testing.T) {
+	if got := sandboxKillFailureMessage(nil); got != "Failed to kill sandbox process" {
+		t.Fatalf("sandboxKillFailureMessage(nil) = %q", got)
+	}
+
+	resp := &pb.ContainerSandboxKillResponse{ErrorMsg: "worker said no"}
+	if got := sandboxKillFailureMessage(resp); got != "worker said no" {
+		t.Fatalf("sandboxKillFailureMessage(resp) = %q", got)
+	}
+}
+
+func TestSandboxKillRejectsNilRequest(t *testing.T) {
+	service := &GenericPodService{}
+
+	resp, err := service.SandboxKill(context.Background(), nil)
+	if resp != nil {
+		t.Fatalf("SandboxKill response = %#v, want nil", resp)
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("SandboxKill error code = %s, want %s", status.Code(err), codes.InvalidArgument)
+	}
+}
+
+func TestSandboxKillRejectsMissingAuthContext(t *testing.T) {
+	service := &GenericPodService{}
+
+	resp, err := service.SandboxKill(context.Background(), &pb.PodSandboxKillRequest{ContainerId: "sandbox-123", Pid: 1})
+	if resp != nil {
+		t.Fatalf("SandboxKill response = %#v, want nil", resp)
+	}
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("SandboxKill error code = %s, want %s", status.Code(err), codes.Unauthenticated)
 	}
 }

--- a/pkg/abstractions/volume/http.go
+++ b/pkg/abstractions/volume/http.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
-	"github.com/beam-cloud/beta9/pkg/clients"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -345,7 +344,7 @@ func (g *volumeGroup) GetUploadURL(ctx echo.Context) error {
 const PresignedGetURLExpiration = 3600 // 1 hour
 
 func (g *volumeGroup) generatePresignedURL(ctx context.Context, workspace *types.Workspace, volumePath string, urlType string) (string, error) {
-	storageClient, err := clients.NewWorkspaceStorageClient(ctx, workspace.Name, workspace.Storage)
+	storageClient, err := g.gvs.newWorkspaceStorageClientForPresign(ctx, workspace)
 	if err != nil {
 		return "", echo.NewHTTPError(http.StatusInternalServerError, "Failed to create storage client")
 	}

--- a/pkg/abstractions/volume/multipart.go
+++ b/pkg/abstractions/volume/multipart.go
@@ -75,7 +75,7 @@ func (s *GlobalVolumeService) CreatePresignedURL(ctx context.Context, in *pb.Cre
 	bucket := s.config.BucketName
 
 	if authInfo.Workspace.StorageAvailable() {
-		storageClient, err := clients.NewWorkspaceStorageClient(ctx, authInfo.Workspace.Name, authInfo.Workspace.Storage)
+		storageClient, err := s.newWorkspaceStorageClientForPresign(ctx, authInfo.Workspace)
 		if err != nil {
 			return &pb.CreatePresignedURLResponse{
 				Ok:     false,

--- a/pkg/abstractions/volume/volume.go
+++ b/pkg/abstractions/volume/volume.go
@@ -34,9 +34,10 @@ type VolumeService interface {
 
 type GlobalVolumeService struct {
 	pb.UnimplementedVolumeServiceServer
-	config      types.FileServiceConfig
-	backendRepo repository.BackendRepository
-	rdb         *common.RedisClient
+	config                 types.FileServiceConfig
+	workspaceStorageConfig types.WorkspaceStorageConfig
+	backendRepo            repository.BackendRepository
+	rdb                    *common.RedisClient
 }
 
 type FileInfo struct {
@@ -53,11 +54,12 @@ type VolumePathTokenData struct {
 
 var volumeRoutePrefix string = "/volume"
 
-func NewGlobalVolumeService(config types.FileServiceConfig, backendRepo repository.BackendRepository, workspaceRepo repository.WorkspaceRepository, rdb *common.RedisClient, routeGroup *echo.Group) (VolumeService, error) {
+func NewGlobalVolumeService(config types.FileServiceConfig, workspaceStorageConfig types.WorkspaceStorageConfig, backendRepo repository.BackendRepository, workspaceRepo repository.WorkspaceRepository, rdb *common.RedisClient, routeGroup *echo.Group) (VolumeService, error) {
 	gvs := &GlobalVolumeService{
-		config:      config,
-		backendRepo: backendRepo,
-		rdb:         rdb,
+		config:                 config,
+		workspaceStorageConfig: workspaceStorageConfig,
+		backendRepo:            backendRepo,
+		rdb:                    rdb,
 	}
 
 	// Register HTTP routes
@@ -65,6 +67,15 @@ func NewGlobalVolumeService(config types.FileServiceConfig, backendRepo reposito
 	registerVolumeRoutes(routeGroup.Group(volumeRoutePrefix, authMiddleware), gvs)
 
 	return gvs, nil
+}
+
+func (vs *GlobalVolumeService) newWorkspaceStorageClientForPresign(ctx context.Context, workspace *types.Workspace) (*clients.WorkspaceStorageClient, error) {
+	return clients.NewWorkspaceStorageClientWithDefaultPresignEndpoint(
+		ctx,
+		workspace.Name,
+		workspace.Storage,
+		vs.workspaceStorageConfig,
+	)
 }
 
 func (vs *GlobalVolumeService) GetOrCreateVolume(ctx context.Context, in *pb.GetOrCreateVolumeRequest) (*pb.GetOrCreateVolumeResponse, error) {

--- a/pkg/clients/storage.go
+++ b/pkg/clients/storage.go
@@ -39,6 +39,15 @@ func NewWorkspaceStorageClient(ctx context.Context, workspaceName string, worksp
 	return NewWorkspaceStorageClientWithPresignEndpoint(ctx, workspaceName, workspaceStorage, "")
 }
 
+func NewWorkspaceStorageClientWithDefaultPresignEndpoint(ctx context.Context, workspaceName string, workspaceStorage *types.WorkspaceStorage, storageConfig types.WorkspaceStorageConfig) (*WorkspaceStorageClient, error) {
+	return NewWorkspaceStorageClientWithPresignEndpoint(
+		ctx,
+		workspaceName,
+		workspaceStorage,
+		WorkspacePresignEndpointForDefaultStorage(workspaceStorage, storageConfig),
+	)
+}
+
 func NewWorkspaceStorageClientWithPresignEndpoint(ctx context.Context, workspaceName string, workspaceStorage *types.WorkspaceStorage, presignEndpointUrl string) (*WorkspaceStorageClient, error) {
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(*workspaceStorage.Region),
@@ -120,6 +129,61 @@ func firstNonEmpty(values ...string) string {
 
 func presignEndpointForStorage(storageEndpointUrl, presignEndpointUrl string) string {
 	return firstNonEmpty(presignEndpointOverride(storageEndpointUrl, presignEndpointUrl), storageEndpointUrl)
+}
+
+func WorkspacePresignEndpointForDefaultStorage(workspaceStorage *types.WorkspaceStorage, storageConfig types.WorkspaceStorageConfig) string {
+	if workspaceStorage == nil || workspaceStorage.EndpointUrl == nil {
+		return ""
+	}
+
+	if storageConfig.DefaultPresignedEndpointUrl == "" {
+		return ""
+	}
+
+	if !sameStorageEndpoint(*workspaceStorage.EndpointUrl, storageConfig.DefaultEndpointUrl) {
+		return ""
+	}
+
+	return storageConfig.DefaultPresignedEndpointUrl
+}
+
+func sameStorageEndpoint(a, b string) bool {
+	a = strings.TrimRight(strings.TrimSpace(a), "/")
+	b = strings.TrimRight(strings.TrimSpace(b), "/")
+	if a == "" || b == "" {
+		return a == b
+	}
+	if a == b {
+		return true
+	}
+
+	aURL, aErr := url.Parse(a)
+	bURL, bErr := url.Parse(b)
+	if aErr != nil || bErr != nil {
+		return false
+	}
+
+	if !strings.EqualFold(aURL.Scheme, bURL.Scheme) {
+		return false
+	}
+
+	return strings.EqualFold(aURL.Hostname(), bURL.Hostname()) &&
+		effectiveURLPort(aURL) == effectiveURLPort(bURL)
+}
+
+func effectiveURLPort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
 }
 
 func presignEndpointOverride(storageEndpointUrl, presignEndpointUrl string) string {

--- a/pkg/clients/storage_test.go
+++ b/pkg/clients/storage_test.go
@@ -146,6 +146,43 @@ func TestDefaultStorageClientPresignedURLRejectsInheritedLoopbackOverrideForRemo
 	}
 }
 
+func TestWorkspacePresignEndpointForDefaultStorage(t *testing.T) {
+	cfg := types.WorkspaceStorageConfig{
+		DefaultEndpointUrl:          "http://localstack:4566",
+		DefaultPresignedEndpointUrl: "http://127.0.0.1:4566",
+	}
+
+	tests := []struct {
+		name    string
+		storage *types.WorkspaceStorage
+		want    string
+	}{
+		{
+			name:    "uses configured presign endpoint for default storage",
+			storage: testWorkspaceStorage("http://localstack:4566"),
+			want:    "http://127.0.0.1:4566",
+		},
+		{
+			name:    "does not override external storage",
+			storage: testWorkspaceStorage("https://s3.amazonaws.com"),
+			want:    "",
+		},
+		{
+			name:    "handles missing workspace storage",
+			storage: nil,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WorkspacePresignEndpointForDefaultStorage(tt.storage, cfg); got != tt.want {
+				t.Fatalf("WorkspacePresignEndpointForDefaultStorage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsBucketAlreadyCreatedError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -410,7 +410,7 @@ func (g *Gateway) registerServices() error {
 	pb.RegisterEndpointServiceServer(g.grpcServer, ws)
 
 	// Register volume service
-	vs, err := volume.NewGlobalVolumeService(g.Config.FileService, g.BackendRepo, g.WorkspaceRepo, g.RedisClient, g.rootRouteGroup)
+	vs, err := volume.NewGlobalVolumeService(g.Config.FileService, g.Config.Storage.WorkspaceStorage, g.BackendRepo, g.WorkspaceRepo, g.RedisClient, g.rootRouteGroup)
 	if err != nil {
 		return err
 	}

--- a/pkg/gateway/services/object.go
+++ b/pkg/gateway/services/object.go
@@ -3,7 +3,6 @@ package gatewayservices
 import (
 	"context"
 	"io"
-	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -119,8 +118,12 @@ func (gws *GatewayService) CreateObject(ctx context.Context, in *pb.CreateObject
 		}, nil
 	}
 
-	presignEndpointUrl := gws.defaultWorkspacePresignEndpointUrl(authInfo.Workspace.Storage)
-	storageClient, err := clients.NewWorkspaceStorageClientWithPresignEndpoint(ctx, authInfo.Workspace.Name, authInfo.Workspace.Storage, presignEndpointUrl)
+	storageClient, err := clients.NewWorkspaceStorageClientWithDefaultPresignEndpoint(
+		ctx,
+		authInfo.Workspace.Name,
+		authInfo.Workspace.Storage,
+		gws.appConfig.Storage.WorkspaceStorage,
+	)
 	if err != nil {
 		return &pb.CreateObjectResponse{
 			Ok:       false,
@@ -176,62 +179,6 @@ func (gws *GatewayService) CreateObject(ctx context.Context, in *pb.CreateObject
 		PresignedUrl: presignedURL,
 		PutHeaders:   putHeaders,
 	}, nil
-}
-
-func (gws *GatewayService) defaultWorkspacePresignEndpointUrl(workspaceStorage *types.WorkspaceStorage) string {
-	if workspaceStorage == nil || workspaceStorage.EndpointUrl == nil {
-		return ""
-	}
-
-	storageConfig := gws.appConfig.Storage.WorkspaceStorage
-	if storageConfig.DefaultPresignedEndpointUrl == "" {
-		return ""
-	}
-
-	if !sameStorageEndpoint(*workspaceStorage.EndpointUrl, storageConfig.DefaultEndpointUrl) {
-		return ""
-	}
-
-	return storageConfig.DefaultPresignedEndpointUrl
-}
-
-func sameStorageEndpoint(a, b string) bool {
-	a = strings.TrimRight(strings.TrimSpace(a), "/")
-	b = strings.TrimRight(strings.TrimSpace(b), "/")
-	if a == "" || b == "" {
-		return a == b
-	}
-	if a == b {
-		return true
-	}
-
-	aURL, aErr := url.Parse(a)
-	bURL, bErr := url.Parse(b)
-	if aErr != nil || bErr != nil {
-		return false
-	}
-
-	if !strings.EqualFold(aURL.Scheme, bURL.Scheme) {
-		return false
-	}
-
-	return strings.EqualFold(aURL.Hostname(), bURL.Hostname()) &&
-		effectiveURLPort(aURL) == effectiveURLPort(bURL)
-}
-
-func effectiveURLPort(u *url.URL) string {
-	if port := u.Port(); port != "" {
-		return port
-	}
-
-	switch strings.ToLower(u.Scheme) {
-	case "http":
-		return "80"
-	case "https":
-		return "443"
-	default:
-		return ""
-	}
 }
 
 func (gws *GatewayService) PutObjectStream(stream pb.GatewayService_PutObjectStreamServer) error {

--- a/pkg/runtime/runc.go
+++ b/pkg/runtime/runc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -11,6 +12,16 @@ import (
 	"github.com/beam-cloud/go-runc"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+const (
+	runcRestoreStateTimeout      = 2 * time.Second
+	runcRestoreStatePollInterval = 25 * time.Millisecond
+)
+
+type runcCommandResult struct {
+	exitCode int
+	err      error
+}
 
 // Runc implements Runtime using the runc container runtime
 type Runc struct {
@@ -34,7 +45,8 @@ func NewRunc(cfg Config) (*Runc, error) {
 
 	return &Runc{
 		handle: runc.Runc{
-			Debug: cfg.Debug,
+			Command: cfg.RuncPath,
+			Debug:   cfg.Debug,
 		},
 		cfg: cfg,
 	}, nil
@@ -196,19 +208,162 @@ func (r *Runc) Restore(ctx context.Context, containerID string, opts *RestoreOpt
 		return -1, fmt.Errorf("restore options cannot be nil")
 	}
 
-	runcOpts := &runc.RestoreOpts{
-		CheckpointOpts: runc.CheckpointOpts{
-			ImagePath:    opts.ImagePath,
-			WorkDir:      opts.WorkDir,
-			LinkRemap:    true,
-			Cgroups:      runc.Soft,
-			OutputWriter: opts.OutputWriter,
-		},
-		TCPClose: opts.TCPClose,
-		Started:  opts.Started,
+	cmd := exec.CommandContext(context.WithoutCancel(ctx), r.runcCommand(), r.restoreArgs(containerID, opts)...)
+	if opts.OutputWriter != nil {
+		cmd.Stdout = opts.OutputWriter
+		cmd.Stderr = opts.OutputWriter
 	}
 
-	return r.handle.Restore(ctx, containerID, opts.BundlePath, runcOpts)
+	if err := cmd.Start(); err != nil {
+		return -1, err
+	}
+
+	restoreDone := make(chan runcCommandResult, 1)
+	go func() {
+		restoreDone <- runcWaitResult(cmd.Wait())
+		close(restoreDone)
+	}()
+
+	pid, result, err := r.waitForRestoredContainerPID(ctx, containerID, restoreDone)
+	if err != nil {
+		if result != nil {
+			return result.exitCode, result.err
+		}
+		_ = cmd.Process.Kill()
+		return -1, err
+	}
+	if result != nil {
+		return result.exitCode, result.err
+	}
+
+	if opts.Started != nil {
+		select {
+		case opts.Started <- pid:
+		default:
+			_ = cmd.Process.Kill()
+			return -1, fmt.Errorf("restore started but started channel was unavailable")
+		}
+	}
+
+	finalResult := <-restoreDone
+	return finalResult.exitCode, finalResult.err
+}
+
+func (r *Runc) runcCommand() string {
+	if r.handle.Command != "" {
+		return r.handle.Command
+	}
+	return runc.DefaultCommand
+}
+
+func (r *Runc) restoreArgs(containerID string, opts *RestoreOpts) []string {
+	args := r.globalArgs()
+	args = append(args, "restore")
+	args = append(args, restoreCheckpointArgs(opts)...)
+	if opts.TCPClose {
+		args = append(args, "--tcp-close")
+	}
+	args = append(args, "--bundle", opts.BundlePath, containerID)
+	return args
+}
+
+func (r *Runc) globalArgs() []string {
+	var args []string
+	if r.handle.Root != "" {
+		args = append(args, "--root", r.handle.Root)
+	}
+	if r.handle.Debug {
+		args = append(args, "--debug")
+	}
+	if r.handle.Log != "" {
+		args = append(args, "--log", r.handle.Log)
+	}
+	if string(r.handle.LogFormat) != "" {
+		args = append(args, "--log-format", string(r.handle.LogFormat))
+	}
+	if r.handle.SystemdCgroup {
+		args = append(args, "--systemd-cgroup")
+	}
+	if r.handle.Rootless != nil {
+		args = append(args, "--rootless="+strconv.FormatBool(*r.handle.Rootless))
+	}
+	return append(args, r.handle.ExtraArgs...)
+}
+
+func restoreCheckpointArgs(opts *RestoreOpts) []string {
+	var args []string
+	if opts.ImagePath != "" {
+		args = append(args, "--image-path", opts.ImagePath)
+	}
+	if opts.WorkDir != "" {
+		args = append(args, "--work-path", opts.WorkDir)
+	}
+	args = append(args, "--link-remap", "--manage-cgroups-mode", string(runc.Soft))
+	return args
+}
+
+func (r *Runc) waitForRestoredContainerPID(ctx context.Context, containerID string, restoreDone <-chan runcCommandResult) (int, *runcCommandResult, error) {
+	return pollRestoredContainerPID(ctx, containerID, restoreDone, runcRestoreStateTimeout, runcRestoreStatePollInterval, r.State)
+}
+
+func pollRestoredContainerPID(
+	ctx context.Context,
+	containerID string,
+	restoreDone <-chan runcCommandResult,
+	timeout time.Duration,
+	interval time.Duration,
+	stateFn func(context.Context, string) (State, error),
+) (int, *runcCommandResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		state, err := stateFn(ctx, containerID)
+		if err == nil && state.Pid > 0 {
+			return state.Pid, nil, nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = fmt.Errorf("restored container state has no pid")
+		}
+
+		select {
+		case <-ctx.Done():
+			return -1, nil, fmt.Errorf("restore succeeded but restored container state was unavailable: %w", lastErr)
+		case result := <-restoreDone:
+			return -1, &result, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func runcWaitResult(err error) runcCommandResult {
+	if err == nil {
+		return runcCommandResult{exitCode: 0}
+	}
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			if ws.Exited() {
+				return runcCommandResult{exitCode: ws.ExitStatus(), err: err}
+			}
+			if ws.Signaled() {
+				return runcCommandResult{exitCode: 128 + int(ws.Signal()), err: err}
+			}
+		}
+		return runcCommandResult{exitCode: exitErr.ExitCode(), err: err}
+	}
+
+	return runcCommandResult{exitCode: -1, err: err}
+}
+
+func (r *Runc) RestoreWaitsForExit() bool {
+	return true
 }
 
 func (r *Runc) Close() error {

--- a/pkg/runtime/runc_test.go
+++ b/pkg/runtime/runc_test.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestoreArgs(t *testing.T) {
+	rt := &Runc{}
+	args := rt.restoreArgs("container-1", &RestoreOpts{
+		ImagePath:  "/checkpoints/container-1",
+		WorkDir:    "/tmp/restore-work",
+		BundlePath: "/tmp/bundle",
+		TCPClose:   true,
+	})
+
+	require.Equal(t, []string{
+		"restore",
+		"--image-path", "/checkpoints/container-1",
+		"--work-path", "/tmp/restore-work",
+		"--link-remap",
+		"--manage-cgroups-mode", "soft",
+		"--tcp-close",
+		"--bundle", "/tmp/bundle",
+		"container-1",
+	}, args)
+}
+
+func TestPollRestoredContainerPIDWaitsForState(t *testing.T) {
+	attempts := 0
+	pid, result, err := pollRestoredContainerPID(
+		context.Background(),
+		"container-1",
+		make(chan runcCommandResult),
+		time.Second,
+		time.Millisecond,
+		func(context.Context, string) (State, error) {
+			attempts++
+			if attempts < 3 {
+				return State{}, errors.New("state unavailable")
+			}
+			return State{Pid: 4321, Status: types.RuncContainerStatusRunning}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 4321, pid)
+	require.Nil(t, result)
+	require.Equal(t, 3, attempts)
+}
+
+func TestPollRestoredContainerPIDFailsWhenStateUnavailable(t *testing.T) {
+	_, result, err := pollRestoredContainerPID(
+		context.Background(),
+		"container-1",
+		make(chan runcCommandResult),
+		10*time.Millisecond,
+		time.Millisecond,
+		func(context.Context, string) (State, error) {
+			return State{}, ErrContainerNotFound{ContainerID: "container-1"}
+		},
+	)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "restore succeeded but restored container state was unavailable")
+}

--- a/pkg/worker/container_network.go
+++ b/pkg/worker/container_network.go
@@ -52,33 +52,6 @@ type agentContainerNetwork struct {
 	*localContainerNetwork
 }
 
-func (m *agentContainerNetwork) ContainerPortAddress(containerId string, binding PortBinding) (string, error) {
-	info, err := m.getContainerNetworkInfo(containerId)
-	if err != nil {
-		return "", err
-	}
-	if info.ContainerIp == "" {
-		return "", fmt.Errorf("container %s has no bridge IP", containerId)
-	}
-	return joinHostPort(info.ContainerIp, binding.ContainerPort), nil
-}
-
-func (m *agentContainerNetwork) ContainerPortAddressMap(containerId string, bindings []PortBinding) (map[int32]string, error) {
-	info, err := m.getContainerNetworkInfo(containerId)
-	if err != nil {
-		return nil, err
-	}
-	if info.ContainerIp == "" {
-		return nil, fmt.Errorf("container %s has no bridge IP", containerId)
-	}
-
-	addressMap := make(map[int32]string, len(bindings))
-	for _, binding := range bindings {
-		addressMap[int32(binding.ContainerPort)] = joinHostPort(info.ContainerIp, binding.ContainerPort)
-	}
-	return addressMap, nil
-}
-
 func joinHostPort(host string, port int) string {
 	host = strings.TrimSpace(host)
 	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {

--- a/pkg/worker/container_network.go
+++ b/pkg/worker/container_network.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -32,7 +33,7 @@ func (m *localContainerNetwork) ContainerPortAddress(_ string, binding PortBindi
 	if m.podAddr == "" {
 		return "", fmt.Errorf("pod address is empty")
 	}
-	return net.JoinHostPort(m.podAddr, strconv.Itoa(binding.HostPort)), nil
+	return joinHostPort(m.podAddr, binding.HostPort), nil
 }
 
 func (m *localContainerNetwork) ContainerPortAddressMap(containerId string, bindings []PortBinding) (map[int32]string, error) {
@@ -59,7 +60,7 @@ func (m *agentContainerNetwork) ContainerPortAddress(containerId string, binding
 	if info.ContainerIp == "" {
 		return "", fmt.Errorf("container %s has no bridge IP", containerId)
 	}
-	return net.JoinHostPort(info.ContainerIp, strconv.Itoa(binding.ContainerPort)), nil
+	return joinHostPort(info.ContainerIp, binding.ContainerPort), nil
 }
 
 func (m *agentContainerNetwork) ContainerPortAddressMap(containerId string, bindings []PortBinding) (map[int32]string, error) {
@@ -73,12 +74,24 @@ func (m *agentContainerNetwork) ContainerPortAddressMap(containerId string, bind
 
 	addressMap := make(map[int32]string, len(bindings))
 	for _, binding := range bindings {
-		addressMap[int32(binding.ContainerPort)] = net.JoinHostPort(info.ContainerIp, strconv.Itoa(binding.ContainerPort))
+		addressMap[int32(binding.ContainerPort)] = joinHostPort(info.ContainerIp, binding.ContainerPort)
 	}
 	return addressMap, nil
 }
 
+func joinHostPort(host string, port int) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		unwrapped := strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+		if net.ParseIP(unwrapped) != nil {
+			host = unwrapped
+		}
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 func newContainerNetwork(base *ContainerNetworkManager, podAddr string, persistent bool, machineID, transport string) ContainerNetwork {
+	base.podAddr = podAddr
 	local := &localContainerNetwork{
 		ContainerNetworkManager: base,
 		podAddr:                 podAddr,

--- a/pkg/worker/container_network_test.go
+++ b/pkg/worker/container_network_test.go
@@ -46,7 +46,7 @@ func TestNewContainerNetworkFormatsBracketedIPv6PodAddress(t *testing.T) {
 	}, addressMap)
 }
 
-func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testing.T) {
+func TestNewContainerNetworkUsesExposedHostPortForPersistentMachine(t *testing.T) {
 	containerID := "container-one"
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
 	containerInstances.Set(containerID, &ContainerInstance{
@@ -61,7 +61,7 @@ func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testi
 
 	address, err := network.ContainerPortAddress(containerID, PortBinding{HostPort: 32000, ContainerPort: 8001})
 	require.NoError(t, err)
-	require.Equal(t, "192.168.0.44:8001", address)
+	require.Equal(t, "127.0.0.1:32000", address)
 
 	addressMap, err := network.ContainerPortAddressMap(containerID, []PortBinding{
 		{HostPort: 32000, ContainerPort: 8001},
@@ -69,12 +69,12 @@ func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testi
 	})
 	require.NoError(t, err)
 	require.Equal(t, map[int32]string{
-		8001: "192.168.0.44:8001",
-		2222: "192.168.0.44:2222",
+		8001: "127.0.0.1:32000",
+		2222: "127.0.0.1:32001",
 	}, addressMap)
 }
 
-func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
+func TestNewContainerNetworkFormatsPersistentIPv6HostAddress(t *testing.T) {
 	containerID := "container-one"
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
 	containerInstances.Set(containerID, &ContainerInstance{
@@ -82,11 +82,11 @@ func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
 		ContainerIp: "fd00:abcd::3f",
 	})
 
-	network := newContainerNetwork(&ContainerNetworkManager{containerInstances: containerInstances}, "127.0.0.1", true, "machine-one", "tsnet_restricted")
+	network := newContainerNetwork(&ContainerNetworkManager{containerInstances: containerInstances}, "[::1]", true, "machine-one", "tsnet_restricted")
 
 	address, err := network.ContainerPortAddress(containerID, PortBinding{HostPort: 32000, ContainerPort: 8001})
 	require.NoError(t, err)
-	require.Equal(t, "[fd00:abcd::3f]:8001", address)
+	require.Equal(t, "[::1]:32000", address)
 
 	addressMap, err := network.ContainerPortAddressMap(containerID, []PortBinding{
 		{HostPort: 32000, ContainerPort: 8001},
@@ -94,7 +94,7 @@ func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, map[int32]string{
-		8001: "[fd00:abcd::3f]:8001",
-		2222: "[fd00:abcd::3f]:2222",
+		8001: "[::1]:32000",
+		2222: "[::1]:32001",
 	}, addressMap)
 }

--- a/pkg/worker/container_network_test.go
+++ b/pkg/worker/container_network_test.go
@@ -28,6 +28,24 @@ func TestNewContainerNetworkUsesLocalImplementationByDefault(t *testing.T) {
 	}, addressMap)
 }
 
+func TestNewContainerNetworkFormatsBracketedIPv6PodAddress(t *testing.T) {
+	network := newContainerNetwork(&ContainerNetworkManager{}, "[2600:1f18:37a4:c02::7286]", false, "", "")
+
+	address, err := network.ContainerPortAddress("container-one", PortBinding{HostPort: 32000, ContainerPort: 8001})
+	require.NoError(t, err)
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:32000", address)
+
+	addressMap, err := network.ContainerPortAddressMap("container-one", []PortBinding{
+		{HostPort: 32000, ContainerPort: 8001},
+		{HostPort: 32001, ContainerPort: 2222},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[int32]string{
+		8001: "[2600:1f18:37a4:c02::7286]:32000",
+		2222: "[2600:1f18:37a4:c02::7286]:32001",
+	}, addressMap)
+}
+
 func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testing.T) {
 	containerID := "container-one"
 	containerInstances := common.NewSafeMap[*ContainerInstance]()
@@ -53,5 +71,30 @@ func TestNewContainerNetworkUsesAgentImplementationForPersistentMachine(t *testi
 	require.Equal(t, map[int32]string{
 		8001: "192.168.0.44:8001",
 		2222: "192.168.0.44:2222",
+	}, addressMap)
+}
+
+func TestNewContainerNetworkFormatsAgentIPv6ContainerAddress(t *testing.T) {
+	containerID := "container-one"
+	containerInstances := common.NewSafeMap[*ContainerInstance]()
+	containerInstances.Set(containerID, &ContainerInstance{
+		Id:          containerID,
+		ContainerIp: "fd00:abcd::3f",
+	})
+
+	network := newContainerNetwork(&ContainerNetworkManager{containerInstances: containerInstances}, "127.0.0.1", true, "machine-one", "tsnet_restricted")
+
+	address, err := network.ContainerPortAddress(containerID, PortBinding{HostPort: 32000, ContainerPort: 8001})
+	require.NoError(t, err)
+	require.Equal(t, "[fd00:abcd::3f]:8001", address)
+
+	addressMap, err := network.ContainerPortAddressMap(containerID, []PortBinding{
+		{HostPort: 32000, ContainerPort: 8001},
+		{HostPort: 32001, ContainerPort: 2222},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[int32]string{
+		8001: "[fd00:abcd::3f]:8001",
+		2222: "[fd00:abcd::3f]:2222",
 	}, addressMap)
 }

--- a/pkg/worker/container_port_proxy.go
+++ b/pkg/worker/container_port_proxy.go
@@ -1,0 +1,349 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	containerPortProxyReadyPollInterval = 100 * time.Millisecond
+	containerPortProxyDialTimeout       = 250 * time.Millisecond
+	containerPortProxyConnectTimeout    = 2 * time.Second
+)
+
+type containerPortExposure struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	containerID   string
+	hostPort      int
+	containerPort int
+	proxyMu       sync.Mutex
+	proxy         *containerPortProxy
+}
+
+type containerPortProxy struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	containerID   string
+	hostPort      int
+	containerPort int
+	listenNetwork string
+	listenAddress string
+	targets       []string
+	ready         chan struct{}
+	readyOnce     sync.Once
+	listenerMu    sync.Mutex
+	listener      net.Listener
+}
+
+func newContainerPortExposure(parent context.Context, containerID string, binding PortBinding) *containerPortExposure {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &containerPortExposure{
+		ctx:           ctx,
+		cancel:        cancel,
+		containerID:   containerID,
+		hostPort:      binding.HostPort,
+		containerPort: binding.ContainerPort,
+	}
+}
+
+func (e *containerPortExposure) startProxy(family addressFamily, targets []string) {
+	if len(targets) == 0 || e.ctx.Err() != nil {
+		return
+	}
+
+	proxy := newContainerPortProxy(e.ctx, e.containerID, PortBinding{
+		HostPort:      e.hostPort,
+		ContainerPort: e.containerPort,
+	}, family, targets)
+
+	e.proxyMu.Lock()
+	if e.ctx.Err() != nil {
+		e.proxyMu.Unlock()
+		proxy.close()
+		return
+	}
+	e.proxy = proxy
+	e.proxyMu.Unlock()
+
+	go proxy.run()
+}
+
+func (e *containerPortExposure) close() {
+	e.cancel()
+	e.proxyMu.Lock()
+	proxy := e.proxy
+	e.proxy = nil
+	e.proxyMu.Unlock()
+	if proxy != nil {
+		proxy.close()
+	}
+}
+
+func newContainerPortProxy(parent context.Context, containerID string, binding PortBinding, family addressFamily, targets []string) *containerPortProxy {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	listenNetwork, listenAddress := containerPortProxyListenConfig(binding.HostPort, family)
+	return &containerPortProxy{
+		ctx:           ctx,
+		cancel:        cancel,
+		containerID:   containerID,
+		hostPort:      binding.HostPort,
+		containerPort: binding.ContainerPort,
+		listenNetwork: listenNetwork,
+		listenAddress: listenAddress,
+		targets:       append([]string(nil), targets...),
+		ready:         make(chan struct{}),
+	}
+}
+
+type addressFamily int
+
+const (
+	addressFamilyUnknown addressFamily = iota
+	addressFamilyIPv4
+	addressFamilyIPv6
+)
+
+func addressFamilyForHost(host string) addressFamily {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return addressFamilyUnknown
+	}
+	if ip.To4() != nil {
+		return addressFamilyIPv4
+	}
+	return addressFamilyIPv6
+}
+
+func containerPortTargets(info *containerNetworkInfo, containerPort int, family addressFamily) (native, fallback string) {
+	if info == nil {
+		return "", ""
+	}
+
+	port := strconv.Itoa(containerPort)
+	ipv4 := ""
+	if info.ContainerIp != "" {
+		ipv4 = net.JoinHostPort(info.ContainerIp, port)
+	}
+	ipv6 := ""
+	if info.ContainerIpv6 != "" {
+		ipv6 = net.JoinHostPort(info.ContainerIpv6, port)
+	}
+
+	switch family {
+	case addressFamilyIPv6:
+		return ipv6, ipv4
+	case addressFamilyIPv4:
+		return ipv4, ipv6
+	default:
+		return ipv4, ipv6
+	}
+}
+
+func containerPortProxyListenConfig(hostPort int, family addressFamily) (network, address string) {
+	port := strconv.Itoa(hostPort)
+	switch family {
+	case addressFamilyIPv6:
+		return "tcp6", net.JoinHostPort("::", port)
+	case addressFamilyIPv4:
+		return "tcp4", net.JoinHostPort("0.0.0.0", port)
+	default:
+		return "tcp", net.JoinHostPort("", port)
+	}
+}
+
+func (p *containerPortProxy) run() {
+	if err := p.waitForBackend(); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.Debug().
+				Err(err).
+				Str("container_id", p.containerID).
+				Int("host_port", p.hostPort).
+				Int("container_port", p.containerPort).
+				Msg("container port proxy stopped before backend became reachable")
+		}
+		return
+	}
+
+	listener, err := net.Listen(p.listenNetwork, p.listenAddress)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("container_id", p.containerID).
+			Int("host_port", p.hostPort).
+			Int("container_port", p.containerPort).
+			Str("listen_network", p.listenNetwork).
+			Str("listen_address", p.listenAddress).
+			Msg("failed to start container port proxy")
+		return
+	}
+
+	p.listenerMu.Lock()
+	p.listener = listener
+	p.listenerMu.Unlock()
+	p.readyOnce.Do(func() { close(p.ready) })
+	log.Debug().
+		Str("container_id", p.containerID).
+		Int("host_port", p.hostPort).
+		Int("container_port", p.containerPort).
+		Str("listen_network", p.listenNetwork).
+		Str("listen_address", p.listenAddress).
+		Strs("targets", p.targets).
+		Msg("container port proxy started")
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case <-p.ctx.Done():
+				return
+			default:
+				log.Debug().
+					Err(err).
+					Str("container_id", p.containerID).
+					Int("host_port", p.hostPort).
+					Msg("container port proxy accept failed")
+				return
+			}
+		}
+		go p.handle(conn)
+	}
+}
+
+func containerPortTargetReachable(ctx context.Context, target string, timeout time.Duration) bool {
+	if target == "" {
+		return false
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", target)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func (p *containerPortProxy) waitForBackend() error {
+	ticker := time.NewTicker(containerPortProxyReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		conn, err := p.dialBackend(containerPortProxyDialTimeout)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		select {
+		case <-p.ctx.Done():
+			return p.ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *containerPortProxy) handle(client net.Conn) {
+	defer client.Close()
+
+	backend, err := p.dialBackend(containerPortProxyConnectTimeout)
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Str("container_id", p.containerID).
+			Int("host_port", p.hostPort).
+			Int("container_port", p.containerPort).
+			Msg("container port proxy backend dial failed")
+		return
+	}
+	defer backend.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go proxyConnHalf(&wg, backend, client)
+	go proxyConnHalf(&wg, client, backend)
+	wg.Wait()
+}
+
+func proxyConnHalf(wg *sync.WaitGroup, dst, src net.Conn) {
+	defer wg.Done()
+	_, _ = io.Copy(dst, src)
+	if tcp, ok := dst.(*net.TCPConn); ok {
+		_ = tcp.CloseWrite()
+	}
+}
+
+func (p *containerPortProxy) dialBackend(timeout time.Duration) (net.Conn, error) {
+	if len(p.targets) == 0 {
+		return nil, fmt.Errorf("container port proxy has no backend targets")
+	}
+
+	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	defer cancel()
+
+	type dialResult struct {
+		target string
+		conn   net.Conn
+		err    error
+	}
+
+	results := make(chan dialResult, len(p.targets))
+	for _, target := range p.targets {
+		target := target
+		go func() {
+			dialer := &net.Dialer{}
+			conn, err := dialer.DialContext(ctx, "tcp", target)
+			select {
+			case results <- dialResult{target: target, conn: conn, err: err}:
+			case <-ctx.Done():
+				if conn != nil {
+					_ = conn.Close()
+				}
+			}
+		}()
+	}
+
+	var errs []error
+	for range p.targets {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Join(append(errs, ctx.Err())...)
+		case result := <-results:
+			if result.err == nil {
+				cancel()
+				return result.conn, nil
+			}
+			errs = append(errs, fmt.Errorf("%s: %w", result.target, result.err))
+		}
+	}
+	return nil, errors.Join(errs...)
+}
+
+func (p *containerPortProxy) close() {
+	p.cancel()
+	p.listenerMu.Lock()
+	if p.listener != nil {
+		_ = p.listener.Close()
+		p.listener = nil
+	}
+	p.listenerMu.Unlock()
+}

--- a/pkg/worker/container_port_proxy_test.go
+++ b/pkg/worker/container_port_proxy_test.go
@@ -1,0 +1,183 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerPortTargetsPreferNativeFamily(t *testing.T) {
+	info := &containerNetworkInfo{
+		ContainerIp:   "192.168.0.63",
+		ContainerIpv6: "fd00:abcd::3f",
+	}
+
+	native, fallback := containerPortTargets(info, 8781, addressFamilyIPv6)
+	require.Equal(t, "[fd00:abcd::3f]:8781", native)
+	require.Equal(t, "192.168.0.63:8781", fallback)
+
+	native, fallback = containerPortTargets(info, 8781, addressFamilyIPv4)
+	require.Equal(t, "192.168.0.63:8781", native)
+	require.Equal(t, "[fd00:abcd::3f]:8781", fallback)
+}
+
+func TestAddressFamilyForHostHandlesBracketedIPv6(t *testing.T) {
+	require.Equal(t, addressFamilyIPv6, addressFamilyForHost("[2600:1f18:37a4:c02::7286]"))
+	require.Equal(t, addressFamilyIPv4, addressFamilyForHost("10.42.0.34"))
+	require.Equal(t, addressFamilyUnknown, addressFamilyForHost("worker.local"))
+}
+
+func TestContainerPortProxyListenConfigUsesAdvertisedFamily(t *testing.T) {
+	network, address := containerPortProxyListenConfig(8781, addressFamilyIPv6)
+	require.Equal(t, "tcp6", network)
+	require.Equal(t, "[::]:8781", address)
+
+	network, address = containerPortProxyListenConfig(8781, addressFamilyIPv4)
+	require.Equal(t, "tcp4", network)
+	require.Equal(t, "0.0.0.0:8781", address)
+
+	network, address = containerPortProxyListenConfig(8781, addressFamilyUnknown)
+	require.Equal(t, "tcp", network)
+	require.Equal(t, ":8781", address)
+}
+
+func TestContainerPortProxyFallsBackToReachableBackendFamily(t *testing.T) {
+	backend := startLineServer(t, "tcp4", "127.0.0.1:0", "proxy-ok\n")
+	hostPort := freeTCPPortForNetwork(t, "tcp4", "127.0.0.1:0")
+	unusedIPv6Port, err := getRandomFreePort()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	proxy := newContainerPortProxy(ctx, "container-one", PortBinding{
+		HostPort:      hostPort,
+		ContainerPort: 8781,
+	}, addressFamilyIPv4, []string{
+		net.JoinHostPort("::1", fmt.Sprintf("%d", unusedIPv6Port)),
+		backend.Addr().String(),
+	})
+	defer proxy.close()
+	go proxy.run()
+
+	select {
+	case <-proxy.ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for port proxy to become ready")
+	}
+
+	conn, err := net.DialTimeout("tcp4", net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", hostPort)), time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("ping\n"))
+	require.NoError(t, err)
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "proxy-ok\n", line)
+}
+
+func TestContainerPortProxyAcceptsIPv6ForIPv4Backend(t *testing.T) {
+	backend := startLineServer(t, "tcp4", "127.0.0.1:0", "ipv6-to-ipv4-ok\n")
+	hostPort := freeTCPPortForNetwork(t, "tcp6", "[::1]:0")
+
+	proxy := startTestPortProxy(t, hostPort, addressFamilyIPv6, []string{backend.Addr().String()})
+	defer proxy.close()
+
+	line := dialLineServer(t, "tcp6", net.JoinHostPort("::1", fmt.Sprintf("%d", hostPort)))
+	require.Equal(t, "ipv6-to-ipv4-ok\n", line)
+}
+
+func TestContainerPortProxyAcceptsIPv4ForIPv6Backend(t *testing.T) {
+	backend := startLineServer(t, "tcp6", "[::1]:0", "ipv4-to-ipv6-ok\n")
+	hostPort := freeTCPPortForNetwork(t, "tcp4", "127.0.0.1:0")
+
+	proxy := startTestPortProxy(t, hostPort, addressFamilyIPv4, []string{backend.Addr().String()})
+	defer proxy.close()
+
+	line := dialLineServer(t, "tcp4", net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", hostPort)))
+	require.Equal(t, "ipv4-to-ipv6-ok\n", line)
+}
+
+func startTestPortProxy(t *testing.T, hostPort int, family addressFamily, targets []string) *containerPortProxy {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	proxy := newContainerPortProxy(ctx, "container-one", PortBinding{
+		HostPort:      hostPort,
+		ContainerPort: 8781,
+	}, family, targets)
+	go proxy.run()
+
+	select {
+	case <-proxy.ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for port proxy to become ready")
+	}
+	return proxy
+}
+
+func startLineServer(t *testing.T, network, address, response string) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen(network, address)
+	if err != nil && network == "tcp6" {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				if _, err := bufio.NewReader(conn).ReadString('\n'); err != nil {
+					return
+				}
+				_, _ = conn.Write([]byte(response))
+			}()
+		}
+	}()
+
+	return listener
+}
+
+func freeTCPPortForNetwork(t *testing.T, network, address string) int {
+	t.Helper()
+
+	listener, err := net.Listen(network, address)
+	if err != nil && network == "tcp6" {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+	defer listener.Close()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func dialLineServer(t *testing.T, network, address string) string {
+	t.Helper()
+
+	conn, err := net.DialTimeout(network, address, time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("ping\n"))
+	require.NoError(t, err)
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+	return line
+}

--- a/pkg/worker/container_server.go
+++ b/pkg/worker/container_server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/runtime"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
+	goproc "github.com/beam-cloud/goproc/pkg"
 	"github.com/google/shlex"
 	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -38,7 +39,8 @@ import (
 const (
 	gRPCMaxRecvMsgSize                  = 1024 * 1024 * 16
 	gRPCMaxSendMsgSize                  = 1024 * 1024 * 16
-	sandboxExecDialRetryDelay           = 25 * time.Millisecond
+	sandboxProcessManagerClientRetry    = 25 * time.Millisecond
+	sandboxProcessManagerClientTimeout  = 10 * time.Second
 	sandboxProcessManagerReadyTimeout   = 10 * time.Second
 	sandboxProcessManagerReadyPollDelay = 25 * time.Millisecond
 )
@@ -641,42 +643,75 @@ func (s *ContainerRuntimeServer) handleSandboxExec(ctx context.Context, in *pb.C
 }
 
 func (s *ContainerRuntimeServer) execSandboxProcess(ctx context.Context, containerId string, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
-	pid, err := s.execSandboxProcessOnce(ctx, instance, cmd, cwd, env)
-	if err == nil || !isProcessManagerDialFailure(err) {
-		return pid, err
-	}
-
-	log.Debug().
-		Str("container_id", containerId).
-		Str("container_ip", instance.ContainerIp).
-		Err(err).
-		Msg("retrying sandbox process manager exec after dial failure")
-
-	timer := time.NewTimer(sandboxExecDialRetryDelay)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return -1, ctx.Err()
-	case <-timer.C:
-	}
-
-	retryPID, retryErr := s.execSandboxProcessOnce(ctx, instance, cmd, cwd, env)
-	if retryErr != nil {
-		return -1, fmt.Errorf("%w; retry failed: %v", err, retryErr)
-	}
-
-	return retryPID, nil
-}
-
-func (s *ContainerRuntimeServer) execSandboxProcessOnce(ctx context.Context, instance *ContainerInstance, cmd []string, cwd string, env []string) (int, error) {
-	client, err := newProcessManagerClient(ctx, instance)
+	client, err := s.newSandboxProcessManagerClient(ctx, containerId, instance)
 	if err != nil {
 		return -1, err
 	}
 	defer client.Cleanup()
 
 	return client.Exec(cmd, cwd, env, false)
+}
+
+func (s *ContainerRuntimeServer) newSandboxProcessManagerClient(ctx context.Context, containerId string, instance *ContainerInstance) (*goproc.GoProcClient, error) {
+	var lastErr error
+	loggedRetry := false
+	deadline := time.Now().Add(sandboxProcessManagerClientTimeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, sandboxProcessManagerClientError(err, lastErr)
+		}
+		if time.Now().After(deadline) {
+			return nil, sandboxProcessManagerClientTimeoutError(lastErr)
+		}
+
+		instance = s.refreshContainerInstance(containerId, instance)
+		client, err := newProcessManagerClient(ctx, instance)
+		if err == nil {
+			return client, nil
+		}
+
+		lastErr = err
+		retryable := isProcessManagerDialFailure(err)
+		if !retryable {
+			return nil, err
+		}
+		if !loggedRetry {
+			log.Debug().
+				Str("container_id", containerId).
+				Str("container_ip", instance.ContainerIp).
+				Err(err).
+				Msg("waiting for sandbox process manager client after dial failure")
+			loggedRetry = true
+		}
+
+		timer := time.NewTimer(sandboxProcessManagerClientRetry)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, sandboxProcessManagerClientError(ctx.Err(), lastErr)
+		case <-timer.C:
+		}
+	}
+}
+
+func sandboxProcessManagerClientError(ctxErr, lastErr error) error {
+	if errors.Is(ctxErr, context.Canceled) {
+		return errors.New("Request cancelled")
+	}
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return sandboxProcessManagerClientTimeoutError(lastErr)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return ctxErr
+}
+
+func sandboxProcessManagerClientTimeoutError(lastErr error) error {
+	if lastErr != nil {
+		return fmt.Errorf("sandbox process manager client not ready within timeout: %w", lastErr)
+	}
+	return errors.New("sandbox process manager client not ready within timeout")
 }
 
 func isProcessManagerDialFailure(err error) bool {
@@ -793,7 +828,7 @@ func (s *ContainerRuntimeServer) ContainerSandboxStatus(ctx context.Context, in 
 		}, nil
 	}
 
-	client, err := newProcessManagerClient(ctx, instance)
+	client, err := s.newSandboxProcessManagerClient(ctx, in.ContainerId, instance)
 	if err != nil {
 		return &pb.ContainerSandboxStatusResponse{
 			Ok:       false,
@@ -843,7 +878,7 @@ func (s *ContainerRuntimeServer) ContainerSandboxStdout(ctx context.Context, in 
 		}, nil
 	}
 
-	client, err := newProcessManagerClient(ctx, instance)
+	client, err := s.newSandboxProcessManagerClient(ctx, in.ContainerId, instance)
 	if err != nil {
 		return &pb.ContainerSandboxStdoutResponse{
 			Ok:       false,
@@ -882,7 +917,7 @@ func (s *ContainerRuntimeServer) ContainerSandboxStderr(ctx context.Context, in 
 		}, nil
 	}
 
-	client, err := newProcessManagerClient(ctx, instance)
+	client, err := s.newSandboxProcessManagerClient(ctx, in.ContainerId, instance)
 	if err != nil {
 		return &pb.ContainerSandboxStderrResponse{
 			Ok:       false,
@@ -917,7 +952,7 @@ func (s *ContainerRuntimeServer) ContainerSandboxKill(ctx context.Context, in *p
 		return &pb.ContainerSandboxKillResponse{Ok: false, ErrorMsg: "Sandbox process manager is not ready"}, nil
 	}
 
-	client, err := newProcessManagerClient(ctx, instance)
+	client, err := s.newSandboxProcessManagerClient(ctx, in.ContainerId, instance)
 	if err != nil {
 		return &pb.ContainerSandboxKillResponse{Ok: false, ErrorMsg: err.Error()}, nil
 	}
@@ -980,7 +1015,7 @@ func (s *ContainerRuntimeServer) ContainerSandboxListProcesses(ctx context.Conte
 	}
 
 	processes := make([]*pb.ProcessInfo, 0)
-	client, err := newProcessManagerClient(ctx, instance)
+	client, err := s.newSandboxProcessManagerClient(ctx, in.ContainerId, instance)
 	if err != nil {
 		return &pb.ContainerSandboxListProcessesResponse{Ok: false, ErrorMsg: err.Error()}, nil
 	}

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -34,6 +35,8 @@ const (
 	checkpointArchiveExtension = ".tar"
 	checkpointOriginPrefix     = "checkpoints"
 )
+
+var errCRIUManagerUnavailable = errors.New("checkpoint/restore unavailable: CRIU manager is not initialized")
 
 type checkpointCacheMetadata struct {
 	hash        string
@@ -117,6 +120,10 @@ func (s *Worker) attemptRestoreCheckpoint(ctx context.Context, request *types.Co
 		return -1, false, fmt.Errorf("checkpoint not available")
 	}
 
+	if err := s.requireCRIUManager(); err != nil {
+		return -1, false, err
+	}
+
 	outputLogger.Info("Attempting to restore container from checkpoint...")
 	signalDir := checkpointSignalDir(request.ContainerId)
 	if err := os.MkdirAll(signalDir, 0755); err != nil {
@@ -156,27 +163,19 @@ func (s *Worker) attemptRestoreCheckpoint(ctx context.Context, request *types.Co
 		return exitCode, false, err
 	}
 
-	s.signalRestoredSandboxProcessManager(ctx, request, instance)
-
-	if err := s.updateCheckpointRestored(checkpoint.CheckpointId); err != nil {
-		log.Warn().Err(err).Str("checkpoint_id", checkpoint.CheckpointId).Msg("failed to update checkpoint restore timestamp")
-	}
-
-	outputLogger.Info("Checkpoint found and restored")
 	return exitCode, true, nil
 }
 
-func (s *Worker) signalRestoredSandboxProcessManager(ctx context.Context, request *types.ContainerRequest, instance *ContainerInstance) {
-	if request.Stub.Type.Kind() != types.StubTypeSandbox || instance == nil || instance.Runtime == nil {
+func (s *Worker) signalRestoredSandboxProcessManager(ctx context.Context, request *types.ContainerRequest, rt runtime.Runtime) {
+	if request.Stub.Type.Kind() != types.StubTypeSandbox || rt == nil {
 		return
 	}
 
 	signalCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	// SIGWINCH is ignored by older goproc builds, so this nudge is safe during rolling upgrades.
-	if err := instance.Runtime.Kill(signalCtx, request.ContainerId, syscall.SIGWINCH, &runtime.KillOpts{}); err != nil {
-		log.Warn().
+	if err := rt.Kill(signalCtx, request.ContainerId, syscall.SIGWINCH, &runtime.KillOpts{}); err != nil {
+		log.Debug().
 			Err(err).
 			Str("container_id", request.ContainerId).
 			Msg("failed to signal restored sandbox process manager")
@@ -198,6 +197,10 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 	instance, exists := s.containerInstances.Get(opts.Request.ContainerId)
 	if !exists {
 		return fmt.Errorf("container instance not found")
+	}
+
+	if err := s.requireCRIUManager(); err != nil {
+		return err
 	}
 
 	if opts.CheckpointPIDChan != nil {
@@ -631,13 +634,8 @@ func (s *Worker) shouldCreateCheckpoint(request *types.ContainerRequest) bool {
 }
 
 func (s *Worker) IsCRIUAvailable(gpuCount uint32) bool {
-	if s.criuManager == nil {
-		log.Warn().Msg("criu manager not initialized")
-		return false
-	}
-
-	if !s.criuManager.Available() {
-		log.Warn().Msg("criu manager not available")
+	if err := s.requireCRIUManager(); err != nil {
+		log.Warn().Err(err).Msg("C/R unavailable")
 		return false
 	}
 
@@ -654,6 +652,13 @@ func (s *Worker) IsCRIUAvailable(gpuCount uint32) bool {
 	}
 
 	return pool.CRIUEnabled
+}
+
+func (s *Worker) requireCRIUManager() error {
+	if s.criuManager == nil || !s.criuManager.Available() {
+		return errCRIUManagerUnavailable
+	}
+	return nil
 }
 
 func (s *Worker) createCheckpointState(checkpointId string, request *types.ContainerRequest, status types.CheckpointStatus, containerIp string) error {

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/runtime"
 	types "github.com/beam-cloud/beta9/pkg/types"
@@ -17,7 +18,9 @@ import (
 )
 
 const (
-	minNvidiaDriverVersion = 570
+	minNvidiaDriverVersion     = 570
+	gvisorCheckpointAttempts   = 4
+	gvisorCheckpointRetryDelay = 250 * time.Millisecond
 )
 
 type ErrCRIURestoreFailed struct {
@@ -64,17 +67,45 @@ func (c *NvidiaCRIUManager) CreateCheckpoint(ctx context.Context, rt runtime.Run
 		return "", fmt.Errorf("failed to create checkpoint work directory: %w", err)
 	}
 
-	// Create checkpoint with all required options for proper CUDA checkpoint
-	err := rt.Checkpoint(ctx, request.ContainerId, &runtime.CheckpointOpts{
+	checkpointOpts := &runtime.CheckpointOpts{
 		ImagePath:    checkpointPath,
 		WorkDir:      workDir, // Required for checkpoint files (logs, cache, sockets)
 		LeaveRunning: true,    // Keep container running (hot checkpoint)
 		AllowOpenTCP: true,    // Allow open TCP connections
 		SkipInFlight: true,    // Skip in-flight TCP packets
 		LinkRemap:    true,    // Enable link remapping for file descriptors
-	})
-	if err != nil {
-		return "", fmt.Errorf("checkpoint failed for runtime %s: %w", rt.Name(), err)
+	}
+
+	attempts := 1
+	if rt.Name() == types.ContainerRuntimeGvisor.String() {
+		attempts = gvisorCheckpointAttempts
+	}
+
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = rt.Checkpoint(ctx, request.ContainerId, checkpointOpts)
+		if err == nil {
+			break
+		}
+		if attempt == attempts || !retryableGvisorCheckpointError(rt, err) {
+			return "", fmt.Errorf("checkpoint failed for runtime %s: %w", rt.Name(), err)
+		}
+
+		log.Warn().
+			Err(err).
+			Str("runtime", rt.Name()).
+			Str("checkpoint_id", checkpointId).
+			Int("attempt", attempt).
+			Msg("retrying checkpoint after transient runtime error")
+
+		_ = os.RemoveAll(checkpointPath)
+		_ = os.RemoveAll(workDir)
+		if err := os.MkdirAll(workDir, 0755); err != nil {
+			return "", fmt.Errorf("failed to recreate checkpoint work directory: %w", err)
+		}
+		if err := waitCheckpointRetry(ctx, attempt); err != nil {
+			return "", err
+		}
 	}
 
 	log.Info().
@@ -85,6 +116,28 @@ func (c *NvidiaCRIUManager) CreateCheckpoint(ctx context.Context, rt runtime.Run
 		Msg("checkpoint created successfully")
 
 	return checkpointPath, nil
+}
+
+func retryableGvisorCheckpointError(rt runtime.Runtime, err error) bool {
+	if err == nil || rt.Name() != types.ContainerRuntimeGvisor.String() {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "tcp.Endpoint") ||
+		strings.Contains(msg, "invalid memory address or nil pointer dereference")
+}
+
+func waitCheckpointRetry(ctx context.Context, attempt int) error {
+	delay := time.Duration(attempt) * gvisorCheckpointRetryDelay
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, rt runtime.Runtime, opts *RestoreOpts) (int, error) {

--- a/pkg/worker/criu_test.go
+++ b/pkg/worker/criu_test.go
@@ -2,12 +2,14 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/runtime"
 	types "github.com/beam-cloud/beta9/pkg/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -18,9 +20,13 @@ type MockRuntime struct {
 	name             string
 	checkpointCalled bool
 	restoreCalled    bool
+	checkpointCalls  int
 	checkpointError  error
+	checkpointErrors []error
 	restoreError     error
 	restoreExitCode  int
+	killCalled       bool
+	killSignal       syscall.Signal
 	capabilities     runtime.Capabilities
 }
 
@@ -52,6 +58,8 @@ func (m *MockRuntime) Exec(ctx context.Context, containerID string, proc specs.P
 }
 
 func (m *MockRuntime) Kill(ctx context.Context, containerID string, sig syscall.Signal, opts *runtime.KillOpts) error {
+	m.killCalled = true
+	m.killSignal = sig
 	return nil
 }
 
@@ -71,6 +79,14 @@ func (m *MockRuntime) Events(ctx context.Context, containerID string) (<-chan ru
 
 func (m *MockRuntime) Checkpoint(ctx context.Context, containerID string, opts *runtime.CheckpointOpts) error {
 	m.checkpointCalled = true
+	m.checkpointCalls++
+	if len(m.checkpointErrors) > 0 {
+		err := m.checkpointErrors[0]
+		m.checkpointErrors = m.checkpointErrors[1:]
+		if err != nil {
+			return err
+		}
+	}
 	if m.checkpointError != nil {
 		return m.checkpointError
 	}
@@ -99,7 +115,10 @@ func (m *MockRuntime) Close() error {
 // Reset clears the mock runtime state flags for reuse in subtests
 func (m *MockRuntime) Reset() {
 	m.checkpointCalled = false
+	m.checkpointCalls = 0
 	m.restoreCalled = false
+	m.killCalled = false
+	m.killSignal = 0
 }
 
 // TestNvidiaCRIUManager tests NVIDIA CRIU manager with different runtimes
@@ -354,6 +373,123 @@ func TestCheckpointMaterializedRequiresRuntimeAndFilesystemPayload(t *testing.T)
 	}
 	if !checkpointMaterialized(checkpointPath) {
 		t.Fatal("checkpoint with filesystem and runtime payload should be materialized")
+	}
+}
+
+func TestCreateCheckpointRequiresCRIUManager(t *testing.T) {
+	containerID := "container-no-criu"
+	worker := &Worker{containerInstances: common.NewSafeMap[*ContainerInstance]()}
+	worker.containerInstances.Set(containerID, &ContainerInstance{
+		Id:      containerID,
+		Runtime: NewMockRuntime("runc", runtime.Capabilities{CheckpointRestore: true}),
+	})
+
+	err := worker.createCheckpoint(context.Background(), &CreateCheckpointOpts{
+		Request:      &types.ContainerRequest{ContainerId: containerID},
+		CheckpointId: "checkpoint-no-criu",
+	})
+	if !errors.Is(err, errCRIUManagerUnavailable) {
+		t.Fatalf("createCheckpoint error = %v, want %v", err, errCRIUManagerUnavailable)
+	}
+}
+
+func TestCreateCheckpointRetriesTransientGvisorTCPStateError(t *testing.T) {
+	manager := &NvidiaCRIUManager{checkpointRoot: t.TempDir(), available: true}
+	rt := NewMockRuntime(types.ContainerRuntimeGvisor.String(), runtime.Capabilities{CheckpointRestore: true})
+	rt.checkpointErrors = []error{
+		errors.New("encoding error: invalid memory address or nil pointer dereference for object tcp.Endpoint"),
+		nil,
+	}
+
+	_, err := manager.CreateCheckpoint(context.Background(), rt, "checkpoint-retry", &types.ContainerRequest{
+		ContainerId: "sandbox-retry",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateCheckpoint error = %v", err)
+	}
+	if rt.checkpointCalls != 2 {
+		t.Fatalf("checkpoint calls = %d, want 2", rt.checkpointCalls)
+	}
+}
+
+func TestCreateCheckpointDoesNotRetryRuncCheckpointError(t *testing.T) {
+	manager := &NvidiaCRIUManager{checkpointRoot: t.TempDir(), available: true}
+	rt := NewMockRuntime(types.ContainerRuntimeRunc.String(), runtime.Capabilities{CheckpointRestore: true})
+	rt.checkpointError = errors.New("encoding error: invalid memory address or nil pointer dereference for object tcp.Endpoint")
+
+	_, err := manager.CreateCheckpoint(context.Background(), rt, "checkpoint-no-retry", &types.ContainerRequest{
+		ContainerId: "sandbox-no-retry",
+	})
+
+	if err == nil {
+		t.Fatal("expected CreateCheckpoint error")
+	}
+	if rt.checkpointCalls != 1 {
+		t.Fatalf("checkpoint calls = %d, want 1", rt.checkpointCalls)
+	}
+}
+
+func TestAttemptRestoreCheckpointRequiresCRIUManager(t *testing.T) {
+	request := &types.ContainerRequest{
+		ContainerId: "container-restore-no-criu",
+		Checkpoint: &types.Checkpoint{
+			CheckpointId: "checkpoint-no-criu",
+			Status:       string(types.CheckpointStatusAvailable),
+		},
+	}
+
+	exitCode, restored, err := (&Worker{}).attemptRestoreCheckpoint(
+		context.Background(),
+		request,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if !errors.Is(err, errCRIUManagerUnavailable) {
+		t.Fatalf("attemptRestoreCheckpoint error = %v, want %v", err, errCRIUManagerUnavailable)
+	}
+	if restored {
+		t.Fatal("attemptRestoreCheckpoint restored with unavailable CRIU manager")
+	}
+	if exitCode != -1 {
+		t.Fatalf("attemptRestoreCheckpoint exitCode = %d, want -1", exitCode)
+	}
+}
+
+func TestSignalRestoredSandboxProcessManager(t *testing.T) {
+	rt := NewMockRuntime("gvisor", runtime.Capabilities{CheckpointRestore: true})
+	request := &types.ContainerRequest{
+		ContainerId: "sandbox-restore",
+		Stub: types.StubWithRelated{Stub: types.Stub{
+			Type: types.StubType(types.StubTypeSandbox),
+		}},
+	}
+
+	(&Worker{}).signalRestoredSandboxProcessManager(context.Background(), request, rt)
+
+	if !rt.killCalled {
+		t.Fatal("expected restored sandbox process manager to be signaled")
+	}
+	if rt.killSignal != syscall.SIGWINCH {
+		t.Fatalf("signal = %v, want %v", rt.killSignal, syscall.SIGWINCH)
+	}
+}
+
+func TestSignalRestoredSandboxProcessManagerSkipsNonSandbox(t *testing.T) {
+	rt := NewMockRuntime("gvisor", runtime.Capabilities{CheckpointRestore: true})
+	request := &types.ContainerRequest{
+		ContainerId: "endpoint-restore",
+		Stub: types.StubWithRelated{Stub: types.Stub{
+			Type: types.StubType(types.StubTypeEndpoint),
+		}},
+	}
+
+	(&Worker{}).signalRestoredSandboxProcessManager(context.Background(), request, rt)
+
+	if rt.killCalled {
+		t.Fatal("did not expect non-sandbox restore to be signaled")
 	}
 }
 

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -1178,6 +1178,11 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 	request.ConfigPath = configPath
 
 	outputWriter := containerInstance.OutputWriter
+	restoringCheckpoint := request.Checkpoint != nil &&
+		request.Checkpoint.Status == string(types.CheckpointStatusAvailable) &&
+		containerInstance.Runtime != nil &&
+		containerInstance.Runtime.Capabilities().CheckpointRestore &&
+		s.IsCRIUAvailable(request.GpuCount)
 
 	// Log metrics
 	go s.workerUsageMetrics.EmitContainerUsage(ctx, request)
@@ -1226,6 +1231,9 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 			instance, exists := s.containerInstances.Get(containerId)
 			if !exists {
 				return
+			}
+			if restoringCheckpoint {
+				s.signalRestoredSandboxProcessManager(ctx, request, instance.Runtime)
 			}
 
 			phaseStart := time.Now()
@@ -1387,6 +1395,19 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 	}
 
 	supportsCheckpoint := instance.Runtime.Capabilities().CheckpointRestore && s.IsCRIUAvailable(request.GpuCount)
+	restoringCheckpoint := supportsCheckpoint && request.Checkpoint != nil && request.Checkpoint.Status == string(types.CheckpointStatusAvailable)
+	var checkpointRestoredOnce sync.Once
+	markCheckpointRestored := func() {
+		if !restoringCheckpoint {
+			return
+		}
+		checkpointRestoredOnce.Do(func() {
+			if err := s.updateCheckpointRestored(request.Checkpoint.CheckpointId); err != nil {
+				log.Warn().Err(err).Str("checkpoint_id", request.Checkpoint.CheckpointId).Msg("failed to update checkpoint restore timestamp")
+			}
+			outputLogger.Info("Checkpoint found and restored")
+		})
+	}
 
 	// Handle automatic checkpoint creation if applicable
 	// (This occurs when checkpoint_enabled is true and an existing checkpoint is not available)
@@ -1429,6 +1450,7 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 			return
 		}
 		s.markContainerRunning(ctx, request, startupStartedAt)
+		markCheckpointRestored()
 	}
 
 	go func() {
@@ -1455,6 +1477,9 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		if restored {
 			close(runtimeStartedDone)
 			<-runtimeStartedHandled
+			if runtimeRestoreWaitsForExit(instance.Runtime) {
+				return exitCode, err
+			}
 			if err != nil {
 				return exitCode, err
 			}
@@ -1504,6 +1529,7 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 func (s *Worker) waitForRestoredContainerExit(ctx context.Context, rt runtime.Runtime, containerId string, fallbackExitCode int) (int, error) {
 	ticker := time.NewTicker(restoredContainerPollInterval)
 	defer ticker.Stop()
+	observedRunning := false
 
 	for {
 		state, err := rt.State(ctx, containerId)
@@ -1511,11 +1537,15 @@ func (s *Worker) waitForRestoredContainerExit(ctx context.Context, rt runtime.Ru
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return fallbackExitCode, ctxErr
 			}
-			return fallbackExitCode, nil
+			if !observedRunning {
+				return -1, fmt.Errorf("restored container state unavailable: %w", err)
+			}
+			return -1, nil
 		}
 		if state.Status != types.RuncContainerStatusRunning {
-			return fallbackExitCode, nil
+			return -1, nil
 		}
+		observedRunning = true
 
 		select {
 		case <-ctx.Done():
@@ -1523,6 +1553,15 @@ func (s *Worker) waitForRestoredContainerExit(ctx context.Context, rt runtime.Ru
 		case <-ticker.C:
 		}
 	}
+}
+
+type restoreWaitsForExitRuntime interface {
+	RestoreWaitsForExit() bool
+}
+
+func runtimeRestoreWaitsForExit(rt runtime.Runtime) bool {
+	restoreRuntime, ok := rt.(restoreWaitsForExitRuntime)
+	return ok && restoreRuntime.RestoreWaitsForExit()
 }
 
 func (s *Worker) markContainerRunning(ctx context.Context, request *types.ContainerRequest, startupStartedAt time.Time) {

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -524,7 +524,7 @@ func (s *Worker) publishContainerAddresses(ctx context.Context, request *types.C
 
 	containerId := request.ContainerId
 	if len(bindings) > 0 {
-		containerAddr := fmt.Sprintf("%s:%d", s.podAddr, bindings[0].HostPort)
+		containerAddr := joinHostPort(s.podAddr, bindings[0].HostPort)
 		phaseStart := time.Now()
 		_, err := handleGRPCResponse(s.containerRepoClient.SetContainerAddress(context.Background(), &pb.SetContainerAddressRequest{
 			ContainerId: containerId,
@@ -540,7 +540,7 @@ func (s *Worker) publishContainerAddresses(ctx context.Context, request *types.C
 
 	addressMap := make(map[int32]string, len(bindings))
 	for _, binding := range bindings {
-		addressMap[int32(binding.ContainerPort)] = fmt.Sprintf("%s:%d", s.podAddr, binding.HostPort)
+		addressMap[int32(binding.ContainerPort)] = joinHostPort(s.podAddr, binding.HostPort)
 	}
 	s.cacheContainerAddressMap(containerId, addressMap)
 

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -260,6 +260,32 @@ func TestRegisterContainerPortsKeepsLocalAddressBehavior(t *testing.T) {
 	require.Equal(t, "10.0.0.2:30002", instance.ContainerAddressMap[2222])
 }
 
+func TestPublishContainerAddressesFormatsBracketedIPv6PodAddress(t *testing.T) {
+	containerID := "container-ipv6"
+	repoClient := &fakeContainerRepoClient{}
+	worker := &Worker{
+		containerRepoClient: repoClient,
+		containerInstances:  common.NewSafeMap[*ContainerInstance](),
+		podAddr:             "[2600:1f18:37a4:c02::7286]",
+	}
+	worker.containerInstances.Set(containerID, &ContainerInstance{})
+
+	err := worker.publishContainerAddresses(context.Background(), &types.ContainerRequest{
+		ContainerId: containerID,
+	}, []PortBinding{
+		{HostPort: 30001, ContainerPort: 8001},
+		{HostPort: 30002, ContainerPort: 2222},
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, repoClient.lastSetAddress)
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:30001", repoClient.lastSetAddress.Address)
+
+	require.NotNil(t, repoClient.lastSetAddressMap)
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:30001", repoClient.lastSetAddressMap.AddressMap[8001])
+	require.Equal(t, "[2600:1f18:37a4:c02::7286]:30002", repoClient.lastSetAddressMap.AddressMap[2222])
+}
+
 func TestPublishContainerAddressesSkipsAgentWorkers(t *testing.T) {
 	repoClient := &fakeContainerRepoClient{}
 	worker := &Worker{

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -715,14 +715,16 @@ func TestRunContainerRestorePublishesAddressFromStartedHandler(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.Equal(t, 0, exitCode)
+	require.Equal(t, -1, exitCode)
 	require.Equal(t, 1, repoClient.setAddressCalls)
 	require.Equal(t, "10.42.0.10:30001", repoClient.lastSetAddress.Address)
 	require.Equal(t, 1, repoClient.setAddressMapCalls)
 	require.Equal(t, "10.42.0.10:30001", repoClient.lastSetAddressMap.AddressMap[8001])
 	require.Equal(t, 1, repoClient.updateStatusCalls)
 	require.Equal(t, string(types.ContainerStatusRunning), repoClient.lastUpdateStatus.Status)
-	require.Equal(t, 1, backendRepoClient.updateCalls)
+	require.Eventually(t, func() bool {
+		return backendRepoClient.updateCalls == 1 && backendRepoClient.lastUpdate.LastRestoredAt != nil
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestRunContainerRestoreWaitsForRestoredRuntimeExit(t *testing.T) {
@@ -822,6 +824,20 @@ func TestRunContainerRestoreWaitsForRestoredRuntimeExit(t *testing.T) {
 	}
 }
 
+func TestWaitForRestoredContainerExitFailsBeforeRunningState(t *testing.T) {
+	rt := &mockRuntime{
+		state: func(context.Context, string) (runtime.State, error) {
+			return runtime.State{}, runtime.ErrContainerNotFound{ContainerID: "container-restore"}
+		},
+	}
+
+	exitCode, err := (&Worker{}).waitForRestoredContainerExit(context.Background(), rt, "container-restore", 0)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "restored container state unavailable")
+	require.Equal(t, -1, exitCode)
+}
+
 func TestAttemptRestoreCheckpointTreatsGenericErrorAsRestoreFailure(t *testing.T) {
 	restoreErr := assert.AnError
 	containerID := "container-restore-generic-error"
@@ -864,7 +880,7 @@ func TestAttemptRestoreCheckpointTreatsGenericErrorAsRestoreFailure(t *testing.T
 	require.Nil(t, backendRepoClient.lastUpdate.LastRestoredAt)
 }
 
-func TestAttemptRestoreCheckpointSignalsSandboxProcessManagerAfterRestore(t *testing.T) {
+func TestAttemptRestoreCheckpointRestoresRuntimeOnly(t *testing.T) {
 	containerID := "container-restore-sandbox"
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join("/tmp", containerID)) })
 
@@ -901,11 +917,9 @@ func TestAttemptRestoreCheckpointSignalsSandboxProcessManagerAfterRestore(t *tes
 	require.NoError(t, err)
 	require.True(t, restored)
 	require.Equal(t, 0, exitCode)
-	require.Equal(t, []syscall.Signal{syscall.SIGWINCH}, rt.signals)
-	require.Len(t, rt.killOpts, 1)
-	require.False(t, rt.killOpts[0].All)
-	require.Equal(t, 1, backendRepoClient.updateCalls)
-	require.NotNil(t, backendRepoClient.lastUpdate.LastRestoredAt)
+	require.Empty(t, rt.signals)
+	require.Empty(t, rt.killOpts)
+	require.Equal(t, 0, backendRepoClient.updateCalls)
 }
 
 func TestAddRequestMountsBuildsVolumeCacheMap(t *testing.T) {

--- a/pkg/worker/network.go
+++ b/pkg/worker/network.go
@@ -70,9 +70,11 @@ type ContainerNetworkManager struct {
 	containerRepoClient pb.ContainerRepositoryServiceClient
 	eventRepo           repo.EventRepository
 	networkPrefix       string
+	podAddr             string
 	bridgeMu            sync.Mutex
 	ipMu                sync.Mutex
 	iptablesMu          sync.Mutex
+	portExposureMu      sync.Mutex
 	containerLocksMu    sync.Mutex
 	containerLocks      sync.Map
 	config              types.AppConfig
@@ -88,6 +90,7 @@ type ContainerNetworkManager struct {
 	slotMu              sync.Mutex
 	freeSlots           []*containerNetworkSlot
 	containerSlots      map[string]*containerNetworkSlot
+	portExposures       map[int]*containerPortExposure
 	totalSlots          int
 	slotFillRunning     bool
 	slotPoolClosed      bool
@@ -752,6 +755,8 @@ func (m *ContainerNetworkManager) deleteNetworkSlotResources(slotID string) {
 }
 
 func (m *ContainerNetworkManager) Close() error {
+	m.stopAllPortExposures()
+
 	slots := m.drainFreeNetworkSlots()
 	ctx, cancel := context.WithTimeout(context.Background(), workerShutdownRPCTimeout)
 	defer cancel()
@@ -2094,6 +2099,8 @@ func (m *ContainerNetworkManager) TearDown(containerId string) error {
 	unlockContainer := m.lockContainerNetwork(containerId)
 	defer unlockContainer()
 
+	m.stopContainerPortExposures(containerId)
+
 	if slot := m.containerNetworkSlot(containerId); slot != nil {
 		return m.tearDownPreallocatedNetworkSlot(containerId, slot)
 	}
@@ -2301,11 +2308,8 @@ func (m *ContainerNetworkManager) ExposePorts(containerId string, bindings []Por
 		return err
 	}
 
-	m.iptablesMu.Lock()
-	defer m.iptablesMu.Unlock()
-
 	for _, binding := range bindings {
-		if err := m.exposePortLocked(info, binding.HostPort, binding.ContainerPort); err != nil {
+		if err := m.startContainerPortExposure(containerId, info, binding); err != nil {
 			return err
 		}
 	}
@@ -2313,38 +2317,126 @@ func (m *ContainerNetworkManager) ExposePorts(containerId string, bindings []Por
 	return nil
 }
 
-func (m *ContainerNetworkManager) exposePortLocked(info *containerNetworkInfo, hostPort, containerPort int) error {
-	// Insert NAT PREROUTING rule at the top of the chain
-	// IPv4
-	err := m.ipt.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", info.ContainerIp, containerPort), "-m", "comment", "--comment", info.Comment)
-	if err != nil {
-		return err
+func (m *ContainerNetworkManager) startContainerPortExposure(containerId string, info *containerNetworkInfo, binding PortBinding) error {
+	family := addressFamilyForHost(m.podAddr)
+	native, fallback := containerPortTargets(info, binding.ContainerPort, family)
+	if native == "" && fallback == "" {
+		return fmt.Errorf("container %s has no network targets for port %d", containerId, binding.ContainerPort)
 	}
 
-	// IPv6
-	if m.ipt6 != nil && info.ContainerIpv6 != "" {
-		err = m.ipt6.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("[%s]:%d", info.ContainerIpv6, containerPort), "-m", "comment", "--comment", info.Comment)
-		if err != nil {
-			return err
+	exposure := newContainerPortExposure(m.ctx, containerId, binding)
+
+	m.portExposureMu.Lock()
+	if m.portExposures == nil {
+		m.portExposures = map[int]*containerPortExposure{}
+	}
+	if existing := m.portExposures[binding.HostPort]; existing != nil {
+		m.portExposureMu.Unlock()
+		if existing.containerID == containerId && existing.containerPort == binding.ContainerPort {
+			return nil
 		}
+		return fmt.Errorf("host port %d is already proxied for container %s port %d", binding.HostPort, existing.containerID, existing.containerPort)
 	}
+	m.portExposures[binding.HostPort] = exposure
+	m.portExposureMu.Unlock()
 
-	// Add FORWARD rule for the DNAT'd traffic
-	// IPv4
-	err = m.ipt.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIp, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment)
-	if err != nil {
-		return err
-	}
-
-	// IPv6
-	if m.ipt6 != nil && info.ContainerIpv6 != "" {
-		err = m.ipt6.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIpv6, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment)
-		if err != nil {
-			return err
-		}
-	}
-
+	go m.runContainerPortExposure(exposure, info, binding, family, native, fallback)
 	return nil
+}
+
+func (m *ContainerNetworkManager) runContainerPortExposure(exposure *containerPortExposure, info *containerNetworkInfo, binding PortBinding, family addressFamily, native, fallback string) {
+	ticker := time.NewTicker(containerPortProxyReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		nativeReady := containerPortTargetReachable(exposure.ctx, native, containerPortProxyDialTimeout)
+		fallbackReady := containerPortTargetReachable(exposure.ctx, fallback, containerPortProxyDialTimeout)
+		if nativeReady || (family == addressFamilyUnknown && fallbackReady) {
+			if err := m.exposePortDNAT(exposure.ctx, info, binding.HostPort, binding.ContainerPort, family); err != nil {
+				log.Warn().
+					Err(err).
+					Str("container_id", exposure.containerID).
+					Int("host_port", binding.HostPort).
+					Int("container_port", binding.ContainerPort).
+					Msg("failed to expose container port with kernel forwarding")
+			}
+			return
+		}
+		if fallbackReady {
+			exposure.startProxy(family, []string{fallback})
+			return
+		}
+
+		select {
+		case <-exposure.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *ContainerNetworkManager) exposePortDNAT(ctx context.Context, info *containerNetworkInfo, hostPort, containerPort int, family addressFamily) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	m.iptablesMu.Lock()
+	defer m.iptablesMu.Unlock()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return m.exposePortDNATLocked(info, hostPort, containerPort, family)
+}
+
+func (m *ContainerNetworkManager) exposePortDNATLocked(info *containerNetworkInfo, hostPort, containerPort int, family addressFamily) error {
+	if family != addressFamilyIPv6 {
+		if err := m.ipt.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", info.ContainerIp, containerPort), "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+		if err := m.ipt.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIp, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+	}
+	if family != addressFamilyIPv4 && m.ipt6 != nil && info.ContainerIpv6 != "" {
+		if err := m.ipt6.InsertUnique("nat", "PREROUTING", 1, "-p", "tcp", "--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", fmt.Sprintf("[%s]:%d", info.ContainerIpv6, containerPort), "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+		if err := m.ipt6.AppendUnique("filter", "FORWARD", "-p", "tcp", "-d", info.ContainerIpv6, "--dport", fmt.Sprintf("%d", containerPort), "-j", "ACCEPT", "-m", "comment", "--comment", info.Comment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ContainerNetworkManager) stopContainerPortExposures(containerId string) {
+	var exposures []*containerPortExposure
+
+	m.portExposureMu.Lock()
+	for hostPort, exposure := range m.portExposures {
+		if exposure.containerID != containerId {
+			continue
+		}
+		delete(m.portExposures, hostPort)
+		exposures = append(exposures, exposure)
+	}
+	m.portExposureMu.Unlock()
+
+	for _, exposure := range exposures {
+		exposure.close()
+	}
+}
+
+func (m *ContainerNetworkManager) stopAllPortExposures() {
+	m.portExposureMu.Lock()
+	exposures := make([]*containerPortExposure, 0, len(m.portExposures))
+	for hostPort, exposure := range m.portExposures {
+		delete(m.portExposures, hostPort)
+		exposures = append(exposures, exposure)
+	}
+	m.portExposureMu.Unlock()
+
+	for _, exposure := range exposures {
+		exposure.close()
+	}
 }
 
 func (m *ContainerNetworkManager) UpdateNetworkPermissions(containerId string, request *types.ContainerRequest) error {

--- a/sdk/tests/test_sandbox_log_streaming_integration.py
+++ b/sdk/tests/test_sandbox_log_streaming_integration.py
@@ -2,12 +2,21 @@ import os
 import queue
 import threading
 import time
+import urllib.request
 
 import pytest
 
 from beta9 import Image, Sandbox
+from beta9.abstractions import base as base_module
 from beta9.abstractions.base import unset_channel
 from beta9.config import set_settings
+
+
+def _close_global_channel():
+    channel = getattr(base_module, "_channel", None)
+    if channel is not None:
+        channel.close()
+    unset_channel()
 
 
 def _configure_local_gateway(monkeypatch, tmp_path):
@@ -29,7 +38,31 @@ def _configure_local_gateway(monkeypatch, tmp_path):
         monkeypatch.delenv("BETA9_TOKEN", raising=False)
 
     set_settings()
-    unset_channel()
+    _close_global_channel()
+
+
+def _wait_public_url_contains(url, *values):
+    token = os.environ.get("BETA9_TOKEN")
+    deadline = time.monotonic() + 90
+    last_error = None
+    last_body = ""
+
+    while time.monotonic() < deadline:
+        try:
+            request = urllib.request.Request(url)
+            if token:
+                request.add_header("Authorization", f"Bearer {token}")
+            with urllib.request.urlopen(request, timeout=5) as response:
+                last_body = response.read().decode()
+            if all(value in last_body for value in values):
+                return last_body
+        except Exception as exc:
+            last_error = exc
+        time.sleep(0.5)
+
+    raise AssertionError(
+        f"timed out waiting for {url} to contain {values}: body={last_body!r} error={last_error!r}"
+    )
 
 
 def test_python_sdk_sandbox_log_streaming_live(monkeypatch, tmp_path):
@@ -100,3 +133,64 @@ def test_python_sdk_sandbox_log_streaming_live(monkeypatch, tmp_path):
         assert "py-log-out" in combined and "py-log-err" in combined
     finally:
         instance.terminate()
+        _close_global_channel()
+
+
+def test_python_sdk_sandbox_expose_port_listener_families(monkeypatch, tmp_path):
+    _configure_local_gateway(monkeypatch, tmp_path)
+
+    pool = os.environ.get("BETA9_INTEGRATION_POOL")
+    kwargs = {"pool": pool} if pool else {}
+    sandbox = Sandbox(
+        name="python-sdk-listener-families",
+        image=Image(python_version="python3.11"),
+        keep_warm_seconds=300,
+        ports=[8092, 8093],
+        **kwargs,
+    )
+    instance = sandbox.create()
+    servers = []
+    try:
+        instance.fs.create_directory("/workspace/py-sdk")
+        local_file = tmp_path / "file.txt"
+        local_file.write_text("python-sdk-listener-ok\n")
+        instance.fs.upload_file(str(local_file), "/workspace/py-sdk/file.txt")
+
+        servers.append(
+            instance.process.exec(
+                "python3",
+                "-m",
+                "http.server",
+                "8092",
+                "--bind",
+                "0.0.0.0",
+                "--directory",
+                "/workspace/py-sdk",
+            )
+        )
+        servers.append(
+            instance.process.exec(
+                "python3",
+                "-m",
+                "http.server",
+                "8093",
+                "--bind",
+                "::",
+                "--directory",
+                "/workspace/py-sdk",
+            )
+        )
+
+        ipv4_url = instance.expose_port(8092)
+        _wait_public_url_contains(f"{ipv4_url}/file.txt", "python-sdk-listener-ok")
+
+        ipv6_url = instance.expose_port(8093)
+        _wait_public_url_contains(f"{ipv6_url}/file.txt", "python-sdk-listener-ok")
+    finally:
+        for server in servers:
+            try:
+                server.kill()
+            except Exception:
+                pass
+        instance.terminate()
+        _close_global_channel()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes IPv6 port binding and routing for sandboxes by adding a userspace port proxy with IPv4/IPv6 support and correct bracketed address formatting. Also hardens runtime restore, sandbox process manager connectivity, and storage presign endpoint handling.

- **Bug Fixes**
  - Port exposure: added a lightweight userspace port proxy that falls back when kernel DNAT isn’t ready; supports IPv4↔IPv6 and respects advertised family; corrects bracketed IPv6 formatting; persistent machines expose host ports as expected.
  - Address publishing: formats host:port with bracketed IPv6 in repo updates and address maps.
  - Runtime restore: `runc` restore now executes via the binary, polls for the restored PID, and waits for exit to avoid races; added tests.
  - Sandbox process manager: resilient client with retry and timeout; clearer errors; `SandboxKill` validates auth and handles nil responses safely.
  - Checkpoint/restore: require an initialized `CRIU` manager; retry transient gVisor checkpoint errors; signal restored sandbox process manager; clearer failure messages and behavior.
  - SDK: added integration tests to verify IPv4/IPv6 port exposure and log streaming.

- **Refactors**
  - Centralized workspace storage presign endpoint logic in `pkg/clients` via `WorkspacePresignEndpointForDefaultStorage`; added tests.
  - `VolumeService` now takes `types.WorkspaceStorageConfig` and uses `NewWorkspaceStorageClientWithDefaultPresignEndpoint` for presign URLs.
  - Removed duplicate presign logic from the gateway service and simplified callers.

<sup>Written for commit b12bef7ab89c9aecf4b036e317eb13fd0973b1a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

