### PR TITLE
more reconcile improvements

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -204,6 +204,7 @@ func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 		GatewayHTTPURL:  "http://host.docker.internal:1994",
 		GatewayGRPCHost: "host.docker.internal",
 		GatewayGRPCPort: 1993,
+		WorkspaceID:     "workspace-one",
 	}, &pb.AgentWorkerSlot{
 		WorkerId:                  "worker-one",
 		WorkerToken:               "token",
@@ -224,7 +225,8 @@ func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 		t.Fatalf("expected worker platform in docker args: %#v", args)
 	}
 	for _, want := range []string{
-		types.CacheLocalityEnv + "=private",
+		types.WorkerPoolEnv + "=private",
+		types.CacheLocalityEnv + "=workspace-one/private",
 		types.CacheNodeEnv + "=machine",
 		types.CacheHostNetworkEnv + "=true",
 		types.AgentGatewayURLEnv + "=http://host.docker.internal:1994",
@@ -275,6 +277,23 @@ func TestDockerRunArgsUsesConfigurableRouteTargetHost(t *testing.T) {
 		if !containsArg(args, "--add-host", want) {
 			t.Fatalf("expected %s host alias in docker args: %#v", want, args)
 		}
+	}
+}
+
+func TestAgentCacheLocalityScopesPoolByWorkspace(t *testing.T) {
+	slot := &pb.AgentWorkerSlot{PoolName: "aws-cpu-pool"}
+
+	if got := agentCacheLocality(bootstrapConfig{WorkspaceID: "workspace-a"}, slot); got != "workspace-a/aws-cpu-pool" {
+		t.Fatalf("cache locality = %q, want workspace-scoped pool", got)
+	}
+	if got := agentCacheLocality(bootstrapConfig{WorkspaceID: "workspace-b"}, slot); got != "workspace-b/aws-cpu-pool" {
+		t.Fatalf("cache locality = %q, want workspace-scoped pool", got)
+	}
+	if got := agentCacheLocality(bootstrapConfig{}, slot); got != "aws-cpu-pool" {
+		t.Fatalf("cache locality = %q, want raw pool fallback without workspace", got)
+	}
+	if got := agentCacheLocality(bootstrapConfig{WorkspaceID: "workspace-a", PoolName: "bootstrap-pool"}, nil); got != "workspace-a/bootstrap-pool" {
+		t.Fatalf("cache locality = %q, want bootstrap pool fallback", got)
 	}
 }
 
@@ -700,6 +719,7 @@ func TestWriteWorkerConfigUsesGeeseForWorkspaceStorage(t *testing.T) {
 		ImageRegistryStore:     reg.S3ImageRegistryStore,
 		ImageClipVersion:       1,
 		ImageLocalCacheEnabled: true,
+		WorkspaceID:            "workspace-one",
 	}, slot); err != nil {
 		t.Fatal(err)
 	}
