### PR TITLE
cleanup connection handling

### DIFF
--- a/pkg/abstractions/pod/autoscaler_test.go
+++ b/pkg/abstractions/pod/autoscaler_test.go
@@ -73,7 +73,7 @@ func TestDesiredPodDeploymentContainersAppliesGlobalReplicaLimit(t *testing.T) {
 	}
 }
 
-func TestPodAutoscalerSampleUsesSharedConnectionAggregate(t *testing.T) {
+func TestPodAutoscalerSampleUsesSharedConnectionSnapshots(t *testing.T) {
 	server, err := miniredis.Run()
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func TestPodAutoscalerSampleUsesSharedConnectionAggregate(t *testing.T) {
 	buffer := &PodProxyBuffer{}
 	buffer.totalConnections.Store(1)
 
-	if err := rdb.Set(ctx, Keys.podTotalConnections(workspace.Name, stub.ExternalId), 2, 0).Err(); err != nil {
+	if err := rdb.Set(ctx, Keys.podProxyConnections(workspace.Name, stub.ExternalId, "proxy-1", "total"), 2, connectionSnapshotTTL).Err(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/abstractions/pod/connections.go
+++ b/pkg/abstractions/pod/connections.go
@@ -126,10 +126,7 @@ func (pb *PodProxyBuffer) flushConnectionState() {
 	})
 	if _, err := pipe.Exec(ctx); err != nil {
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to publish pod connection snapshot")
-		return
 	}
-
-	pb.refreshConnectionAggregates(ctx)
 }
 
 func (pb *PodProxyBuffer) publishContainerConnectionSnapshot(containerId string, count int64) {
@@ -155,28 +152,6 @@ func (pb *PodProxyBuffer) publishTotalConnectionSnapshot(count int64) {
 
 	if err := pb.rdb.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), count, connectionSnapshotTTL).Err(); err != nil {
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to publish pod total busy snapshot")
-	}
-}
-
-func (pb *PodProxyBuffer) refreshConnectionAggregates(ctx context.Context) {
-	total, _, err := sumRedisIntKeys(ctx, pb.rdb, Keys.podProxyConnectionsScan(pb.workspace.Name, pb.stubId, "total"))
-	if err != nil {
-		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to sum pod total connections")
-		return
-	}
-
-	pipe := pb.rdb.Pipeline()
-	pipe.Set(ctx, Keys.podTotalConnections(pb.workspace.Name, pb.stubId), total, podContainerConnectionTimeout)
-	for _, c := range pb.availableContainerSnapshot() {
-		containerTotal, _, err := sumRedisIntKeys(ctx, pb.rdb, Keys.podProxyConnectionsScan(pb.workspace.Name, pb.stubId, c.id))
-		if err != nil {
-			log.Debug().Err(err).Str("stub_id", pb.stubId).Str("container_id", c.id).Msg("failed to sum pod container connections")
-			continue
-		}
-		pipe.Set(ctx, Keys.podContainerConnections(pb.workspace.Name, pb.stubId, c.id), containerTotal, podContainerConnectionTimeout)
-	}
-	if _, err := pipe.Exec(ctx); err != nil {
-		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to publish pod connection aggregates")
 	}
 }
 
@@ -212,15 +187,7 @@ func sharedPodTotalConnections(ctx context.Context, rdb *common.RedisClient, wor
 		return 0, nil
 	}
 
-	total, found, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionsScan(workspaceName, stubId, "total"))
-	if err != nil || found {
-		return total, err
-	}
-
-	total, err = rdb.Get(ctx, Keys.podTotalConnections(workspaceName, stubId)).Int64()
-	if err == redis.Nil {
-		return 0, nil
-	}
+	total, _, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionsScan(workspaceName, stubId, "total"))
 	return total, err
 }
 
@@ -229,15 +196,7 @@ func sharedPodContainerConnections(ctx context.Context, rdb *common.RedisClient,
 		return 0, nil
 	}
 
