### PR TITLE
remove index repair

### DIFF
--- a/pkg/abstractions/pod/connections.go
+++ b/pkg/abstractions/pod/connections.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	connectionSyncInterval time.Duration = 100 * time.Millisecond
-	connectionSnapshotTTL  time.Duration = 2 * time.Second
+	connectionSyncInterval      time.Duration = 100 * time.Millisecond
+	connectionSnapshotTTL       time.Duration = 2 * time.Second
+	connectionIndexRefreshEvery time.Duration = connectionSnapshotTTL / 2
 )
 
 func (pb *PodProxyBuffer) incrementTotalConnections() (int64, error) {
@@ -25,7 +26,9 @@ func (pb *PodProxyBuffer) incrementTotalConnections() (int64, error) {
 }
 
 func (pb *PodProxyBuffer) decrementTotalConnections() error {
-	decrementCounter(&pb.totalConnections)
+	if decrementCounter(&pb.totalConnections) == 0 {
+		pb.idleSnapshotUntil.Store(time.Now().Add(connectionSnapshotTTL).UnixNano())
+	}
 	return nil
 }
 
@@ -107,25 +110,39 @@ func (pb *PodProxyBuffer) flushConnectionState() {
 		return
 	}
 
+	now := time.Now()
+	total := pb.totalConnections.Load()
+	hasContainerSnapshots := false
+	pb.containerConnections.Range(func(_, _ any) bool {
+		hasContainerSnapshots = true
+		return true
+	})
+	if total == 0 && !hasContainerSnapshots && now.UnixNano() > pb.idleSnapshotUntil.Load() {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	pipe := pb.rdb.Pipeline()
-	pb.queueProxyConnectionIndex(ctx, pipe)
-	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), pb.totalConnections.Load(), connectionSnapshotTTL)
+	refreshingIndex := pb.queueProxyConnectionIndex(ctx, pipe)
+	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), total, connectionSnapshotTTL)
 	pb.containerConnections.Range(func(key, value any) bool {
 		containerId, ok := key.(string)
 		if !ok {
 			return true
 		}
 		count := value.(*atomic.Int64).Load()
+		pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, containerId), count, connectionSnapshotTTL)
 		if count == 0 {
 			pb.containerConnections.Delete(key)
 		}
-		pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, containerId), count, connectionSnapshotTTL)
 		return true
 	})
 	if _, err := pipe.Exec(ctx); err != nil {
+		if refreshingIndex {
+			pb.proxyIndexRefreshAfter.Store(0)
+		}
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to publish pod connection snapshot")
 	}
 }
@@ -139,9 +156,12 @@ func (pb *PodProxyBuffer) publishContainerConnectionSnapshot(containerId string,
 	defer cancel()
 
 	pipe := pb.rdb.Pipeline()
-	pb.queueProxyConnectionIndex(ctx, pipe)
+	refreshingIndex := pb.queueProxyConnectionIndex(ctx, pipe)
 	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, containerId), count, connectionSnapshotTTL)
 	if _, err := pipe.Exec(ctx); err != nil {
+		if refreshingIndex {
+			pb.proxyIndexRefreshAfter.Store(0)
+		}
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Str("container_id", containerId).Msg("failed to publish pod container busy snapshot")
 	}
 }
@@ -155,17 +175,38 @@ func (pb *PodProxyBuffer) publishTotalConnectionSnapshot(count int64) {
 	defer cancel()
 
 	pipe := pb.rdb.Pipeline()
-	pb.queueProxyConnectionIndex(ctx, pipe)
+	refreshingIndex := pb.queueProxyConnectionIndex(ctx, pipe)
 	pipe.Set(ctx, Keys.podProxyConnections(pb.workspace.Name, pb.stubId, pb.proxyId, "total"), count, connectionSnapshotTTL)
 	if _, err := pipe.Exec(ctx); err != nil {
+		if refreshingIndex {
+			pb.proxyIndexRefreshAfter.Store(0)
+		}
 		log.Debug().Err(err).Str("stub_id", pb.stubId).Msg("failed to publish pod total busy snapshot")
 	}
 }
 
