### PR TITLE
fix scheduling race

### DIFF
--- a/pkg/abstractions/pod/autoscaler_test.go
+++ b/pkg/abstractions/pod/autoscaler_test.go
@@ -94,6 +94,9 @@ func TestPodAutoscalerSampleUsesSharedConnectionSnapshots(t *testing.T) {
 	if err := rdb.Set(ctx, Keys.podProxyConnections(workspace.Name, stub.ExternalId, "proxy-1", "total"), 2, connectionSnapshotTTL).Err(); err != nil {
 		t.Fatal(err)
 	}
+	if err := rdb.SAdd(ctx, Keys.podProxyConnectionIndex(workspace.Name, stub.ExternalId), "proxy-1").Err(); err != nil {
+		t.Fatal(err)
+	}
 
 	instance := &podInstance{
 		AutoscaledInstance: &abstractions.AutoscaledInstance{

--- a/pkg/abstractions/pod/connections.go
+++ b/pkg/abstractions/pod/connections.go
@@ -111,6 +111,7 @@ func (pb *PodProxyBuffer) flushConnectionState() {
 	defer cancel()
 
 	pipe := pb.rdb.Pipeline()
+	pb.queueProxyConnectionIndex(ctx, pipe)
 	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), pb.totalConnections.Load(), connectionSnapshotTTL)
 	pb.containerConnections.Range(func(key, value any) bool {
 		containerId, ok := key.(string)
@@ -137,7 +138,10 @@ func (pb *PodProxyBuffer) publishContainerConnectionSnapshot(containerId string,
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	if err := pb.rdb.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, containerId), count, connectionSnapshotTTL).Err(); err != nil {
+	pipe := pb.rdb.Pipeline()
+	pb.queueProxyConnectionIndex(ctx, pipe)
+	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, containerId), count, connectionSnapshotTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Str("container_id", containerId).Msg("failed to publish pod container busy snapshot")
 	}
 }
@@ -150,9 +154,18 @@ func (pb *PodProxyBuffer) publishTotalConnectionSnapshot(count int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	if err := pb.rdb.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), count, connectionSnapshotTTL).Err(); err != nil {
+	pipe := pb.rdb.Pipeline()
+	pb.queueProxyConnectionIndex(ctx, pipe)
+	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), count, connectionSnapshotTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to publish pod total busy snapshot")
 	}
+}
+
+func (pb *PodProxyBuffer) queueProxyConnectionIndex(ctx context.Context, pipe redis.Pipeliner) {
+	indexKey := Keys.podProxyConnectionIndex(pb.workspace.Name, pb.stubId)
+	pipe.SAdd(ctx, indexKey, pb.proxyId)
+	pipe.Expire(ctx, indexKey, connectionSnapshotTTL)
 }
 
 func (pb *PodProxyBuffer) setPodKeepWarmLock(containerID string) {
@@ -187,7 +200,9 @@ func sharedPodTotalConnections(ctx context.Context, rdb *common.RedisClient, wor
 		return 0, nil
 	}
 
-	total, _, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionsScan(workspaceName, stubId, "total"))
+	total, _, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionIndex(workspaceName, stubId), func(proxyId string) string {
+		return Keys.podProxyConnections(workspaceName, stubId, proxyId, "total")
+	}, true)
 	return total, err
 }
 
@@ -196,21 +211,29 @@ func sharedPodContainerConnections(ctx context.Context, rdb *common.RedisClient,
 		return 0, nil
 	}
 
-	total, _, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionsScan(workspaceName, stubId, containerId))
+	total, _, err := sumRedisIntKeys(ctx, rdb, Keys.podProxyConnectionIndex(workspaceName, stubId), func(proxyId string) string {
+		return Keys.podProxyConnections(workspaceName, stubId, proxyId, containerId)
+	}, false)
 	return total, err
 }
 