-	total, found, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionsScan(workspaceName, stubId, containerId))
-	if err != nil || found {
-		return total, err
-	}
-
-	total, err = rdb.Get(ctx, Keys.podContainerConnections(workspaceName, stubId, containerId)).Int64()
-	if err == redis.Nil {
-		return 0, nil
-	}
+	total, _, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionsScan(workspaceName, stubId, containerId))
 	return total, err
 }
 

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
 	"github.com/beam-cloud/beta9/pkg/auth"
@@ -35,12 +34,11 @@ type PodServiceOpts struct {
 }
 
 const (
-	podContainerPrefix            string = "pod"
-	sandboxContainerPrefix        string = "sandbox"
-	podRoutePrefix                string = "/pod"
-	sandboxRoutePrefix            string = "/sandbox"
-	podContainerConnectionTimeout        = 600 * time.Second
-	podProxyBufferSize                   = 300
+	podContainerPrefix     string = "pod"
+	sandboxContainerPrefix string = "sandbox"
+	podRoutePrefix         string = "/pod"
+	sandboxRoutePrefix     string = "/sandbox"
+	podProxyBufferSize            = 300
 )
 
 type PodService interface {

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -203,7 +203,11 @@ func TestReserveContainerForPortSkipsContainersWithoutPort(t *testing.T) {
 	}
 
 	pb.flushConnectionState()
-	if connections := redisInt64(t, rdb, Keys.podContainerConnections("workspace", "stub", "right-port")); connections != 1 {
+	connections, err := sharedPodContainerConnections(context.Background(), rdb, "workspace", "stub", "right-port")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connections != 1 {
 		t.Fatalf("published connections = %d, want 1", connections)
 	}
 }
@@ -271,7 +275,7 @@ func TestReadyAddressMapFiltersUnreadyPorts(t *testing.T) {
 	}
 }
 
