### PR TITLE
Fix sandbox workspace metadata and readiness

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -264,9 +264,9 @@ EOT
 RUN apt-get install -y ripgrep wget
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.11/goproc-0.1.11-linux-arm64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
+      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.12/goproc-0.1.12-linux-arm64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
     elif [ "$TARGETARCH" = "amd64" ]; then \
-      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.11/goproc-0.1.11-linux-amd64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
+      wget https://github.com/beam-cloud/goproc/releases/download/v0.1.12/goproc-0.1.12-linux-amd64 -O /usr/local/bin/goproc && chmod +x /usr/local/bin/goproc ; \
     else \
       echo "Unsupported architecture: $TARGETARCH" && exit 1 ; \
     fi

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
 	github.com/beam-cloud/clip v0.0.0-20260622205455-9f3db21c0c89
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
-	github.com/beam-cloud/goproc v0.1.11
+	github.com/beam-cloud/goproc v0.1.12
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324
 	github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1/go.mod h1:aw0zhDi28Hemve0raHcfU9suxZwkCpyNANOEwKZSSXo=
 github.com/beam-cloud/gofuse v0.0.0-20260524202825-ee695e692747 h1:OZJmeUHKMeejeznwdFNt254KZIxtADnyHuRZiUV8AoI=
 github.com/beam-cloud/gofuse v0.0.0-20260524202825-ee695e692747/go.mod h1:JYi9iIxdYNgxmMgLwtSHO/hmVnP2kfX1oc+mtx+XWLA=
-github.com/beam-cloud/goproc v0.1.11 h1:MPGjcCnyfadkJeu15uuBM4uVJtiXOlMKQxTBURB0yTI=
-github.com/beam-cloud/goproc v0.1.11/go.mod h1:eis19sZHSHNCmj8PjiRCdHwp3kkc31wdW3hrynKZq8k=
+github.com/beam-cloud/goproc v0.1.12 h1:anIN5cRWzXgWbbNdFQuOAZv9+yrUCKWWNTgM6HXcoS4=
+github.com/beam-cloud/goproc v0.1.12/go.mod h1:eis19sZHSHNCmj8PjiRCdHwp3kkc31wdW3hrynKZq8k=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324 h1:2BWf8G8CaZ8vN0rST9uu5BL8P/bDUBwXJYVLwWwaLVU=
 github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324/go.mod h1:pBb6ZWEw7rhALuBZTGZxT3p+Sd5b8jsvP5EPEsM8T/Q=
 github.com/beam-cloud/rendezvous v0.0.0-20250415141250-2a0f81633db8 h1:lc3G6/sHW4e5/XPHO2w2Ni43fbu42nojS/uX45Ws6Ck=

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -290,13 +290,17 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 	if !podRunnableStub(stub.Type) {
 		return "", fmt.Errorf("stub type <%s> cannot be run through pods", stub.Type)
 	}
+	workspace, err := podRunWorkspace(authInfo, stub)
+	if err != nil {
+		return "", err
+	}
 
 	stubConfig := types.StubConfigV1{}
 	if err := json.Unmarshal([]byte(stub.Config), &stubConfig); err != nil {
 		return "", err
 	}
 
-	secrets, err := abstractions.ConfigureContainerRequestSecrets(authInfo.Workspace, stubConfig)
+	secrets, err := abstractions.ConfigureContainerRequestSecrets(workspace, stubConfig)
 	if err != nil {
 		return "", err
 	}
@@ -306,7 +310,7 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 	mounts, err := abstractions.ConfigureContainerRequestMounts(
 		containerId,
 		stub.Object.ExternalId,
-		authInfo.Workspace,
+		workspace,
 		stubConfig,
 		stub.ExternalId,
 	)
@@ -347,7 +351,7 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 	setPodKeepWarmLock(
 		context.Background(),
 		s.containerRepo,
-		authInfo.Workspace.Name,
+		workspace.Name,
 		stub.ExternalId,
 		containerId,
 		stubConfig.KeepWarmSeconds,
@@ -373,8 +377,8 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 		Mounts:            mounts,
 		Stub:              *stub,
 		ImageId:           *imageId,
-		WorkspaceId:       authInfo.Workspace.ExternalId,
-		Workspace:         *authInfo.Workspace,
+		WorkspaceId:       workspace.ExternalId,
+		Workspace:         *workspace,
 		EntryPoint:        stubConfig.EntryPoint,
 		Ports:             ports,
 		CheckpointEnabled: checkpointEnabled,
@@ -391,11 +395,27 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 	}
 
 	go s.eventRepo.PushRunStubEvent(
-		authInfo.Workspace.ExternalId,
+		workspace.ExternalId,
 		&stub.Stub,
 	)
 
 	return containerId, nil
