### PR TITLE
fix hetzner release

### DIFF
--- a/pkg/compute/hetzner.go
+++ b/pkg/compute/hetzner.go
@@ -319,7 +319,13 @@ func (c *HetznerClient) DeleteReservation(ctx context.Context, id string) error 
 	if err := c.validate(); err != nil {
 		return err
 	}
-	return c.api.Do(ctx, http.MethodDelete, "/servers/"+id, nil, nil)
+	if err := c.api.Do(ctx, http.MethodDelete, "/servers/"+id, nil, nil); err != nil {
+		if statusErr, ok := err.(*HTTPStatusError); ok && statusErr.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *HetznerClient) validate() error {

--- a/pkg/compute/hetzner_test.go
+++ b/pkg/compute/hetzner_test.go
@@ -189,6 +189,23 @@ func TestHetznerCreateGetDeleteReservation(t *testing.T) {
 	require.True(t, sawDelete)
 }
 
+func TestHetznerDeleteReservationIsIdempotentWhenServerIsGone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer hetzner-token", r.Header.Get("Authorization"))
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/servers/42", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewHetzner(HetznerConfig{
+		APIToken: "hetzner-token",
+		BaseURL:  server.URL,
+	})
+
+	require.NoError(t, client.DeleteReservation(context.Background(), "42"))
+}
+
 func TestHetznerCreateReservationRequiresPrivateNetworkSubnetInNetworkZone(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer hetzner-token", r.Header.Get("Authorization"))

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -1480,6 +1480,19 @@ func TestDeletePoolReleasesAWSBYOCMachines(t *testing.T) {
 	}
 }
 
