### PR TITLE
fix stuck build containers

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -358,8 +358,8 @@ func (i *AutoscaledInstance) Sync() error {
 			return err
 		}
 
-		if len(deployments) == 1 && !deployments[0].Active {
-			i.IsActive = false
+		if len(deployments) == 1 {
+			i.IsActive = deployments[0].Active
 		}
 
 		stubConfigRaw := deployments[0].Stub.Config

--- a/pkg/abstractions/common/instance_test.go
+++ b/pkg/abstractions/common/instance_test.go
@@ -2,6 +2,7 @@ package abstractions
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -148,6 +149,53 @@ func TestHandleScalingEventInactiveStopsRunningContainers(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected inactive instance to stop running container")
+	}
+}
+
+func TestSyncMirrorsDeploymentActiveState(t *testing.T) {
+	stubConfig, err := json.Marshal(&types.StubConfigV1{
+		Autoscaler: &types.Autoscaler{MaxContainers: 1, TasksPerContainer: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workspace := types.Workspace{Id: 1, Name: "workspace"}
+	stub := types.Stub{
+		ExternalId:  "stub",
+		Type:        types.StubType(types.StubTypePodDeployment),
+		Config:      string(stubConfig),
+		WorkspaceId: workspace.Id,
+	}
+	backendRepo := &testInstanceControllerBackendRepo{
+		deployments: []types.DeploymentWithRelated{{
+			Deployment: types.Deployment{Active: true},
+			Workspace:  workspace,
+			Stub:       stub,
+		}},
+	}
+
+	instance := &AutoscaledInstance{
+		Ctx:         context.Background(),
+		IsActive:    false,
+		BackendRepo: backendRepo,
+		Stub:        &types.StubWithRelated{Stub: stub, Workspace: workspace},
+		StubConfig:  &types.StubConfigV1{},
+	}
+
+	if err := instance.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	if !instance.IsActive {
+		t.Fatal("expected active deployment to reactivate the instance")
+	}
+
+	backendRepo.deployments[0].Active = false
+	if err := instance.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	if instance.IsActive {
+		t.Fatal("expected inactive deployment to deactivate the instance")
 	}
 }
 

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 
@@ -39,6 +40,7 @@ const (
 type request struct {
 	ctx        echo.Context
 	task       *EndpointTask
+	requestID  string
 	done       chan struct{}
 	started    chan struct{}
 	abandoned  atomic.Bool
@@ -151,6 +153,11 @@ func (rb *RequestBuffer) handleHeartbeatEvents() {
 func (rb *RequestBuffer) ForwardRequest(ctx echo.Context, task *EndpointTask) error {
 	ctx.Set("stubId", rb.stubId)
 
+	requestID := uuid.NewString()
+	if task != nil && task.msg != nil && task.msg.TaskId != "" {
+		requestID = task.msg.TaskId
+	}
+
 	done := make(chan struct{})
 	started := make(chan struct{})
 	req := &request{
@@ -158,6 +165,7 @@ func (rb *RequestBuffer) ForwardRequest(ctx echo.Context, task *EndpointTask) er
 		done:       done,
 		started:    started,
 		task:       task,
+		requestID:  requestID,
 		enqueuedAt: time.Now(),
 	}
 	rb.enqueueRequest(req, false)
@@ -197,45 +205,6 @@ func (rb *RequestBuffer) ForwardRequest(ctx echo.Context, task *EndpointTask) er
 			return nil
 		}
 	}
-}
-
-func (rb *RequestBuffer) ForwardHealthRequest(ctx echo.Context) error {
-	ctx.Set("stubId", rb.stubId)
-
-	containers := rb.availableContainerSnapshot()
-	if len(containers) == 0 {
-		return ctx.JSON(http.StatusOK, map[string]interface{}{
-			"ok": true,
-		})
-	}
-
-	c := containers[0]
-	request := ctx.Request()
-	backendURL := backendHTTPURL("http", c.address, ctx.Param("subPath"), request.URL.RawQuery)
-	httpReq, err := http.NewRequestWithContext(request.Context(), request.Method, backendURL, request.Body)
-	if err != nil {
-		return ctx.JSON(http.StatusInternalServerError, map[string]interface{}{
-			"error": "Internal server error",
-		})
-	}
-
-	httpReq.Header = request.Header.Clone()
-	httpReq.Header.Del("X-TASK-ID")
-
-	resp, err := rb.getHttpClient(c.address, checkAddressIsReadyTimeout).Do(httpReq)
-	if err != nil {
-		return ctx.JSON(http.StatusBadGateway, map[string]interface{}{
-			"error": "Backend route unavailable",
-		})
-	}
-	defer resp.Body.Close()
-
-	if err := writeBackendResponse(ctx, resp); err != nil && err != io.EOF && err != context.Canceled {
-		return ctx.JSON(http.StatusInternalServerError, map[string]interface{}{
-			"error": "Internal server error",
-		})
-	}
-	return nil
 }
 
 func (rb *RequestBuffer) requestQueueTimeout() time.Duration {
@@ -725,7 +694,11 @@ func (rb *RequestBuffer) handleHttpRequest(req *request, c container) {
 
 	httpReq.Header = request.Header.Clone()
 
-	httpReq.Header.Add("X-TASK-ID", req.task.msg.TaskId) // Add task ID to header
+	if req.task != nil && req.task.msg != nil && req.task.msg.TaskId != "" {
+		httpReq.Header.Set("X-TASK-ID", req.task.msg.TaskId)
+	} else {
+		httpReq.Header.Del("X-TASK-ID")
+	}
 
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
@@ -840,8 +813,8 @@ func (rb *RequestBuffer) refreshRequestTokenTTL(containerId string) {
 
 func (rb *RequestBuffer) afterRequest(req *request, containerId string) {
 	defer rb.signalWork()
-	defer rb.releaseRequestToken(containerId, req.task.msg.TaskId)
 	defer close(req.done)
+	defer rb.releaseRequestToken(containerId, req.requestID)
 
 	if rb.rdb == nil || rb.workspace == nil || rb.stubConfig.KeepWarmSeconds == 0 {
 		return
@@ -872,7 +845,9 @@ func (rb *RequestBuffer) proxyWebsocketConnection(r *request, c container, diale
 	}
 
 	headers := http.Header{}
-	headers.Add("X-TASK-ID", r.task.msg.TaskId) // Add task ID to header
+	if r.task != nil && r.task.msg != nil && r.task.msg.TaskId != "" {
+		headers.Set("X-TASK-ID", r.task.msg.TaskId)
+	}
 
 	wsDst, resp, err := dialer.Dial(dstAddress, headers)
 	if err != nil {

--- a/pkg/abstractions/endpoint/buffer_test.go
+++ b/pkg/abstractions/endpoint/buffer_test.go
@@ -48,24 +48,7 @@ func TestIsASGIHealthRequest(t *testing.T) {
 	}
 }
 
-func TestForwardHealthRequestReturnsOKWhenNoBackendIsReady(t *testing.T) {
-	e := echo.New()
-	httpReq := httptest.NewRequest(http.MethodGet, "/health", nil)
-	rec := httptest.NewRecorder()
-	ctx := e.NewContext(httpReq, rec)
-	ctx.SetParamNames("subPath")
-	ctx.SetParamValues("health")
-
-	rb := &RequestBuffer{}
-	if err := rb.ForwardHealthRequest(ctx); err != nil {
-		t.Fatal(err)
-	}
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
-	}
-}
-
-func TestForwardHealthRequestProxiesWithoutTaskHeader(t *testing.T) {
+func TestTasklessASGIRequestProxiesWithoutTaskHeader(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-TASK-ID"); got != "" {
 			t.Errorf("forwarded X-TASK-ID = %q, want empty", got)
@@ -95,15 +78,30 @@ func TestForwardHealthRequestProxiesWithoutTaskHeader(t *testing.T) {
 	ctx.SetParamNames("subPath")
 	ctx.SetParamValues("health")
 
+	rdb := newEndpointBufferTestRedis(t)
+	bufferCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	rb := &RequestBuffer{
-		ctx:        context.Background(),
-		httpClient: backend.Client(),
+		ctx:           bufferCtx,
+		rdb:           rdb,
+		containerRepo: repository.NewContainerRedisRepositoryForTest(rdb),
+		workspace:     &types.Workspace{Name: "workspace"},
+		stubId:        "stub",
+		stubConfig:    &types.StubConfigV1{TaskPolicy: types.TaskPolicy{Timeout: 30}},
+		buffer:        abstractions.NewRingBuffer[*request](1),
+		httpClient:    backend.Client(),
+		maxTokens:     1,
+		isASGI:        true,
+		workReady:     make(chan struct{}, 1),
 		availableContainers: []container{{
 			id:      "container-1",
 			address: backendURL.Host,
 		}},
 	}
-	if err := rb.ForwardHealthRequest(ctx); err != nil {
+	go rb.processRequests()
+
+	if err := rb.ForwardRequest(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
 	if rec.Code != http.StatusNoContent {
@@ -112,6 +110,11 @@ func TestForwardHealthRequestProxiesWithoutTaskHeader(t *testing.T) {
 	if got := rec.Header().Get("X-Backend-Health"); got != "ok" {
 		t.Fatalf("response header = %q, want ok", got)
 	}
+
+	key := Keys.endpointRequestTokens("workspace", "stub", "container-1")
+	waitForCondition(t, 50*time.Millisecond, func() bool {
+		return redisInt64(t, rdb, key) == 1
+	})
 }
 
 func TestBackendDialTimeoutCapsLongRequestTimeouts(t *testing.T) {
@@ -221,10 +224,11 @@ func TestProcessRequestsWakesWhenBackendBecomesAvailable(t *testing.T) {
 		workReady:           make(chan struct{}, 1),
 	}
 	req := &request{
-		ctx:     reqCtx,
-		task:    &EndpointTask{msg: &types.TaskMessage{TaskId: "task"}},
-		done:    make(chan struct{}),
-		started: make(chan struct{}),
+		ctx:       reqCtx,
+		task:      &EndpointTask{msg: &types.TaskMessage{TaskId: "task"}},
+		requestID: "task",
+		done:      make(chan struct{}),
+		started:   make(chan struct{}),
 	}
 	if rb.buffer.Push(req, false) {
 		t.Fatal("unexpected overwrite")
@@ -406,6 +410,59 @@ func TestRefreshRequestTokenTTLExtendsTokenKey(t *testing.T) {
 	}
 	if ttl < rb.requestTokenTTL()-time.Second {
 		t.Fatalf("ttl = %s, want refreshed close to %s", ttl, rb.requestTokenTTL())
+	}
+}
+
+func TestStoppableContainersSkipsInFlightEndpointRequests(t *testing.T) {
+	rdb := newEndpointBufferTestRedis(t)
+	containerRepo := repository.NewContainerRedisRepositoryForTest(rdb)
+	state := &types.ContainerState{
+		ContainerId: "container-1",
+		StubId:      "stub",
+		WorkspaceId: "workspace",
+		Status:      types.ContainerStatusRunning,
+		ScheduledAt: time.Now().Unix(),
+		StartedAt:   time.Now().Unix(),
+	}
+	if err := containerRepo.SetContainerState(state.ContainerId, state); err != nil {
+		t.Fatal(err)
+	}
+
+	rb := newEndpointRequestTokenTestBuffer(rdb, 1)
+	rb.containerRepo = containerRepo
+	if err := rb.acquireRequestToken("container-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := &endpointInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{
+			Rdb:           rdb,
+			IsActive:      true,
+			Workspace:     &types.Workspace{Name: "workspace"},
+			Stub:          &types.StubWithRelated{Stub: types.Stub{ExternalId: "stub", Type: types.StubType(types.StubTypeEndpointDeployment)}},
+			StubConfig:    &types.StubConfigV1{},
+			ContainerRepo: containerRepo,
+		},
+		buffer: rb,
+	}
+
+	containers, err := instance.stoppableContainers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(containers) != 0 {
+		t.Fatalf("stoppable containers = %v, want none while request token is consumed", containers)
+	}
+
+	if err := rb.releaseRequestToken("container-1", "request-1"); err != nil {
+		t.Fatal(err)
+	}
+	containers, err = instance.stoppableContainers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(containers) != 1 || containers[0] != "container-1" {
+		t.Fatalf("stoppable containers = %v, want [container-1] after request token release", containers)
 	}
 }
 

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -205,6 +205,19 @@ func (es *HttpEndpointService) forwardRequest(
 	return task.Execute(ctx.Request().Context(), ctx, authInfo)
 }
 
+func (es *HttpEndpointService) forwardASGIHealthRequest(ctx echo.Context, stubId string) error {
+	instance, err := es.getOrCreateEndpointInstance(ctx.Request().Context(), stubId)
+	if err != nil {
+		return err
+	}
+
+	if err := instance.ensureReadyForTasklessRequest(); err != nil {
+		return err
+	}
+
+	return instance.buffer.ForwardRequest(ctx, nil)
+}
+
 func (es *HttpEndpointService) InstanceFactory(ctx context.Context, stubId string, options ...func(abstractions.IAutoscaledInstance)) (abstractions.IAutoscaledInstance, error) {
 	return es.getOrCreateEndpointInstance(ctx, stubId)
 }

--- a/pkg/abstractions/endpoint/http.go
+++ b/pkg/abstractions/endpoint/http.go
@@ -97,11 +97,7 @@ func (g *endpointGroup) ASGIRequest(ctx echo.Context) error {
 	}
 
 	if isASGIHealthRequest(ctx) {
-		instance, err := g.es.getOrCreateEndpointInstance(ctx.Request().Context(), stubId)
-		if err != nil {
-			return err
-		}
-		return instance.buffer.ForwardHealthRequest(ctx)
+		return g.es.forwardASGIHealthRequest(ctx, stubId)
 	}
 
 	return g.es.forwardRequest(ctx, cc.AuthInfo, stubId)

--- a/pkg/abstractions/endpoint/instance.go
+++ b/pkg/abstractions/endpoint/instance.go
@@ -32,6 +32,22 @@ type endpointInstance struct {
 	isASGI bool
 }
 
+func (i *endpointInstance) ensureReadyForTasklessRequest() error {
+	if err := i.Sync(); err != nil {
+		return err
+	}
+
+	state, err := i.State()
+	if err != nil {
+		return err
+	}
+
+	if state.RunningContainers+state.PendingContainers > 0 {
+		return nil
+	}
+	return i.HandleScalingEvent(1)
+}
+
 func (i *endpointInstance) startContainers(containersToRun int) error {
 	secrets, err := abstractions.ConfigureContainerRequestSecrets(i.Workspace, *i.buffer.stubConfig)
 	if err != nil {
@@ -177,6 +193,17 @@ func (i *endpointInstance) stoppableContainers() ([]string, error) {
 		if !i.IsActive {
 			keys = append(keys, container.ContainerId)
 			continue
+		}
+
+		if i.buffer != nil {
+			availableTokens, err := i.buffer.requestTokens(container.ContainerId)
+			if err != nil {
+				log.Error().Str("instance_name", i.Name).Err(err).Msg("error getting endpoint request tokens for container")
+				continue
+			}
+			if availableTokens < i.buffer.effectiveMaxTokens() {
+				continue
+			}
 		}
 
 		if i.Stub.Type.IsDeployment() {

--- a/pkg/abstractions/pod/instance.go
+++ b/pkg/abstractions/pod/instance.go
@@ -18,6 +18,34 @@ type podInstance struct {
 	buffer *PodProxyBuffer
 }
 
+func (i *podInstance) ensureReadyForRequest() error {
+	if err := i.Sync(); err != nil {
+		return err
+	}
+
+	state, err := i.State()
+	if err != nil {
+		return err
+	}
+	if state.RunningContainers+state.PendingContainers > 0 {
+		return nil
+	}
+
+	desiredContainers := 1
+	if i.Stub.Type == types.StubType(types.StubTypePodDeployment) {
+		desiredContainers = desiredPodDeploymentContainers(
+			i.StubConfig,
+			1,
+			i.AppConfig.GatewayService.StubLimits.MaxReplicas,
+		)
+	}
+	if desiredContainers <= 0 {
+		return nil
+	}
+
+	return i.HandleScalingEvent(desiredContainers)
+}
+
 func (i *podInstance) startContainers(containersToRun int) error {
 	secrets, err := abstractions.ConfigureContainerRequestSecrets(i.Workspace, *i.StubConfig)
 	if err != nil {

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -163,6 +163,12 @@ func (ps *GenericPodService) forwardRequest(ctx echo.Context, stubId string) err
 		return err
 	}
 
+	if !instance.buffer.hasAvailableContainers() {
+		if err := instance.ensureReadyForRequest(); err != nil {
+			return err
+		}
+	}
+
 	return instance.buffer.ForwardRequest(ctx)
 }
 
@@ -170,6 +176,12 @@ func (ps *GenericPodService) forwardTCPRequest(tc *tcpConnection, stubId string)
 	instance, err := ps.getOrCreatePodInstance(stubId)
 	if err != nil {
 		return err
+	}
+
+	if !instance.buffer.hasAvailableContainers() {
+		if err := instance.ensureReadyForRequest(); err != nil {
+			return err
+		}
 	}
 
 	return instance.buffer.ForwardTCPRequest(tc)

--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -288,6 +288,13 @@ func (pb *PodProxyBuffer) availableContainerSnapshot() []container {
 	return containers
 }
 
+func (pb *PodProxyBuffer) hasAvailableContainers() bool {
+	pb.availableContainersLock.RLock()
+	defer pb.availableContainersLock.RUnlock()
+
+	return len(pb.availableContainers) > 0
+}
+
 func (pb *PodProxyBuffer) reserveContainerForPort(port int32) (container, bool, bool, bool) {
 	pb.availableContainersLock.RLock()
 	defer pb.availableContainersLock.RUnlock()

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -2610,13 +2610,13 @@ func (c *ImageClient) getBuildContext(ctx context.Context, buildPath string, req
 	if request.StorageAvailable() {
 		buildCtxPath = path.Join(buildPath, "build-ctx")
 
-		if workspaceStorageDownloadAvailable(request.Workspace.Storage) {
-			objectPath = path.Join(buildPath, "build-ctx.zip")
-			if err := downloadWorkspaceBuildContext(ctx, request, *request.BuildOptions.BuildCtxObject, objectPath); err != nil {
-				return "", err
-			}
-		} else {
-			objectPath = path.Join(c.config.Storage.WorkspaceStorage.BaseMountPath, request.Workspace.Name, "objects", *request.BuildOptions.BuildCtxObject)
+		if !workspaceStorageDownloadAvailable(request.Workspace.Storage) {
+			return "", fmt.Errorf("workspace storage credentials are required to download build context %q directly", *request.BuildOptions.BuildCtxObject)
+		}
+
+		objectPath = path.Join(buildPath, "build-ctx.zip")
+		if err := downloadWorkspaceBuildContext(ctx, request, *request.BuildOptions.BuildCtxObject, objectPath); err != nil {
+			return "", err
 		}
 	}
 

--- a/pkg/worker/image_test.go
+++ b/pkg/worker/image_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"testing"
@@ -59,6 +60,46 @@ func TestEmbeddedImageCacheFallbackLogLevel(t *testing.T) {
 	logEmbeddedImageCacheFallback(errors.New("cache unavailable"), "runtime-image", &types.ContainerRequest{})
 	require.Contains(t, buf.String(), `"level":"warn"`)
 	require.Contains(t, buf.String(), "falling back to registry")
+}
+
+func TestGetBuildContextDoesNotFallBackToWorkspaceFuseMount(t *testing.T) {
+	baseMountPath := t.TempDir()
+	buildPath := t.TempDir()
+	workspaceName := "workspace"
+	objectID := "build-context"
+	storageID := uint(1)
+	bucket := "bucket"
+
+	fuseFallbackPath := filepath.Join(baseMountPath, workspaceName, types.DefaultObjectPrefix, objectID)
+	require.NoError(t, writeZipObject(fuseFallbackPath, map[string]string{
+		"main.py": "print('do not read through fuse')\n",
+	}))
+
+	client := &ImageClient{
+		config: types.AppConfig{
+			Storage: types.StorageConfig{
+				WorkspaceStorage: types.WorkspaceStorageConfig{
+					BaseMountPath: baseMountPath,
+				},
+			},
+		},
+	}
+	request := &types.ContainerRequest{
+		Workspace: types.Workspace{
+			Name: workspaceName,
+			Storage: &types.WorkspaceStorage{
+				Id:         &storageID,
+				BucketName: &bucket,
+			},
+		},
+		BuildOptions: types.BuildOptions{
+			BuildCtxObject: &objectID,
+		},
+	}
+
+	_, err := client.getBuildContext(context.Background(), buildPath, request)
+
+	require.ErrorContains(t, err, "workspace storage credentials are required")
 }
 
 func TestNewBuildahCommandUsesCancelableProcessGroup(t *testing.T) {

--- a/pkg/worker/mount.go
+++ b/pkg/worker/mount.go
@@ -123,7 +123,9 @@ func (c *ContainerMountManager) RequiresWorkspaceStorageMount(request *types.Con
 	}
 
 	if request.IsBuildRequest() {
-		return true
+		return request.BuildOptions.Dockerfile != nil &&
+			request.BuildOptions.BuildCtxObject != nil &&
+			!workspaceStorageDownloadAvailable(request.Workspace.Storage)
 	}
 
 	directCodeDownload := workspaceStorageDownloadAvailable(request.Workspace.Storage)

--- a/pkg/worker/mount_test.go
+++ b/pkg/worker/mount_test.go
@@ -284,10 +284,20 @@ func TestRequiresWorkspaceStorageMount(t *testing.T) {
 	})
 
 	t.Run("build request", func(t *testing.T) {
-		sourceImage := "alpine"
+		dockerfile := "FROM alpine"
 		request := stubCodeMountRequest("container-build", "workspace", "object")
 		request.Workspace.Storage = directWorkspaceStorage()
-		request.BuildOptions.SourceImage = &sourceImage
+		request.BuildOptions.Dockerfile = &dockerfile
+		request.BuildOptions.BuildCtxObject = &request.Stub.Object.ExternalId
+
+		require.False(t, manager.RequiresWorkspaceStorageMount(request))
+	})
+
+	t.Run("build request with incomplete direct storage", func(t *testing.T) {
+		dockerfile := "FROM alpine"
+		request := stubCodeMountRequest("container-build-incomplete", "workspace", "object")
+		request.BuildOptions.Dockerfile = &dockerfile
+		request.BuildOptions.BuildCtxObject = &request.Stub.Object.ExternalId
 
 		require.True(t, manager.RequiresWorkspaceStorageMount(request))
 	})

--- a/pkg/worker/runtime_credentials.go
+++ b/pkg/worker/runtime_credentials.go
@@ -11,7 +11,11 @@ import (
 )
 
 func (s *Worker) hydrateRuntimeCredentials(ctx context.Context, request *types.ContainerRequest) error {
-	if !s.agentWorker() || request.IsBuildRequest() {
+	if request.IsBuildRequest() {
+		return s.hydrateBuildWorkspaceStorageCredentials(ctx, request)
+	}
+
+	if !s.agentWorker() {
 		return nil
 	}
 
@@ -29,6 +33,40 @@ func (s *Worker) hydrateRuntimeCredentials(ctx context.Context, request *types.C
 	}
 
 	applyRuntimeCredentials(request, resp)
+	return nil
+}
+
+func (s *Worker) hydrateBuildWorkspaceStorageCredentials(ctx context.Context, request *types.ContainerRequest) error {
+	if request == nil ||
+		request.BuildOptions.Dockerfile == nil ||
+		request.BuildOptions.BuildCtxObject == nil ||
+		!request.Workspace.StorageAvailable() ||
+		workspaceStorageDownloadAvailable(request.Workspace.Storage) {
+		return nil
+	}
+	if s.workerRepoClient == nil {
+		return errors.New("worker repository client is required to hydrate build workspace storage credentials")
+	}
+
+	credentialRequest := &pb.GetContainerRuntimeCredentialsRequest{
+		WorkspaceId:      request.WorkspaceId,
+		StubId:           request.StubId,
+		ContainerId:      request.ContainerId,
+		WorkspaceStorage: true,
+	}
+
+	resp, err := handleGRPCResponse(s.workerRepoClient.GetContainerRuntimeCredentials(ctx, credentialRequest))
+	if err != nil {
+		return err
+	}
+	if !resp.Ok {
+		return errors.New(resp.ErrorMsg)
+	}
+
+	applyRuntimeCredentials(request, resp)
+	if !workspaceStorageDownloadAvailable(request.Workspace.Storage) {
+		return errors.New("workspace storage credentials are required to download build context directly")
+	}
 	return nil
 }
 

--- a/pkg/worker/runtime_credentials_test.go
+++ b/pkg/worker/runtime_credentials_test.go
@@ -1,11 +1,13 @@
 package worker
 
 import (
+	"context"
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func TestMergeRuntimeEnvReplacesVendedKeys(t *testing.T) {
@@ -49,4 +51,63 @@ func TestApplyMountCredentialsMatchesPathAndBucket(t *testing.T) {
 	require.Empty(t, request.Mounts[0].MountPointConfig.AccessKey)
 	require.Equal(t, "access-b", request.Mounts[1].MountPointConfig.AccessKey)
 	require.Equal(t, "secret-b", request.Mounts[1].MountPointConfig.SecretKey)
+}
+
+func TestHydrateRuntimeCredentialsForBuildOnlyRequestsWorkspaceStorage(t *testing.T) {
+	storageID := uint(1)
+	dockerfile := "FROM alpine"
+	buildCtxObject := "build-context"
+	repo := &fakeRuntimeCredentialsWorkerRepo{
+		resp: &pb.GetContainerRuntimeCredentialsResponse{
+			Ok: true,
+			WorkspaceStorage: &pb.CacheWorkspaceStorageCredentials{
+				EndpointUrl: "https://storage.example",
+				Region:      "us-east-1",
+				BucketName:  "bucket",
+				AccessKey:   "access",
+				SecretKey:   "secret",
+			},
+		},
+	}
+	request := &types.ContainerRequest{
+		ContainerId:          "build-1",
+		WorkspaceId:          "workspace-1",
+		StubId:               "stub-1",
+		RuntimeSecretNames:   []string{"SECRET"},
+		RuntimeTokenRequired: true,
+		Workspace: types.Workspace{
+			Storage: &types.WorkspaceStorage{Id: &storageID},
+		},
+		BuildOptions: types.BuildOptions{
+			Dockerfile:     &dockerfile,
+			BuildCtxObject: &buildCtxObject,
+		},
+	}
+	worker := &Worker{workerRepoClient: repo}
+
+	require.NoError(t, worker.hydrateRuntimeCredentials(context.Background(), request))
+
+	require.NotNil(t, repo.lastReq)
+	require.True(t, repo.lastReq.WorkspaceStorage)
+	require.False(t, repo.lastReq.RuntimeToken)
+	require.Empty(t, repo.lastReq.SecretNames)
+	require.Empty(t, repo.lastReq.MountCredentials)
+	require.Equal(t, "access", *request.Workspace.Storage.AccessKey)
+	require.Equal(t, "secret", *request.Workspace.Storage.SecretKey)
+	require.Equal(t, "https://storage.example", *request.Workspace.Storage.EndpointUrl)
+}
+
+type fakeRuntimeCredentialsWorkerRepo struct {
+	pb.WorkerRepositoryServiceClient
+	lastReq *pb.GetContainerRuntimeCredentialsRequest
+	resp    *pb.GetContainerRuntimeCredentialsResponse
+	err     error
+}
+
+func (f *fakeRuntimeCredentialsWorkerRepo) GetContainerRuntimeCredentials(ctx context.Context, req *pb.GetContainerRuntimeCredentialsRequest, opts ...grpc.CallOption) (*pb.GetContainerRuntimeCredentialsResponse, error) {
+	f.lastReq = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stuck build and endpoint containers by requiring direct workspace storage credentials for build contexts and by preventing shutdown of containers with in‑flight requests. Also ensures containers spin up for taskless/health requests and correctly mirrors deployment active state.

- **Bug Fixes**
  - Builds: remove FUSE fallback for build contexts; require direct workspace storage creds; hydrate creds on build-only path via worker repo; update mount logic; add tests in `pkg/worker`.
  - Endpoint/Pod: skip stopping containers with consumed request tokens; generate request IDs for taskless requests; set/remove `X-TASK-ID` header only when a task exists; start containers for ASGI health and pod requests when none are running; remove `ForwardHealthRequest`; add tests in `pkg/abstractions/endpoint` and `pkg/abstractions/pod`.
  - Instance: `Sync()` mirrors deployment `Active` flag to re/activate instances; add tests in `pkg/abstractions/common`.

- **Migration**
  - Builds that use `Dockerfile` + `BuildCtxObject` now require direct workspace storage credentials. Ensure the worker can fetch workspace storage creds from the repository service or provide them directly; otherwise builds will fail with a credentials error.

<sup>Written for commit a7731ac138aa2a4cfe879e6143c5475f60c7958e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

