### PR TITLE
add restore fallback

### DIFF
--- a/pkg/gateway/services/compute/byoc.go
+++ b/pkg/gateway/services/compute/byoc.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,9 +14,15 @@ import (
 )
 
 const (
-	byocBootstrapJoinTokenHashLabel   = "join_token_hash"
-	byocBootstrapJoinTokenHashesLabel = "join_token_hashes"
-	byocDeletedPoolRetention          = 5 * time.Minute
+	byocBootstrapJoinTokenHashLabel            = "join_token_hash"
+	byocBootstrapJoinTokenHashesLabel          = "join_token_hashes"
+	byocDeletedPoolRetention                   = 5 * time.Minute
+	byocProviderControlUnavailableCleanupGrace = 30 * time.Minute
+)
+
+var (
+	errBYOCProviderControlUnavailable = errors.New("BYOC provider control plane is unavailable")
+	errBYOCProviderResourceNotFound   = errors.New("BYOC provider resource not found")
 )
 
 // byocProvider owns provider-specific validation and setup links; the service
@@ -398,8 +405,7 @@ func byocPoolStateToProto(state *model.PoolState, pool *pb.PrivatePool) *pb.BYOC
 }
 
 func (s *Service) cleanupDeletedBYOCPoolIfNeeded(ctx context.Context, workspaceID string, state *model.PoolState, machines []*model.AgentTokenState, now time.Time) (bool, error) {
-	resourceDeleted, _ := s.byocProviderResourceDeleted(ctx, workspaceID, state)
-	if !resourceDeleted && !byocPoolLooksDeleted(state, machines, now) {
+	if !s.byocPoolDeletedForCleanup(ctx, workspaceID, state, machines, now) && !byocPoolLooksDeleted(state, machines, now) {
 		return false, nil
 	}
 
@@ -413,14 +419,37 @@ func (s *Service) cleanupDeletedBYOCPoolIfNeeded(ctx context.Context, workspaceI
 		if err != nil {
 			return err
 		}
-		freshResourceDeleted, _ := s.byocProviderResourceDeleted(ctx, workspaceID, fresh)
-		if !freshResourceDeleted && !byocPoolLooksDeleted(fresh, freshMachines, now) {
+		if !s.byocPoolDeletedForCleanup(ctx, workspaceID, fresh, freshMachines, now) && !byocPoolLooksDeleted(fresh, freshMachines, now) {
 			return nil
 		}
 		deleted = true
 		return s.deleteBYOCPoolLocalState(ctx, workspaceID, fresh, freshMachines, "cloud_resource_deleted")
 	})
 	return deleted, err
+}
+
+func (s *Service) byocPoolDeletedForCleanup(ctx context.Context, workspaceID string, state *model.PoolState, machines []*model.AgentTokenState, now time.Time) bool {
+	resourceDeleted, err := s.byocProviderResourceDeleted(ctx, workspaceID, state)
+	if resourceDeleted {
+		return true
+	}
+	if !errors.Is(err, errBYOCProviderControlUnavailable) && !errors.Is(err, errBYOCProviderResourceNotFound) {
+		return false
+	}
+	return byocProviderResourceUnavailableLooksDeleted(state, machines, now)
+}
+
+func byocPoolInProvisioningGrace(state *model.PoolState, machines []*model.AgentTokenState, now time.Time) bool {
+	if state == nil || state.BYOC == nil || len(machines) > 0 {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if state.CreatedAt.IsZero() {
+		return false
+	}
+	return now.Sub(state.CreatedAt) < byocProviderControlUnavailableCleanupGrace
 }
 
 func (s *Service) byocProviderResourceDeleted(ctx context.Context, workspaceID string, state *model.PoolState) (bool, error) {
@@ -436,6 +465,19 @@ func (s *Service) byocProviderResourceDeleted(ctx context.Context, workspaceID s
 		Pool:         state,
 		ProviderData: state.BYOC,
 	})
+}
+
+func byocProviderResourceUnavailableLooksDeleted(state *model.PoolState, machines []*model.AgentTokenState, now time.Time) bool {
+	if byocPoolLooksDeleted(state, machines, now) {
+		return true
+	}
+	if byocPoolInProvisioningGrace(state, machines, now) || state == nil || state.BYOC == nil || len(machines) > 0 || state.CreatedAt.IsZero() {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.Sub(state.CreatedAt) >= byocProviderControlUnavailableCleanupGrace
 }
 
 // Without provider credentials, external stack deletion is observable as all

--- a/pkg/gateway/services/compute/byoc_aws.go
+++ b/pkg/gateway/services/compute/byoc_aws.go
@@ -335,8 +335,8 @@ func awsBYOCCapacityLabels(req byocPoolRequest) map[string]string {
 		"sandboxes_per_node":       strconv.FormatUint(uint64(awsBYOCSandboxesPerNode), 10),
 		"hourly_cost_micros":       strconv.FormatInt(hourlyCostMicros, 10),
 		"total_hourly_cost_micros": strconv.FormatInt(totalHourlyMicros, 10),
-		"capacity_unit":            "normal_sandbox",
-		"capacity_unit_label":      "normal sandboxes",
+		"capacity_unit":            "concurrent_sandbox",
+		"capacity_unit_label":      "concurrent sandboxes",
 	}
 }
 
@@ -458,19 +458,46 @@ func realAWSBYOCResourceDeleted(ctx context.Context, input awsBYOCResourceDelete
 		StackName: aws.String(input.StackName),
 	})
 	if err != nil {
-		if awsBYOCCloudFormationStackNotFound(err) || awsBYOCControlRoleUnavailable(err) {
-			return true, nil
+		if awsBYOCCloudFormationStackNotFound(err) {
+			return false, errBYOCProviderResourceNotFound
+		}
+		if awsBYOCControlRoleUnavailable(err) {
+			return false, errBYOCProviderControlUnavailable
 		}
 		return false, fmt.Errorf("describe AWS BYOC stack: %w", err)
 	}
 	if len(out.Stacks) == 0 {
+		return false, errBYOCProviderResourceNotFound
+	}
+	status := out.Stacks[0].StackStatus
+	if awsBYOCStackStatusCreating(status) {
+		return false, nil
+	}
+	if awsBYOCStackStatusDeleted(status) {
 		return true, nil
 	}
-	switch out.Stacks[0].StackStatus {
-	case cftypes.StackStatusDeleteInProgress, cftypes.StackStatusDeleteComplete:
-		return true, nil
+	return false, nil
+}
+
+func awsBYOCStackStatusCreating(status cftypes.StackStatus) bool {
+	switch status {
+	case cftypes.StackStatusReviewInProgress,
+		cftypes.StackStatusCreateInProgress,
+		cftypes.StackStatusImportInProgress,
+		cftypes.StackStatusUpdateInProgress,
+		cftypes.StackStatusUpdateCompleteCleanupInProgress:
+		return true
 	default:
-		return false, nil
+		return false
+	}
+}
+
+func awsBYOCStackStatusDeleted(status cftypes.StackStatus) bool {
+	switch status {
+	case cftypes.StackStatusDeleteInProgress, cftypes.StackStatusDeleteComplete:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/smithy-go"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	model "github.com/beam-cloud/beta9/pkg/compute"
@@ -779,6 +780,194 @@ func TestListPrivatePoolsCleansDeletedBYOCPoolWithoutMachinesWhenProviderResourc
 	}
 }
 
+func TestListPrivatePoolsKeepsFreshBYOCPoolWhenProviderControlUnavailable(t *testing.T) {
+	ctx := testAuthContext("workspace-1", "owner-token")
+	resourceURL := awsCloudFormationStackURL("us-east-1", "beam-aws-cpu-test")
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{
+					Name:             "aws-cpu",
+					CreatedByTokenID: "owner-token",
+					Source:           model.SourceAWS,
+					Config:           &pb.PoolConfig{Name: "aws-cpu", Regions: []string{"us-east-1"}},
+					CreatedAt:        time.Now().UTC(),
+					BYOC: &model.BYOCProviderState{
+						Provider:     "aws",
+						AccountID:    "123456789012",
+						Region:       "us-east-1",
+						ResourceName: "beam-aws-cpu-test",
+						ResourceURL:  resourceURL,
+						DestroyURL:   resourceURL,
+						Labels: map[string]string{
+							"instance_type":                   "i4i.xlarge",
+							"desired_nodes":                   "2",
+							"max_nodes":                       "2",
+							"target_sandboxes":                "40",
+							"sandboxes_per_node":              "20",
+							awsBYOCAutoScalingGroupNameLabel:  "beam-asg-aws-cpu-test",
+							awsBYOCControlRoleArnLabel:        "arn:aws:iam::123456789012:role/beam-control-aws-cpu-test",
+							awsBYOCControlRoleExternalIDLabel: "beam-byoc-test-external-id",
+						},
+					},
+				},
+			},
+		},
+	}
+	oldResourceDeleted := awsBYOCResourceDeleted
+	awsBYOCResourceDeleted = func(context.Context, awsBYOCResourceDeletedInput) (bool, error) {
+		return false, errBYOCProviderControlUnavailable
+	}
+	defer func() {
+		awsBYOCResourceDeleted = oldResourceDeleted
+	}()
+
+	res, err := (&Service{computeRepo: repo}).ListPrivatePools(ctx, &pb.ListPrivatePoolsRequest{})
+	if err != nil {
+		t.Fatalf("ListPrivatePools() error = %v", err)
+	}
+	if !res.Ok {
+		t.Fatalf("ListPrivatePools() not ok: %s", res.ErrMsg)
+	}
+	if got := len(res.Pools); got != 1 {
+		t.Fatalf("pool count = %d, want fresh creating BYOC pool to remain visible", got)
+	}
+	if got := len(repo.pools["workspace-1"]); got != 1 {
+		t.Fatalf("stored pool count = %d, want 1", got)
+	}
+	if got, want := res.Pools[0].GetByoc().GetPhase(), "waiting_for_provider"; got != want {
+		t.Fatalf("BYOC phase = %q, want %q", got, want)
+	}
+}
+
+func TestListPrivatePoolsKeepsFreshBYOCPoolDuringProviderNotFoundRace(t *testing.T) {
+	ctx := testAuthContext("workspace-1", "owner-token")
+	resourceURL := awsCloudFormationStackURL("us-east-1", "beam-aws-cpu-test")
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{
+					Name:             "aws-cpu",
+					CreatedByTokenID: "owner-token",
+					Source:           model.SourceAWS,
+					Config:           &pb.PoolConfig{Name: "aws-cpu", Regions: []string{"us-east-1"}},
+					CreatedAt:        time.Now().UTC(),
+					BYOC: &model.BYOCProviderState{
+						Provider:     "aws",
+						AccountID:    "123456789012",
+						Region:       "us-east-1",
+						ResourceName: "beam-aws-cpu-test",
+						ResourceURL:  resourceURL,
+						DestroyURL:   resourceURL,
+						Labels: map[string]string{
+							"instance_type":                   "i4i.xlarge",
+							"desired_nodes":                   "2",
+							"max_nodes":                       "2",
+							"target_sandboxes":                "40",
+							"sandboxes_per_node":              "20",
+							awsBYOCAutoScalingGroupNameLabel:  "beam-asg-aws-cpu-test",
+							awsBYOCControlRoleArnLabel:        "arn:aws:iam::123456789012:role/beam-control-aws-cpu-test",
+							awsBYOCControlRoleExternalIDLabel: "beam-byoc-test-external-id",
+						},
+					},
+				},
+			},
+		},
+	}
+	oldResourceDeleted := awsBYOCResourceDeleted
+	awsBYOCResourceDeleted = func(context.Context, awsBYOCResourceDeletedInput) (bool, error) {
+		return false, errBYOCProviderResourceNotFound
+	}
+	defer func() {
+		awsBYOCResourceDeleted = oldResourceDeleted
+	}()
+
+	res, err := (&Service{computeRepo: repo}).ListPrivatePools(ctx, &pb.ListPrivatePoolsRequest{})
+	if err != nil {
+		t.Fatalf("ListPrivatePools() error = %v", err)
+	}
+	if !res.Ok {
+		t.Fatalf("ListPrivatePools() not ok: %s", res.ErrMsg)
+	}
+	if got := len(res.Pools); got != 1 {
+		t.Fatalf("pool count = %d, want fresh creating BYOC pool to remain visible", got)
+	}
+	if got := len(repo.pools["workspace-1"]); got != 1 {
+		t.Fatalf("stored pool count = %d, want 1", got)
+	}
+}
+
+func TestListPrivatePoolsCleansOldNeverJoinedBYOCPoolWhenProviderControlUnavailable(t *testing.T) {
+	ctx := testAuthContext("workspace-1", "owner-token")
+	tokenHash := hashComputeToken("byoc-token")
+	resourceURL := awsCloudFormationStackURL("us-east-1", "beam-aws-cpu-test")
+	repo := &fakeComputeRepo{
+		pools: map[string][]*model.PoolState{
+			"workspace-1": {
+				{
+					Name:             "aws-cpu",
+					CreatedByTokenID: "owner-token",
+					Source:           model.SourceAWS,
+					Config:           &pb.PoolConfig{Name: "aws-cpu", Regions: []string{"us-east-1"}},
+					CreatedAt:        time.Now().UTC().Add(-byocProviderControlUnavailableCleanupGrace - time.Minute),
+					BYOC: &model.BYOCProviderState{
+						Provider:     "aws",
+						AccountID:    "123456789012",
+						Region:       "us-east-1",
+						ResourceName: "beam-aws-cpu-test",
+						ResourceURL:  resourceURL,
+						DestroyURL:   resourceURL,
+						Labels: map[string]string{
+							byocBootstrapJoinTokenHashLabel:   tokenHash,
+							byocBootstrapJoinTokenHashesLabel: tokenHash,
+							"instance_type":                   "i4i.xlarge",
+							"desired_nodes":                   "2",
+							"max_nodes":                       "2",
+							"target_sandboxes":                "40",
+							"sandboxes_per_node":              "20",
+							awsBYOCAutoScalingGroupNameLabel:  "beam-asg-aws-cpu-test",
+							awsBYOCControlRoleArnLabel:        "arn:aws:iam::123456789012:role/beam-control-aws-cpu-test",
+							awsBYOCControlRoleExternalIDLabel: "beam-byoc-test-external-id",
+						},
+					},
+				},
+			},
+		},
+		joinTokens: map[string]*model.JoinTokenState{
+			tokenHash: {
+				TokenHash:        tokenHash,
+				WorkspaceID:      "workspace-1",
+				PoolName:         "aws-cpu",
+				CreatedByTokenID: "owner-token",
+			},
+		},
+	}
+	oldResourceDeleted := awsBYOCResourceDeleted
+	awsBYOCResourceDeleted = func(context.Context, awsBYOCResourceDeletedInput) (bool, error) {
+		return false, errBYOCProviderControlUnavailable
+	}
+	defer func() {
+		awsBYOCResourceDeleted = oldResourceDeleted
+	}()
+
+	res, err := (&Service{computeRepo: repo}).ListPrivatePools(ctx, &pb.ListPrivatePoolsRequest{})
+	if err != nil {
+		t.Fatalf("ListPrivatePools() error = %v", err)
+	}
+	if !res.Ok {
+		t.Fatalf("ListPrivatePools() not ok: %s", res.ErrMsg)
+	}
+	if got := len(res.Pools); got != 0 {
+		t.Fatalf("pool count = %d, want stale never-joined BYOC pool cleaned up", got)
+	}
+	if got := len(repo.pools["workspace-1"]); got != 0 {
+		t.Fatalf("stored pool count = %d, want 0", got)
+	}
+	if token := repo.joinTokens[tokenHash]; token == nil || !token.Revoked {
+		t.Fatalf("BYOC bootstrap token revoked = %v, want true", token != nil && token.Revoked)
+	}
+}
+
 func TestListPrivatePoolsKeepsRecentlyDisconnectedBYOCPool(t *testing.T) {
 	now := time.Now().UTC()
 	ctx := testAuthContext("workspace-1", "owner-token")
@@ -1235,7 +1424,7 @@ func TestAWSBYOCStackDeletionErrorClassification(t *testing.T) {
 		Message: "Stack with id beam-aws-cpu-test does not exist",
 	}
 	if !awsBYOCCloudFormationStackNotFound(stackMissing) {
-		t.Fatal("CloudFormation missing-stack validation error should be treated as deleted")
+		t.Fatal("CloudFormation missing-stack validation error should be recognized as not found")
 	}
 
 	assumeRoleDenied := &smithy.OperationError{
@@ -1260,6 +1449,15 @@ func TestAWSBYOCStackDeletionErrorClassification(t *testing.T) {
 	}
 	if awsBYOCControlRoleUnavailable(cloudFormationDenied) {
 		t.Fatal("CloudFormation authorization errors should not be treated as stack deletion")
+	}
+	if !awsBYOCStackStatusCreating(cftypes.StackStatusCreateInProgress) {
+		t.Fatal("CREATE_IN_PROGRESS should be treated as creating")
+	}
+	if awsBYOCStackStatusDeleted(cftypes.StackStatusCreateInProgress) {
+		t.Fatal("CREATE_IN_PROGRESS should not be treated as deleted")
+	}
+	if !awsBYOCStackStatusDeleted(cftypes.StackStatusDeleteInProgress) {
+		t.Fatal("DELETE_IN_PROGRESS should be treated as deleted")
 	}
 }
 

--- a/pkg/runtime/runc.go
+++ b/pkg/runtime/runc.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	runcRestoreStateTimeout      = 2 * time.Second
+	runcRestoreStateTimeout      = 30 * time.Second
 	runcRestoreStatePollInterval = 25 * time.Millisecond
 )
 

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -254,6 +254,33 @@ func deleteFailedRestoreRuntimeContainer(ctx context.Context, rt runtime.Runtime
 	return nil
 }
 
