### PR TITLE
mount fallback

### DIFF
--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -43,4 +43,5 @@ var dockerInDockerCapabilities = []string{
 	"CAP_SYS_ADMIN",
 	"CAP_SYS_CHROOT",
 	"CAP_SYS_PTRACE",
+	"CAP_SYS_RESOURCE",
 }

--- a/pkg/runtime/docker_test.go
+++ b/pkg/runtime/docker_test.go
@@ -29,6 +29,10 @@ func TestAddDockerInDockerCapabilities(t *testing.T) {
 	require.Equal(t, 1, countCapability(spec.Process.Capabilities.Bounding, "CAP_CHOWN"))
 }
 
+func TestDockerInDockerCapabilitiesIncludesNestedRuncRequirements(t *testing.T) {
+	require.Contains(t, DockerInDockerCapabilities(), "CAP_SYS_RESOURCE")
+}
+
 func countCapability(values []string, cap string) int {
 	count := 0
 	for _, value := range values {

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -33,12 +33,37 @@ type containerMountPoint struct {
 	storage   storage.Storage
 }
 
-func NewContainerMountManager(config types.AppConfig) *ContainerMountManager {
+func NewContainerMountManager(config types.AppConfig, poolConfig ...types.WorkerPoolConfig) *ContainerMountManager {
 	return &ContainerMountManager{
 		mountPointMounts: common.NewSafeMap[[]containerMountPoint](),
 		storageConfig:    config.Storage,
-		codeCacheRoot:    filepath.Join(os.TempDir(), "beta9-stub-code-cache"),
+		codeCacheRoot:    stubCodeCacheRoot(config, poolConfig...),
 	}
+}
+
+func stubCodeCacheRoot(config types.AppConfig, poolConfigs ...types.WorkerPoolConfig) string {
+	cacheEnabled := config.Cache.Enabled && config.Worker.CacheEnabled
+	diskEnabled := config.Cache.Disk.Enabled
+	mountPath := config.Cache.Disk.MountPath
+
+	if len(poolConfigs) > 0 {
+		poolCache := poolConfigs[0].Cache
+		if poolCache.Enabled != nil {
+			cacheEnabled = cacheEnabled && *poolCache.Enabled
+		}
+		if poolCache.Disk.Enabled != nil {
+			diskEnabled = *poolCache.Disk.Enabled
+		}
+		if poolCache.Disk.MountPath != "" {
+			mountPath = poolCache.Disk.MountPath
+		}
+	}
+
+	if cacheEnabled && diskEnabled && mountPath != "" {
+		return filepath.Join(filepath.Clean(mountPath), "stub-code")
+	}
+
+	return filepath.Join(os.TempDir(), "beta9-stub-code-cache")
 }
 
 // SetupContainerMounts initializes any external storage for a container

--- a/pkg/worker/mount_test.go
+++ b/pkg/worker/mount_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/cache"
 	"github.com/beam-cloud/beta9/pkg/storage"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,47 @@ func TestSetupContainerMountsCachesStubCodeWithoutSharingContainerWorkspaces(t *
 	workspace2Bytes, err := os.ReadFile(filepath.Join(workspace2, "main.py"))
 	require.NoError(t, err)
 	require.Equal(t, "print('hello')\n", string(workspace2Bytes))
+}
+
+func TestSetupContainerMountsReusesDurableStubCodeCacheAcrossManagers(t *testing.T) {
+	cacheRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Storage: types.StorageConfig{
+			WorkspaceStorage: types.WorkspaceStorageConfig{
+				BaseMountPath: storageRoot,
+			},
+		},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   true,
+				MountPath: cacheRoot,
+			},
+		},
+	}
+
+	workspace := "workspace-durable"
+	objectID := "object-durable"
+	objectPath := filepath.Join(storageRoot, workspace, types.DefaultObjectPrefix, objectID)
+	require.NoError(t, writeZipObject(objectPath, map[string]string{
+		"main.py": "print('durable')\n",
+	}))
+
+	request1 := stubCodeMountRequest("container-durable-1", workspace, objectID)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(types.TempContainerWorkspace(request1.ContainerId))) })
+	require.NoError(t, NewContainerMountManager(config).SetupContainerMounts(context.Background(), request1, discardLogger()))
+	require.NoError(t, os.Remove(objectPath))
+
+	request2 := stubCodeMountRequest("container-durable-2", workspace, objectID)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(types.TempContainerWorkspace(request2.ContainerId))) })
+	require.NoError(t, NewContainerMountManager(config).SetupContainerMounts(context.Background(), request2, discardLogger()))
+
+	workspaceBytes, err := os.ReadFile(filepath.Join(request2.Mounts[0].LocalPath, "main.py"))
+	require.NoError(t, err)
+	require.Equal(t, "print('durable')\n", string(workspaceBytes))
+	require.FileExists(t, filepath.Join(cacheRoot, "stub-code", stubCodeCacheKey(workspace, objectID), ".beta9-cache-ready"))
 }
 
 func TestStubCodeCacheKeyDoesNotCollideAcrossWorkspaceObjectPairs(t *testing.T) {
@@ -123,6 +165,84 @@ func TestSetupContainerMountsPrefersDirectWorkspaceStorageForStubCode(t *testing
 	workspaceBytes, err := os.ReadFile(filepath.Join(workspacePath, "main.py"))
 	require.NoError(t, err)
 	require.Equal(t, "direct\n", string(workspaceBytes))
+}
+
+func TestStubCodeCacheRootUsesDiskCacheWhenEnabled(t *testing.T) {
+	cacheRoot := t.TempDir()
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   true,
+				MountPath: cacheRoot,
+			},
+		},
+	}
+
+	require.Equal(t, filepath.Join(cacheRoot, "stub-code"), stubCodeCacheRoot(config))
+}
+
+func TestStubCodeCacheRootFallsBackToTempWhenDiskCacheDisabled(t *testing.T) {
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   false,
+				MountPath: t.TempDir(),
+			},
+		},
+	}
+
+	require.Equal(t, filepath.Join(os.TempDir(), "beta9-stub-code-cache"), stubCodeCacheRoot(config))
+}
+
+func TestStubCodeCacheRootRespectsPoolDiskCacheOverride(t *testing.T) {
+	globalCacheRoot := t.TempDir()
+	poolCacheRoot := t.TempDir()
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   true,
+				MountPath: globalCacheRoot,
+			},
+		},
+	}
+	poolConfig := types.WorkerPoolConfig{
+		Cache: types.WorkerPoolCacheConfig{
+			Disk: types.WorkerPoolCacheDiskConfig{
+				MountPath: poolCacheRoot,
+			},
+		},
+	}
+
+	require.Equal(t, filepath.Join(poolCacheRoot, "stub-code"), stubCodeCacheRoot(config, poolConfig))
+}
+
+func TestStubCodeCacheRootRespectsPoolDiskCacheDisable(t *testing.T) {
+	disabled := false
+	config := types.AppConfig{
+		Worker: types.WorkerConfig{CacheEnabled: true},
+		Cache: cache.Config{
+			Enabled: true,
+			Disk: cache.DiskConfig{
+				Enabled:   true,
+				MountPath: t.TempDir(),
+			},
+		},
+	}
+	poolConfig := types.WorkerPoolConfig{
+		Cache: types.WorkerPoolCacheConfig{
+			Disk: types.WorkerPoolCacheDiskConfig{
+				Enabled: &disabled,
+			},
+		},
+	}
+
+	require.Equal(t, filepath.Join(os.TempDir(), "beta9-stub-code-cache"), stubCodeCacheRoot(config, poolConfig))
 }
 
 func TestRequiresWorkspaceStorageMount(t *testing.T) {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -383,7 +383,7 @@ func NewWorker() (_ *Worker, err error) {
 		fileCacheManager:        fileCacheManager,
 		containerGPUManager:     NewContainerNvidiaManager(uint32(gpuCount)),
 		containerNetworkManager: containerNetworkManager,
-		containerMountManager:   NewContainerMountManager(config),
+		containerMountManager:   NewContainerMountManager(config, poolConfig),
 		podAddr:                 podAddr,
 		routeLocalTargetHost:    routeLocalTargetHost,
 		imageClient:             imageClient,

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.245"
+version = "0.1.246"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a durable stub-code cache that prefers a disk mount when enabled and falls back to a temp dir when not. Also adds CAP_SYS_RESOURCE to Docker-in-Docker capabilities to support nested runc.

- New Features
  - Stub-code cache uses disk cache when enabled and a mount path is set; otherwise it uses a temp path. Cache is reused across managers.
  - Worker now passes pool config to the mount manager, so pool-level cache enable/disable and mount path overrides are respected.

- Bug Fixes
  - Include CAP_SYS_RESOURCE in Docker-in-Docker capabilities to satisfy nested runc requirements.

<sup>Written for commit 3436cf1f4514ef6aee063741f534d9e1d957ea42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

