### PR TITLE
Fix pod proxy HTTP forwarding

### DIFF
--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -62,7 +62,6 @@ type PodProxyBuffer struct {
 	stubConfig              *types.StubConfigV1
 	httpClient              *http.Client
 	backendTransports       sync.Map
-	backendProxies          sync.Map
 	tailscale               *network.Tailscale
 	tsConfig                types.TailscaleConfig
 	availableContainers     []container
@@ -406,6 +405,8 @@ func (pb *PodProxyBuffer) handleConnection(conn *connection, container container
 	subPath := conn.ctx.Param("subPath")
 	if subPath != "" && subPath[0] != '/' {
 		subPath = "/" + subPath
+	} else if subPath == "" {
+		subPath = "/"
 	}
 
 	request.URL.Scheme = "http"
@@ -424,7 +425,12 @@ func (pb *PodProxyBuffer) handleConnection(conn *connection, container container
 		}
 	}()
 
-	pb.backendProxy(targetHost).ServeHTTP(conn.ctx.Response(), request)
+	proxy, err := pb.backendProxy(targetHost)
+	if err != nil {
+		conn.ctx.String(http.StatusInternalServerError, "Invalid target URL")
+		return
+	}
+	proxy.ServeHTTP(conn.ctx.Response(), request)
 }
 
 func (pb *PodProxyBuffer) recordQueuedRequestWait(conn *connection, protocol string) {
@@ -441,25 +447,19 @@ func podBackendHost(address string) string {
 	return address
 }
 
-func (pb *PodProxyBuffer) backendProxy(targetHost string) *httputil.ReverseProxy {
-	if proxy, ok := pb.backendProxies.Load(targetHost); ok {
-		return proxy.(*httputil.ReverseProxy)
+func (pb *PodProxyBuffer) backendProxy(targetHost string) (*httputil.ReverseProxy, error) {
+	targetURL, err := url.Parse(podBackendURL("http", targetHost, "", ""))
+	if err != nil {
+		return nil, err
 	}
 
-	proxy := &httputil.ReverseProxy{
-		Director:   func(req *http.Request) {},
-		Transport:  pb.backendTransport(targetHost),
-		BufferPool: abstractions.ProxyBufferPool{},
-		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
-			http.Error(rw, "Backend route unavailable", http.StatusBadGateway)
-		},
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	proxy.Transport = pb.backendTransport(targetHost)
+	proxy.BufferPool = abstractions.ProxyBufferPool{}
+	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		http.Error(rw, "Backend route unavailable", http.StatusBadGateway)
 	}
-
-	actual, loaded := pb.backendProxies.LoadOrStore(targetHost, proxy)
-	if loaded {
-		return actual.(*httputil.ReverseProxy)
-	}
-	return proxy
+	return proxy, nil
 }
 
 func (pb *PodProxyBuffer) backendTransport(targetHost string) *http.Transport {
@@ -514,7 +514,6 @@ func (pb *PodProxyBuffer) pruneBackendTransports(containers []container) {
 		}
 		value.(*http.Transport).CloseIdleConnections()
 		pb.backendTransports.Delete(key)
-		pb.backendProxies.Delete(key)
 		return true
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes HTTP forwarding in the pod proxy by switching to a proper single-host reverse proxy and normalizing request paths. Requests now route to the correct container backend with clearer errors.

- **Bug Fixes**
  - Use `httputil.NewSingleHostReverseProxy` to correctly rewrite scheme/host and forward to the target.
  - Normalize `subPath` (prepend "/" or default to "/") to prevent missing-path issues.
  - Return 500 for invalid target URLs and 502 when the backend is unavailable; removed the unused reverse proxy cache while keeping transport pooling.

<sup>Written for commit e27304debf052386ba7fe42233eb8297088a0648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