+func (s *Worker) prepareRestoreFallback(request *types.ContainerRequest, config []byte) error {
+	if request == nil || request.ConfigPath == "" || len(config) == 0 {
+		return nil
+	}
+
+	instance, exists := s.containerInstances.Get(request.ContainerId)
+	if exists && instance.Overlay != nil {
+		upperDir := filepath.Join(filepath.Dir(instance.Overlay.TopLayerPath()), "upper")
+		entries, err := os.ReadDir(upperDir)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		for _, entry := range entries {
+			if err := os.RemoveAll(filepath.Join(upperDir, entry.Name())); err != nil {
+				return err
+			}
+		}
+		for _, dir := range []string{"workspace", "volumes"} {
+			if err := os.MkdirAll(filepath.Join(upperDir, dir), 0755); err != nil {
+				return err
+			}
+		}
+	}
+
+	return os.WriteFile(request.ConfigPath, config, 0644)
+}
+
 func runtimeContainerNotFound(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -1406,6 +1406,11 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 
 	supportsCheckpoint := instance.Runtime.Capabilities().CheckpointRestore && s.IsCRIUAvailable(request.GpuCount)
 	restoringCheckpoint := supportsCheckpoint && request.Checkpoint != nil && request.Checkpoint.Status == string(types.CheckpointStatusAvailable)
+	bundlePath := filepath.Dir(request.ConfigPath)
+	originalConfig, originalConfigErr := os.ReadFile(request.ConfigPath)
+	if originalConfigErr != nil {
+		log.Warn().Err(originalConfigErr).Str("container_id", request.ContainerId).Msg("failed to snapshot container config before checkpoint restore")
+	}
 	var checkpointRestoredOnce sync.Once
 	markCheckpointRestored := func() {
 		if !restoringCheckpoint {
@@ -1427,6 +1432,9 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 	fallbackFromCheckpoint := func(startCheckpoint bool) {
 		restoringCheckpoint = false
 		request.Checkpoint = nil
+		if err := s.prepareRestoreFallback(request, originalConfig); err != nil {
+			log.Warn().Err(err).Str("container_id", request.ContainerId).Msg("failed to prepare checkpoint restore fallback")
+		}
 		if startCheckpoint {
 			startAutoCheckpoint()
 		}
@@ -1436,7 +1444,6 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		startAutoCheckpoint()
 	}
 
-	bundlePath := filepath.Dir(request.ConfigPath)
 	runtimeStartedChan := make(chan int, 1)
 	runtimeStartedDone := make(chan struct{})
 	runtimeStartedHandled := make(chan struct{})

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -954,7 +954,7 @@ func TestRunContainerRestoreFailureCleansRuntimeBeforeFallback(t *testing.T) {
 			capabilities: runtime.Capabilities{CheckpointRestore: true},
 		},
 	}
-	criuManager := &observingRestoreErrorCRIUManager{err: restoreErr}
+	criuManager := &observingRestoreErrorCRIUManager{err: restoreErr, removeConfig: true}
 	backendRepoClient := &fakeBackendRepoClient{}
 	repoClient := &fakeContainerRepoClient{
 		state: &pb.ContainerState{Status: string(types.ContainerStatusPending)},
@@ -974,9 +974,13 @@ func TestRunContainerRestoreFailureCleansRuntimeBeforeFallback(t *testing.T) {
 		Id:      containerID,
 		Runtime: rt,
 	})
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configContents := []byte(runtime.GetBaseConfig("runc"))
+	require.NoError(t, os.WriteFile(configPath, configContents, 0644))
+	rt.runConfigPath = configPath
 	request := &types.ContainerRequest{
 		ContainerId:       containerID,
-		ConfigPath:        filepath.Join(t.TempDir(), "config.json"),
+		ConfigPath:        configPath,
 		Stub:              types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeASGIDeployment)}},
 		CheckpointEnabled: true,
 		Checkpoint: &types.Checkpoint{
@@ -1008,6 +1012,8 @@ func TestRunContainerRestoreFailureCleansRuntimeBeforeFallback(t *testing.T) {
 	require.True(t, request.CheckpointEnabled)
 	require.Equal(t, 1, repoClient.updateStatusCalls)
 	require.Equal(t, string(types.ContainerStatusRunning), repoClient.lastUpdateStatus.Status)
+	require.Contains(t, string(rt.runConfigContents), `"ociVersion"`)
+	require.Contains(t, string(rt.runConfigContents), "CHECKPOINT_ENABLED=true")
 }
 
 func TestRunContainerMaterializeFailureFallsBackWithoutRestore(t *testing.T) {
@@ -1738,6 +1744,7 @@ type observingRestoreErrorCRIUManager struct {
 	err                  error
 	deleteCallsAtRestore int
 	restoreCalls         int
+	removeConfig         bool
 }
 
 func (m *observingRestoreErrorCRIUManager) Available() bool {
@@ -1754,14 +1761,19 @@ func (m *observingRestoreErrorCRIUManager) RestoreCheckpoint(ctx context.Context
 		m.deleteCallsAtRestore = cleanupRuntime.deleteCalls
 	}
 	opts.started <- 4321
+	if m.removeConfig {
+		_ = os.Remove(opts.configPath)
+	}
 	return -1, m.err
 }
 
 type restoreFallbackRuntime struct {
 	mockRuntime
-	deleteCalls      int
-	deleteCallsAtRun int
-	runCalled        bool
+	deleteCalls       int
+	deleteCallsAtRun  int
+	runCalled         bool
+	runConfigPath     string
+	runConfigContents []byte
 }
 
 func (m *restoreFallbackRuntime) Delete(ctx context.Context, containerID string, opts *runtime.DeleteOpts) error {
@@ -1772,6 +1784,9 @@ func (m *restoreFallbackRuntime) Delete(ctx context.Context, containerID string,
 func (m *restoreFallbackRuntime) Run(ctx context.Context, containerID, bundlePath string, opts *runtime.RunOpts) (int, error) {
 	m.runCalled = true
 	m.deleteCallsAtRun = m.deleteCalls
+	if m.runConfigPath != "" {
+		m.runConfigContents, _ = os.ReadFile(m.runConfigPath)
+	}
 	if opts != nil && opts.Started != nil {
 		opts.Started <- 1234
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a fallback path when checkpoint restore fails so containers still start, and hardens BYOC pool deletion checks to avoid cleaning active pools when the provider is unavailable. Also increases `runc` restore timeout and improves AWS status/error handling.

- **New Features**
  - `pkg/worker`: On CRIU restore failure, clear overlay upper dir, recreate `workspace`/`volumes`, and restore the original bundle config before starting without a checkpoint; auto-checkpointing stays enabled. Increased `runc` restore state timeout to 30s.

- **Bug Fixes**
  - `pkg/gateway/services/compute`: BYOC cleanup adds a 30m provisioning grace when provider control is unavailable; skips deleting fresh pools with no machines and cleans up old never-joined pools. Introduces `errBYOCProviderControlUnavailable` and `errBYOCProviderResourceNotFound`.
  - AWS BYOC: precise CloudFormation classification (creating vs. deleted; not-found vs. IAM denial). Capacity labels switched to "concurrent sandboxes".

<sup>Written for commit 322de3595e7a223aec71e76aa32f58fad4152b57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

