### PR TITLE
criu cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.44.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.45.0 // indirect
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.13 h1:THZJJ6TU/FOiM7DZFnisYV9d49o
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.13/go.mod h1:VISUTg6n+uBaYIWPBaIG0jk7mbBxm7DUqBtU2cUDDWI=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.44.4 h1:B7Z9Od27vYJsf2n2xgKe/AcEyk9p+ccUAFgCO9w9Z38=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.44.4/go.mod h1:Gmv7s//GGvs3nj9aqltFYnLStW8vDIwch0USkE67G4E=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.45.0 h1:QxVQWd9D3cep9PqLuBr8lslwzbdcj0L40yA/O6XqZcg=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.45.0/go.mod h1:yzEbAEHVPD1zOS1Rz3xPEQ/6zF0WZKT+gsZJSjtFmJE=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0 h1:1KE7EgE5xiPZ6H19hdF27B/p/CGhB2UNO5wcpOHe0JM=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0/go.mod h1:hIsHE0PaWAQakLCshKS7VKWMGXaqrAFp4m95s2W9E6c=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0 h1:e9RAM6FgxAN3ca3LKaCr20+YnMqg8vhX/k6WDA8BpT8=

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -599,6 +599,11 @@ func TestWriteWorkerConfigUsesGatewayBootstrapParts(t *testing.T) {
 	if got := workerConfig["useHostResolvConf"]; got != true {
 		t.Fatalf("useHostResolvConf = %v, want true", got)
 	}
+	poolsConfig := workerConfig["pools"].(map[string]any)
+	poolConfig := poolsConfig["private-dev"].(map[string]any)
+	if got := poolConfig["criuEnabled"]; got != true {
+		t.Fatalf("private pool criuEnabled = %v, want true", got)
+	}
 }
 
 func TestAgentLocalRegistryForwardTargetUsesLocalK3DPort(t *testing.T) {
@@ -818,6 +823,16 @@ func TestWriteWorkerConfigClearsDefaultRegistryCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 	config := configManager.GetConfig()
+	pool, ok := config.Worker.Pools["private-dev"]
+	if !ok {
+		t.Fatal("private-dev pool missing from effective worker config")
+	}
+	if !pool.CRIUEnabled {
+		t.Fatal("private-dev pool should enable CRIU")
+	}
+	if config.Worker.CRIU.Mode != types.CRIUConfigModeNvidia {
+		t.Fatalf("worker CRIU mode = %q, want %q", config.Worker.CRIU.Mode, types.CRIUConfigModeNvidia)
+	}
 
 	s3 := config.ImageService.Registries.S3
 	if s3.BucketName != "" || s3.AccessKey != "" || s3.SecretKey != "" || s3.Endpoint != "" || s3.Region != "" {

--- a/pkg/agent/worker_config.go
+++ b/pkg/agent/worker_config.go
@@ -254,7 +254,7 @@ func newAgentWorkerConfig(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) a
 					NetworkSlotPoolSize:       int(slot.NetworkSlotPoolSize),
 					RequiresPoolSelector:      true,
 					Priority:                  1000,
-					CRIUEnabled:               false,
+					CRIUEnabled:               true,
 					TmpSizeLimit:              types.AgentTmpSizeLimit,
 					StorageMode:               workspaceStorageMode,
 					CheckpointPath:            types.AgentCheckpointPath,
@@ -291,7 +291,7 @@ func (c agentWorkerConfig) sanitizedForAgent() agentWorkerConfig {
 	c.Worker.CacheEnabled = true
 	for name, pool := range c.Worker.Pools {
 		pool.Mode = string(types.PoolModePrivate)
-		pool.CRIUEnabled = false
+		pool.CRIUEnabled = true
 		pool.RequiresPoolSelector = true
 		pool.Cache.Enabled = true
 		pool.Cache.Disk.Enabled = true

--- a/pkg/gateway/services/compute/byoc.go
+++ b/pkg/gateway/services/compute/byoc.go
@@ -28,6 +28,8 @@ type byocProvider interface {
 	Setup(context.Context, byocProviderSetupInput) (*byocProviderSetupResult, error)
 	Resource(workspaceID string, state *model.PoolState) (*byocProviderResource, error)
 	Scale(context.Context, byocProviderScaleInput) error
+	ResourceDeleted(context.Context, byocProviderResourceInput) (bool, error)
+	ReleaseMachine(context.Context, byocProviderReleaseMachineInput) error
 	UpdateScaleState(*model.PoolState, byocPoolRequest) error
 	ValidateExistingPool(*model.PoolState) error
 }
@@ -74,6 +76,19 @@ type byocProviderScaleInput struct {
 	Request      byocPoolRequest
 	Pool         *model.PoolState
 	ProviderData *model.BYOCProviderState
+}
+
+type byocProviderResourceInput struct {
+	WorkspaceID  string
+	Pool         *model.PoolState
+	ProviderData *model.BYOCProviderState
+}
+
+type byocProviderReleaseMachineInput struct {
+	WorkspaceID  string
+	Pool         *model.PoolState
+	ProviderData *model.BYOCProviderState
+	Machine      *model.AgentTokenState
 }
 
 type byocProviderResource struct {
@@ -383,7 +398,8 @@ func byocPoolStateToProto(state *model.PoolState, pool *pb.PrivatePool) *pb.BYOC
 }
 
 func (s *Service) cleanupDeletedBYOCPoolIfNeeded(ctx context.Context, workspaceID string, state *model.PoolState, machines []*model.AgentTokenState, now time.Time) (bool, error) {
-	if !byocPoolLooksDeleted(state, machines, now) {
+	resourceDeleted, _ := s.byocProviderResourceDeleted(ctx, workspaceID, state)
+	if !resourceDeleted && !byocPoolLooksDeleted(state, machines, now) {
 		return false, nil
 	}
 
@@ -397,13 +413,29 @@ func (s *Service) cleanupDeletedBYOCPoolIfNeeded(ctx context.Context, workspaceI
 		if err != nil {
 			return err
 		}
-		if !byocPoolLooksDeleted(fresh, freshMachines, now) {
+		freshResourceDeleted, _ := s.byocProviderResourceDeleted(ctx, workspaceID, fresh)
+		if !freshResourceDeleted && !byocPoolLooksDeleted(fresh, freshMachines, now) {
 			return nil
 		}
 		deleted = true
 		return s.deleteBYOCPoolLocalState(ctx, workspaceID, fresh, freshMachines, "cloud_resource_deleted")
 	})
 	return deleted, err
+}
+
+func (s *Service) byocProviderResourceDeleted(ctx context.Context, workspaceID string, state *model.PoolState) (bool, error) {
+	if state == nil || state.BYOC == nil {
+		return false, nil
+	}
+	provider, err := byocProviderForState(state)
+	if err != nil {
+		return false, err
+	}
+	return provider.ResourceDeleted(ctx, byocProviderResourceInput{
+		WorkspaceID:  workspaceID,
+		Pool:         state,
+		ProviderData: state.BYOC,
+	})
 }
 
 // Without provider credentials, external stack deletion is observable as all

--- a/pkg/gateway/services/compute/byoc_aws.go
+++ b/pkg/gateway/services/compute/byoc_aws.go
@@ -16,7 +16,12 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 	model "github.com/beam-cloud/beta9/pkg/compute"
 	"github.com/beam-cloud/beta9/pkg/types"
 )
@@ -43,6 +48,7 @@ var (
 	awsAccountIDPattern    = regexp.MustCompile(`^\d{12}$`)
 	awsPrincipalARNPattern = regexp.MustCompile(`^arn:[^:]+:iam::\d{12}:(role/.+|root)$`)
 	awsS3TemplateHostRe    = regexp.MustCompile(`^(?:s3[.-][a-z0-9-]+|[a-z0-9][a-z0-9.-]*\.s3[.-][a-z0-9-]+)\.amazonaws\.com$`)
+	awsEC2InstanceIDRe     = regexp.MustCompile(`^i-[a-f0-9]{8,17}$`)
 	cloudFormationPartRe   = regexp.MustCompile(`[^a-z0-9-]+`)
 	cloudFormationDashRe   = regexp.MustCompile(`-+`)
 	awsBYOCInstanceCatalog = map[string]awsBYOCInstanceType{
@@ -56,6 +62,7 @@ var (
 )
 
 var errBYOCDirectScaleUnavailable = errors.New("direct BYOC scaling is unavailable for this pool; recreate the AWS stack from Beam to enable one-click resizing")
+var errAWSBYOCResourceNotFound = errors.New("AWS BYOC resource not found")
 
 type byocAWSProvider struct{}
 
@@ -231,10 +238,7 @@ func (byocAWSProvider) Scale(ctx context.Context, input byocProviderScaleInput) 
 	if input.ProviderData == nil {
 		return fmt.Errorf("missing AWS BYOC resource metadata")
 	}
-	labels := input.ProviderData.Labels
-	roleARN := awsBYOCLabelString(labels, awsBYOCControlRoleArnLabel, "")
-	externalID := awsBYOCLabelString(labels, awsBYOCControlRoleExternalIDLabel, "")
-	asgName := awsBYOCLabelString(labels, awsBYOCAutoScalingGroupNameLabel, "")
+	roleARN, externalID, asgName := awsBYOCControlMetadata(input.ProviderData.Labels)
 	if roleARN == "" || externalID == "" || asgName == "" {
 		return errBYOCDirectScaleUnavailable
 	}
@@ -245,6 +249,39 @@ func (byocAWSProvider) Scale(ctx context.Context, input byocProviderScaleInput) 
 		AutoScalingGroupName: asgName,
 		DesiredNodes:         input.Request.desiredNodes,
 		MaxNodes:             input.Request.maxNodes,
+	})
+}
+
+func (byocAWSProvider) ResourceDeleted(ctx context.Context, input byocProviderResourceInput) (bool, error) {
+	if input.ProviderData == nil {
+		return false, fmt.Errorf("missing AWS BYOC resource metadata")
+	}
+	roleARN, externalID, _ := awsBYOCControlMetadata(input.ProviderData.Labels)
+	if roleARN == "" || externalID == "" || input.ProviderData.ResourceName == "" {
+		return false, errBYOCDirectScaleUnavailable
+	}
+	return awsBYOCResourceDeleted(ctx, awsBYOCResourceDeletedInput{
+		Region:     input.ProviderData.Region,
+		RoleARN:    roleARN,
+		ExternalID: externalID,
+		StackName:  input.ProviderData.ResourceName,
+	})
+}
+
+func (byocAWSProvider) ReleaseMachine(ctx context.Context, input byocProviderReleaseMachineInput) error {
+	if input.ProviderData == nil {
+		return fmt.Errorf("missing AWS BYOC resource metadata")
+	}
+	roleARN, externalID, asgName := awsBYOCControlMetadata(input.ProviderData.Labels)
+	if roleARN == "" || externalID == "" || asgName == "" {
+		return errBYOCDirectScaleUnavailable
+	}
+	return awsBYOCReleaseMachine(ctx, awsBYOCReleaseMachineInput{
+		Region:               input.ProviderData.Region,
+		RoleARN:              roleARN,
+		ExternalID:           externalID,
+		AutoScalingGroupName: asgName,
+		Machine:              input.Machine,
 	})
 }
 
@@ -350,6 +387,12 @@ func awsBYOCDirectScaleEnabled(labels map[string]string) bool {
 		awsBYOCLabelString(labels, awsBYOCAutoScalingGroupNameLabel, "") != ""
 }
 
+func awsBYOCControlMetadata(labels map[string]string) (roleARN, externalID, asgName string) {
+	return awsBYOCLabelString(labels, awsBYOCControlRoleArnLabel, ""),
+		awsBYOCLabelString(labels, awsBYOCControlRoleExternalIDLabel, ""),
+		awsBYOCLabelString(labels, awsBYOCAutoScalingGroupNameLabel, "")
+}
+
 type awsBYOCScaleAutoScalingGroupInput struct {
 	Region               string
 	RoleARN              string
@@ -360,20 +403,32 @@ type awsBYOCScaleAutoScalingGroupInput struct {
 }
 
 var awsBYOCScaleAutoScalingGroup = realAWSBYOCScaleAutoScalingGroup
+var awsBYOCResourceDeleted = realAWSBYOCResourceDeleted
+var awsBYOCReleaseMachine = realAWSBYOCReleaseMachine
+
+type awsBYOCResourceDeletedInput struct {
+	Region     string
+	RoleARN    string
+	ExternalID string
+	StackName  string
+}
+
+type awsBYOCReleaseMachineInput struct {
+	Region               string
+	RoleARN              string
+	ExternalID           string
+	AutoScalingGroupName string
+	Machine              *model.AgentTokenState
+}
 
 func realAWSBYOCScaleAutoScalingGroup(ctx context.Context, input awsBYOCScaleAutoScalingGroupInput) error {
 	if input.Region == "" || input.RoleARN == "" || input.ExternalID == "" || input.AutoScalingGroupName == "" {
 		return errBYOCDirectScaleUnavailable
 	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(input.Region))
+	cfg, err := awsBYOCControlConfig(ctx, input.Region, input.RoleARN, input.ExternalID, "beam-byoc-scale")
 	if err != nil {
-		return fmt.Errorf("load AWS config: %w", err)
+		return err
 	}
-	provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), input.RoleARN, func(options *stscreds.AssumeRoleOptions) {
-		options.ExternalID = aws.String(input.ExternalID)
-		options.RoleSessionName = "beam-byoc-scale"
-	})
-	cfg.Credentials = aws.NewCredentialsCache(provider)
 	client := autoscaling.NewFromConfig(cfg)
 	if input.MaxNodes < input.DesiredNodes {
 		input.MaxNodes = input.DesiredNodes
@@ -388,6 +443,240 @@ func realAWSBYOCScaleAutoScalingGroup(ctx context.Context, input awsBYOCScaleAut
 		return fmt.Errorf("update AWS BYOC node group: %w", err)
 	}
 	return nil
+}
+
+func realAWSBYOCResourceDeleted(ctx context.Context, input awsBYOCResourceDeletedInput) (bool, error) {
+	if input.Region == "" || input.RoleARN == "" || input.ExternalID == "" || input.StackName == "" {
+		return false, errBYOCDirectScaleUnavailable
+	}
+	cfg, err := awsBYOCControlConfig(ctx, input.Region, input.RoleARN, input.ExternalID, "beam-byoc-stack-check")
+	if err != nil {
+		return false, err
+	}
+	client := cloudformation.NewFromConfig(cfg)
+	out, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String(input.StackName),
+	})
+	if err != nil {
+		if awsBYOCCloudFormationStackNotFound(err) || awsBYOCControlRoleUnavailable(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("describe AWS BYOC stack: %w", err)
+	}
+	if len(out.Stacks) == 0 {
+		return true, nil
+	}
+	switch out.Stacks[0].StackStatus {
+	case cftypes.StackStatusDeleteInProgress, cftypes.StackStatusDeleteComplete:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func realAWSBYOCReleaseMachine(ctx context.Context, input awsBYOCReleaseMachineInput) error {
+	if input.Region == "" || input.RoleARN == "" || input.ExternalID == "" || input.AutoScalingGroupName == "" {
+		return errBYOCDirectScaleUnavailable
+	}
+	cfg, err := awsBYOCControlConfig(ctx, input.Region, input.RoleARN, input.ExternalID, "beam-byoc-release")
+	if err != nil {
+		return err
+	}
+	instanceID, err := awsBYOCResolveMachineInstanceID(ctx, cfg, input)
+	if err != nil {
+		if errors.Is(err, errAWSBYOCResourceNotFound) {
+			return nil
+		}
+		return err
+	}
+	_, err = autoscaling.NewFromConfig(cfg).TerminateInstanceInAutoScalingGroup(ctx, &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String(instanceID),
+		ShouldDecrementDesiredCapacity: aws.Bool(false),
+	})
+	if err != nil {
+		return fmt.Errorf("terminate AWS BYOC node %s: %w", instanceID, err)
+	}
+	return nil
+}
+
+func awsBYOCControlConfig(ctx context.Context, region, roleARN, externalID, sessionName string) (aws.Config, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("load AWS config: %w", err)
+	}
+	provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), roleARN, func(options *stscreds.AssumeRoleOptions) {
+		options.ExternalID = aws.String(externalID)
+		options.RoleSessionName = sessionName
+	})
+	cfg.Credentials = aws.NewCredentialsCache(provider)
+	return cfg, nil
+}
+
+func awsBYOCResolveMachineInstanceID(ctx context.Context, cfg aws.Config, input awsBYOCReleaseMachineInput) (string, error) {
+	instanceIDs, err := awsBYOCAutoScalingGroupInstanceIDs(ctx, cfg, input.AutoScalingGroupName)
+	if err != nil {
+		return "", err
+	}
+	if len(instanceIDs) == 0 {
+		return "", errAWSBYOCResourceNotFound
+	}
+
+	candidateIDs := awsBYOCMachineInstanceIDCandidates(input.Machine)
+	for _, instanceID := range instanceIDs {
+		if candidateIDs[instanceID] {
+			return instanceID, nil
+		}
+	}
+	if len(candidateIDs) > 0 {
+		return "", errAWSBYOCResourceNotFound
+	}
+
+	out, err := ec2.NewFromConfig(cfg).DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: instanceIDs,
+	})
+	if err != nil {
+		return "", fmt.Errorf("describe AWS BYOC nodes: %w", err)
+	}
+	for _, reservation := range out.Reservations {
+		for _, instance := range reservation.Instances {
+			if awsBYOCMachineMatchesInstance(input.Machine, instance) && instance.InstanceId != nil {
+				return *instance.InstanceId, nil
+			}
+		}
+	}
+	machineID := ""
+	if input.Machine != nil {
+		machineID = input.Machine.MachineID
+	}
+	return "", fmt.Errorf("unable to find AWS BYOC instance for machine %q in Auto Scaling Group %q", machineID, input.AutoScalingGroupName)
+}
+
+func awsBYOCAutoScalingGroupInstanceIDs(ctx context.Context, cfg aws.Config, asgName string) ([]string, error) {
+	out, err := autoscaling.NewFromConfig(cfg).DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []string{asgName},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe AWS BYOC Auto Scaling Group: %w", err)
+	}
+	if len(out.AutoScalingGroups) == 0 {
+		return nil, errAWSBYOCResourceNotFound
+	}
+	instanceIDs := make([]string, 0, len(out.AutoScalingGroups[0].Instances))
+	for _, instance := range out.AutoScalingGroups[0].Instances {
+		if instance.InstanceId == nil || *instance.InstanceId == "" {
+			continue
+		}
+		instanceIDs = append(instanceIDs, *instance.InstanceId)
+	}
+	return instanceIDs, nil
+}
+
+func awsBYOCMachineInstanceIDCandidates(machine *model.AgentTokenState) map[string]bool {
+	candidates := map[string]bool{}
+	if machine == nil {
+		return candidates
+	}
+	for _, value := range []string{machine.MachineFingerprint, machine.Hostname, machine.MachineID} {
+		value = strings.TrimSpace(value)
+		if awsEC2InstanceIDRe.MatchString(value) {
+			candidates[value] = true
+		}
+	}
+	return candidates
+}
+
+func awsBYOCMachineMatchesInstance(machine *model.AgentTokenState, instance ec2types.Instance) bool {
+	if machine == nil {
+		return false
+	}
+	candidates := awsBYOCMachineHostCandidates(machine)
+	for _, value := range []string{
+		aws.ToString(instance.PrivateDnsName),
+		aws.ToString(instance.PublicDnsName),
+		aws.ToString(instance.PrivateIpAddress),
+		aws.ToString(instance.InstanceId),
+	} {
+		for _, candidate := range normalizedAWSBYOCIdentityValues(value) {
+			if candidates[candidate] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func awsBYOCMachineHostCandidates(machine *model.AgentTokenState) map[string]bool {
+	candidates := map[string]bool{}
+	if machine == nil {
+		return candidates
+	}
+	for _, value := range []string{machine.Hostname, machine.MachineFingerprint} {
+		for _, candidate := range normalizedAWSBYOCIdentityValues(value) {
+			candidates[candidate] = true
+		}
+	}
+	return candidates
+}
+
+func normalizedAWSBYOCIdentityValues(value string) []string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return nil
+	}
+	values := []string{value}
+	if host, _, ok := strings.Cut(value, "."); ok && host != "" {
+		values = append(values, host)
+	}
+	if ip := awsBYOCPrivateDNSHostIP(value); ip != "" {
+		values = append(values, ip)
+	}
+	return values
+}
+
+func awsBYOCPrivateDNSHostIP(hostname string) string {
+	host, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(hostname)), ".")
+	if !strings.HasPrefix(host, "ip-") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(host, "ip-"), "-")
+	if len(parts) != 4 {
+		return ""
+	}
+	for _, part := range parts {
+		if _, err := strconv.Atoi(part); err != nil {
+			return ""
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+func awsBYOCCloudFormationStackNotFound(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return strings.EqualFold(apiErr.ErrorCode(), "ValidationError") && strings.Contains(strings.ToLower(apiErr.ErrorMessage()), "does not exist")
+}
+
+func awsBYOCControlRoleUnavailable(err error) bool {
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "sts:assumerole") && !strings.Contains(msg, "assume role") && !strings.Contains(msg, "assumerole") {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := strings.ToLower(apiErr.ErrorCode())
+		switch code {
+		case "accessdenied", "accessdeniedexception", "nosuchentity", "validationerror":
+			return true
+		}
+	}
+
+	return strings.Contains(msg, "not authorized") ||
+		strings.Contains(msg, "cannot be assumed") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "not found")
 }
 
 func awsCloudFormationConsoleURL(region, stackName, templateURL string, params map[string]string) string {

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/smithy-go"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	model "github.com/beam-cloud/beta9/pkg/compute"
 	"github.com/beam-cloud/beta9/pkg/repository"
@@ -700,6 +701,84 @@ func TestListPrivatePoolsCleansDeletedBYOCPool(t *testing.T) {
 	}
 }
 
