### PR TITLE
update default pricing

### DIFF
--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -18,8 +18,8 @@ config:
     billableMarginPct: 0.10
     byoc:
       pricing:
-        memoryHourlyMicrosPerGB: 9000
-        cpuHourlyMicrosPerVCPU: 19000
+        memoryHourlyMicrosPerGB: 4500
+        cpuHourlyMicrosPerVCPU: 9500
       aws:
         templateUrl: ""
     billing:

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -399,8 +399,8 @@ managedCompute:
   billableMarginPct: 0.10
   byoc:
     pricing:
-      memoryHourlyMicrosPerGB: 9000
-      cpuHourlyMicrosPerVCPU: 19000
+      memoryHourlyMicrosPerGB: 4500
+      cpuHourlyMicrosPerVCPU: 9500
     aws:
       templateUrl: ""
       controlRolePrincipalArn: ""

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -311,17 +311,17 @@ func TestCreateBYOCPoolCreatesAWSCPUPrivatePool(t *testing.T) {
 		"max_nodes":                "4",
 		"target_sandboxes":         "40",
 		"sandboxes_per_node":       "20",
-		"hourly_cost_micros":       "364000",
-		"total_hourly_cost_micros": "728000",
+		"hourly_cost_micros":       "182000",
+		"total_hourly_cost_micros": "364000",
 	} {
 		if got := stored.BYOC.Labels[key]; got != want {
 			t.Fatalf("stored BYOC label %s = %q, want %q", key, got, want)
 		}
 	}