-func (pb *PodProxyBuffer) queueProxyConnectionIndex(ctx context.Context, pipe redis.Pipeliner) {
+func (pb *PodProxyBuffer) queueProxyConnectionIndex(ctx context.Context, pipe redis.Pipeliner) bool {
+	if !pb.shouldRefreshProxyConnectionIndex(time.Now()) {
+		return false
+	}
+
 	indexKey := Keys.podProxyConnectionIndex(pb.workspace.Name, pb.stubId)
 	pipe.SAdd(ctx, indexKey, pb.proxyId)
 	pipe.Expire(ctx, indexKey, connectionSnapshotTTL)
+	return true
+}
+
+func (pb *PodProxyBuffer) shouldRefreshProxyConnectionIndex(now time.Time) bool {
+	nowNS := now.UnixNano()
+	for {
+		next := pb.proxyIndexRefreshAfter.Load()
+		if next > nowNS {
+			return false
+		}
+		if pb.proxyIndexRefreshAfter.CompareAndSwap(next, now.Add(connectionIndexRefreshEvery).UnixNano()) {
+			return true
+		}
+	}
 }
 
 func (pb *PodProxyBuffer) setPodKeepWarmLock(containerID string) {
@@ -183,14 +224,15 @@ func (pb *PodProxyBuffer) setPodKeepWarmLock(containerID string) {
 	setPodKeepWarmLock(ctx, pb.containerRepo, pb.workspace.Name, pb.stubId, containerID, pb.stubConfig.KeepWarmSeconds)
 }
 
-func decrementCounter(counter *atomic.Int64) {
+func decrementCounter(counter *atomic.Int64) int64 {
 	for {
 		current := counter.Load()
 		if current <= 0 {
-			return
+			return 0
 		}
-		if counter.CompareAndSwap(current, current-1) {
-			return
+		next := current - 1
+		if counter.CompareAndSwap(current, next) {
+			return next
 		}
 	}
 }

--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -83,6 +83,8 @@ type PodProxyBuffer struct {
 	availableContainersLock sync.RWMutex
 	totalConnections        atomic.Int64
 	containerConnections    sync.Map
+	idleSnapshotUntil       atomic.Int64
+	proxyIndexRefreshAfter  atomic.Int64
 	buffer                  *abstractions.RingBuffer[*connection]
 	workReady               chan struct{}
 }

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -745,6 +745,46 @@ func TestFlushConnectionStatePublishesSnapshots(t *testing.T) {
 	}
 }
 
+func TestFlushConnectionStateSkipsIdleSnapshots(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	pb := newPodProxyConnectionTestBuffer(rdb)
+
+	pb.flushConnectionState()
+
+	totalSnapshotKey := Keys.podProxyConnections("workspace", "stub", pb.proxyId, "total")
+	if exists, err := rdb.Exists(context.Background(), totalSnapshotKey).Result(); err != nil {
+		t.Fatal(err)
+	} else if exists != 0 {
+		t.Fatalf("idle snapshot exists = %d, want absent", exists)
+	}
+
+	if _, err := pb.incrementTotalConnections(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pb.decrementTotalConnections(); err != nil {
+		t.Fatal(err)
+	}
+	pb.flushConnectionState()
+	if got := redisInt64(t, rdb, totalSnapshotKey); got != 0 {
+		t.Fatalf("idle transition snapshot = %d, want 0", got)
+	}
+}
+
+func TestProxyConnectionIndexRefreshIsThrottled(t *testing.T) {
+	pb := &PodProxyBuffer{}
+	now := time.Unix(0, 100)
+
+	if !pb.shouldRefreshProxyConnectionIndex(now) {
+		t.Fatal("expected first index refresh to publish")
+	}
+	if pb.shouldRefreshProxyConnectionIndex(now.Add(connectionIndexRefreshEvery / 2)) {
+		t.Fatal("expected index refresh to be throttled before refresh interval")
+	}
+	if !pb.shouldRefreshProxyConnectionIndex(now.Add(connectionIndexRefreshEvery + time.Nanosecond)) {
+		t.Fatal("expected index refresh after interval")
+	}
+}
+
 func newPodProxyTestRedis(t *testing.T) *common.RedisClient {
 	t.Helper()
 

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -12,7 +12,6 @@ var (
 	schedulerWorkerIndex             string = "scheduler:worker:worker_index"
 	schedulerWorkerPoolIndex         string = "scheduler:worker:pool_index:%s"
 	schedulerWorkerMachineIndex      string = "scheduler:worker:machine_index:%s"
-	schedulerWorkerIndexRepairLock   string = "scheduler:worker:index_repair:lock"
 	schedulerWorkerState             string = "scheduler:worker:state:%s"
 	schedulerContainerConfig         string = "scheduler:container:config:%s"
 	schedulerContainerState          string = "scheduler:container:state:%s"
@@ -153,10 +152,6 @@ func (rk *redisKeys) SchedulerWorkerPoolIndex(poolName string) string {
 
 func (rk *redisKeys) SchedulerWorkerMachineIndex(machineId string) string {
 	return fmt.Sprintf(schedulerWorkerMachineIndex, machineId)
-}
-
-func (rk *redisKeys) SchedulerWorkerIndexRepairLock() string {
-	return schedulerWorkerIndexRepairLock
 }
 
 func (rk *redisKeys) SchedulerContainerRequests() string {

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -145,7 +145,8 @@ func NewWorkerRedisRepository(r *common.RedisClient, config types.WorkerConfig) 
 
 // AddWorker adds or updates a worker
 func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
-	err := r.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerWorkerLock(worker.Id), schedulerWorkerLockOptions)
+	ctx := context.TODO()
+	err := r.lock.Acquire(ctx, common.RedisKeys.SchedulerWorkerLock(worker.Id), schedulerWorkerLockOptions)
 	if err != nil {
 		return err
 	}
@@ -163,24 +164,23 @@ func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 	}
 
 	worker.ResourceVersion = 0
-	err = r.rdb.HSet(context.TODO(), stateKey, common.ToSlice(worker)).Err()
-	if err != nil {
-		return fmt.Errorf("failed to add worker state <%s>: %v", stateKey, err)
-	}
 
-	// Set TTL on state key
-	err = r.rdb.Expire(context.TODO(), stateKey, r.config.CleanupPendingWorkerAgeLimit).Err()
-	if err != nil {
-		return fmt.Errorf("failed to set worker state ttl <%v>: %w", stateKey, err)
-	}
-
-	if err := r.addWorkerIndexEntries(context.TODO(), stateKey, worker); err != nil {
-		return err
+	pipe := r.rdb.TxPipeline()
+	pipe.HSet(ctx, stateKey, common.ToSlice(worker))
+	pipe.Expire(ctx, stateKey, r.config.CleanupPendingWorkerAgeLimit)
+	for _, indexKey := range r.workerIndexKeys(worker) {
+		pipe.SAdd(ctx, indexKey, stateKey)
 	}
 	if oldWorker != nil {
-		if err := r.removeStaleWorkerPlacementIndexes(context.TODO(), stateKey, oldWorker, worker); err != nil {
-			return err
+		if oldWorker.PoolName != "" && oldWorker.PoolName != worker.PoolName {
+			pipe.SRem(ctx, common.RedisKeys.SchedulerWorkerPoolIndex(oldWorker.PoolName), stateKey)
 		}
+		if oldWorker.MachineId != "" && oldWorker.MachineId != worker.MachineId {
+			pipe.SRem(ctx, common.RedisKeys.SchedulerWorkerMachineIndex(oldWorker.MachineId), stateKey)
+		}
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("failed to add worker state and indexes <%s>: %w", stateKey, err)
 	}
 
 	return nil
@@ -508,33 +508,10 @@ func (r *WorkerRedisRepository) workerIndexKeys(worker *types.Worker) []string {
 	return keys
 }
 
-func (r *WorkerRedisRepository) addWorkerIndexEntries(ctx context.Context, stateKey string, worker *types.Worker) error {
-	for _, indexKey := range r.workerIndexKeys(worker) {
-		if err := r.rdb.SAdd(ctx, indexKey, stateKey).Err(); err != nil {
-			return fmt.Errorf("failed to add worker state key to index <%v>: %w", indexKey, err)
-		}
-	}
-	return nil
-}
-
 func (r *WorkerRedisRepository) removeWorkerIndexEntries(ctx context.Context, stateKey string, worker *types.Worker) error {
 	for _, indexKey := range r.workerIndexKeys(worker) {
 		if err := r.rdb.SRem(ctx, indexKey, stateKey).Err(); err != nil {
 			return fmt.Errorf("failed to remove worker state key from index <%v>: %w", indexKey, err)
-		}
-	}
-	return nil
-}
-
-func (r *WorkerRedisRepository) removeStaleWorkerPlacementIndexes(ctx context.Context, stateKey string, oldWorker, newWorker *types.Worker) error {
-	if oldWorker.PoolName != "" && oldWorker.PoolName != newWorker.PoolName {
-		if err := r.rdb.SRem(ctx, common.RedisKeys.SchedulerWorkerPoolIndex(oldWorker.PoolName), stateKey).Err(); err != nil {
-			return fmt.Errorf("failed to remove worker state key from old pool index: %w", err)
-		}
-	}
-	if oldWorker.MachineId != "" && oldWorker.MachineId != newWorker.MachineId {
-		if err := r.rdb.SRem(ctx, common.RedisKeys.SchedulerWorkerMachineIndex(oldWorker.MachineId), stateKey).Err(); err != nil {
-			return fmt.Errorf("failed to remove worker state key from old machine index: %w", err)
 		}
 	}
 	return nil

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/common"
@@ -19,19 +18,15 @@ import (
 )
 
 type WorkerRedisRepository struct {
-	rdb                   *common.RedisClient
-	lock                  *common.RedisLock
-	config                types.WorkerConfig
-	workerIndexRepairMu   sync.Mutex
-	lastWorkerIndexRepair time.Time
+	rdb    *common.RedisClient
+	lock   *common.RedisLock
+	config types.WorkerConfig
 }
 
 const (
 	schedulerWorkerLockTTL      = 10
 	schedulerWorkerLockRetries  = 20
 	schedulerWorkerLockInterval = 50 * time.Millisecond
-	workerIndexRepairLockTTL    = 30
-	workerIndexRepairInterval   = 30 * time.Second
 )
 
 var schedulerWorkerLockOptions = common.RedisLockOptions{
@@ -545,44 +540,6 @@ func (r *WorkerRedisRepository) removeStaleWorkerPlacementIndexes(ctx context.Co
 	return nil
 }
 
-func (r *WorkerRedisRepository) maybeRepairWorkerSecondaryIndexes(ctx context.Context) {
-	r.workerIndexRepairMu.Lock()
-	if time.Since(r.lastWorkerIndexRepair) < workerIndexRepairInterval {
-		r.workerIndexRepairMu.Unlock()
-		return
-	}
-	r.lastWorkerIndexRepair = time.Now()
-	r.workerIndexRepairMu.Unlock()
-
-	r.repairWorkerSecondaryIndexes(ctx)
-}
-
-func (r *WorkerRedisRepository) repairWorkerSecondaryIndexes(ctx context.Context) {
-	err := r.lock.Acquire(ctx, common.RedisKeys.SchedulerWorkerIndexRepairLock(), common.RedisLockOptions{TtlS: workerIndexRepairLockTTL, Retries: 0})
-	if err != nil {
-		return
-	}
-	defer r.lock.Release(common.RedisKeys.SchedulerWorkerIndexRepairLock())
-
-	keys, err := r.rdb.SMembers(ctx, common.RedisKeys.SchedulerWorkerIndex()).Result()
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to list workers for index repair")
-		return
-	}
-
-	workers, err := r.getWorkersFromKeys(keys, common.RedisKeys.SchedulerWorkerIndex())
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to load workers for index repair")
-		return
-	}
-	for _, worker := range workers {
-		stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
-		if err := r.addWorkerIndexEntries(ctx, stateKey, worker); err != nil {
-			log.Warn().Err(err).Str("worker_id", worker.Id).Msg("failed to repair worker index")
-		}
-	}
-}
-
 // getWorkers retrieves a list of worker objects from the Redis store that match a given pattern.
 // If useLock is set to true, a lock will be acquired for each worker and released after retrieval.
 // If you can afford to not have the most up-to-date worker information, you can set useLock to false.
@@ -834,8 +791,6 @@ func (r *WorkerRedisRepository) GetAllWorkers() ([]*types.Worker, error) {
 }
 
 func (r *WorkerRedisRepository) GetAllWorkersInPool(poolName string) ([]*types.Worker, error) {
-	r.maybeRepairWorkerSecondaryIndexes(context.TODO())
-
 	indexKey := common.RedisKeys.SchedulerWorkerPoolIndex(poolName)
 	keys, err := r.rdb.SMembers(context.TODO(), indexKey).Result()
 	if err != nil {
@@ -872,8 +827,6 @@ func (r *WorkerRedisRepository) CordonAllPendingWorkersInPool(poolName string) e
 }
 
 func (r *WorkerRedisRepository) GetAllWorkersOnMachine(machineId string) ([]*types.Worker, error) {
-	r.maybeRepairWorkerSecondaryIndexes(context.TODO())
-
 	indexKey := common.RedisKeys.SchedulerWorkerMachineIndex(machineId)
 	keys, err := r.rdb.SMembers(context.TODO(), indexKey).Result()
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes worker secondary index repair and pipelines worker updates; also reduces Redis writes for pod proxy connections by throttling index refresh and skipping idle snapshots. This simplifies worker indexing and lowers load without changing external APIs.

- **Refactors**
  - Removed worker index repair logic and its Redis lock key; dropped repair calls from pool/machine queries.
  - Batched worker state and index updates in AddWorker using a single Redis pipeline, with inline cleanup of stale pool/machine index entries.
  - Throttled proxy connection index refresh (once per half-TTL) and reset the throttle on pipeline errors.
  - Skipped idle connection snapshots; publish a single 0 snapshot on idle transition.

<sup>Written for commit 67c40e16e9aa688d0bf652b6de87852c56b301cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