+func TestListPrivatePoolsCleansDeletedBYOCPoolWithoutMachinesWhenProviderResourceGone(t *testing.T) {
+	ctx := testAuthContext("workspace-1", "owner-token")
+	resourceURL := awsCloudFormationStackURL("us-east-1", "beam-aws-cpu-test")
+	tokenHash := hashComputeToken("byoc-token")
+	roleARN := "arn:aws:iam::123456789012:role/beam-control-aws-cpu-test"
+	externalID := "beam-byoc-test-external-id"
+	asgName := "beam-asg-aws-cpu-test"
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{
+					Name:             "aws-cpu",
+					CreatedByTokenID: "owner-token",
+					Source:           model.SourceAWS,
+					Config:           &pb.PoolConfig{Name: "aws-cpu", Regions: []string{"us-east-1"}},
+					BYOC: &model.BYOCProviderState{
+						Provider:     "aws",
+						AccountID:    "123456789012",
+						Region:       "us-east-1",
+						ResourceName: "beam-aws-cpu-test",
+						ResourceURL:  resourceURL,
+						DestroyURL:   resourceURL,
+						Labels: map[string]string{
+							byocBootstrapJoinTokenHashLabel:   tokenHash,
+							byocBootstrapJoinTokenHashesLabel: tokenHash,
+							"instance_type":                   "i4i.xlarge",
+							"desired_nodes":                   "2",
+							"max_nodes":                       "2",
+							"target_sandboxes":                "40",
+							"sandboxes_per_node":              "20",
+							awsBYOCAutoScalingGroupNameLabel:  asgName,
+							awsBYOCControlRoleArnLabel:        roleARN,
+							awsBYOCControlRoleExternalIDLabel: externalID,
+						},
+					},
+				},
+			},
+		},
+		joinTokens: map[string]*model.JoinTokenState{
+			tokenHash: {
+				TokenHash:        tokenHash,
+				WorkspaceID:      "workspace-1",
+				PoolName:         "aws-cpu",
+				CreatedByTokenID: "owner-token",
+			},
+		},
+	}
+	var stackCheck awsBYOCResourceDeletedInput
+	oldResourceDeleted := awsBYOCResourceDeleted
+	awsBYOCResourceDeleted = func(ctx context.Context, input awsBYOCResourceDeletedInput) (bool, error) {
+		stackCheck = input
+		return true, nil
+	}
+	defer func() {
+		awsBYOCResourceDeleted = oldResourceDeleted
+	}()
+
+	res, err := (&Service{computeRepo: repo}).ListPrivatePools(ctx, &pb.ListPrivatePoolsRequest{})
+	if err != nil {
+		t.Fatalf("ListPrivatePools() error = %v", err)
+	}
+	if !res.Ok {
+		t.Fatalf("ListPrivatePools() not ok: %s", res.ErrMsg)
+	}
+	if got := len(res.Pools); got != 0 {
+		t.Fatalf("pool count = %d, want 0 after provider-deleted BYOC cleanup", got)
+	}
+	if got := len(repo.pools["workspace-1"]); got != 0 {
+		t.Fatalf("stored pool count = %d, want 0", got)
+	}
+	if token := repo.joinTokens[tokenHash]; token == nil || !token.Revoked {
+		t.Fatalf("BYOC bootstrap token revoked = %v, want true", token != nil && token.Revoked)
+	}
+	if stackCheck.Region != "us-east-1" || stackCheck.RoleARN != roleARN || stackCheck.ExternalID != externalID || stackCheck.StackName != "beam-aws-cpu-test" {
+		t.Fatalf("stack check input = %+v, want AWS control metadata", stackCheck)
+	}
+}
+
 func TestListPrivatePoolsKeepsRecentlyDisconnectedBYOCPool(t *testing.T) {
 	now := time.Now().UTC()
 	ctx := testAuthContext("workspace-1", "owner-token")
@@ -758,6 +837,113 @@ func TestListPrivatePoolsKeepsRecentlyDisconnectedBYOCPool(t *testing.T) {
 	}
 	if got, want := res.Pools[0].GetByoc().GetPhase(), "nodes_booting"; got != want {
 		t.Fatalf("BYOC phase = %q, want %q", got, want)
+	}
+}
+
+func TestReleasePrivateMachineTerminatesAWSBYOCNode(t *testing.T) {
+	now := time.Now().UTC()
+	roleARN := "arn:aws:iam::123456789012:role/beam-control-aws-cpu-test"
+	externalID := "beam-byoc-test-external-id"
+	asgName := "beam-asg-aws-cpu-test"
+	state := &model.PoolState{
+		WorkspaceID:      "workspace-1",
+		Name:             "aws-cpu",
+		CreatedByTokenID: "owner-token",
+		Source:           model.SourceAWS,
+		BYOC: &model.BYOCProviderState{
+			Provider: string(model.SourceAWS),
+			Region:   "us-east-1",
+			Labels: map[string]string{
+				awsBYOCAutoScalingGroupNameLabel:  asgName,
+				awsBYOCControlRoleArnLabel:        roleARN,
+				awsBYOCControlRoleExternalIDLabel: externalID,
+			},
+		},
+	}
+	machine := &model.AgentTokenState{
+		WorkspaceID:        "workspace-1",
+		PoolName:           "aws-cpu",
+		MachineID:          "machine-1",
+		MachineFingerprint: "i-0123456789abcdef0",
+		Hostname:           "i-0123456789abcdef0",
+		Schedulable:        true,
+		LastHeartbeatAt:    now,
+	}
+	repo := &fakeComputeRepo{
+		pools:    map[string][]*model.PoolState{"workspace-1": {state}},
+		machines: map[string][]*model.AgentTokenState{fakeComputeKey("workspace-1", "aws-cpu"): {machine}},
+	}
+	var releaseInput awsBYOCReleaseMachineInput
+	oldReleaseMachine := awsBYOCReleaseMachine
+	awsBYOCReleaseMachine = func(ctx context.Context, input awsBYOCReleaseMachineInput) error {
+		releaseInput = input
+		return nil
+	}
+	defer func() {
+		awsBYOCReleaseMachine = oldReleaseMachine
+	}()
+
+	if err := (&Service{computeRepo: repo}).releasePrivateMachine(context.Background(), machine); err != nil {
+		t.Fatalf("releasePrivateMachine() error = %v", err)
+	}
+	if releaseInput.Region != "us-east-1" || releaseInput.RoleARN != roleARN || releaseInput.ExternalID != externalID || releaseInput.AutoScalingGroupName != asgName {
+		t.Fatalf("release input = %+v, want AWS control metadata", releaseInput)
+	}
+	if releaseInput.Machine != machine {
+		t.Fatal("release did not pass the machine to the AWS provider")
+	}
+	if machine.Schedulable {
+		t.Fatal("releasePrivateMachine() did not mark the machine unschedulable")
+	}
+	if got := len(repo.machines[fakeComputeKey("workspace-1", "aws-cpu")]); got != 0 {
+		t.Fatalf("machine count after release = %d, want 0", got)
+	}
+}
+
+func TestReleasePrivateMachineKeepsLocalStateWhenAWSBYOCTerminationFails(t *testing.T) {
+	now := time.Now().UTC()
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "aws-cpu",
+		Source:      model.SourceAWS,
+		BYOC: &model.BYOCProviderState{
+			Provider: string(model.SourceAWS),
+			Region:   "us-east-1",
+			Labels: map[string]string{
+				awsBYOCAutoScalingGroupNameLabel:  "beam-asg-aws-cpu-test",
+				awsBYOCControlRoleArnLabel:        "arn:aws:iam::123456789012:role/beam-control-aws-cpu-test",
+				awsBYOCControlRoleExternalIDLabel: "beam-byoc-test-external-id",
+			},
+		},
+	}
+	machine := &model.AgentTokenState{
+		WorkspaceID:     "workspace-1",
+		PoolName:        "aws-cpu",
+		MachineID:       "machine-1",
+		Schedulable:     true,
+		LastHeartbeatAt: now,
+	}
+	repo := &fakeComputeRepo{
+		pools:    map[string][]*model.PoolState{"workspace-1": {state}},
+		machines: map[string][]*model.AgentTokenState{fakeComputeKey("workspace-1", "aws-cpu"): {machine}},
+	}
+	oldReleaseMachine := awsBYOCReleaseMachine
+	awsBYOCReleaseMachine = func(context.Context, awsBYOCReleaseMachineInput) error {
+		return errors.New("aws failed")
+	}
+	defer func() {
+		awsBYOCReleaseMachine = oldReleaseMachine
+	}()
+
+	err := (&Service{computeRepo: repo}).releasePrivateMachine(context.Background(), machine)
+	if err == nil || !strings.Contains(err.Error(), "aws failed") {
+		t.Fatalf("releasePrivateMachine() error = %v, want AWS failure", err)
+	}
+	if !machine.Schedulable {
+		t.Fatal("failed release should not mark the machine unschedulable")
+	}
+	if got := len(repo.machines[fakeComputeKey("workspace-1", "aws-cpu")]); got != 1 {
+		t.Fatalf("machine count after failed release = %d, want 1", got)
 	}
 }
 