-func TestTotalConnectionsAggregateAcrossProxyBuffers(t *testing.T) {
+func TestSharedTotalConnectionsAcrossProxyBuffers(t *testing.T) {
 	rdb := newPodProxyTestRedis(t)
 	pb1 := newPodProxyConnectionTestBuffer(rdb)
 	pb2 := newPodProxyConnectionTestBuffer(rdb)
@@ -285,16 +289,19 @@ func TestTotalConnectionsAggregateAcrossProxyBuffers(t *testing.T) {
 	pb1.flushConnectionState()
 	pb2.flushConnectionState()
 
-	key := Keys.podTotalConnections("workspace", "stub")
-	if got := redisInt64(t, rdb, key); got != 2 {
-		t.Fatalf("total connections = %d, want aggregate count from both proxy buffers", got)
+	if got, err := sharedPodTotalConnections(context.Background(), rdb, "workspace", "stub"); err != nil {
+		t.Fatal(err)
+	} else if got != 2 {
+		t.Fatalf("total connections = %d, want shared count from both proxy buffers", got)
 	}
 
 	if err := pb1.decrementTotalConnections(); err != nil {
 		t.Fatal(err)
 	}
 	pb1.flushConnectionState()
-	if got := redisInt64(t, rdb, key); got != 1 {
+	if got, err := sharedPodTotalConnections(context.Background(), rdb, "workspace", "stub"); err != nil {
+		t.Fatal(err)
+	} else if got != 1 {
 		t.Fatalf("total connections after first decrement = %d, want 1", got)
 	}
 
@@ -302,7 +309,9 @@ func TestTotalConnectionsAggregateAcrossProxyBuffers(t *testing.T) {
 		t.Fatal(err)
 	}
 	pb1.flushConnectionState()
-	if got := redisInt64(t, rdb, key); got != 1 {
+	if got, err := sharedPodTotalConnections(context.Background(), rdb, "workspace", "stub"); err != nil {
+		t.Fatal(err)
+	} else if got != 1 {
 		t.Fatalf("total connections after duplicate first-buffer decrement = %d, want other buffer count preserved", got)
 	}
 
@@ -310,7 +319,9 @@ func TestTotalConnectionsAggregateAcrossProxyBuffers(t *testing.T) {
 		t.Fatal(err)
 	}
 	pb2.flushConnectionState()
-	if got := redisInt64(t, rdb, key); got != 0 {
+	if got, err := sharedPodTotalConnections(context.Background(), rdb, "workspace", "stub"); err != nil {
+		t.Fatal(err)
+	} else if got != 0 {
 		t.Fatalf("total connections after second decrement = %d, want 0", got)
 	}
 
@@ -318,12 +329,14 @@ func TestTotalConnectionsAggregateAcrossProxyBuffers(t *testing.T) {
 		t.Fatal(err)
 	}
 	pb2.flushConnectionState()
-	if got := redisInt64(t, rdb, key); got != 0 {
+	if got, err := sharedPodTotalConnections(context.Background(), rdb, "workspace", "stub"); err != nil {
+		t.Fatal(err)
+	} else if got != 0 {
 		t.Fatalf("total connections after extra decrement = %d, want capped zero", got)
 	}
 }
 
-func TestContainerConnectionsAggregateAcrossProxyBuffers(t *testing.T) {
+func TestSharedContainerConnectionsAcrossProxyBuffers(t *testing.T) {
 	rdb := newPodProxyTestRedis(t)
 	pb1 := newPodProxyConnectionTestBuffer(rdb)
 	pb2 := newPodProxyConnectionTestBuffer(rdb)
@@ -419,7 +432,35 @@ func TestConnectionCountersPublishBusySnapshotsBeforeFlush(t *testing.T) {
 	}
 }
 
-func TestFlushConnectionStatePublishesSnapshotsAndAggregates(t *testing.T) {
+func TestSharedPodConnectionsIgnoreStaleAggregatesWithoutSnapshots(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	ctx := context.Background()
+
+	if err := rdb.Set(ctx, Keys.podTotalConnections("workspace", "stub"), 1, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rdb.Set(ctx, Keys.podContainerConnections("workspace", "stub", "container-1"), 1, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	total, err := sharedPodTotalConnections(ctx, rdb, "workspace", "stub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 {
+		t.Fatalf("total connections = %d, want 0 without live proxy snapshots", total)
+	}
+
+	containerTotal, err := sharedPodContainerConnections(ctx, rdb, "workspace", "stub", "container-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containerTotal != 0 {
+		t.Fatalf("container connections = %d, want 0 without live proxy snapshots", containerTotal)
+	}
+}
+
+func TestFlushConnectionStatePublishesSnapshots(t *testing.T) {
 	rdb := newPodProxyTestRedis(t)
 	pb := newPodProxyConnectionTestBuffer(rdb)
 	pb.availableContainers = []container{{id: "container-1"}}
@@ -443,12 +484,6 @@ func TestFlushConnectionStatePublishesSnapshotsAndAggregates(t *testing.T) {
 	}
 	if ttl <= 0 || ttl > connectionSnapshotTTL {
 		t.Fatalf("snapshot ttl = %s, want within %s", ttl, connectionSnapshotTTL)
-	}
-	if got := redisInt64(t, rdb, Keys.podTotalConnections("workspace", "stub")); got != 1 {
-		t.Fatalf("aggregate total connections = %d, want 1", got)
-	}
-	if got := redisInt64(t, rdb, Keys.podContainerConnections("workspace", "stub", "container-1")); got != 1 {
-		t.Fatalf("aggregate container connections = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified pod connection tracking by removing Redis aggregates and relying only on per-proxy snapshot counters with TTL. This avoids stale counts and ensures accurate shared totals across proxies for autoscaling.

- **Refactors**
  - Removed aggregate keys and fallbacks (`Keys.podTotalConnections`, `Keys.podContainerConnections`); totals are now computed by summing snapshot keys (`Keys.podProxyConnections*`).
  - `flushConnectionState` publishes only snapshot counters with TTL; aggregate refresh path deleted.
  - Updated autoscaler and proxy tests to read shared counts from snapshots and verify stale aggregates are ignored; removed the unused `podContainerConnectionTimeout`.

<sup>Written for commit 6298c7d2b0324040f11318d8850b6e582d972a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

