### PR TITLE
reconcile fix

### DIFF
--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -655,7 +655,6 @@ func TestEnsureCheckpointMaterializedReportsMissingCheckpointDemand(t *testing.T
 	require.Error(t, err)
 	require.Len(t, worker.cacheManager.reconcileNow, 1)
 
-	reporter.flush()
 	require.Equal(t, 1, metadata.recent)
 	require.Len(t, fake.pushed, 1)
 	require.Equal(t, types.CacheContentKindCheckpoint, fake.pushed[0].Kind)
@@ -699,7 +698,6 @@ func TestEnsureCheckpointMaterializedReportsAlreadyLocalCheckpoint(t *testing.T)
 	require.Equal(t, filepath.Join(checkpointRoot, checkpointID), path)
 	require.Empty(t, worker.cacheManager.reconcileNow)
 
-	reporter.flush()
 	require.Equal(t, 1, metadata.recent)
 	require.Len(t, fake.pushed, 1)
 	require.Equal(t, checkpoint.CacheHash, fake.pushed[0].Items[0].Hash)
@@ -748,7 +746,6 @@ func TestEnsureCheckpointMaterializedRestoresFromEmbeddedCache(t *testing.T) {
 	require.True(t, checkpointMaterialized(path))
 	require.Len(t, worker.cacheManager.reconcileNow, 1)
 
-	reporter.flush()
 	require.Len(t, fake.pushed, 1)
 	require.Equal(t, types.CacheContentKindCheckpoint, fake.pushed[0].Kind)
 	require.Equal(t, hash, fake.pushed[0].Items[0].Hash)

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -774,6 +774,7 @@ func (s *Worker) reportCheckpointRequiredContent(request *types.ContainerRequest
 		CheckpointID: checkpointId,
 		Accelerator:  metadata.accelerator,
 	}})
+	reporter.flush()
 }
 
 // shouldCreateCheckpoint checks if a checkpoint should be created for a given container


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Flush the reporter after reporting required checkpoint content to trigger reconcile immediately and prevent missed checkpoint push events. Removed redundant manual flushes in tests.

- **Bug Fixes**
  - Call `reporter.flush()` in `reportCheckpointRequiredContent` so checkpoint demand is emitted right away.
  - Remove manual `reporter.flush()` calls in cache reconciler tests.

<sup>Written for commit 2259191b91d235cee4942ee991b44b09009291e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