@@ -868,17 +1054,17 @@ func TestScaleBYOCPoolUpdatesAWSAutoScalingGroupAndState(t *testing.T) {
 						ResourceURL:  resourceURL,
 						DestroyURL:   resourceURL,
 						Labels: map[string]string{
-							"instance_type":                     "i4i.xlarge",
-							"desired_nodes":                     "1",
-							"max_nodes":                         "4",
-							"target_sandboxes":                  "20",
-							"sandboxes_per_node":                "20",
-							"hourly_cost_micros":                "343000",
-							"total_hourly_cost_micros":          "343000",
-							awsBYOCAutoScalingGroupNameLabel:    asgName,
-							awsBYOCControlRoleArnLabel:          roleARN,
-							awsBYOCControlRoleExternalIDLabel:   externalID,
-							awsBYOCControlRoleNameLabel:         "beam-control-aws-cpu-test",
+							"instance_type":                   "i4i.xlarge",
+							"desired_nodes":                   "1",
+							"max_nodes":                       "4",
+							"target_sandboxes":                "20",
+							"sandboxes_per_node":              "20",
+							"hourly_cost_micros":              "343000",
+							"total_hourly_cost_micros":        "343000",
+							awsBYOCAutoScalingGroupNameLabel:  asgName,
+							awsBYOCControlRoleArnLabel:        roleARN,
+							awsBYOCControlRoleExternalIDLabel: externalID,
+							awsBYOCControlRoleNameLabel:       "beam-control-aws-cpu-test",
 						},
 					},
 				},