+}
+
+func podRunWorkspace(authInfo *auth.AuthInfo, stub *types.StubWithRelated) (*types.Workspace, error) {
+	if authInfo == nil || authInfo.Workspace == nil {
+		return nil, fmt.Errorf("missing workspace auth")
+	}
+	if stub == nil {
+		return nil, fmt.Errorf("missing stub")
+	}
+	if stub.Workspace.ExternalId != "" && stub.Workspace.ExternalId != authInfo.Workspace.ExternalId {
+		return nil, fmt.Errorf("stub does not belong to workspace")
+	}
+	if stub.Workspace.ExternalId != "" {
+		return &stub.Workspace, nil
+	}
+	return authInfo.Workspace, nil
 }
 
 func podRunnableStub(stubType types.StubType) bool {

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"google.golang.org/grpc/codes"
@@ -77,6 +78,39 @@ func TestPodRunnableStubOnlyAllowsPodAndSandboxKinds(t *testing.T) {
 				t.Fatalf("podRunnableStub(%q) = %t, want %t", tt.stubType, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPodRunWorkspacePrefersStubWorkspace(t *testing.T) {
+	storageID := uint(2)
+	authWorkspace := &types.Workspace{ExternalId: "workspace-id", Name: "auth"}
+	stub := &types.StubWithRelated{
+		Workspace: types.Workspace{
+			ExternalId: "workspace-id",
+			Name:       "stub",
+			Storage:    &types.WorkspaceStorage{Id: &storageID},
+		},
+	}
+
+	got, err := podRunWorkspace(&auth.AuthInfo{Workspace: authWorkspace}, stub)
+	if err != nil {
+		t.Fatalf("podRunWorkspace returned error: %v", err)
+	}
+	if got != &stub.Workspace {
+		t.Fatalf("podRunWorkspace did not return stub workspace")
+	}
+	if !got.StorageAvailable() {
+		t.Fatalf("podRunWorkspace returned workspace without storage")
+	}
+}
+
+func TestPodRunWorkspaceRejectsWorkspaceMismatch(t *testing.T) {
+	_, err := podRunWorkspace(
+		&auth.AuthInfo{Workspace: &types.Workspace{ExternalId: "auth-workspace"}},
+		&types.StubWithRelated{Workspace: types.Workspace{ExternalId: "other-workspace"}},
+	)
+	if err == nil {
+		t.Fatal("podRunWorkspace returned nil error for workspace mismatch")
 	}
 }
 

--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -445,8 +445,9 @@ func (s *Worker) waitForProcessManager(ctx context.Context, containerId string, 
 		}
 
 		stats.TCPAttempts++
-		tcp := probeProcessManager(ctx, instance)
-		if tcp.Connected {
+		stats.ReadyAttempts++
+		client, err := newProcessManagerClient(ctx, instance)
+		if err == nil {
 			if !tcpReadyRecorded {
 				stats.FirstTCPReadyAfter = time.Since(start)
 				s.recordContainerLifecycle(ctx, instance.Request, containerLifecycleFromDuration(
@@ -459,27 +460,6 @@ func (s *Worker) waitForProcessManager(ctx context.Context, containerId string, 
 				))
 				tcpReadyRecorded = true
 			}
-		} else {
-			lastErr = tcp.Err
-			stats.TCPFailures++
-			stats.LastTCPFailureClass = tcp.Class
-			stats.TCPFailureClasses[tcp.Class]++
-			if tcp.Err != nil {
-				stats.LastError = tcp.Err.Error()
-			}
-
-			if err := waitProcessManagerBackoff(ctx, backoff); err != nil {
-				stats.LastError = ctx.Err().Error()
-				return nil, false, stats
-			}
-
-			backoff = nextProcessManagerBackoff(backoff)
-			continue
-		}
-
-		stats.ReadyAttempts++
-		client, err := newProcessManagerClient(ctx, instance)
-		if err == nil {
 			log.Info().
 				Str("container_id", containerId).
 				Dur("wait_time", time.Since(start)).
@@ -494,6 +474,9 @@ func (s *Worker) waitForProcessManager(ctx context.Context, containerId string, 
 		stats.LastError = err.Error()
 		stats.LastReadyClass = classifyProcessManagerReadyError(err)
 		stats.ReadyFailureClasses[stats.LastReadyClass]++
+		stats.TCPFailures++
+		stats.LastTCPFailureClass = stats.LastReadyClass
+		stats.TCPFailureClasses[stats.LastTCPFailureClass]++
 
 		if err := waitProcessManagerBackoff(ctx, backoff); err != nil {
 			stats.LastError = ctx.Err().Error()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes workspace metadata for sandbox/pod runs by preferring the stub’s workspace and blocking cross‑workspace runs. Streamlines sandbox readiness by waiting for a real process‑manager client and recording accurate TCP/ready stats.

- **Bug Fixes**
  - Choose the stub’s workspace when present; reject mismatches; use it for secrets, mounts, keep‑warm locks, and event metadata.
  - Wait for readiness via `newProcessManagerClient` instead of a separate TCP probe; unify failure class tracking and stats.
  - Added tests for workspace selection and mismatch validation.

- **Dependencies**
  - Bump `github.com/beam-cloud/goproc` to `v0.1.12` and update Docker download URLs for `arm64`/`amd64`.

<sup>Written for commit dfd11bfc57a3e6c7e6a088fe9d593021a31feaac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