-func sumRedisIntKeys(ctx context.Context, rdb *common.RedisClient, pattern string) (int64, bool, error) {
+func sumRedisIntKeys(ctx context.Context, rdb *common.RedisClient, indexKey string, keyForProxy func(string) string, pruneMissing bool) (int64, bool, error) {
 	var total int64
 
-	keys, err := rdb.Scan(ctx, pattern)
+	proxyIds, err := rdb.SMembers(ctx, indexKey).Result()
 	if err != nil {
 		return 0, false, err
 	}
+	if len(proxyIds) == 0 {
+		return 0, false, nil
+	}
 
-	for _, key := range keys {
-		value, err := rdb.Get(ctx, key).Int64()
+	for _, proxyId := range proxyIds {
+		value, err := rdb.Get(ctx, keyForProxy(proxyId)).Int64()
 		if err == redis.Nil {
+			if pruneMissing {
+				_ = rdb.SRem(ctx, indexKey, proxyId).Err()
+			}
 			continue
 		}
 		if err != nil {
@@ -221,5 +244,5 @@ func sumRedisIntKeys(ctx context.Context, rdb *common.RedisClient, pattern strin
 		}
 	}
 
-	return total, len(keys) > 0, nil
+	return total, true, nil
 }

--- a/pkg/abstractions/pod/keys.go
+++ b/pkg/abstractions/pod/keys.go
@@ -12,7 +12,7 @@ var (
 	podContainerConnections string = "pod:%s:%s:container_connections:%s"
 	podTotalConnections     string = "pod:%s:%s:total_connections"
 	podProxyConnections     string = "pod:%s:%s:proxy_connections:%s:%s"
-	podProxyConnectionsScan string = "pod:%s:%s:proxy_connections:*:%s"
+	podProxyConnectionIndex string = "pod:%s:%s:proxy_connection_proxies"
 )
 
 var Keys = &keys{}
@@ -39,6 +39,6 @@ func (k *keys) podProxyConnections(workspaceName, stubId, proxyId, target string
 	return fmt.Sprintf(podProxyConnections, workspaceName, stubId, proxyId, target)
 }
 
-func (k *keys) podProxyConnectionsScan(workspaceName, stubId, target string) string {
-	return fmt.Sprintf(podProxyConnectionsScan, workspaceName, stubId, target)
+func (k *keys) podProxyConnectionIndex(workspaceName, stubId string) string {
+	return fmt.Sprintf(podProxyConnectionIndex, workspaceName, stubId)
 }

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -10,6 +10,9 @@ var (
 	schedulerWorkerLock              string = "scheduler:worker:lock:%s"
 	schedulerWorkerRequests          string = "scheduler:worker:requests:%s"
 	schedulerWorkerIndex             string = "scheduler:worker:worker_index"
+	schedulerWorkerPoolIndex         string = "scheduler:worker:pool_index:%s"
+	schedulerWorkerMachineIndex      string = "scheduler:worker:machine_index:%s"
+	schedulerWorkerIndexRepairLock   string = "scheduler:worker:index_repair:lock"
 	schedulerWorkerState             string = "scheduler:worker:state:%s"
 	schedulerContainerConfig         string = "scheduler:container:config:%s"
 	schedulerContainerState          string = "scheduler:container:state:%s"
@@ -142,6 +145,18 @@ func (rk *redisKeys) SchedulerPrefix() string {
 
 func (rk *redisKeys) SchedulerWorkerIndex() string {
 	return schedulerWorkerIndex
+}
+
+func (rk *redisKeys) SchedulerWorkerPoolIndex(poolName string) string {
+	return fmt.Sprintf(schedulerWorkerPoolIndex, poolName)
+}
+
+func (rk *redisKeys) SchedulerWorkerMachineIndex(machineId string) string {
+	return fmt.Sprintf(schedulerWorkerMachineIndex, machineId)
+}
+
+func (rk *redisKeys) SchedulerWorkerIndexRepairLock() string {
+	return schedulerWorkerIndexRepairLock
 }
 
 func (rk *redisKeys) SchedulerContainerRequests() string {

--- a/pkg/repository/worker_pool_redis.go
+++ b/pkg/repository/worker_pool_redis.go
@@ -14,6 +14,8 @@ type WorkerPoolRedisRepository struct {
 	lock *common.RedisLock
 }
 
+const workerPoolSizerLockTTLSeconds = 30
+
 func NewWorkerPoolRedisRepository(rdb *common.RedisClient) WorkerPoolRepository {
 	return &WorkerPoolRedisRepository{rdb: rdb, lock: common.NewRedisLock(rdb)}
 }
@@ -65,7 +67,7 @@ func (r *WorkerPoolRedisRepository) SetWorkerPoolState(ctx context.Context, pool
 }
 
 func (r *WorkerPoolRedisRepository) SetWorkerPoolSizerLock(poolName string) error {
-	return r.lock.Acquire(context.TODO(), common.RedisKeys.WorkerPoolSizerLock(poolName), common.RedisLockOptions{TtlS: 3, Retries: 0})
+	return r.lock.Acquire(context.TODO(), common.RedisKeys.WorkerPoolSizerLock(poolName), common.RedisLockOptions{TtlS: workerPoolSizerLockTTLSeconds, Retries: 0})
 }
 
 func (r *WorkerPoolRedisRepository) RemoveWorkerPoolSizerLock(poolName string) error {

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/common"
@@ -18,15 +19,19 @@ import (
 )
 
 type WorkerRedisRepository struct {
-	rdb    *common.RedisClient
-	lock   *common.RedisLock
-	config types.WorkerConfig
+	rdb                   *common.RedisClient
+	lock                  *common.RedisLock
+	config                types.WorkerConfig
+	workerIndexRepairMu   sync.Mutex
+	lastWorkerIndexRepair time.Time
 }
 
 const (
 	schedulerWorkerLockTTL      = 10
 	schedulerWorkerLockRetries  = 20
 	schedulerWorkerLockInterval = 50 * time.Millisecond
+	workerIndexRepairLockTTL    = 30
+	workerIndexRepairInterval   = 30 * time.Second
 )
 
 var schedulerWorkerLockOptions = common.RedisLockOptions{
@@ -152,12 +157,14 @@ func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 	defer r.lock.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id))
 
 	stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
-	indexKey := common.RedisKeys.SchedulerWorkerIndex()
-
-	// Cache worker state key in index so we don't have to scan for it
-	err = r.rdb.SAdd(context.TODO(), indexKey, stateKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to add worker state key to index <%v>: %w", indexKey, err)
+	var oldWorker *types.Worker
+	if existingWorker, err := r.getWorkerFromKey(stateKey); err == nil {
+		oldWorker = existingWorker
+	} else {
+		var notFound *types.ErrWorkerNotFound
+		if !errors.As(err, &notFound) {
+			return err
+		}
 	}
 
 	worker.ResourceVersion = 0
@@ -170,6 +177,15 @@ func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 	err = r.rdb.Expire(context.TODO(), stateKey, r.config.CleanupPendingWorkerAgeLimit).Err()
 	if err != nil {
 		return fmt.Errorf("failed to set worker state ttl <%v>: %w", stateKey, err)
+	}
+
+	if err := r.addWorkerIndexEntries(context.TODO(), stateKey, worker); err != nil {
+		return err
+	}
+	if oldWorker != nil {
+		if err := r.removeStaleWorkerPlacementIndexes(context.TODO(), stateKey, oldWorker, worker); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -194,16 +210,18 @@ func (r *WorkerRedisRepository) RemoveWorker(workerId string) error {
 		return &types.ErrWorkerNotFound{WorkerId: workerId}
 	}
 
+	worker, err := r.getWorkerFromKey(stateKey)
+	if err != nil {
+		return err
+	}
+
 	requeued, err := r.requeueWorkerRequests(ctx, workerId)
 	if err != nil {
 		return err
 	}
 
-	// Remove worker state from index
-	indexKey := common.RedisKeys.SchedulerWorkerIndex()
-	err = r.rdb.SRem(ctx, indexKey, stateKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to remove worker state key from index <%v>: %w", indexKey, err)
+	if err := r.removeWorkerIndexEntries(ctx, stateKey, worker); err != nil {
+		return err
 	}
 
 	err = r.rdb.Del(ctx, stateKey).Err()
@@ -481,6 +499,90 @@ func (r *WorkerRedisRepository) ToggleWorkerAvailable(workerId string) error {
 	return r.updateWorkerStatus(workerId, types.WorkerStatusAvailable, true)
 }
 
+func (r *WorkerRedisRepository) workerIndexKeys(worker *types.Worker) []string {
+	keys := []string{common.RedisKeys.SchedulerWorkerIndex()}
+	if worker == nil {
+		return keys
+	}
+	if worker.PoolName != "" {
+		keys = append(keys, common.RedisKeys.SchedulerWorkerPoolIndex(worker.PoolName))
+	}
+	if worker.MachineId != "" {
+		keys = append(keys, common.RedisKeys.SchedulerWorkerMachineIndex(worker.MachineId))
+	}
+	return keys
+}
+
+func (r *WorkerRedisRepository) addWorkerIndexEntries(ctx context.Context, stateKey string, worker *types.Worker) error {
+	for _, indexKey := range r.workerIndexKeys(worker) {
+		if err := r.rdb.SAdd(ctx, indexKey, stateKey).Err(); err != nil {
+			return fmt.Errorf("failed to add worker state key to index <%v>: %w", indexKey, err)
+		}
+	}
+	return nil
+}
+
+func (r *WorkerRedisRepository) removeWorkerIndexEntries(ctx context.Context, stateKey string, worker *types.Worker) error {
+	for _, indexKey := range r.workerIndexKeys(worker) {
+		if err := r.rdb.SRem(ctx, indexKey, stateKey).Err(); err != nil {
+			return fmt.Errorf("failed to remove worker state key from index <%v>: %w", indexKey, err)
+		}
+	}
+	return nil
+}
+
+func (r *WorkerRedisRepository) removeStaleWorkerPlacementIndexes(ctx context.Context, stateKey string, oldWorker, newWorker *types.Worker) error {
+	if oldWorker.PoolName != "" && oldWorker.PoolName != newWorker.PoolName {
+		if err := r.rdb.SRem(ctx, common.RedisKeys.SchedulerWorkerPoolIndex(oldWorker.PoolName), stateKey).Err(); err != nil {
+			return fmt.Errorf("failed to remove worker state key from old pool index: %w", err)
+		}
+	}
+	if oldWorker.MachineId != "" && oldWorker.MachineId != newWorker.MachineId {
+		if err := r.rdb.SRem(ctx, common.RedisKeys.SchedulerWorkerMachineIndex(oldWorker.MachineId), stateKey).Err(); err != nil {
+			return fmt.Errorf("failed to remove worker state key from old machine index: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *WorkerRedisRepository) maybeRepairWorkerSecondaryIndexes(ctx context.Context) {
+	r.workerIndexRepairMu.Lock()
+	if time.Since(r.lastWorkerIndexRepair) < workerIndexRepairInterval {
+		r.workerIndexRepairMu.Unlock()
+		return
+	}
+	r.lastWorkerIndexRepair = time.Now()
+	r.workerIndexRepairMu.Unlock()
+
+	r.repairWorkerSecondaryIndexes(ctx)
+}
+
+func (r *WorkerRedisRepository) repairWorkerSecondaryIndexes(ctx context.Context) {
+	err := r.lock.Acquire(ctx, common.RedisKeys.SchedulerWorkerIndexRepairLock(), common.RedisLockOptions{TtlS: workerIndexRepairLockTTL, Retries: 0})
+	if err != nil {
+		return
+	}
+	defer r.lock.Release(common.RedisKeys.SchedulerWorkerIndexRepairLock())
+
+	keys, err := r.rdb.SMembers(ctx, common.RedisKeys.SchedulerWorkerIndex()).Result()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to list workers for index repair")
+		return
+	}
+
+	workers, err := r.getWorkersFromKeys(keys, common.RedisKeys.SchedulerWorkerIndex())
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to load workers for index repair")
+		return
+	}
+	for _, worker := range workers {
+		stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
+		if err := r.addWorkerIndexEntries(ctx, stateKey, worker); err != nil {
+			log.Warn().Err(err).Str("worker_id", worker.Id).Msg("failed to repair worker index")
+		}
+	}
+}
+
 // getWorkers retrieves a list of worker objects from the Redis store that match a given pattern.
 // If useLock is set to true, a lock will be acquired for each worker and released after retrieval.
 // If you can afford to not have the most up-to-date worker information, you can set useLock to false.
@@ -493,7 +595,7 @@ func (r *WorkerRedisRepository) getWorkers(useLock bool) ([]*types.Worker, error
 	}
 
 	if !useLock {
-		workers, err := r.getWorkersFromKeys(keys)
+		workers, err := r.getWorkersFromKeys(keys, common.RedisKeys.SchedulerWorkerIndex())
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve worker state keys: %v", err)
 		}
@@ -543,7 +645,11 @@ func (r *WorkerRedisRepository) GetWorkerById(workerId string) (*types.Worker, e
 	return r.getWorkerFromKey(key)
 }
 
-func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Worker, error) {
+func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string, cleanupIndexKeys ...string) ([]*types.Worker, error) {
+	if len(keys) == 0 {
+		return []*types.Worker{}, nil
+	}
+
 	pipe := r.rdb.Pipeline()
 	cmds := make([]*redis.MapStringStringCmd, len(keys))
 
@@ -561,9 +667,7 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 	for i, cmd := range cmds {
 		res, err := cmd.Result()
 		if err != nil || len(res) == 0 {
-			// If there is an error or the result is empty, remove the key from the index
-			indexKey := common.RedisKeys.SchedulerWorkerIndex()
-			r.rdb.SRem(context.TODO(), indexKey, keys[i]).Err()
+			r.removeMissingWorkerFromIndexes(context.TODO(), keys[i], cleanupIndexKeys...)
 			continue
 		}
 
@@ -578,6 +682,30 @@ func (r *WorkerRedisRepository) getWorkersFromKeys(keys []string) ([]*types.Work
 	}
 
 	return workers, nil
+}
+
+func (r *WorkerRedisRepository) removeMissingWorkerFromIndexes(ctx context.Context, stateKey string, indexKeys ...string) {
+	indexSet := map[string]struct{}{common.RedisKeys.SchedulerWorkerIndex(): {}}
+	for _, indexKey := range indexKeys {
+		if indexKey != "" {
+			indexSet[indexKey] = struct{}{}
+		}
+	}
+	for indexKey := range indexSet {
+		_ = r.rdb.SRem(ctx, indexKey, stateKey).Err()
+	}
+}
+
+func (r *WorkerRedisRepository) filterIndexedWorkers(ctx context.Context, workers []*types.Worker, indexKey string, keep func(*types.Worker) bool) []*types.Worker {
+	filtered := make([]*types.Worker, 0, len(workers))
+	for _, worker := range workers {
+		if keep(worker) {
+			filtered = append(filtered, worker)
+			continue
+		}
+		_ = r.rdb.SRem(ctx, indexKey, common.RedisKeys.SchedulerWorkerState(worker.Id)).Err()
+	}
+	return filtered
 }
 
 func (r *WorkerRedisRepository) getWorkerFromKey(key string) (*types.Worker, error) {
@@ -706,19 +834,21 @@ func (r *WorkerRedisRepository) GetAllWorkers() ([]*types.Worker, error) {
 }
 
 func (r *WorkerRedisRepository) GetAllWorkersInPool(poolName string) ([]*types.Worker, error) {
-	workers, err := r.getWorkers(false)
+	r.maybeRepairWorkerSecondaryIndexes(context.TODO())
+
+	indexKey := common.RedisKeys.SchedulerWorkerPoolIndex(poolName)
+	keys, err := r.rdb.SMembers(context.TODO(), indexKey).Result()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve worker pool index <%s>: %w", indexKey, err)
 	}
 
-	poolWorkers := []*types.Worker{}
-	for _, w := range workers {
-		if w.PoolName == poolName {
-			poolWorkers = append(poolWorkers, w)
-		}
+	workers, err := r.getWorkersFromKeys(keys, indexKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve worker state keys from pool index <%s>: %w", indexKey, err)
 	}
-
-	return poolWorkers, nil
+	return r.filterIndexedWorkers(context.TODO(), workers, indexKey, func(worker *types.Worker) bool {
+		return worker.PoolName == poolName
+	}), nil
 }
 
 func (r *WorkerRedisRepository) CordonAllPendingWorkersInPool(poolName string) error {
@@ -742,19 +872,21 @@ func (r *WorkerRedisRepository) CordonAllPendingWorkersInPool(poolName string) e
 }
 
 func (r *WorkerRedisRepository) GetAllWorkersOnMachine(machineId string) ([]*types.Worker, error) {
-	workers, err := r.getWorkers(false)
+	r.maybeRepairWorkerSecondaryIndexes(context.TODO())
+
+	indexKey := common.RedisKeys.SchedulerWorkerMachineIndex(machineId)
+	keys, err := r.rdb.SMembers(context.TODO(), indexKey).Result()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve worker machine index <%s>: %w", indexKey, err)
 	}
 
-	machineWorkers := []*types.Worker{}
-	for _, w := range workers {
-		if w.MachineId == machineId {
-			machineWorkers = append(machineWorkers, w)
-		}
+	workers, err := r.getWorkersFromKeys(keys, indexKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve worker state keys from machine index <%s>: %w", indexKey, err)
 	}
-
-	return machineWorkers, nil
+	return r.filterIndexedWorkers(context.TODO(), workers, indexKey, func(worker *types.Worker) bool {
+		return worker.MachineId == machineId
+	}), nil
 }
 
 func capacityMemoryForRequest(request *types.ContainerRequest) int64 {

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -580,6 +580,139 @@ func TestGetAllWorkers(t *testing.T) {
 	assert.Equal(t, nWorkers, pendingCount)
 }
 
+func TestGetAllWorkersInPoolUsesPoolIndex(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	assert.Nil(t, repo.AddWorker(&types.Worker{Id: "worker-pool-a", PoolName: "pool-a", MachineId: "machine-a"}))
+	assert.Nil(t, repo.AddWorker(&types.Worker{Id: "worker-pool-b", PoolName: "pool-b", MachineId: "machine-a"}))
+
+	workers, err := repo.GetAllWorkersInPool("pool-a")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(workers))
+	assert.Equal(t, "worker-pool-a", workers[0].Id)
+}
+
+func TestGetAllWorkersOnMachineUsesMachineIndex(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	assert.Nil(t, repo.AddWorker(&types.Worker{Id: "worker-machine-a", PoolName: "pool-a", MachineId: "machine-a"}))
+	assert.Nil(t, repo.AddWorker(&types.Worker{Id: "worker-machine-b", PoolName: "pool-a", MachineId: "machine-b"}))
+
+	workers, err := repo.GetAllWorkersOnMachine("machine-a")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(workers))
+	assert.Equal(t, "worker-machine-a", workers[0].Id)
+}
+
+func TestWorkerSecondaryIndexesRemoveStaleMembers(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	staleKey := common.RedisKeys.SchedulerWorkerState("worker-stale")
+	poolIndexKey := common.RedisKeys.SchedulerWorkerPoolIndex("pool-a")
+
+	assert.Nil(t, rdb.SAdd(context.TODO(), poolIndexKey, staleKey).Err())
+
+	workers, err := repo.GetAllWorkersInPool("pool-a")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(workers))
+
+	members, err := rdb.SMembers(context.TODO(), poolIndexKey).Result()
+	assert.Nil(t, err)
+	assert.NotContains(t, members, staleKey)
+}
+
+func TestWorkerSecondaryIndexesIgnoreWrongPoolMembers(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{Id: "worker-wrong-pool", PoolName: "pool-a"}
+	assert.Nil(t, repo.AddWorker(worker))
+
+	stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
+	wrongPoolIndex := common.RedisKeys.SchedulerWorkerPoolIndex("pool-b")
+	assert.Nil(t, rdb.SAdd(context.TODO(), wrongPoolIndex, stateKey).Err())
+
+	workers, err := repo.GetAllWorkersInPool("pool-b")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(workers))
+
+	inWrongPool, err := rdb.SIsMember(context.TODO(), wrongPoolIndex, stateKey).Result()
+	assert.Nil(t, err)
+	assert.False(t, inWrongPool)
+}
+
+func TestWorkerSecondaryIndexesIgnoreWrongMachineMembers(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{Id: "worker-wrong-machine", MachineId: "machine-a"}
+	assert.Nil(t, repo.AddWorker(worker))
+
+	stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
+	wrongMachineIndex := common.RedisKeys.SchedulerWorkerMachineIndex("machine-b")
+	assert.Nil(t, rdb.SAdd(context.TODO(), wrongMachineIndex, stateKey).Err())
+
+	workers, err := repo.GetAllWorkersOnMachine("machine-b")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(workers))
+
+	inWrongMachine, err := rdb.SIsMember(context.TODO(), wrongMachineIndex, stateKey).Result()
+	assert.Nil(t, err)
+	assert.False(t, inWrongMachine)
+}
+
+func TestWorkerSecondaryIndexesUpdateAndRemove(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{Id: "worker-moving", PoolName: "pool-a", MachineId: "machine-a"}
+	assert.Nil(t, repo.AddWorker(worker))
+
+	worker.PoolName = "pool-b"
+	worker.MachineId = "machine-b"
+	assert.Nil(t, repo.AddWorker(worker))
+
+	stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
+	inOldPool, err := rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerWorkerPoolIndex("pool-a"), stateKey).Result()
+	assert.Nil(t, err)
+	assert.False(t, inOldPool)
+	inNewPool, err := rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerWorkerPoolIndex("pool-b"), stateKey).Result()
+	assert.Nil(t, err)
+	assert.True(t, inNewPool)
+	inOldMachine, err := rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerWorkerMachineIndex("machine-a"), stateKey).Result()
+	assert.Nil(t, err)
+	assert.False(t, inOldMachine)
+	inNewMachine, err := rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerWorkerMachineIndex("machine-b"), stateKey).Result()
+	assert.Nil(t, err)
+	assert.True(t, inNewMachine)
+
+	assert.Nil(t, repo.RemoveWorker(worker.Id))
+	for _, indexKey := range []string{
+		common.RedisKeys.SchedulerWorkerIndex(),
+		common.RedisKeys.SchedulerWorkerPoolIndex("pool-b"),
+		common.RedisKeys.SchedulerWorkerMachineIndex("machine-b"),
+	} {
+		exists, err := rdb.SIsMember(context.TODO(), indexKey, stateKey).Result()
+		assert.Nil(t, err)
+		assert.False(t, exists)
+	}
+}
+
 func TestScheduleContainerRequestRestoresCapacityWhenQueuePushFails(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -64,6 +64,14 @@ func (s *WorkerPoolSizer) Start() {
 		}
 
 		func() {
+			if err := s.workerPoolRepo.SetWorkerPoolSizerLock(s.controller.Name()); err != nil {
+				if !errors.Is(err, redislock.ErrNotObtained) {
+					log.Error().Str("pool_name", s.controller.Name()).Err(err).Msg("failed to acquire worker pool sizing lock")
+				}
+				return
+			}
+			defer s.workerPoolRepo.RemoveWorkerPoolSizerLock(s.controller.Name())
+
 			nextState, err := s.controller.State() // Get the current state of the pool
 			if err != nil {
 				return
@@ -99,8 +107,8 @@ func (s *WorkerPoolSizer) Start() {
 
 			// Handle case where we want to make sure all available manually provisioned nodes have available workers
 			if s.workerPoolConfig.Mode == types.PoolModeExternal {
-				err := s.occupyAvailableMachines()
-				if err != nil && !errors.Is(err, redislock.ErrNotObtained) {
+				err := s.occupyAvailableMachinesLocked()
+				if err != nil {
 					log.Error().Str("pool_name", s.controller.Name()).Err(err).Msg("failed to list machines in external pool")
 				}
 			}
@@ -117,6 +125,10 @@ func (s *WorkerPoolSizer) occupyAvailableMachines() error {
 	}
 	defer s.workerPoolRepo.RemoveWorkerPoolSizerLock(s.controller.Name())
 
+	return s.occupyAvailableMachinesLocked()
+}
+
+func (s *WorkerPoolSizer) occupyAvailableMachinesLocked() error {
 	machines, err := s.providerRepo.ListAllMachines(string(*s.workerPoolConfig.Provider), s.controller.Name(), true)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a scheduling race by replacing SCAN-based lookups with deterministic Redis indexes and adding stronger locks during pool sizing. This stabilizes autoscaling and worker selection, reduces stale reads, and avoids duplicate sizer runs.

- **Bug Fixes**
  - Pod proxy connections: maintain a per-pod proxy index set and publish snapshots via a pipeline; sum via SMEMBERS + GET and prune missing entries; set index TTL with each publish.
  - Worker indexing: maintain `scheduler:worker:worker_index` plus `scheduler:worker:pool_index:<pool>` and `scheduler:worker:machine_index:<machine>`; update Add/Remove to keep indexes in sync and remove stale placements on moves.
  - Index hygiene: clean up missing/wrong members when reading from secondary indexes; periodic index repair with `scheduler:worker:index_repair:lock`.
  - Pool sizing: acquire a pool-level sizing lock at the start of each loop and when occupying machines; increase lock TTL to 30s; add `occupyAvailableMachinesLocked` to avoid double locking.
  - Tests: add coverage for pool/machine indexes, stale member cleanup, and wrong membership removal.

<sup>Written for commit 2f35c1e2ebc25a6233bea325e433ea8b4d6c7297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