-	if got, want := res.GetByoc().GetHourlyCostMicros(), int64(364000); got != want {
+	if got, want := res.GetByoc().GetHourlyCostMicros(), int64(182000); got != want {
 		t.Fatalf("BYOC hourly cost micros = %d, want %d", got, want)
 	}
-	if got, want := res.GetByoc().GetTotalHourlyCostMicros(), int64(728000); got != want {
+	if got, want := res.GetByoc().GetTotalHourlyCostMicros(), int64(364000); got != want {
 		t.Fatalf("BYOC total hourly cost micros = %d, want %d", got, want)
 	}
 	if res.GetByoc().GetGpu() != "" || res.GetByoc().GetGpuCount() != 0 {
@@ -383,8 +383,8 @@ func TestCreateBYOCPoolCreatesAWSGPUPrivatePool(t *testing.T) {
 		"gpu_count":                "1",
 		"capacity_unit":            "gpu",
 		"capacity_unit_label":      "GPUs",
-		"hourly_cost_micros":       "220000",
-		"total_hourly_cost_micros": "440000",
+		"hourly_cost_micros":       "110000",
+		"total_hourly_cost_micros": "220000",
 	} {
 		if got := stored.BYOC.Labels[key]; got != want {
 			t.Fatalf("stored BYOC label %s = %q, want %q", key, got, want)
@@ -396,7 +396,7 @@ func TestCreateBYOCPoolCreatesAWSGPUPrivatePool(t *testing.T) {
 	if got, want := res.GetByoc().GetGpuCount(), uint32(1); got != want {
 		t.Fatalf("BYOC gpu count = %d, want %d", got, want)
 	}
-	if got, want := res.GetByoc().GetTotalHourlyCostMicros(), int64(440000); got != want {
+	if got, want := res.GetByoc().GetTotalHourlyCostMicros(), int64(220000); got != want {
 		t.Fatalf("BYOC total hourly cost micros = %d, want %d", got, want)
 	}
 }
@@ -743,10 +743,10 @@ func TestListPrivatePoolsIncludesBYOCState(t *testing.T) {
 	if got, want := byoc.TargetSandboxes, uint32(40); got != want {
 		t.Fatalf("target sandboxes = %d, want %d", got, want)
 	}
-	if got, want := byoc.HourlyCostMicros, int64(364000); got != want {
+	if got, want := byoc.HourlyCostMicros, int64(182000); got != want {
 		t.Fatalf("hourly cost micros = %d, want %d", got, want)
 	}
-	if got, want := byoc.TotalHourlyCostMicros, int64(728000); got != want {
+	if got, want := byoc.TotalHourlyCostMicros, int64(364000); got != want {
 		t.Fatalf("total hourly cost micros = %d, want %d", got, want)
 	}
 }
@@ -1520,8 +1520,8 @@ func TestScaleBYOCPoolUpdatesAWSAutoScalingGroupAndState(t *testing.T) {
 							"max_nodes":                       "4",
 							"target_sandboxes":                "20",
 							"sandboxes_per_node":              "20",
-							"hourly_cost_micros":              "364000",
-							"total_hourly_cost_micros":        "364000",
+							"hourly_cost_micros":              "182000",
+							"total_hourly_cost_micros":        "182000",
 							awsBYOCAutoScalingGroupNameLabel:  asgName,
 							awsBYOCControlRoleArnLabel:        roleARN,
 							awsBYOCControlRoleExternalIDLabel: externalID,
@@ -1564,7 +1564,7 @@ func TestScaleBYOCPoolUpdatesAWSAutoScalingGroupAndState(t *testing.T) {
 		"desired_nodes":            "3",
 		"max_nodes":                "5",
 		"target_sandboxes":         "60",
-		"total_hourly_cost_micros": "1092000",
+		"total_hourly_cost_micros": "546000",
 	} {
 		if got := stored.BYOC.Labels[key]; got != want {
 			t.Fatalf("stored label %s = %q, want %q", key, got, want)
@@ -2196,9 +2196,9 @@ func TestManagedBYOCNodeHourlyCostMicros(t *testing.T) {
 		config        types.ManagedComputeConfig
 		want          int64
 	}{
-		{name: "i4i xlarge shape", cpuMillicores: 4_000, memoryMB: 32 * 1024, want: 364_000},
-		{name: "single gpu xlarge shape", cpuMillicores: 4_000, memoryMB: 16 * 1024, want: 220_000},
-		{name: "fractional resources round up", cpuMillicores: 250, memoryMB: 512, want: 9_250},
+		{name: "i4i xlarge shape", cpuMillicores: 4_000, memoryMB: 32 * 1024, want: 182_000},
+		{name: "single gpu xlarge shape", cpuMillicores: 4_000, memoryMB: 16 * 1024, want: 110_000},
+		{name: "fractional resources round up", cpuMillicores: 250, memoryMB: 512, want: 4_625},
 		{
 			name:          "configured rate card",
 			cpuMillicores: 4_000,
@@ -3269,7 +3269,8 @@ func TestRecordManagedUsageSkipsActiveSubCentWindow(t *testing.T) {
 
 func TestRecordManagedUsageRecordsBYOCMachineWithManagedRates(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
-	cursor := now.Add(-2 * time.Minute)
+	activeWindow := 4 * time.Minute
+	cursor := now.Add(-activeWindow)
 	state := &model.PoolState{
 		WorkspaceID: "workspace-1",
 		Name:        "aws-cpu",
@@ -3318,13 +3319,14 @@ func TestRecordManagedUsageRecordsBYOCMachineWithManagedRates(t *testing.T) {
 	if got, want := usage.Cloud, "aws"; got != want {
 		t.Fatalf("cloud = %q, want %q", got, want)
 	}
-	if got, want := usage.HourlyCostMicros, int64(364_000); got != want {
+	if got, want := usage.HourlyCostMicros, int64(182_000); got != want {
 		t.Fatalf("hourly cost micros = %d, want %d", got, want)
 	}
 	if got, want := usage.CostCents, 1.0; got < want-0.001 || got > want+0.001 {
 		t.Fatalf("cost cents = %f, want about %f", got, want)
 	}
-	if got, want := usage.DurationSeconds, float64(98); got != want {
+	wantBillableDuration := time.Duration(float64(activeWindow) * (1.0 / managedCostCents(182_000, activeWindow))).Truncate(time.Second)
+	if got, want := usage.DurationSeconds, wantBillableDuration.Seconds(); got != want {
 		t.Fatalf("duration seconds = %f, want %f", got, want)
 	}
 	if got, want := usage.CPUMillicores, int64(4_000); got != want {
@@ -3336,7 +3338,7 @@ func TestRecordManagedUsageRecordsBYOCMachineWithManagedRates(t *testing.T) {
 	if got, want := usage.GPU, "A10G"; got != want {
 		t.Fatalf("gpu = %q, want %q", got, want)
 	}
-	if want := cursor.Add(98 * time.Second); !machine.BillingCursorAt.Equal(want) {
+	if want := cursor.Add(wantBillableDuration); !machine.BillingCursorAt.Equal(want) {
 		t.Fatalf("machine billing cursor = %s, want %s", machine.BillingCursorAt, want)
 	}
 	if got, want := len(usageRepo.counters), 2; got != want {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -660,8 +660,8 @@ const (
 	ManagedComputeDefaultMinimumCreditCents int64   = 2500
 	ManagedComputeDefaultBillableMarginPct  float64 = 0.10
 
-	ManagedComputeDefaultBYOCMemoryHourlyMicrosPerGB int64 = 9_000
-	ManagedComputeDefaultBYOCCPUHourlyMicrosPerVCPU  int64 = 19_000
+	ManagedComputeDefaultBYOCMemoryHourlyMicrosPerGB int64 = 4_500
+	ManagedComputeDefaultBYOCCPUHourlyMicrosPerVCPU  int64 = 9_500
 )
 
 type ManagedComputeConfig struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Halved default BYOC pricing for managed compute to reduce per-node costs (CPU 19,000→9,500 micros/vCPU-hour, memory 9,000→4,500 micros/GB-hour). Updated configs and tests to reflect the new rates.

- **Refactors**
  - Updated defaults in `pkg/types/config.go`, `pkg/common/config.default.yaml`, and `deploy/charts/beta9/values.yaml`.
  - Adjusted compute tests to reflect halved hourly/total costs and compute billable duration dynamically for the 1¢ threshold.

<sup>Written for commit 90b0695f5a74caa931b52a419cdff34b3e17e84c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