@@ -1029,12 +1215,51 @@ func TestAWSBYOCTemplateDoesNotEmbedSecrets(t *testing.T) {
 		"BeamControlRolePrincipalArn:",
 		"sts:ExternalId: !Ref BeamControlExternalId",
 		"autoscaling:UpdateAutoScalingGroup",
+		"autoscaling:TerminateInstanceInAutoScalingGroup",
+		"cloudformation:DescribeStacks",
+		"ec2:DescribeInstances",
 		"autoScalingGroupName/${BeamAutoScalingGroupName}",
 		"AutoScalingGroupName: !Ref BeamAutoScalingGroupName",
+		"BEAM_AGENT_MACHINE_FINGERPRINT=\"$INSTANCE_ID\"",
+		"BEAM_AGENT_HOSTNAME=\"$INSTANCE_ID\"",
 	} {
 		if !strings.Contains(template, fragment) {
 			t.Fatalf("template missing %q", fragment)
 		}
+	}
+}
+
+func TestAWSBYOCStackDeletionErrorClassification(t *testing.T) {
+	stackMissing := &smithy.GenericAPIError{
+		Code:    "ValidationError",
+		Message: "Stack with id beam-aws-cpu-test does not exist",
+	}
+	if !awsBYOCCloudFormationStackNotFound(stackMissing) {
+		t.Fatal("CloudFormation missing-stack validation error should be treated as deleted")
+	}
+
+	assumeRoleDenied := &smithy.OperationError{
+		ServiceID:     "STS",
+		OperationName: "AssumeRole",
+		Err: &smithy.GenericAPIError{
+			Code:    "AccessDenied",
+			Message: "User is not authorized to perform: sts:AssumeRole",
+		},
+	}
+	if !awsBYOCControlRoleUnavailable(fmt.Errorf("get credentials: %w", assumeRoleDenied)) {
+		t.Fatal("STS assume-role denial should be treated as the BYOC control role being unavailable")
+	}
+
+	cloudFormationDenied := &smithy.OperationError{
+		ServiceID:     "CloudFormation",
+		OperationName: "DescribeStacks",
+		Err: &smithy.GenericAPIError{
+			Code:    "AccessDenied",
+			Message: "User is not authorized to perform: cloudformation:DescribeStacks",
+		},
+	}
+	if awsBYOCControlRoleUnavailable(cloudFormationDenied) {
+		t.Fatal("CloudFormation authorization errors should not be treated as stack deletion")
 	}
 }
 