+func TestDeletePoolIsIdempotentWhenPoolAlreadyGone(t *testing.T) {
+	repo := &fakeComputeRepo{pools: map[string][]*model.PoolState{}}
+	service := &Service{computeRepo: repo}
+
+	res, err := service.DeletePool(testAuthContext("workspace-1", "owner-token"), &pb.DeletePoolRequest{Name: "codex-hetzner-latency"})
+	if err != nil {
+		t.Fatalf("DeletePool() error = %v", err)
+	}
+	if res == nil || !res.Ok {
+		t.Fatalf("DeletePool() response = %#v", res)
+	}
+}
+
 func TestScaleBYOCPoolUpdatesAWSAutoScalingGroupAndState(t *testing.T) {
 	ctx := testAuthContext("workspace-1", "owner-token")
 	resourceURL := awsCloudFormationStackURL("us-east-1", "beam-aws-cpu-test")
@@ -2751,7 +2764,9 @@ func TestValidatePoolLaunchCompatibleRejectsGPUMismatch(t *testing.T) {
 }
 
 type fakeVendor struct {
-	extended map[string]time.Time
+	extended  map[string]time.Time
+	deleted   []string
+	deleteErr error
 }
 
 func (v *fakeVendor) Name() string { return "shadeform" }
@@ -2771,7 +2786,10 @@ func (v *fakeVendor) ExtendReservation(_ context.Context, id string, expiresAt t
 	v.extended[id] = expiresAt
 	return nil
 }
-func (v *fakeVendor) DeleteReservation(context.Context, string) error { return nil }
+func (v *fakeVendor) DeleteReservation(_ context.Context, id string) error {
+	v.deleted = append(v.deleted, id)
+	return v.deleteErr
+}
 
 func TestRenewManagedReservationsExtendsExpiringReservation(t *testing.T) {
 	now := time.Now().UTC()
@@ -3826,6 +3844,54 @@ func TestReleasePrivateMachineTransitionsManagedReservation(t *testing.T) {
 	}
 	if token := repo.joinTokens["join-token-hash"]; token == nil || !token.Revoked {
 		t.Fatal("releasePrivateMachine() did not revoke the reservation join token")
+	}
+}
+
+func TestTerminateReservationTreatsProviderNotFoundAsDeleted(t *testing.T) {
+	now := time.Now().UTC()
+	state := &model.PoolState{
+		WorkspaceID: "workspace-1",
+		Name:        "codex-hetzner-latency",
+		Reservations: []model.Reservation{
+			{
+				ID:               "reservation-1",
+				Provider:         "hetzner",
+				InstanceID:       "42",
+				Source:           model.SourceCLIReservation,
+				Status:           model.ReservationActive,
+				CreatedAt:        now.Add(-time.Hour),
+				ExpiresAt:        now.Add(time.Hour),
+				HourlyCostMicros: 1_000_000,
+			},
+		},
+	}
+	vendor := &fakeVendor{deleteErr: &model.HTTPStatusError{
+		Method:     http.MethodDelete,
+		Path:       "/servers/42",
+		StatusCode: http.StatusNotFound,
+		Body:       "not found",
+	}}
+	service := &Service{}
+
+	if !service.terminateReservation(
+		context.Background(),
+		"workspace-1",
+		state,
+		&state.Reservations[0],
+		map[string]model.Vendor{"hetzner": vendor},
+		reconcileReasonMachineReleased,
+		machineReleasedMessage,
+	) {
+		t.Fatal("terminateReservation() did not report a change")
+	}
+	if got, want := state.Reservations[0].Status, model.ReservationDeleted; got != want {
+		t.Fatalf("reservation status = %q, want %q", got, want)
+	}
+	if got := state.Reservations[0].LastError; got != "" {
+		t.Fatalf("reservation last error = %q, want empty", got)
+	}
+	if got, want := vendor.deleted, []string{"42"}; !sameStrings(got, want) {
+		t.Fatalf("deleted reservations = %v, want %v", got, want)
 	}
 }
 

--- a/pkg/gateway/services/compute/pools.go
+++ b/pkg/gateway/services/compute/pools.go
@@ -136,7 +136,7 @@ func (s *Service) DeletePool(ctx context.Context, in *pb.DeletePoolRequest) (*pb
 		return &pb.DeletePoolResponse{Ok: false, ErrMsg: err.Error()}, nil
 	}
 	if state == nil {
-		return &pb.DeletePoolResponse{Ok: false, ErrMsg: "pool not found"}, nil
+		return &pb.DeletePoolResponse{Ok: true}, nil
 	}
 
 	if err := s.releasePrivatePoolMachines(ctx, workspaceID, state.Name); err != nil {

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -2,8 +2,10 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"strings"
 	"time"
 
@@ -728,7 +730,7 @@ func (s *Service) terminateReservation(ctx context.Context, workspaceID string, 
 		reservation.LastError = fmt.Sprintf("vendor %q is not configured", reservation.Provider)
 		return true
 	}
-	if err := vendor.DeleteReservation(ctx, computeReservationInstanceID(*reservation)); err != nil {
+	if err := vendor.DeleteReservation(ctx, computeReservationInstanceID(*reservation)); err != nil && !managedReservationDeleteAlreadyGone(err) {
 		reservation.Status = model.ReservationTerminating
 		reservation.TerminatingReason = reason
 		reservation.LastError = err.Error()
@@ -740,6 +742,11 @@ func (s *Service) terminateReservation(ctx context.Context, workspaceID string, 
 	reservation.LastError = ""
 	s.emitComputeEvent(types.EventComputePool, computeReservationEvent(workspaceID, state, *reservation, types.EventComputeActionReservationTerminating, reason))
 	return true
+}
+
+func managedReservationDeleteAlreadyGone(err error) bool {
+	var statusErr *model.HTTPStatusError
+	return errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound
 }
 
 func (s *Service) reconcileStaleMachines(ctx context.Context, workspaceID string, state *model.PoolState, now time.Time) bool {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Hetzner release by treating NotFound as success and making delete operations idempotent. This prevents stuck reservations and lets pool deletes succeed when the target is already gone.

- **Bug Fixes**
  - `HetznerClient.DeleteReservation` now returns success on 404 Not Found (idempotent release).
  - Reservation termination ignores provider 404s and marks the reservation as deleted (helper added to detect `HTTPStatusError` 404).
  - `DeletePool` returns `Ok: true` when the pool does not exist; tests added for these behaviors.

<sup>Written for commit 21eab3668ba972ff5c8fcb441cb8def18d3c6db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