@@ -780,6 +800,7 @@ func TestWriteWorkerConfigUsesGeeseForWorkspaceStorage(t *testing.T) {
 
 	cacheConfig := config["cache"].(map[string]any)
 	cacheDisk := cacheConfig["disk"].(map[string]any)
+	cacheGlobal := cacheConfig["global"].(map[string]any)
 	cacheServer := cacheConfig["server"].(map[string]any)
 	cacheClient := cacheConfig["client"].(map[string]any)
 	cacheFS := cacheClient["cachefs"].(map[string]any)
@@ -789,7 +810,10 @@ func TestWriteWorkerConfigUsesGeeseForWorkspaceStorage(t *testing.T) {
 	if got := cacheDisk["mountPath"]; got != types.AgentCachePath {
 		t.Fatalf("cache disk mount path = %v, want %q", got, types.AgentCachePath)
 	}
-	if got := cacheServer["diskCacheDir"]; got != filepath.Join(types.AgentCachePath, "private-dev", "machine-a") {
+	if got := cacheGlobal["defaultLocality"]; got != "workspace-one/private-dev" {
+		t.Fatalf("cache default locality = %v, want workspace-scoped private pool", got)
+	}
+	if got := cacheServer["diskCacheDir"]; got != filepath.Join(types.AgentCachePath, "workspace-one-private-dev", "machine-a") {
 		t.Fatalf("cache disk dir = %v, want machine-scoped persistent path", got)
 	}
 	if got := cacheFS["mountPoint"]; got != types.AgentCacheFSMountPath {

--- a/pkg/agent/worker_config.go
+++ b/pkg/agent/worker_config.go
@@ -185,6 +185,7 @@ func newAgentWorkerConfig(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) a
 	cache := agentDiskCacheConfig()
 	httpHost, httpPort, httpTLS := agentGatewayHTTPParts(bootstrap)
 	cacheFSEnabled := !envBool(types.AgentInContainerEnv)
+	cacheLocality := agentCacheLocality(bootstrap, slot)
 
 	return agentWorkerConfig{
 		ClusterName: types.DefaultAgentName,
@@ -267,10 +268,10 @@ func newAgentWorkerConfig(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) a
 			Disk:    cache.Disk,
 			Memory:  &agentConfigCacheMemory{Enabled: false},
 			Global: &agentConfigCacheGlobal{
-				DefaultLocality: firstNonEmpty(slot.PoolName, types.DefaultAgentName),
+				DefaultLocality: cacheLocality,
 			},
 			Server: &agentConfigCacheServer{
-				DiskCacheDir: pathpkg.Join(types.AgentCachePath, sanitizeDockerName(slot.PoolName), sanitizeDockerName(slot.MachineId)),
+				DiskCacheDir: pathpkg.Join(types.AgentCachePath, sanitizeDockerName(cacheLocality), sanitizeDockerName(slot.MachineId)),
 			},
 			Client: &agentConfigCacheClient{
 				CacheFS: agentConfigCacheFS{
@@ -280,6 +281,17 @@ func newAgentWorkerConfig(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) a
 			},
 		},
 	}
+}
+
+func agentCacheLocality(bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot) string {
+	poolName := firstNonEmpty(bootstrap.PoolName, types.DefaultAgentName)
+	if slot != nil && slot.PoolName != "" {
+		poolName = slot.PoolName
+	}
+	if bootstrap.WorkspaceID != "" {
+		return bootstrap.WorkspaceID + "/" + poolName
+	}
+	return poolName
 }
 
 func (c agentWorkerConfig) sanitizedForAgent() agentWorkerConfig {

--- a/pkg/agent/worker_container.go
+++ b/pkg/agent/worker_container.go
@@ -13,6 +13,7 @@ import (
 
 func dockerRunArgs(name, image, imageID, configPath string, bootstrap bootstrapConfig, slot *pb.AgentWorkerSlot, dirs workerDirs) []string {
 	localTargetHost := firstNonEmpty(os.Getenv(types.AgentTargetHostEnv), types.LoopbackHost)
+	cacheLocality := agentCacheLocality(bootstrap, slot)
 	args := []string{
 		"run", "--rm",
 		"--name", name,
@@ -89,7 +90,7 @@ func dockerRunArgs(name, image, imageID, configPath string, bootstrap bootstrapC
 		types.WorkerPodHostEnv:        types.LoopbackHost,
 		types.WorkerPodIPEnv:          types.LoopbackHost,
 		types.WorkerNetworkPrefixEnv:  slot.NetworkPrefix,
-		types.CacheLocalityEnv:        slot.PoolName,
+		types.CacheLocalityEnv:        cacheLocality,
 		types.CacheNodeEnv:            slot.MachineId,
 		types.CacheHostNetworkEnv:     "true",
 		types.WorkerPersistentEnv:     "true",

--- a/pkg/gateway/services/repository/cache_coordinator_test.go
+++ b/pkg/gateway/services/repository/cache_coordinator_test.go
@@ -339,6 +339,142 @@ func TestCacheMetadataScopesWorkerLocalityByWorkspace(t *testing.T) {
 	require.Len(t, listA.Stubs, 1)
 	require.Equal(t, "workspace-a", listA.Stubs[0].WorkspaceId)
 	require.Equal(t, "stub-a", listA.Stubs[0].StubId)
+
+	listB, err := service.ListRecentCacheStubs(cacheRepositoryWorkspaceAuthContext("workspace-b"), &pb.ListRecentCacheStubsRequest{
+		Locality:   "shared-pool",
+		TtlSeconds: 3600,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.True(t, listB.Ok, listB.ErrorMsg)
+	require.Len(t, listB.Stubs, 1)
+	require.Equal(t, "workspace-b", listB.Stubs[0].WorkspaceId)
+	require.Equal(t, "stub-b", listB.Stubs[0].StubId)
+}
+
+func TestCacheMetadataScopesPrivateWorkerLocksAndMarkersByWorkspace(t *testing.T) {
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(server.Close)
+
+	rdb := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	service := &WorkerRepositoryService{
+		cacheMetadata: cache.NewRedisCacheMetadataStoreWithClient(cache.GlobalConfig{}, cache.ServerConfig{}, rdb),
+	}
+	ctxA := cacheRepositoryWorkspaceAuthContext("workspace-a")
+	ctxB := cacheRepositoryWorkspaceAuthContext("workspace-b")
+
+	markedA, err := service.MarkCacheStubReported(ctxA, &pb.MarkCacheStubReportedRequest{
+		Locality:   "shared-pool",
+		StubId:     "stub",
+		TtlSeconds: 3600,
+	})
+	require.NoError(t, err)
+	require.True(t, markedA.Ok, markedA.ErrorMsg)
+	require.True(t, markedA.Claimed)
+
+	markedB, err := service.MarkCacheStubReported(ctxB, &pb.MarkCacheStubReportedRequest{
+		Locality:   "shared-pool",
+		StubId:     "stub",
+		TtlSeconds: 3600,
+	})
+	require.NoError(t, err)
+	require.True(t, markedB.Ok, markedB.ErrorMsg)
+	require.True(t, markedB.Claimed)
+
+	markedAAgain, err := service.MarkCacheStubReported(ctxA, &pb.MarkCacheStubReportedRequest{
+		Locality:   "shared-pool",
+		StubId:     "stub",
+		TtlSeconds: 3600,
+	})
+	require.NoError(t, err)
+	require.True(t, markedAAgain.Ok, markedAAgain.ErrorMsg)
+	require.False(t, markedAAgain.Claimed)
+
+	lockA, err := service.AcquireCacheReconcileLock(ctxA, &pb.AcquireCacheReconcileLockRequest{
+		Locality:    "shared-pool",
+		LogicalHost: "logical-host",
+		Hash:        "hash",
+		TtlSeconds:  300,
+	})
+	require.NoError(t, err)
+	require.True(t, lockA.Ok, lockA.ErrorMsg)
+	require.True(t, lockA.Acquired)
+
+	lockB, err := service.AcquireCacheReconcileLock(ctxB, &pb.AcquireCacheReconcileLockRequest{
+		Locality:    "shared-pool",
+		LogicalHost: "logical-host",
+		Hash:        "hash",
+		TtlSeconds:  300,
+	})
+	require.NoError(t, err)
+	require.True(t, lockB.Ok, lockB.ErrorMsg)
+	require.True(t, lockB.Acquired)
+
+	lockAAgain, err := service.AcquireCacheReconcileLock(ctxA, &pb.AcquireCacheReconcileLockRequest{
+		Locality:    "shared-pool",
+		LogicalHost: "logical-host",
+		Hash:        "hash",
+		TtlSeconds:  300,
+	})
+	require.NoError(t, err)
+	require.True(t, lockAAgain.Ok, lockAAgain.ErrorMsg)
+	require.False(t, lockAAgain.Acquired)
+
+	storeA, err := service.SetCacheStoreFromContentLock(ctxA, &pb.SetCacheStoreFromContentLockRequest{
+		Locality:   "shared-pool",
+		SourcePath: "/images/image.clip",
+	})
+	require.NoError(t, err)
+	require.True(t, storeA.Ok, storeA.ErrorMsg)
+
+	storeB, err := service.SetCacheStoreFromContentLock(ctxB, &pb.SetCacheStoreFromContentLockRequest{
+		Locality:   "shared-pool",
+		SourcePath: "/images/image.clip",
+	})
+	require.NoError(t, err)
+	require.True(t, storeB.Ok, storeB.ErrorMsg)
+
+	storeAAgain, err := service.SetCacheStoreFromContentLock(ctxA, &pb.SetCacheStoreFromContentLockRequest{
+		Locality:   "shared-pool",
+		SourcePath: "/images/image.clip",
+	})
+	require.NoError(t, err)
+	require.False(t, storeAAgain.Ok)
+}
+
+func TestCacheMetadataKeepsClusterWorkerMarkersUnscoped(t *testing.T) {
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(server.Close)
+
+	rdb := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	service := &WorkerRepositoryService{
+		cacheMetadata: cache.NewRedisCacheMetadataStoreWithClient(cache.GlobalConfig{}, cache.ServerConfig{}, rdb),
+	}
+	ctx := cacheRepositoryAuthContext(types.TokenTypeWorker)
+
+	first, err := service.MarkCacheStubReported(ctx, &pb.MarkCacheStubReportedRequest{
+		Locality:   "managed-locality",
+		StubId:     "stub",
+		TtlSeconds: 3600,
+	})
+	require.NoError(t, err)
+	require.True(t, first.Ok, first.ErrorMsg)
+	require.True(t, first.Claimed)
+
+	second, err := service.MarkCacheStubReported(ctx, &pb.MarkCacheStubReportedRequest{
+		Locality:   "managed-locality",
+		StubId:     "stub",
+		TtlSeconds: 3600,
+	})
+	require.NoError(t, err)
+	require.True(t, second.Ok, second.ErrorMsg)
+	require.False(t, second.Claimed)
 }
 
 func TestPruneStaleCacheCheckpointsUsesRecentStubsAcrossLocalities(t *testing.T) {

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -79,10 +79,10 @@ const (
 var EventStubCacheRequiredContentSchemaVersion = "1.0"
 var EventPlatformCacheSchemaVersion = "1.0"
 
-// CacheRequiredContentItem describes a single piece of content a stub needs
-// warm in a locality. Source is a non-secret descriptor (OCI layer identity or
-// workspace object path) used to resolve an origin fetch; it never carries
-// credentials.
+// CacheRequiredContentItem describes a single piece of content a stub needs.
+// Locality-scoped recent-stub indexes decide where it is kept warm. Source is a
+// non-secret descriptor (OCI layer identity or workspace object path) used to
+// resolve an origin fetch; it never carries credentials.
 type CacheRequiredContentItem struct {
 	Hash         string           `json:"hash"`
 	RoutingKey   string           `json:"routing_key"`
@@ -96,7 +96,9 @@ type CacheRequiredContentItem struct {
 }
 
 // EventStubCacheRequiredContentSchema is the coalesced required-content report
-// for a stub within a locality, persisted to the stub cache stream in S2.
+// for a stub, persisted to the stub cache stream in S2. Locality records where
+// the content was observed; the reconciler uses the locality-scoped recent-stub
+// index to decide where to materialize it.
 type EventStubCacheRequiredContentSchema struct {
 	WorkspaceID string                     `json:"workspace_id"`
 	StubID      string                     `json:"stub_id"`

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -68,6 +68,21 @@ func TestNormalizeCacheConfigDefaultsTopHostsToThree(t *testing.T) {
 	require.Equal(t, 3, got.Client.NTopHosts)
 }
 
+func TestCacheLocalityUsesEnvThenPoolGroupThenDefault(t *testing.T) {
+	config := types.AppConfig{
+		Cache: cache.Config{
+			Global: cache.GlobalConfig{DefaultLocality: "managed-default"},
+		},
+	}
+
+	require.Equal(t, "pool-group", cacheLocality(config, types.WorkerPoolConfig{ConfigGroup: "pool-group"}))
+	require.Equal(t, "managed-default", cacheLocality(config, types.WorkerPoolConfig{}))
+	require.Equal(t, cacheDefaultLocality, cacheLocality(types.AppConfig{}, types.WorkerPoolConfig{}))
+
+	t.Setenv(types.CacheLocalityEnv, "workspace-a/byoc-pool")
+	require.Equal(t, "workspace-a/byoc-pool", cacheLocality(config, types.WorkerPoolConfig{ConfigGroup: "pool-group"}))
+}
+
 func TestWorkerCacheManagerDisabledWhenPoolDiskCacheDisabled(t *testing.T) {
 	disabled := false
 	manager := &WorkerCacheManager{
@@ -336,6 +351,17 @@ func TestCacheLogicalHostIDIgnoresWorkerPool(t *testing.T) {
 	buildPool := cacheLogicalHostID("default", "node-a", filepath.Join(types.AgentCachePath, "default", "node-a"))
 
 	require.Equal(t, defaultPool, buildPool)
+}
+
+func TestCacheLogicalHostIDSeparatesWorkspaceScopedLocalities(t *testing.T) {
+	identityPath := filepath.Join(types.AgentCachePath, "aws-cpu-pool", "node-a")
+
+	workspaceA := cacheLogicalHostID("workspace-a/aws-cpu-pool", "node-a", identityPath)
+	workspaceB := cacheLogicalHostID("workspace-b/aws-cpu-pool", "node-a", identityPath)
+
+	require.NotEqual(t, workspaceA, workspaceB)
+	require.Contains(t, workspaceA, "workspace-a-aws-cpu-pool")
+	require.Contains(t, workspaceB, "workspace-b-aws-cpu-pool")
 }
 
 func TestCachePlacementIdentityUsesHostPathForDefaultDiskDir(t *testing.T) {

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -520,7 +520,7 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 		if m.requiredContentComplete(server, item, routingKey) {
 			continue
 		}
-		if m.reconcileRecentlySucceeded(item.Hash, routingKey) {
+		if reconcileSuccessBackoffApplies(item) && m.reconcileRecentlySucceeded(item.Hash, routingKey) {
 			continue
 		}
 
@@ -681,7 +681,11 @@ func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHos
 	switch {
 	case status == types.CacheAuditStatusMaterialized:
 		m.clearReconcileFailure(item.Hash, routingKey)
-		m.recordReconcileSuccess(item.Hash, routingKey)
+		if reconcileSuccessBackoffApplies(item) {
+			m.recordReconcileSuccess(item.Hash, routingKey)
+		} else {
+			m.clearReconcileSuccess(item.Hash, routingKey)
+		}
 		m.reconcileLogFields(log.Info(), localHostID, stub, item).
 			Str("status", status).Dur("duration", elapsed).
 			Msg("cache content reconciled")
@@ -714,6 +718,13 @@ func reconcileStatusIsFailure(status string) bool {
 	default:
 		return false
 	}
+}
+
+// Success backoff is only valid when the cache blob is the complete materialized
+// state. Checkpoints also require an extracted runtime/filesystem payload, which
+// can be pruned independently of the archive blob.
+func reconcileSuccessBackoffApplies(item types.CacheRequiredContentItem) bool {
+	return item.Kind != types.CacheContentKindCheckpoint
 }
 
 // reconcileBackingOff reports whether an item failed to materialize recently and
@@ -792,6 +803,13 @@ func (m *WorkerCacheManager) recordReconcileSuccess(hash, routingKey string) {
 		m.reconcileSuccesses = make(map[string]time.Time)
 	}
 	m.reconcileSuccesses[key] = time.Now()
+	m.reconcileSuccessesMu.Unlock()
+}
+
+func (m *WorkerCacheManager) clearReconcileSuccess(hash, routingKey string) {
+	key := reconcileItemKey(hash, routingKey)
+	m.reconcileSuccessesMu.Lock()
+	delete(m.reconcileSuccesses, key)
 	m.reconcileSuccessesMu.Unlock()
 }
 

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -34,6 +34,7 @@ type fakeEventRepo struct {
 	pushed      []types.EventStubCacheRequiredContentSchema
 	cacheEvents []types.EventPlatformCacheSchema
 	items       []types.CacheRequiredContentItem
+	itemsByStub map[string]map[string]types.CacheRequiredContentItem
 	readKeys    []string
 	err         error
 	readErr     error
@@ -44,6 +45,24 @@ func (f *fakeEventRepo) PushStubCacheRequiredContent(schema types.EventStubCache
 	defer f.mu.Unlock()
 	if f.err != nil {
 		return f.err
+	}
+	if f.itemsByStub == nil {
+		f.itemsByStub = map[string]map[string]types.CacheRequiredContentItem{}
+	}
+	stubKey := schema.WorkspaceID + "|" + schema.StubID
+	bucket := f.itemsByStub[stubKey]
+	if bucket == nil {
+		bucket = map[string]types.CacheRequiredContentItem{}
+		f.itemsByStub[stubKey] = bucket
+	}
+	for _, item := range schema.Items {
+		if item.Hash == "" {
+			continue
+		}
+		if item.Kind == "" {
+			item.Kind = schema.Kind
+		}
+		bucket[item.Hash+"\x00"+item.RoutingKey] = item
 	}
 	f.pushed = append(f.pushed, schema)
 	return nil
@@ -62,6 +81,15 @@ func (f *fakeEventRepo) ReadStubCacheRequiredContent(ctx context.Context, worksp
 		return nil, f.readErr
 	}
 	f.readKeys = append(f.readKeys, workspaceID+"|"+stubID)
+	if f.itemsByStub != nil {
+		if bucket := f.itemsByStub[workspaceID+"|"+stubID]; len(bucket) > 0 {
+			items := make([]types.CacheRequiredContentItem, 0, len(bucket))
+			for _, item := range bucket {
+				items = append(items, item)
+			}
+			return items, nil
+		}
+	}
 	return append([]types.CacheRequiredContentItem(nil), f.items...), nil
 }
 
@@ -147,13 +175,39 @@ type claimedMetadataStore struct {
 
 type localityRecentMetadataStore struct {
 	*cache.MockCacheMetadataStore
+	mu     sync.Mutex
 	stubs  map[string][]cache.RecentStub
 	listed []string
 }
 
-func (m *localityRecentMetadataStore) ListRecentStubs(ctx context.Context, locality string, ttl time.Duration, limit int) ([]cache.RecentStub, error) {
+func (m *localityRecentMetadataStore) AddRecentStub(_ context.Context, locality, workspaceID, stubID string, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stubs == nil {
+		m.stubs = map[string][]cache.RecentStub{}
+	}
+	stubs := m.stubs[locality]
+	now := time.Now()
+	for i := range stubs {
+		if stubs[i].WorkspaceID == workspaceID && stubs[i].StubID == stubID {
+			stubs[i].LastSeen = now
+			m.stubs[locality] = stubs
+			return nil
+		}
+	}
+	m.stubs[locality] = append(stubs, cache.RecentStub{WorkspaceID: workspaceID, StubID: stubID, LastSeen: now})
+	return nil
+}
+
+func (m *localityRecentMetadataStore) ListRecentStubs(_ context.Context, locality string, _ time.Duration, limit int) ([]cache.RecentStub, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.listed = append(m.listed, locality)
-	return append([]cache.RecentStub(nil), m.stubs[locality]...), nil
+	stubs := append([]cache.RecentStub(nil), m.stubs[locality]...)
+	if limit > 0 && len(stubs) > limit {
+		stubs = stubs[:limit]
+	}
+	return stubs, nil
 }
 
 func (m *claimedMetadataStore) MarkStubReported(_ context.Context, locality, _ string, _ time.Duration) (bool, error) {
@@ -841,6 +895,127 @@ func TestReconcileCheckpointIgnoresSuccessBackoffWhenExtractedPayloadMissing(t *
 	require.Len(t, fake.cacheEvents, 1)
 	require.Equal(t, types.CacheAuditStatusMaterialized, fake.cacheEvents[0].Status)
 	require.False(t, manager.reconcileRecentlySucceeded(hash, hash))
+}
+
+func TestRequiredContentReportedByOneWorkerReconcilesCheckpointOnPeerInLocality(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := testCacheManagerConfig(t.TempDir()).Cache
+	cfg.Client.NTopHosts = 2
+	metadata := &localityRecentMetadataStore{
+		MockCacheMetadataStore: cache.NewMockCacheMetadataStore(),
+		stubs:                  map[string][]cache.RecentStub{},
+	}
+	newServer := func(hostID string) (*cache.Server, *cache.Host) {
+		t.Helper()
+		serverCfg := cfg
+		serverCfg.Server.DiskCacheDir = t.TempDir()
+		server, err := cache.NewServerWithOptions(ctx, serverCfg, "locality-a", cache.WithServerMetadataStore(cache.NewMockCacheMetadataStore()), cache.WithServerHostID(hostID))
+		require.NoError(t, err)
+		addr, err := server.Serve("127.0.0.1:0", "")
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+		host := server.Host()
+		require.NotNil(t, host)
+		host.Addr = addr
+		host.PrivateAddr = addr
+		return server, host
+	}
+
+	sourceServer, sourceHost := newServer("source-host")
+	destinationServer, destinationHost := newServer("destination-host")
+
+	clientCfg := cfg
+	clientCfg.Server.DiskCacheDir = t.TempDir()
+	destinationClient, err := cache.NewClientWithHostDirectory(ctx, clientCfg, metadata, testHostDirectoryFunc(func(context.Context, string) ([]*cache.Host, error) {
+		return []*cache.Host{sourceHost, destinationHost}, nil
+	}), "locality-a")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, destinationClient.Cleanup()) })
+	destinationClient.AttachLocalServer(destinationServer)
+	require.Eventually(t, func() bool {
+		return len(destinationClient.RankedReadHosts("probe")) == 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	checkpointID := ""
+	archivePath := ""
+	hash := ""
+	size := int64(0)
+	for i := 0; i < 32; i++ {
+		candidateID := fmt.Sprintf("checkpoint-peer-reconcile-%d", i)
+		candidateArchive, candidateHash, candidateSize := createCheckpointArchiveForTest(t, candidateID)
+		ranked := destinationClient.RankedReadHosts(candidateHash)
+		if len(ranked) > 0 && ranked[0].HostId == sourceHost.HostId {
+			checkpointID = candidateID
+			archivePath = candidateArchive
+			hash = candidateHash
+			size = candidateSize
+			break
+		}
+	}
+	require.NotEmpty(t, checkpointID, "expected a checkpoint hash that reads from the source host first")
+
+	archive, err := os.Open(archivePath)
+	require.NoError(t, err)
+	_, _, err = sourceServer.StoreReader(ctx, archive, hash)
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+	require.True(t, sourceServer.HasCompleteContent(hash, size))
+	require.False(t, destinationServer.HasCompleteContent(hash, size))
+
+	events := &fakeEventRepo{}
+	reporter := newTestReporter(events)
+	reporter.metadata = metadata
+	reporter.locality = "locality-a"
+	reporter.recentStubTTL = time.Hour
+	workerA := &Worker{cacheManager: &WorkerCacheManager{reporter: reporter}}
+	workerA.reportCheckpointRequiredContent(&types.ContainerRequest{
+		WorkspaceId: "workspace",
+		StubId:      "stub",
+	}, checkpointID, &checkpointCacheMetadata{
+		hash:        hash,
+		sizeBytes:   size,
+		originKey:   "checkpoints/" + checkpointID + checkpointArchiveExtension,
+		locality:    "locality-a",
+		accelerator: "CPU",
+	})
+
+	checkpointRoot := filepath.Join(t.TempDir(), "checkpoints")
+	managerB := &WorkerCacheManager{
+		ctx:                ctx,
+		config:             types.AppConfig{Cache: cfg},
+		locality:           "locality-a",
+		accelerator:        "CPU",
+		metadataStore:      metadata,
+		eventRepo:          events,
+		client:             destinationClient,
+		server:             destinationServer,
+		checkpointRoot:     checkpointRoot,
+		reconcileFailures:  make(map[string]time.Time),
+		reconcileSuccesses: make(map[string]time.Time),
+	}
+
+	managerB.reconcileOnce()
+
+	require.True(t, destinationServer.HasCompleteContent(hash, size))
+	require.True(t, checkpointMaterialized(filepath.Join(checkpointRoot, checkpointID)))
+	require.Equal(t, []string{"locality-a"}, metadata.listed)
+
+	events.mu.Lock()
+	pushed := append([]types.EventStubCacheRequiredContentSchema(nil), events.pushed...)
+	cacheEvents := append([]types.EventPlatformCacheSchema(nil), events.cacheEvents...)
+	readKeys := append([]string(nil), events.readKeys...)
+	events.mu.Unlock()
+
+	require.Len(t, pushed, 1)
+	require.Equal(t, "locality-a", pushed[0].Locality)
+	require.Equal(t, []string{"workspace|stub"}, readKeys)
+	require.Len(t, cacheEvents, 1)
+	require.Equal(t, "locality-a", cacheEvents[0].Locality)
+	require.Equal(t, destinationHost.HostId, cacheEvents[0].LogicalHost)
+	require.Equal(t, types.CacheAuditStatusMaterialized, cacheEvents[0].Status)
 }
 
 func TestReconcileStubFansOutCheckpointsAcrossMatchingHosts(t *testing.T) {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -138,9 +138,11 @@ func createCheckpointArchiveForTest(t *testing.T, checkpointID string) (archiveP
 
 type claimedMetadataStore struct {
 	cache.CacheMetadataStore
-	claimed bool
-	marked  int
-	recent  int
+	claimed          bool
+	marked           int
+	recent           int
+	markedLocalities []string
+	recentLocalities []string
 }
 
 type localityRecentMetadataStore struct {
@@ -154,13 +156,15 @@ func (m *localityRecentMetadataStore) ListRecentStubs(ctx context.Context, local
 	return append([]cache.RecentStub(nil), m.stubs[locality]...), nil
 }
 
-func (m *claimedMetadataStore) MarkStubReported(context.Context, string, string, time.Duration) (bool, error) {
+func (m *claimedMetadataStore) MarkStubReported(_ context.Context, locality, _ string, _ time.Duration) (bool, error) {
 	m.marked++
+	m.markedLocalities = append(m.markedLocalities, locality)
 	return m.claimed, nil
 }
 
-func (m *claimedMetadataStore) AddRecentStub(context.Context, string, string, string, time.Duration) error {
+func (m *claimedMetadataStore) AddRecentStub(_ context.Context, locality, _, _ string, _ time.Duration) error {
 	m.recent++
+	m.recentLocalities = append(m.recentLocalities, locality)
 	return nil
 }
 
@@ -224,6 +228,7 @@ func TestReporterMarksRedisAfterSuccessfulRequiredContentWrite(t *testing.T) {
 	metadata := &claimedMetadataStore{claimed: true}
 	r := newTestReporter(fake)
 	r.metadata = metadata
+	r.locality = "locality-a"
 
 	r.reportItems("ws", "stub", types.CacheContentKindClipV1, []types.CacheRequiredContentItem{{Hash: "h1"}})
 	require.Zero(t, metadata.marked)
@@ -231,6 +236,9 @@ func TestReporterMarksRedisAfterSuccessfulRequiredContentWrite(t *testing.T) {
 	r.flush()
 	require.Len(t, fake.pushed, 1)
 	require.Equal(t, 1, metadata.marked)
+	require.Equal(t, []string{"locality-a"}, metadata.recentLocalities)
+	require.Equal(t, []string{"locality-a"}, metadata.markedLocalities)
+	require.Equal(t, "locality-a", fake.pushed[0].Locality)
 }
 
 func TestReporterRetriesRequiredContentWhenEventWriteFails(t *testing.T) {
@@ -656,7 +664,9 @@ func TestEnsureCheckpointMaterializedReportsMissingCheckpointDemand(t *testing.T
 	require.Len(t, worker.cacheManager.reconcileNow, 1)
 
 	require.Equal(t, 1, metadata.recent)
+	require.Equal(t, []string{"default"}, metadata.recentLocalities)
 	require.Len(t, fake.pushed, 1)
+	require.Equal(t, "default", fake.pushed[0].Locality)
 	require.Equal(t, types.CacheContentKindCheckpoint, fake.pushed[0].Kind)
 	require.Equal(t, "workspace", fake.pushed[0].WorkspaceID)
 	require.Equal(t, "stub", fake.pushed[0].StubID)
@@ -699,7 +709,9 @@ func TestEnsureCheckpointMaterializedReportsAlreadyLocalCheckpoint(t *testing.T)
 	require.Empty(t, worker.cacheManager.reconcileNow)
 
 	require.Equal(t, 1, metadata.recent)
+	require.Equal(t, []string{"default"}, metadata.recentLocalities)
 	require.Len(t, fake.pushed, 1)
+	require.Equal(t, "default", fake.pushed[0].Locality)
 	require.Equal(t, checkpoint.CacheHash, fake.pushed[0].Items[0].Hash)
 	require.Equal(t, checkpoint.CheckpointId, fake.pushed[0].Items[0].CheckpointID)
 	require.Equal(t, checkpoint.OriginKey, fake.pushed[0].Items[0].Source)
@@ -785,6 +797,50 @@ func TestReconcileCheckpointExtractsEmbeddedCacheArchive(t *testing.T) {
 
 	require.Equal(t, types.CacheAuditStatusMaterialized, status)
 	require.True(t, checkpointMaterialized(filepath.Join(checkpointRoot, checkpointID)))
+}
+
+func TestReconcileCheckpointIgnoresSuccessBackoffWhenExtractedPayloadMissing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client := newCheckpointCacheForTest(t, ctx)
+	checkpointID := "checkpoint-success-backoff"
+	archivePath, hash, size := createCheckpointArchiveForTest(t, checkpointID)
+	_, err := client.StoreContentFromLocalFile(cache.LocalContentSource{
+		Path:      archivePath,
+		CachePath: "checkpoints/" + checkpointID + checkpointArchiveExtension,
+	}, cache.StoreContentOptions{RoutingKey: hash, Lock: true})
+	require.NoError(t, err)
+
+	fake := &fakeEventRepo{items: []types.CacheRequiredContentItem{{
+		Kind:         types.CacheContentKindCheckpoint,
+		Hash:         hash,
+		RoutingKey:   hash,
+		SizeBytes:    size,
+		CheckpointID: checkpointID,
+		Accelerator:  "CPU",
+	}}}
+	checkpointRoot := filepath.Join(t.TempDir(), "checkpoints")
+	manager := &WorkerCacheManager{
+		ctx:            ctx,
+		locality:       "test",
+		accelerator:    "CPU",
+		metadataStore:  cache.NewMockCacheMetadataStore(),
+		eventRepo:      fake,
+		client:         client,
+		checkpointRoot: checkpointRoot,
+	}
+	manager.recordReconcileSuccess(hash, hash)
+
+	manager.reconcileStub(server, "local-host", cache.RecentStub{
+		WorkspaceID: "workspace",
+		StubID:      "stub",
+	}, newReconcileBudget(10))
+
+	require.True(t, checkpointMaterialized(filepath.Join(checkpointRoot, checkpointID)))
+	require.Len(t, fake.cacheEvents, 1)
+	require.Equal(t, types.CacheAuditStatusMaterialized, fake.cacheEvents[0].Status)
+	require.False(t, manager.reconcileRecentlySucceeded(hash, hash))
 }
 
 func TestReconcileStubFansOutCheckpointsAcrossMatchingHosts(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scope cache locality by workspace and propagate it end-to-end so peers in the same locality reconcile checkpoints and place cache where it’s needed. Also disable success backoff for checkpoints and re-check when the extracted payload is missing.

- **Bug Fixes**
  - Apply success backoff only to complete blobs; checkpoints always re-check and clear prior successes (gated in `reconcileStub` and `materializeOwnedItem`).
  - Workspace-scoped locality: agents/workers default to `workspace-id/pool`, set `types.WorkerPoolEnv`, set `types.CacheLocalityEnv` accordingly, use workspace-prefixed disk paths, and separate logical host IDs by workspace; metadata indexes recent stubs and private-worker locks/markers per workspace (cluster-worker markers remain unscoped).
  - Required-content events include `Locality`; reconciler lists stubs by locality and materializes checkpoints on peers in that locality; added tests for locality propagation, workspace scoping, and checkpoint backoff behavior.

<sup>Written for commit 8845497abdaf9102beb3106323e567a22cb0ca92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