--- a/pkg/gateway/services/compute/release.go
+++ b/pkg/gateway/services/compute/release.go
@@ -15,10 +15,33 @@ func (s *Service) releasePrivateMachine(ctx context.Context, machine *model.Agen
 	if machine == nil {
 		return nil
 	}
+	if err := s.releaseBYOCProviderMachine(ctx, machine); err != nil {
+		return err
+	}
 	if err := s.releaseManagedMachineReservation(ctx, machine); err != nil {
 		return err
 	}
 	return s.removePrivateMachine(ctx, machine)
+}
+
+func (s *Service) releaseBYOCProviderMachine(ctx context.Context, machine *model.AgentTokenState) error {
+	if machine == nil {
+		return nil
+	}
+	state, err := s.getPrivatePoolState(ctx, machine.WorkspaceID, machine.PoolName)
+	if err != nil || state == nil || state.BYOC == nil {
+		return err
+	}
+	provider, err := byocProviderForState(state)
+	if err != nil {
+		return err
+	}
+	return provider.ReleaseMachine(ctx, byocProviderReleaseMachineInput{
+		WorkspaceID:  machine.WorkspaceID,
+		Pool:         state,
+		ProviderData: state.BYOC,
+		Machine:      machine,
+	})
 }
 
 func (s *Service) removePrivateMachine(ctx context.Context, machine *model.AgentTokenState) error {

--- a/pkg/gateway/services/compute/templates/aws/byoc.yaml
+++ b/pkg/gateway/services/compute/templates/aws/byoc.yaml
@@ -260,11 +260,14 @@ Resources:
               - Effect: Allow
                 Action:
                   - autoscaling:SetDesiredCapacity
+                  - autoscaling:TerminateInstanceInAutoScalingGroup
                   - autoscaling:UpdateAutoScalingGroup
                 Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${BeamAutoScalingGroupName}
               - Effect: Allow
                 Action:
                   - autoscaling:DescribeAutoScalingGroups
+                  - cloudformation:DescribeStacks
+                  - ec2:DescribeInstances
                 Resource: "*"
       Tags:
         - Key: beam:pool
@@ -332,6 +335,17 @@ Resources:
               printf '{"data-root":"%s"}\n' "$BEAM_NVME_ROOT/docker" > /etc/docker/daemon.json
             fi
             mkdir -p "$BEAM_STATE_DIR"
+            IMDS_TOKEN="$(curl -fsS -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600' http://169.254.169.254/latest/api/token || true)"
+            INSTANCE_ID=""
+            if [ -n "$IMDS_TOKEN" ]; then
+              INSTANCE_ID="$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id || true)"
+            else
+              INSTANCE_ID="$(curl -fsS http://169.254.169.254/latest/meta-data/instance-id || true)"
+            fi
+            if [ -n "$INSTANCE_ID" ]; then
+              export BEAM_AGENT_MACHINE_FINGERPRINT="$INSTANCE_ID"
+              export BEAM_AGENT_HOSTNAME="$INSTANCE_ID"
+            fi
             export BEAM_AGENT_INSTALL_DOCKER=1
             curl -fsSL '${BeamGatewayURL}/install/agent' | sh -s -- \
               --gateway '${BeamGatewayURL}' \

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -2842,13 +2842,13 @@ func (r *PostgresBackendRepository) GetLatestCheckpointByStubId(ctx context.Cont
 		       c.cache_hash, c.cache_size_bytes, c.origin_key, c.locality, c.accelerator
 		FROM checkpoint c
 		INNER JOIN stub s ON c.stub_id = s.id
-		WHERE s.external_id = $1 AND c.deleted_at IS NULL
+		WHERE s.external_id = $1 AND c.deleted_at IS NULL AND c.status = $2
 		ORDER BY c.created_at DESC
 		LIMIT 1;`
 
 	var checkpoint types.Checkpoint
 	var exposedPortsInt32 []int32
-	err := r.client.QueryRowxContext(ctx, query, stubExternalId).Scan(
+	err := r.client.QueryRowxContext(ctx, query, stubExternalId, string(types.CheckpointStatusAvailable)).Scan(
 		&checkpoint.CheckpointId,
 		&checkpoint.ExternalId,
 		&checkpoint.SourceContainerId,

--- a/pkg/repository/backend_postgres_test.go
+++ b/pkg/repository/backend_postgres_test.go
@@ -284,6 +284,63 @@ func TestListStaleCheckpointsRequiresStubUpdatedBeforeCutoff(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetLatestCheckpointByStubIdOnlyReturnsAvailable(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	postgresRepo := repo.(*PostgresBackendRepository)
+	createdAt := time.Now().Add(-time.Minute)
+	restoredAt := time.Now()
+
+	mock.ExpectQuery(`c\.status = \$2`).
+		WithArgs("stub-123", string(types.CheckpointStatusAvailable)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"checkpoint_id",
+			"external_id",
+			"source_container_id",
+			"container_ip",
+			"status",
+			"remote_key",
+			"workspace_id",
+			"stub_id",
+			"stub_type",
+			"app_id",
+			"exposed_ports",
+			"created_at",
+			"last_restored_at",
+			"cache_hash",
+			"cache_size_bytes",
+			"origin_key",
+			"locality",
+			"accelerator",
+		}).AddRow(
+			"checkpoint-available",
+			"external-available",
+			"container-available",
+			"10.0.0.12",
+			string(types.CheckpointStatusAvailable),
+			"checkpoint-available",
+			uint(1),
+			uint(2),
+			types.StubTypeASGI,
+			uint(3),
+			"{8001}",
+			createdAt,
+			restoredAt,
+			"sha256-cache",
+			int64(128),
+			"checkpoints/checkpoint-available.tar",
+			"default",
+			"cpu",
+		))
+
+	checkpoint, err := postgresRepo.GetLatestCheckpointByStubId(context.Background(), "stub-123")
+
+	require.NoError(t, err)
+	require.Equal(t, "checkpoint-available", checkpoint.CheckpointId)
+	require.Equal(t, string(types.CheckpointStatusAvailable), checkpoint.Status)
+	require.Equal(t, []uint32{8001}, checkpoint.ExposedPorts)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func expectTaskWithRelatedQuery(mock sqlmock.Sqlmock, taskSnapshot types.Task, dbStatus types.TaskStatus) {
 	mock.ExpectQuery("SELECT").
 		WithArgs(taskSnapshot.ExternalId).

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -229,7 +229,7 @@ func (s *Scheduler) Run(request *types.ContainerRequest) error {
 	// Add checkpoint state to request if auto checkpoint is enabled and checkpoint is not set
 	if request.CheckpointEnabled && request.Checkpoint == nil {
 		checkpoint, err := s.backendRepo.GetLatestCheckpointByStubId(context.Background(), request.StubId)
-		if err == nil && checkpoint != nil {
+		if err == nil && checkpoint != nil && checkpoint.Status == string(types.CheckpointStatusAvailable) {
 			requestLog(log.Info(), request).Str("checkpoint_id", checkpoint.CheckpointId).Msg("adding checkpoint to request")
 			request.Checkpoint = checkpoint
 		}

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -81,6 +81,61 @@ func newTestReporter(eventRepo repo.EventRepository) *cacheContentReporter {
 	}
 }
 
+func newCheckpointCacheForTest(t *testing.T, ctx context.Context) (*cache.Server, *cache.Client) {
+	t.Helper()
+
+	cfg := testCacheManagerConfig(t.TempDir()).Cache
+	metadataStore := cache.NewMockCacheMetadataStore()
+	server, err := cache.NewServerWithOptions(ctx, cfg, "test", cache.WithServerMetadataStore(metadataStore), cache.WithServerHostID("local-host"))
+	require.NoError(t, err)
+
+	addr, err := server.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	host := server.Host()
+	require.NotNil(t, host)
+	host.Addr = addr
+	host.PrivateAddr = addr
+
+	client, err := cache.NewClientWithHostDirectory(ctx, cfg, metadataStore, testHostDirectoryFunc(func(context.Context, string) ([]*cache.Host, error) {
+		return []*cache.Host{host}, nil
+	}), "test")
+	require.NoError(t, err)
+	client.AttachLocalServer(server)
+
+	require.Eventually(t, func() bool {
+		_, err := client.PrimaryReadHost("checkpoint-test-probe")
+		return err == nil
+	}, 3*time.Second, 20*time.Millisecond)
+
+	t.Cleanup(func() { require.NoError(t, client.Cleanup()) })
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	return server, client
+}
+
+func createMaterializedCheckpointForTest(t *testing.T, checkpointPath string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(checkpointPath, checkpointFsDir), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(checkpointPath, checkpointFsDir, "state.txt"), []byte("filesystem payload"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(checkpointPath, "inventory.img"), []byte("runtime payload"), 0644))
+}
+
+func createCheckpointArchiveForTest(t *testing.T, checkpointID string) (archivePath, hash string, size int64) {
+	t.Helper()
+
+	root := t.TempDir()
+	checkpointPath := filepath.Join(root, checkpointID)
+	createMaterializedCheckpointForTest(t, checkpointPath)
+
+	archivePath = filepath.Join(t.TempDir(), checkpointID+checkpointArchiveExtension)
+	require.NoError(t, createTar(checkpointPath, archivePath))
+
+	hash, size, err := fileSHA256(archivePath)
+	require.NoError(t, err)
+	return archivePath, hash, size
+}
+
 type claimedMetadataStore struct {
 	cache.CacheMetadataStore
 	claimed bool
@@ -609,6 +664,130 @@ func TestEnsureCheckpointMaterializedReportsMissingCheckpointDemand(t *testing.T
 	require.Equal(t, checkpoint.CacheHash, fake.pushed[0].Items[0].Hash)
 	require.Equal(t, checkpoint.CheckpointId, fake.pushed[0].Items[0].CheckpointID)
 	require.Equal(t, checkpoint.Accelerator, fake.pushed[0].Items[0].Accelerator)
+}
+
+func TestEnsureCheckpointMaterializedReportsAlreadyLocalCheckpoint(t *testing.T) {
+	fake := &fakeEventRepo{}
+	metadata := &claimedMetadataStore{}
+	reporter := newTestReporter(fake)
+	reporter.metadata = metadata
+
+	checkpointID := "checkpoint-local"
+	checkpointRoot := t.TempDir()
+	createMaterializedCheckpointForTest(t, filepath.Join(checkpointRoot, checkpointID))
+	worker := &Worker{
+		cacheManager: &WorkerCacheManager{
+			checkpointRoot: checkpointRoot,
+			reporter:       reporter,
+			reconcileNow:   make(chan struct{}, 1),
+		},
+	}
+	checkpoint := &types.Checkpoint{
+		CheckpointId:   checkpointID,
+		CacheHash:      strings.Repeat("c", 64),
+		CacheSizeBytes: 128,
+		OriginKey:      "checkpoints/checkpoint-local.tar",
+		Accelerator:    "CPU",
+	}
+
+	path, err := worker.ensureCheckpointMaterialized(context.Background(), &types.ContainerRequest{
+		WorkspaceId: "workspace",
+		StubId:      "stub",
+	}, checkpoint)
+
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(checkpointRoot, checkpointID), path)
+	require.Empty(t, worker.cacheManager.reconcileNow)
+
+	reporter.flush()
+	require.Equal(t, 1, metadata.recent)
+	require.Len(t, fake.pushed, 1)
+	require.Equal(t, checkpoint.CacheHash, fake.pushed[0].Items[0].Hash)
+	require.Equal(t, checkpoint.CheckpointId, fake.pushed[0].Items[0].CheckpointID)
+	require.Equal(t, checkpoint.OriginKey, fake.pushed[0].Items[0].Source)
+}
+
+func TestEnsureCheckpointMaterializedRestoresFromEmbeddedCache(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client := newCheckpointCacheForTest(t, ctx)
+	checkpointID := "checkpoint-cache-hit"
+	archivePath, hash, size := createCheckpointArchiveForTest(t, checkpointID)
+	_, err := client.StoreContentFromLocalFile(cache.LocalContentSource{
+		Path:      archivePath,
+		CachePath: "checkpoints/" + checkpointID + checkpointArchiveExtension,
+	}, cache.StoreContentOptions{RoutingKey: hash, Lock: true})
+	require.NoError(t, err)
+	require.True(t, server.HasCompleteContent(hash, size))
+
+	fake := &fakeEventRepo{}
+	reporter := newTestReporter(fake)
+	reporter.metadata = &claimedMetadataStore{}
+	checkpointRoot := filepath.Join(t.TempDir(), "checkpoints")
+	worker := &Worker{
+		cacheManager: &WorkerCacheManager{
+			client:         client,
+			checkpointRoot: checkpointRoot,
+			reporter:       reporter,
+			reconcileNow:   make(chan struct{}, 1),
+		},
+	}
+
+	path, err := worker.ensureCheckpointMaterialized(context.Background(), &types.ContainerRequest{
+		WorkspaceId: "workspace",
+		StubId:      "stub",
+	}, &types.Checkpoint{
+		CheckpointId:   checkpointID,
+		CacheHash:      hash,
+		CacheSizeBytes: size,
+		OriginKey:      "checkpoints/" + checkpointID + checkpointArchiveExtension,
+	})
+
+	require.NoError(t, err)
+	require.True(t, checkpointMaterialized(path))
+	require.Len(t, worker.cacheManager.reconcileNow, 1)
+
+	reporter.flush()
+	require.Len(t, fake.pushed, 1)
+	require.Equal(t, types.CacheContentKindCheckpoint, fake.pushed[0].Kind)
+	require.Equal(t, hash, fake.pushed[0].Items[0].Hash)
+	require.Equal(t, hash, fake.pushed[0].Items[0].RoutingKey)
+	require.Equal(t, checkpointID, fake.pushed[0].Items[0].CheckpointID)
+}
+
+func TestReconcileCheckpointExtractsEmbeddedCacheArchive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client := newCheckpointCacheForTest(t, ctx)
+	checkpointID := "checkpoint-reconcile"
+	archivePath, hash, size := createCheckpointArchiveForTest(t, checkpointID)
+	_, err := client.StoreContentFromLocalFile(cache.LocalContentSource{
+		Path:      archivePath,
+		CachePath: "checkpoints/" + checkpointID + checkpointArchiveExtension,
+	}, cache.StoreContentOptions{RoutingKey: hash, Lock: true})
+	require.NoError(t, err)
+
+	checkpointRoot := filepath.Join(t.TempDir(), "checkpoints")
+	manager := &WorkerCacheManager{
+		ctx:            ctx,
+		client:         client,
+		checkpointRoot: checkpointRoot,
+	}
+	status := manager.materializeCheckpoint(ctx, server, cache.RecentStub{
+		WorkspaceID: "workspace",
+		StubID:      "stub",
+	}, types.CacheRequiredContentItem{
+		Kind:         types.CacheContentKindCheckpoint,
+		Hash:         hash,
+		RoutingKey:   hash,
+		SizeBytes:    size,
+		CheckpointID: checkpointID,
+	}, hash)
+
+	require.Equal(t, types.CacheAuditStatusMaterialized, status)
+	require.True(t, checkpointMaterialized(filepath.Join(checkpointRoot, checkpointID)))
 }
 
 func TestReconcileStubFansOutCheckpointsAcrossMatchingHosts(t *testing.T) {

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -60,6 +60,11 @@ type CRIUManager interface {
 	RestoreCheckpoint(ctx context.Context, runtime runtime.Runtime, opts *RestoreOpts) (int, error)
 }
 
+type restoreCheckpointResult struct {
+	exitCode int
+	err      error
+}
+
 // InitializeCRIUManager initializes a new CRIU manager that can be used to checkpoint and restore containers.
 func InitializeCRIUManager(ctx context.Context, config types.CRIUConfig, checkpointRoot string) (CRIUManager, error) {
 	var criuManager CRIUManager = nil
@@ -114,56 +119,174 @@ func (s *Worker) attemptAutoCheckpoint(ctx context.Context, request *types.Conta
 	}
 }
 
-func (s *Worker) attemptRestoreCheckpoint(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger, outputWriter io.Writer, startedChan chan int, checkpointPIDChan chan int) (exitCode int, restored bool, err error) {
+func (s *Worker) attemptRestoreCheckpoint(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger, outputWriter io.Writer, startedChan chan int, checkpointPIDChan chan int) (exitCode int, restored bool, started bool, err error) {
 	checkpoint := request.Checkpoint
 	if checkpoint.Status != string(types.CheckpointStatusAvailable) {
-		return -1, false, fmt.Errorf("checkpoint not available")
+		return -1, false, false, fmt.Errorf("checkpoint not available")
 	}
 
 	if err := s.requireCRIUManager(); err != nil {
-		return -1, false, err
+		return -1, false, false, err
 	}
 
 	outputLogger.Info("Attempting to restore container from checkpoint...")
 	signalDir := checkpointSignalDir(request.ContainerId)
 	if err := os.MkdirAll(signalDir, 0755); err != nil {
 		log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", checkpoint.CheckpointId).Msgf("failed to create checkpoint signal dir: %v", err)
-		return -1, false, err
+		return -1, false, false, err
 	}
 
 	f, err := os.Create(filepath.Join(signalDir, checkpointCompleteFileName))
 	if err != nil {
 		log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", checkpoint.CheckpointId).Msgf("failed to create checkpoint complete file: %v", err)
-		return -1, false, err
+		return -1, false, false, err
 	}
 	defer f.Close()
 
 	instance, exists := s.containerInstances.Get(request.ContainerId)
 	if !exists {
-		return -1, false, fmt.Errorf("container instance not found")
+		return -1, false, false, fmt.Errorf("container instance not found")
 	}
 
-	exitCode, err = s.criuManager.RestoreCheckpoint(ctx, instance.Runtime, &RestoreOpts{
-		request:      request,
-		checkpoint:   checkpoint,
-		outputWriter: outputWriter,
-		started:      startedChan,
-		configPath:   request.ConfigPath,
-	})
+	restoreStarted := make(chan int, 1)
+	restoreDone := make(chan restoreCheckpointResult, 1)
+	go func() {
+		exitCode, err := s.criuManager.RestoreCheckpoint(ctx, instance.Runtime, &RestoreOpts{
+			request:      request,
+			checkpoint:   checkpoint,
+			outputWriter: outputWriter,
+			started:      restoreStarted,
+			configPath:   request.ConfigPath,
+		})
+		restoreDone <- restoreCheckpointResult{exitCode: exitCode, err: err}
+	}()
+
+	restoreStartedChan := (<-chan int)(restoreStarted)
+	for restoreDone != nil {
+		select {
+		case pid := <-restoreStartedChan:
+			started = true
+			restoreStartedChan = nil
+			if err := forwardRestoreStarted(ctx, startedChan, pid); err != nil {
+				return -1, false, started, err
+			}
+		case result := <-restoreDone:
+			exitCode, err = result.exitCode, result.err
+			restoreDone = nil
+			if !started {
+				if pid, ok := restoreStartedPID(restoreStarted); ok {
+					started = true
+					if err == nil {
+						if forwardErr := forwardRestoreStarted(ctx, startedChan, pid); forwardErr != nil {
+							return -1, false, started, forwardErr
+						}
+					}
+				}
+			}
+		case <-ctx.Done():
+			return -1, false, started, ctx.Err()
+		}
+	}
+
 	if err != nil {
 		log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", checkpoint.CheckpointId).Msgf("failed to restore checkpoint: %v", err)
 
 		outputLogger.Info("Failed to restore checkpoint")
-
-		updateStateErr := s.updateCheckpointState(checkpoint.CheckpointId, request, types.CheckpointStatusRestoreFailed)
-		if updateStateErr != nil {
-			log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", checkpoint.CheckpointId).Msgf("failed to update checkpoint state: %v", updateStateErr)
+		if cleanupErr := deleteFailedRestoreRuntimeContainer(ctx, instance.Runtime, request.ContainerId); cleanupErr != nil {
+			log.Warn().
+				Err(cleanupErr).
+				Str("container_id", request.ContainerId).
+				Str("checkpoint_id", checkpoint.CheckpointId).
+				Msg("failed to clean up runtime container after checkpoint restore failure")
 		}
+		s.markCheckpointRestoreFailed(request, checkpoint)
 
-		return exitCode, false, err
+		return exitCode, false, started, err
 	}
 
-	return exitCode, true, nil
+	if !started {
+		err := fmt.Errorf("checkpoint restore completed without runtime start")
+		log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", checkpoint.CheckpointId).Msg(err.Error())
+		s.markCheckpointRestoreFailed(request, checkpoint)
+		return -1, false, false, err
+	}
+
+	return exitCode, true, started, nil
+}
+
+func forwardRestoreStarted(ctx context.Context, startedChan chan int, pid int) error {
+	if startedChan == nil {
+		return nil
+	}
+
+	select {
+	case startedChan <- pid:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func restoreStartedPID(started <-chan int) (int, bool) {
+	select {
+	case pid := <-started:
+		return pid, true
+	default:
+		return 0, false
+	}
+}
+
+func deleteFailedRestoreRuntimeContainer(ctx context.Context, rt runtime.Runtime, containerId string) error {
+	if rt == nil || containerId == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), runtimeDeleteTimeout)
+	defer cancel()
+
+	err := rt.Delete(cleanupCtx, containerId, &runtime.DeleteOpts{Force: true})
+	if err != nil && !runtimeContainerNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func runtimeContainerNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var notFoundValue runtime.ErrContainerNotFound
+	if errors.As(err, &notFoundValue) {
+		return true
+	}
+
+	var notFound *runtime.ErrContainerNotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "no such container")
+}
+
+func (s *Worker) markCheckpointRestoreFailed(request *types.ContainerRequest, checkpoint *types.Checkpoint) {
+	if request == nil || checkpoint == nil || checkpoint.CheckpointId == "" {
+		return
+	}
+
+	if err := s.updateCheckpointState(checkpoint.CheckpointId, request, types.CheckpointStatusRestoreFailed); err != nil {
+		log.Error().
+			Err(err).
+			Str("container_id", request.ContainerId).
+			Str("checkpoint_id", checkpoint.CheckpointId).
+			Msg("failed to update checkpoint state")
+	}
 }
 
 func (s *Worker) signalRestoredSandboxProcessManager(ctx context.Context, request *types.ContainerRequest, rt runtime.Runtime) {
@@ -364,13 +487,16 @@ func (s *Worker) ensureCheckpointMaterialized(ctx context.Context, request *type
 	if checkpointPath == "" {
 		return "", fmt.Errorf("checkpoint path is unavailable")
 	}
+	metadataComplete := checkpoint.CacheHash != "" && checkpoint.CacheSizeBytes > 0 && checkpoint.OriginKey != ""
+	if metadataComplete {
+		s.reportCheckpointRequiredContent(request, checkpoint.CheckpointId, checkpointCacheMetadataFromRecord(request, checkpoint))
+	}
 	if checkpointMaterialized(checkpointPath) {
 		return checkpointPath, nil
 	}
-	if checkpoint.CacheHash == "" || checkpoint.CacheSizeBytes <= 0 || checkpoint.OriginKey == "" {
+	if !metadataComplete {
 		return "", fmt.Errorf("checkpoint cache metadata is incomplete")
 	}
-	s.reportCheckpointRequiredContent(request, checkpoint.CheckpointId, checkpointCacheMetadataFromRecord(request, checkpoint))
 	s.cacheManager.requestReconcile()
 
 	archivePath := s.checkpointArchivePath(checkpoint.CheckpointId)
@@ -476,6 +602,10 @@ func writeCacheContentFile(ctx context.Context, client *cache.Client, filePath, 
 	}
 	tmpPath := filePath + ".tmp"
 	_ = os.Remove(tmpPath)
+
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return err
+	}
 
 	f, err := os.Create(tmpPath)
 	if err != nil {
@@ -626,7 +756,7 @@ func (s *Worker) shouldCreateCheckpoint(request *types.ContainerRequest) bool {
 		return false
 	}
 
-	if request.Checkpoint != nil {
+	if request.Checkpoint != nil && request.Checkpoint.Status == string(types.CheckpointStatusAvailable) {
 		return false
 	}
 

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -21,6 +21,7 @@ const (
 	minNvidiaDriverVersion     = 570
 	gvisorCheckpointAttempts   = 4
 	gvisorCheckpointRetryDelay = 250 * time.Millisecond
+	maxRestoreStderrBytes      = 4096
 )
 
 type ErrCRIURestoreFailed struct {
@@ -177,7 +178,7 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, rt runtime.Ru
 			return -1, &ErrCRIURestoreFailed{Stderr: stderr}
 		}
 
-		return exitCode, fmt.Errorf("restore failed for runtime %s: %w", rt.Name(), err)
+		return exitCode, restoreFailureError(rt.Name(), err, stderr)
 	}
 
 	log.Info().
@@ -188,6 +189,17 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, rt runtime.Ru
 		Msg("checkpoint restored successfully")
 
 	return exitCode, nil
+}
+
+func restoreFailureError(runtimeName string, err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" || strings.Contains(err.Error(), "stderr:") {
+		return fmt.Errorf("restore failed for runtime %s: %w", runtimeName, err)
+	}
+	if len(stderr) > maxRestoreStderrBytes {
+		stderr = stderr[:maxRestoreStderrBytes] + "...[truncated]"
+	}
+	return fmt.Errorf("restore failed for runtime %s: %w (stderr: %s)", runtimeName, err, stderr)
 }
 
 func (c *NvidiaCRIUManager) Available() bool {

--- a/pkg/worker/criu_test.go
+++ b/pkg/worker/criu_test.go
@@ -439,7 +439,7 @@ func TestAttemptRestoreCheckpointRequiresCRIUManager(t *testing.T) {
 		},
 	}
 
-	exitCode, restored, err := (&Worker{}).attemptRestoreCheckpoint(
+	exitCode, restored, started, err := (&Worker{}).attemptRestoreCheckpoint(
 		context.Background(),
 		request,
 		nil,
@@ -452,6 +452,9 @@ func TestAttemptRestoreCheckpointRequiresCRIUManager(t *testing.T) {
 	}
 	if restored {
 		t.Fatal("attemptRestoreCheckpoint restored with unavailable CRIU manager")
+	}
+	if started {
+		t.Fatal("attemptRestoreCheckpoint started with unavailable CRIU manager")
 	}
 	if exitCode != -1 {
 		t.Fatalf("attemptRestoreCheckpoint exitCode = %d, want -1", exitCode)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -1419,16 +1419,34 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		})
 	}
 
-	// Handle automatic checkpoint creation if applicable
-	// (This occurs when checkpoint_enabled is true and an existing checkpoint is not available)
-	if supportsCheckpoint && request.CheckpointEnabled {
-		go s.attemptAutoCheckpoint(ctx, request, outputLogger, outputWriter, startedChan, checkpointPIDChan)
+	startAutoCheckpoint := func() {
+		if supportsCheckpoint && request.CheckpointEnabled {
+			go s.attemptAutoCheckpoint(ctx, request, outputLogger, outputWriter, startedChan, checkpointPIDChan)
+		}
+	}
+	fallbackFromCheckpoint := func(startCheckpoint bool) {
+		restoringCheckpoint = false
+		request.Checkpoint = nil
+		if startCheckpoint {
+			startAutoCheckpoint()
+		}
+	}
+
+	if !restoringCheckpoint {
+		startAutoCheckpoint()
 	}
 
 	bundlePath := filepath.Dir(request.ConfigPath)
 	runtimeStartedChan := make(chan int, 1)
 	runtimeStartedDone := make(chan struct{})
 	runtimeStartedHandled := make(chan struct{})
+	var runtimeStartedOnce sync.Once
+	finishRuntimeStarted := func() {
+		runtimeStartedOnce.Do(func() {
+			close(runtimeStartedDone)
+			<-runtimeStartedHandled
+		})
+	}
 	runtimeStart := time.Now()
 
 	handleRuntimeStarted := func(pid int) {
@@ -1460,7 +1478,6 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 			return
 		}
 		s.markContainerRunning(ctx, request, startupStartedAt)
-		markCheckpointRestored()
 	}
 
 	go func() {
@@ -1469,41 +1486,47 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 	}()
 
 	// Handle restore from checkpoint if available
-	if supportsCheckpoint && request.Checkpoint != nil {
-		if request.Checkpoint != nil && request.Checkpoint.Status == string(types.CheckpointStatusAvailable) {
-			checkpointPath, err := s.ensureCheckpointMaterialized(ctx, request, request.Checkpoint)
+	if restoringCheckpoint {
+		checkpointPath, err := s.ensureCheckpointMaterialized(ctx, request, request.Checkpoint)
+		if err != nil {
+			log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", request.Checkpoint.CheckpointId).Msgf("failed to materialize checkpoint: %v", err)
+		} else {
+			err = copyDirectory(filepath.Join(checkpointPath, checkpointFsDir), filepath.Dir(request.ConfigPath), []string{})
 			if err != nil {
-				log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", request.Checkpoint.CheckpointId).Msgf("failed to materialize checkpoint: %v", err)
-			} else {
-				err = copyDirectory(filepath.Join(checkpointPath, checkpointFsDir), filepath.Dir(request.ConfigPath), []string{})
-			}
-			if err != nil {
-				log.Error().Str("container_id", request.ContainerId).Msgf("failed to copy checkpoint directory: %v", err)
+				log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", request.Checkpoint.CheckpointId).Msgf("failed to copy checkpoint directory: %v", err)
 			}
 		}
+		if err != nil {
+			s.markCheckpointRestoreFailed(request, request.Checkpoint)
+			if !request.Stub.Type.IsDeployment() {
+				finishRuntimeStarted()
+				return -1, err
+			}
+			fallbackFromCheckpoint(true)
+		} else {
+			runtimeStart = time.Now()
+			exitCode, restored, restoreStarted, err := s.attemptRestoreCheckpoint(ctx, request, outputLogger, outputWriter, runtimeStartedChan, checkpointPIDChan)
+			if restored {
+				finishRuntimeStarted()
+				markCheckpointRestored()
+				if runtimeRestoreWaitsForExit(instance.Runtime) {
+					return exitCode, err
+				}
+				if err != nil {
+					return exitCode, err
+				}
+				return s.waitForRestoredContainerExit(ctx, instance.Runtime, request.ContainerId, exitCode)
+			}
 
-		runtimeStart = time.Now()
-		exitCode, restored, err := s.attemptRestoreCheckpoint(ctx, request, outputLogger, outputWriter, runtimeStartedChan, checkpointPIDChan)
-		if restored {
-			close(runtimeStartedDone)
-			<-runtimeStartedHandled
-			if runtimeRestoreWaitsForExit(instance.Runtime) {
+			// If this is not a deployment stub, don't fall back to running the container
+			if !restored && !request.Stub.Type.IsDeployment() {
+				finishRuntimeStarted()
 				return exitCode, err
 			}
-			if err != nil {
-				return exitCode, err
+			if restoreStarted {
+				finishRuntimeStarted()
 			}
-			return s.waitForRestoredContainerExit(ctx, instance.Runtime, request.ContainerId, exitCode)
-		}
-
-		// If this is not a deployment stub, don't fall back to running the container
-		if !restored && !request.Stub.Type.IsDeployment() {
-			close(runtimeStartedDone)
-			<-runtimeStartedHandled
-			return exitCode, err
-		} else if !restored {
-			// Disable checkpoint flag if the restore fails
-			request.CheckpointEnabled = false
+			fallbackFromCheckpoint(!restoreStarted)
 		}
 	}
 
@@ -1527,8 +1550,7 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		Started:       runtimeStartedChan,
 		DockerEnabled: request.DockerEnabled,
 	})
-	close(runtimeStartedDone)
-	<-runtimeStartedHandled
+	finishRuntimeStarted()
 	if err != nil {
 		log.Warn().Str("container_id", request.ContainerId).Err(err).Msgf("error running container from bundle, exit code %d", exitCode)
 	}

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -919,7 +919,7 @@ func TestAttemptRestoreCheckpointTreatsGenericErrorAsRestoreFailure(t *testing.T
 		},
 	}
 
-	exitCode, restored, err := worker.attemptRestoreCheckpoint(
+	exitCode, restored, started, err := worker.attemptRestoreCheckpoint(
 		context.Background(),
 		request,
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -930,11 +930,167 @@ func TestAttemptRestoreCheckpointTreatsGenericErrorAsRestoreFailure(t *testing.T
 
 	require.ErrorIs(t, err, restoreErr)
 	require.False(t, restored)
+	require.False(t, started)
 	require.Equal(t, 17, exitCode)
 	require.Equal(t, 1, backendRepoClient.updateCalls)
 	require.Equal(t, request.Checkpoint.CheckpointId, backendRepoClient.lastUpdate.CheckpointId)
 	require.Equal(t, string(types.CheckpointStatusRestoreFailed), backendRepoClient.lastUpdate.Status)
 	require.Nil(t, backendRepoClient.lastUpdate.LastRestoredAt)
+}
+
+func TestRunContainerRestoreFailureCleansRuntimeBeforeFallback(t *testing.T) {
+	t.Setenv("WORKER_POOL_NAME", "default")
+
+	restoreErr := assert.AnError
+	containerID := "container-restore-fallback"
+	checkpointID := "checkpoint-restore-fallback"
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "checkpoints", checkpointID, checkpointFsDir), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "checkpoints", checkpointID, "inventory.img"), []byte("runtime payload"), 0644))
+
+	rt := &restoreFallbackRuntime{
+		mockRuntime: mockRuntime{
+			name:         "runc",
+			capabilities: runtime.Capabilities{CheckpointRestore: true},
+		},
+	}
+	criuManager := &observingRestoreErrorCRIUManager{err: restoreErr}
+	backendRepoClient := &fakeBackendRepoClient{}
+	repoClient := &fakeContainerRepoClient{
+		state: &pb.ContainerState{Status: string(types.ContainerStatusPending)},
+	}
+	worker := &Worker{
+		config: types.AppConfig{Worker: types.WorkerConfig{Pools: map[string]types.WorkerPoolConfig{
+			"default": {CRIUEnabled: true},
+		}}},
+		podAddr:             "10.42.0.10",
+		criuManager:         criuManager,
+		containerRepoClient: repoClient,
+		backendRepoClient:   backendRepoClient,
+		containerInstances:  common.NewSafeMap[*ContainerInstance](),
+		cacheManager:        &WorkerCacheManager{checkpointRoot: filepath.Join(tmpDir, "checkpoints")},
+	}
+	worker.containerInstances.Set(containerID, &ContainerInstance{
+		Id:      containerID,
+		Runtime: rt,
+	})
+	request := &types.ContainerRequest{
+		ContainerId:       containerID,
+		ConfigPath:        filepath.Join(t.TempDir(), "config.json"),
+		Stub:              types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeASGIDeployment)}},
+		CheckpointEnabled: true,
+		Checkpoint: &types.Checkpoint{
+			CheckpointId: checkpointID,
+			Status:       string(types.CheckpointStatusAvailable),
+		},
+	}
+
+	exitCode, err := worker.runContainer(
+		context.Background(),
+		request,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		common.NewOutputWriter(func(string) {}),
+		make(chan int, 1),
+		make(chan int, 1),
+		time.Now(),
+		[]PortBinding{{HostPort: 30001, ContainerPort: 8001}},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.True(t, rt.runCalled)
+	require.Equal(t, 0, criuManager.deleteCallsAtRestore)
+	require.Equal(t, 1, rt.deleteCallsAtRun)
+	require.Equal(t, 1, backendRepoClient.updateCalls)
+	require.Equal(t, string(types.CheckpointStatusRestoreFailed), backendRepoClient.lastUpdate.Status)
+	require.Nil(t, backendRepoClient.lastUpdate.LastRestoredAt)
+	require.Nil(t, request.Checkpoint)
+	require.True(t, request.CheckpointEnabled)
+	require.Equal(t, 1, repoClient.updateStatusCalls)
+	require.Equal(t, string(types.ContainerStatusRunning), repoClient.lastUpdateStatus.Status)
+}
+
+func TestRunContainerMaterializeFailureFallsBackWithoutRestore(t *testing.T) {
+	t.Setenv("WORKER_POOL_NAME", "default")
+
+	containerID := "container-materialize-fallback"
+	rt := &restoreFallbackRuntime{
+		mockRuntime: mockRuntime{
+			name:         "runc",
+			capabilities: runtime.Capabilities{CheckpointRestore: true},
+		},
+	}
+	criuManager := &observingRestoreErrorCRIUManager{err: assert.AnError}
+	backendRepoClient := &fakeBackendRepoClient{}
+	repoClient := &fakeContainerRepoClient{
+		state: &pb.ContainerState{Status: string(types.ContainerStatusPending)},
+	}
+	worker := &Worker{
+		config: types.AppConfig{Worker: types.WorkerConfig{Pools: map[string]types.WorkerPoolConfig{
+			"default": {CRIUEnabled: true},
+		}}},
+		podAddr:             "10.42.0.10",
+		criuManager:         criuManager,
+		containerRepoClient: repoClient,
+		backendRepoClient:   backendRepoClient,
+		containerInstances:  common.NewSafeMap[*ContainerInstance](),
+	}
+	worker.containerInstances.Set(containerID, &ContainerInstance{
+		Id:      containerID,
+		Runtime: rt,
+	})
+	request := &types.ContainerRequest{
+		ContainerId: containerID,
+		ConfigPath:  filepath.Join(t.TempDir(), "config.json"),
+		Stub:        types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeASGIDeployment)}},
+		Checkpoint: &types.Checkpoint{
+			CheckpointId: "checkpoint-missing-payload",
+			Status:       string(types.CheckpointStatusAvailable),
+		},
+	}
+
+	exitCode, err := worker.runContainer(
+		context.Background(),
+		request,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		common.NewOutputWriter(func(string) {}),
+		make(chan int, 1),
+		make(chan int, 1),
+		time.Now(),
+		[]PortBinding{{HostPort: 30001, ContainerPort: 8001}},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.True(t, rt.runCalled)
+	require.Equal(t, 0, criuManager.restoreCalls)
+	require.Equal(t, 1, backendRepoClient.updateCalls)
+	require.Equal(t, string(types.CheckpointStatusRestoreFailed), backendRepoClient.lastUpdate.Status)
+	require.Nil(t, request.Checkpoint)
+}
+
+func TestShouldCreateCheckpointIgnoresNonAvailableAttachedCheckpoint(t *testing.T) {
+	t.Setenv("WORKER_POOL_NAME", "default")
+
+	worker := &Worker{
+		config: types.AppConfig{Worker: types.WorkerConfig{Pools: map[string]types.WorkerPoolConfig{
+			"default": {CRIUEnabled: true},
+		}}},
+		criuManager: &startedCRIUManager{},
+	}
+	request := &types.ContainerRequest{
+		CheckpointEnabled: true,
+		GpuCount:          0,
+		Checkpoint: &types.Checkpoint{
+			CheckpointId: "checkpoint-failed",
+			Status:       string(types.CheckpointStatusRestoreFailed),
+		},
+	}
+
+	require.True(t, worker.shouldCreateCheckpoint(request))
+
+	request.Checkpoint.Status = string(types.CheckpointStatusAvailable)
+	require.False(t, worker.shouldCreateCheckpoint(request))
 }
 
 func TestAttemptRestoreCheckpointRestoresRuntimeOnly(t *testing.T) {
@@ -962,7 +1118,7 @@ func TestAttemptRestoreCheckpointRestoresRuntimeOnly(t *testing.T) {
 		},
 	}
 
-	exitCode, restored, err := worker.attemptRestoreCheckpoint(
+	exitCode, restored, started, err := worker.attemptRestoreCheckpoint(
 		context.Background(),
 		request,
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -973,6 +1129,7 @@ func TestAttemptRestoreCheckpointRestoresRuntimeOnly(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, restored)
+	require.True(t, started)
 	require.Equal(t, 0, exitCode)
 	require.Empty(t, rt.signals)
 	require.Empty(t, rt.killOpts)
@@ -1575,6 +1732,50 @@ func (m *restoreErrorCRIUManager) CreateCheckpoint(ctx context.Context, rt runti
 
 func (m *restoreErrorCRIUManager) RestoreCheckpoint(ctx context.Context, rt runtime.Runtime, opts *RestoreOpts) (int, error) {
 	return m.exitCode, m.err
+}
+
+type observingRestoreErrorCRIUManager struct {
+	err                  error
+	deleteCallsAtRestore int
+	restoreCalls         int
+}
+
+func (m *observingRestoreErrorCRIUManager) Available() bool {
+	return true
+}
+
+func (m *observingRestoreErrorCRIUManager) CreateCheckpoint(ctx context.Context, rt runtime.Runtime, checkpointId string, request *types.ContainerRequest) (string, error) {
+	return "", assert.AnError
+}
+
+func (m *observingRestoreErrorCRIUManager) RestoreCheckpoint(ctx context.Context, rt runtime.Runtime, opts *RestoreOpts) (int, error) {
+	m.restoreCalls++
+	if cleanupRuntime, ok := rt.(*restoreFallbackRuntime); ok {
+		m.deleteCallsAtRestore = cleanupRuntime.deleteCalls
+	}
+	opts.started <- 4321
+	return -1, m.err
+}
+
+type restoreFallbackRuntime struct {
+	mockRuntime
+	deleteCalls      int
+	deleteCallsAtRun int
+	runCalled        bool
+}
+
+func (m *restoreFallbackRuntime) Delete(ctx context.Context, containerID string, opts *runtime.DeleteOpts) error {
+	m.deleteCalls++
+	return nil
+}
+
+func (m *restoreFallbackRuntime) Run(ctx context.Context, containerID, bundlePath string, opts *runtime.RunOpts) (int, error) {
+	m.runCalled = true
+	m.deleteCallsAtRun = m.deleteCalls
+	if opts != nil && opts.Started != nil {
+		opts.Started <- 1234
+	}
+	return 0, nil
 }
 
 type fakeBackendRepoClient struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable CRIU by default for BYOC pools and harden checkpoint restore/materialization. Add AWS BYOC cleanup and node release via CloudFormation/Auto Scaling with template and permission updates.

- **New Features**
  - Enable CRIU for private BYOC pools; improve restore flow and materialize checkpoints from the content cache (reports required content and extracts archives).
  - AWS BYOC lifecycle: detect deleted stacks with `cloudformation:DescribeStacks` and clean them up; terminate BYOC nodes on machine release via `autoscaling:TerminateInstanceInAutoScalingGroup` (uses `github.com/aws/aws-sdk-go-v2/service/cloudformation`).
  - Update AWS BYOC template: add IAM for terminate/describe actions and set `BEAM_AGENT_MACHINE_FINGERPRINT`/`BEAM_AGENT_HOSTNAME` from the EC2 instance ID.

- **Bug Fixes**
  - Only use “Available” checkpoints (repo query, scheduler, and `shouldCreateCheckpoint` logic).
  - On restore failure, include truncated stderr in errors, clean up the runtime container, and avoid fallback for non-deployments; deployments fall back and keep auto-checkpointing.
  - Ensure checkpoint directories are created before cache writes and improve started-signal handling to prevent missed starts.

<sup>Written for commit 869f0cdfaf93ced98e073e9a6300ceb89d86797d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

