### PR TITLE
sdk and rollout improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## ✨ Features
 
-- **Fast Image Builds**: Launch containers in under a second using a custom container runtime
+- **Fast Cold Starts**: Launch containers in under a second using a custom container runtime, scheduler, and embedded caching
 - **Parallelization and Concurrency**: Fan out workloads to 100s of containers
 - **First-Class Developer Experience**: Hot-reloading, webhooks, and scheduled jobs
 - **Scale-to-Zero**: Workloads are serverless by default

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -73,6 +73,9 @@ controllers:
     annotations: {}
     labels: {}
     replicas: 1
+    pod:
+      # 180s gateway shutdownTimeout + 10s readiness propagation + 5s buffer.
+      terminationGracePeriodSeconds: "195"
     strategy: Recreate # Can be Recreate or RollingUpdate
     rollingUpdate:
       unavailable:

--- a/manifests/kustomize/components/beta9-gateway/deployment.yaml
+++ b/manifests/kustomize/components/beta9-gateway/deployment.yaml
@@ -22,7 +22,8 @@ spec:
         app.kubernetes.io/name: beta9
     spec:
       automountServiceAccountToken: true
-      terminationGracePeriodSeconds: 185
+      # 180s gateway shutdownTimeout + 10s readiness propagation + 5s buffer.
+      terminationGracePeriodSeconds: 195
       initContainers:
       - name: wait-on-backends
         image: busybox:1.37.0

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 
 	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
@@ -31,6 +32,7 @@ type PodServiceOpts struct {
 	RedisClient   *common.RedisClient
 	EventRepo     repository.EventRepository
 	RouteGroup    *echo.Group
+	DrainContext  context.Context
 }
 
 const (
@@ -63,6 +65,7 @@ type GenericPodService struct {
 	podInstances    *common.SafeMap[*podInstance]
 	clientCache     sync.Map
 	tcpServer       *PodTCPServer
+	drainCtx        context.Context
 }
 
 func NewPodService(
@@ -87,6 +90,10 @@ func NewPodService(
 		config:          opts.Config,
 		eventRepo:       opts.EventRepo,
 		podInstances:    common.NewSafeMap[*podInstance](),
+		drainCtx:        opts.DrainContext,
+	}
+	if ps.drainCtx == nil {
+		ps.drainCtx = context.Background()
 	}
 
 	// Listen for container events with a certain prefix
@@ -157,7 +164,28 @@ func (ps *GenericPodService) IsPublic(stubId string) (*types.Workspace, error) {
 	return instance.Workspace, nil
 }
 
+func (ps *GenericPodService) isDraining() bool {
+	if ps == nil || ps.drainCtx == nil {
+		return false
+	}
+	select {
+	case <-ps.drainCtx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (ps *GenericPodService) rejectDrainingRequest(ctx echo.Context) error {
+	ctx.Response().Header().Set(echo.HeaderConnection, "close")
+	return ctx.String(http.StatusServiceUnavailable, "Service is draining")
+}
+
 func (ps *GenericPodService) forwardRequest(ctx echo.Context, stubId string) error {
+	if ps.isDraining() {
+		return ps.rejectDrainingRequest(ctx)
+	}
+
 	instance, err := ps.getOrCreatePodInstance(stubId)
 	if err != nil {
 		return err
@@ -173,6 +201,10 @@ func (ps *GenericPodService) forwardRequest(ctx echo.Context, stubId string) err
 }
 
 func (ps *GenericPodService) forwardContainerRequest(ctx echo.Context, stubId, containerId string) error {
+	if ps.isDraining() {
+		return ps.rejectDrainingRequest(ctx)
+	}
+
 	instance, err := ps.getOrCreatePodInstance(stubId)
 	if err != nil {
 		return err
@@ -182,6 +214,11 @@ func (ps *GenericPodService) forwardContainerRequest(ctx echo.Context, stubId, c
 }
 
 func (ps *GenericPodService) forwardTCPRequest(tc *tcpConnection, stubId string) error {
+	if ps.isDraining() {
+		tc.Conn.Close()
+		return nil
+	}
+
 	instance, err := ps.getOrCreatePodInstance(stubId)
 	if err != nil {
 		return err
@@ -256,7 +293,7 @@ func (ps *GenericPodService) getOrCreatePodInstance(stubId string, options ...fu
 		return nil, err
 	}
 
-	instance.buffer = NewPodProxyBuffer(autoscaledInstance.Ctx, ps.rdb, &stub.Workspace, stubId, podProxyBufferSize, ps.containerRepo, ps.keyEventManager, stubConfig, ps.tailscale, ps.config.Tailscale)
+	instance.buffer = NewPodProxyBuffer(autoscaledInstance.Ctx, ps.drainCtx, ps.rdb, &stub.Workspace, stubId, podProxyBufferSize, ps.containerRepo, ps.keyEventManager, stubConfig, ps.tailscale, ps.config.Tailscale)
 
 	// Embed autoscaled instance struct
 	instance.AutoscaledInstance = autoscaledInstance

--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -49,6 +49,7 @@ type connection struct {
 	ctx         echo.Context
 	tc          *tcpConnection
 	done        chan struct{}
+	finishOnce  sync.Once
 	enqueuedAt  time.Time
 	dialTimeout time.Duration
 }
@@ -67,6 +68,7 @@ func (c *connection) backendDialTimeout() time.Duration {
 
 type PodProxyBuffer struct {
 	ctx                     context.Context
+	drainCtx                context.Context
 	rdb                     *common.RedisClient
 	workspace               *types.Workspace
 	stubId                  string
@@ -89,7 +91,7 @@ type PodProxyBuffer struct {
 	workReady               chan struct{}
 }
 
-func NewPodProxyBuffer(ctx context.Context,
+func NewPodProxyBuffer(ctx, drainCtx context.Context,
 	rdb *common.RedisClient,
 	workspace *types.Workspace,
 	stubId string,
@@ -100,8 +102,13 @@ func NewPodProxyBuffer(ctx context.Context,
 	tailscale *network.Tailscale,
 	tsConfig types.TailscaleConfig,
 ) *PodProxyBuffer {
+	if drainCtx == nil {
+		drainCtx = context.Background()
+	}
+
 	pb := &PodProxyBuffer{
 		ctx:                     ctx,
+		drainCtx:                drainCtx,
 		rdb:                     rdb,
 		workspace:               workspace,
 		stubId:                  stubId,
@@ -128,6 +135,10 @@ func NewPodProxyBuffer(ctx context.Context,
 
 func (pb *PodProxyBuffer) ForwardRequest(ctx echo.Context) error {
 	ctx.Set("stubId", pb.stubId)
+
+	if pb.isDraining() {
+		return pb.failDrainingRequest(ctx)
+	}
 
 	if _, err := pb.incrementTotalConnections(); err != nil {
 		return ctx.String(http.StatusServiceUnavailable, "Failed to connect to service")
@@ -167,6 +178,10 @@ func (pb *PodProxyBuffer) ForwardRequest(ctx echo.Context) error {
 func (pb *PodProxyBuffer) ForwardContainerRequest(ctx echo.Context, containerId string) error {
 	ctx.Set("stubId", pb.stubId)
 
+	if pb.isDraining() {
+		return pb.failDrainingRequest(ctx)
+	}
+
 	if _, err := pb.incrementTotalConnections(); err != nil {
 		return ctx.String(http.StatusServiceUnavailable, "Failed to connect to service")
 	}
@@ -203,6 +218,9 @@ func (pb *PodProxyBuffer) waitForConnection(ctx echo.Context, conn *connection) 
 		select {
 		case <-pb.ctx.Done():
 			return ctx.String(http.StatusServiceUnavailable, "Failed to connect to service")
+		case <-pb.drainDone():
+			pb.failQueuedConnection(conn, http.StatusServiceUnavailable, "Service is draining")
+			return nil
 		case <-conn.done:
 			return nil
 		case <-ctx.Request().Context().Done():
@@ -212,6 +230,11 @@ func (pb *PodProxyBuffer) waitForConnection(ctx echo.Context, conn *connection) 
 }
 
 func (pb *PodProxyBuffer) ForwardTCPRequest(tc *tcpConnection) error {
+	if pb.isDraining() {
+		tc.Conn.Close()
+		return nil
+	}
+
 	if _, err := pb.incrementTotalConnections(); err != nil {
 		tc.Conn.Close()
 		return err
@@ -242,6 +265,9 @@ func (pb *PodProxyBuffer) processBuffer() {
 		select {
 		case <-pb.ctx.Done():
 			return
+		case <-pb.drainDone():
+			pb.failQueuedConnections(http.StatusServiceUnavailable, "Service is draining")
+			return
 		case <-pb.workReady:
 			for {
 				conn, ok := pb.buffer.Pop()
@@ -251,6 +277,10 @@ func (pb *PodProxyBuffer) processBuffer() {
 				pb.recordBufferOccupancy()
 
 				if conn.tc != nil {
+					if pb.isDraining() {
+						pb.failQueuedConnection(conn, http.StatusServiceUnavailable, "Service is draining")
+						continue
+					}
 					port := int32(conn.tc.Fields.Port)
 					container, ok, hasContainers, hasPort := pb.reserveContainerForPort(port)
 					if !ok {
@@ -258,7 +288,7 @@ func (pb *PodProxyBuffer) processBuffer() {
 							pb.requeueConnection(conn)
 							break
 						} else {
-							close(conn.done)
+							conn.finish()
 							conn.tc.Conn.Close()
 						}
 						continue
@@ -269,14 +299,18 @@ func (pb *PodProxyBuffer) processBuffer() {
 				}
 
 				if conn.ctx.Request().Context().Err() != nil {
-					close(conn.done)
+					conn.finish()
+					continue
+				}
+				if pb.isDraining() {
+					pb.failQueuedConnection(conn, http.StatusServiceUnavailable, "Service is draining")
 					continue
 				}
 
 				port, err := strconv.Atoi(conn.ctx.Param("port"))
 				if err != nil {
 					conn.ctx.String(http.StatusBadRequest, "Invalid port")
-					close(conn.done)
+					conn.finish()
 					continue
 				}
 
@@ -287,7 +321,7 @@ func (pb *PodProxyBuffer) processBuffer() {
 						break
 					} else {
 						conn.ctx.String(http.StatusServiceUnavailable, "Port not available")
-						close(conn.done)
+						conn.finish()
 					}
 					continue
 				}
@@ -323,11 +357,51 @@ func (pb *PodProxyBuffer) failQueuedConnection(conn *connection, status int, mes
 	if conn.tc != nil {
 		conn.tc.Conn.Close()
 	} else if conn.ctx != nil && !conn.ctx.Response().Committed {
+		conn.ctx.Response().Header().Set(echo.HeaderConnection, "close")
 		_ = conn.ctx.String(status, message)
 	}
-	if conn.done != nil {
-		close(conn.done)
+	conn.finish()
+}
+
+func (pb *PodProxyBuffer) failQueuedConnections(status int, message string) {
+	for {
+		conn, ok := pb.buffer.Pop()
+		if !ok {
+			break
+		}
+		pb.failQueuedConnection(conn, status, message)
 	}
+	pb.recordBufferOccupancy()
+}
+
+func (pb *PodProxyBuffer) failDrainingRequest(ctx echo.Context) error {
+	ctx.Response().Header().Set(echo.HeaderConnection, "close")
+	return ctx.String(http.StatusServiceUnavailable, "Service is draining")
+}
+
+func (pb *PodProxyBuffer) isDraining() bool {
+	select {
+	case <-pb.drainDone():
+		return true
+	default:
+		return false
+	}
+}
+
+func (pb *PodProxyBuffer) drainDone() <-chan struct{} {
+	if pb == nil || pb.drainCtx == nil {
+		return nil
+	}
+	return pb.drainCtx.Done()
+}
+
+func (c *connection) finish() {
+	if c == nil || c.done == nil {
+		return
+	}
+	c.finishOnce.Do(func() {
+		close(c.done)
+	})
 }
 
 func (pb *PodProxyBuffer) availableContainerSnapshot() []container {
@@ -439,7 +513,7 @@ func (pb *PodProxyBuffer) requeueConnection(conn *connection) {
 }
 
 func (pb *PodProxyBuffer) handleTCPConnection(conn *connection, container container) {
-	defer close(conn.done)
+	defer conn.finish()
 	defer pb.decrementContainerConnections(container.id)
 
 	tc := conn.tc
@@ -510,7 +584,7 @@ func (pb *PodProxyBuffer) handleTCPConnection(conn *connection, container contai
 }
 
 func (pb *PodProxyBuffer) handleConnection(conn *connection, container container, port int32) {
-	defer close(conn.done)
+	defer conn.finish()
 	defer pb.decrementContainerConnections(container.id)
 	pb.recordQueuedRequestWait(conn, "http")
 
@@ -722,6 +796,8 @@ func (pb *PodProxyBuffer) discoverContainers() {
 	for {
 		select {
 		case <-pb.ctx.Done():
+			return
+		case <-pb.drainDone():
 			return
 		default:
 			containerStates, err := pb.containerRepo.GetActiveContainersByStubId(pb.stubId)

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -176,6 +176,96 @@ func TestForwardRequestProxiesReadyBackendWithoutQueueing(t *testing.T) {
 	}
 }
 
+func TestForwardRequestRejectsImmediatelyWhenDraining(t *testing.T) {
+	drainCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("port")
+	ctx.SetParamValues("8000")
+
+	pb := &PodProxyBuffer{
+		ctx:      context.Background(),
+		drainCtx: drainCtx,
+		stubId:   "stub",
+	}
+
+	if err := pb.ForwardRequest(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if got := rec.Header().Get(echo.HeaderConnection); got != "close" {
+		t.Fatalf("Connection header = %q, want close", got)
+	}
+	if got := pb.totalConnectionCount(); got != 0 {
+		t.Fatalf("total connections = %d, want drain rejection before accounting", got)
+	}
+}
+
+func TestForwardRequestFailsQueuedRequestWhenDraining(t *testing.T) {
+	drainCtx, cancelDrain := context.WithCancel(context.Background())
+	defer cancelDrain()
+
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	defer cancelParent()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("port")
+	ctx.SetParamValues("8000")
+
+	pb := &PodProxyBuffer{
+		ctx:        parentCtx,
+		drainCtx:   drainCtx,
+		workspace:  &types.Workspace{Name: "workspace"},
+		stubId:     "stub",
+		stubConfig: &types.StubConfigV1{},
+		buffer:     abstractions.NewRingBuffer[*connection](1),
+		workReady:  make(chan struct{}, 1),
+	}
+
+	go pb.processBuffer()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pb.ForwardRequest(ctx)
+	}()
+
+	waitForCondition(t, 50*time.Millisecond, func() bool {
+		return pb.buffer.Len() == 1
+	})
+	cancelDrain()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("queued request was not released during drain")
+	}
+
+	waitForCondition(t, 50*time.Millisecond, func() bool {
+		return pb.buffer.Len() == 0
+	})
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if got := rec.Header().Get(echo.HeaderConnection); got != "close" {
+		t.Fatalf("Connection header = %q, want close", got)
+	}
+	if got := pb.totalConnectionCount(); got != 0 {
+		t.Fatalf("total connections = %d, want released after drain", got)
+	}
+}
+
 func TestForwardContainerRequestProxiesPinnedContainerWithoutQueueing(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() != "/health?probe=1" {
@@ -221,6 +311,37 @@ func TestForwardContainerRequestProxiesPinnedContainerWithoutQueueing(t *testing
 	}
 	if got := pb.containerConnectionCount(containerId); got != 0 {
 		t.Fatalf("container connections = %d, want released", got)
+	}
+}
+
+func TestForwardContainerRequestRejectsImmediatelyWhenDraining(t *testing.T) {
+	drainCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("port")
+	ctx.SetParamValues("8765")
+
+	pb := &PodProxyBuffer{
+		ctx:      context.Background(),
+		drainCtx: drainCtx,
+		stubId:   "stub",
+	}
+
+	if err := pb.ForwardContainerRequest(ctx, "container-1"); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if got := rec.Header().Get(echo.HeaderConnection); got != "close" {
+		t.Fatalf("Connection header = %q, want close", got)
+	}
+	if got := pb.totalConnectionCount(); got != 0 {
+		t.Fatalf("total connections = %d, want drain rejection before accounting", got)
 	}
 }
 

--- a/pkg/api/v1/health.go
+++ b/pkg/api/v1/health.go
@@ -14,17 +14,31 @@ type HealthGroup struct {
 	redisClient *common.RedisClient
 	backendRepo repository.BackendRepository
 	routerGroup *echo.Group
+	ready       func() bool
 }
 
-func NewHealthGroup(g *echo.Group, rdb *common.RedisClient, backendRepo repository.BackendRepository) *HealthGroup {
-	group := &HealthGroup{routerGroup: g, redisClient: rdb, backendRepo: backendRepo}
+func NewHealthGroup(g *echo.Group, rdb *common.RedisClient, backendRepo repository.BackendRepository, ready func() bool) *HealthGroup {
+	group := &HealthGroup{routerGroup: g, redisClient: rdb, backendRepo: backendRepo, ready: ready}
 
 	g.GET("", group.HealthCheck)
+	g.GET("/live", group.Live)
 
 	return group
 }
 
+func (h *HealthGroup) Live(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{
+		"status": "ok",
+	})
+}
+
 func (h *HealthGroup) HealthCheck(c echo.Context) error {
+	if h.ready != nil && !h.ready() {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"status": "draining",
+		})
+	}
+
 	g, ctx := errgroup.WithContext(c.Request().Context())
 
 	g.Go(func() error {

--- a/pkg/api/v1/health_test.go
+++ b/pkg/api/v1/health_test.go
@@ -1,0 +1,22 @@
+package apiv1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheckReportsDrainingBeforeDependencyChecks(t *testing.T) {
+	e := echo.New()
+	group := &HealthGroup{ready: func() bool { return false }}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+
+	err := group.HealthCheck(e.NewContext(req, rec))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -62,6 +63,7 @@ type Gateway struct {
 	Config               types.AppConfig
 	httpServer           *http.Server
 	grpcServer           *grpc.Server
+	healthServer         *health.Server
 	RedisClient          *common.RedisClient
 	TaskDispatcher       *task.Dispatcher
 	TaskRepo             repository.TaskRepository
@@ -79,9 +81,17 @@ type Gateway struct {
 	Scheduler            *scheduler.Scheduler
 	ctx                  context.Context
 	cancelFunc           context.CancelFunc
+	drainCtx             context.Context
+	drainCancelFunc      context.CancelFunc
 	baseRouteGroup       *echo.Group
 	rootRouteGroup       *echo.Group
+	draining             atomic.Bool
 }
+
+const (
+	gatewayDrainPropagationDelay = 10 * time.Second
+	gatewayGRPCShutdownMaxWait   = 5 * time.Second
+)
 
 func NewGateway() (*Gateway, error) {
 	configManager, err := common.NewConfigManager[types.AppConfig]()
@@ -108,11 +118,14 @@ func NewGateway() (*Gateway, error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	drainCtx, drainCancel := context.WithCancel(context.Background())
 	gateway := &Gateway{
-		RedisClient: redisClient,
-		ctx:         ctx,
-		cancelFunc:  cancel,
-		Storage:     storage,
+		RedisClient:     redisClient,
+		ctx:             ctx,
+		cancelFunc:      cancel,
+		drainCtx:        drainCtx,
+		drainCancelFunc: drainCancel,
+		Storage:         storage,
 	}
 
 	backendRepo, err := repository.NewBackendPostgresRepository(config.Database.Postgres, eventRepo)
@@ -210,6 +223,8 @@ func (g *Gateway) initHttp() error {
 		AllowHeaders: g.Config.GatewayService.HTTP.CORS.AllowedHeaders,
 		AllowMethods: g.Config.GatewayService.HTTP.CORS.AllowedMethods,
 	}))
+	// Subdomain middleware can dispatch requests directly, so drain handling must run first.
+	e.Use(g.drainMiddleware)
 	e.Use(gatewaymiddleware.Subdomain(g.Config.GatewayService.HTTP.GetExternalURL(), g.BackendRepo, g.RedisClient))
 	e.Use(middleware.Recover())
 	e.GET("/install/agent", agentInstallScriptHandler())
@@ -225,7 +240,7 @@ func (g *Gateway) initHttp() error {
 	g.baseRouteGroup = e.Group(apiv1.HttpServerBaseRoute)
 	g.rootRouteGroup = e.Group(apiv1.HttpServerRootRoute)
 
-	apiv1.NewHealthGroup(g.baseRouteGroup.Group("/health"), g.RedisClient, g.BackendRepo)
+	apiv1.NewHealthGroup(g.baseRouteGroup.Group("/health"), g.RedisClient, g.BackendRepo, g.isReady)
 	apiv1.NewMachineGroup(g.baseRouteGroup.Group("/machine", authMiddleware), g.ProviderRepo, g.Tailscale, g.Config, g.workerRepo)
 	apiv1.NewWorkspaceGroup(g.baseRouteGroup.Group("/workspace", authMiddleware), g.BackendRepo, g.WorkspaceRepo, g.DefaultStorageClient, g.Config)
 	apiv1.NewTokenGroup(g.baseRouteGroup.Group("/token", authMiddleware), g.BackendRepo, g.WorkspaceRepo, g.Config)
@@ -429,6 +444,7 @@ func (g *Gateway) registerServices() error {
 			EventRepo:     g.EventRepo,
 			RouteGroup:    g.rootRouteGroup,
 			WorkspaceRepo: g.WorkspaceRepo,
+			DrainContext:  g.drainCtx,
 		},
 	)
 	if err != nil {
@@ -523,6 +539,7 @@ func (g *Gateway) registerServices() error {
 	// Register health service
 	hs := health.NewServer()
 	hs.Resume()
+	g.healthServer = hs
 	go func() {
 		<-g.ctx.Done()
 		hs.Shutdown()
@@ -573,7 +590,7 @@ func (g *Gateway) Start() error {
 			log.Fatal().Err(err).Msg("failed to listen")
 		}
 
-		if err := g.grpcServer.Serve(lis); err != nil {
+		if err := g.grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
 			log.Fatal().Err(err).Msg("failed to start grpc server")
 		}
 	}()
@@ -594,17 +611,70 @@ func (g *Gateway) Start() error {
 
 	terminationSignal := make(chan os.Signal, 1)
 	signal.Notify(terminationSignal, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(terminationSignal)
 	<-terminationSignal
 	log.Info().Msg("termination signal received. shutting down...")
+	g.startDraining()
+	waitForDrainPropagation(g.ctx)
 	g.shutdown()
 
 	return nil
 }
 
+func (g *Gateway) isReady() bool {
+	return !g.draining.Load()
+}
+
+func (g *Gateway) drainMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Before(func() {
+			if g.draining.Load() {
+				c.Response().Header().Set(echo.HeaderConnection, "close")
+			}
+		})
+		return next(c)
+	}
+}
+
+func (g *Gateway) startDraining() {
+	if !g.draining.CompareAndSwap(false, true) {
+		return
+	}
+
+	if g.httpServer != nil {
+		g.httpServer.SetKeepAlivesEnabled(false)
+	}
+	if g.healthServer != nil {
+		g.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+	}
+	if g.drainCancelFunc != nil {
+		g.drainCancelFunc()
+	}
+	log.Info().Msg("gateway entering drain mode")
+}
+
+func waitForDrainPropagation(ctx context.Context) {
+	timer := time.NewTimer(gatewayDrainPropagationDelay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+}
+
+func grpcGracefulStopTimeout(shutdownTimeout time.Duration) time.Duration {
+	if shutdownTimeout <= 0 || shutdownTimeout > gatewayGRPCShutdownMaxWait {
+		return gatewayGRPCShutdownMaxWait
+	}
+	return shutdownTimeout
+}
+
 // Shutdown gracefully shuts down the gateway.
 // This function is blocking and will only return when the gateway has been shut down.
 func (g *Gateway) shutdown() {
-	ctx, cancel := context.WithTimeout(context.Background(), g.Config.GatewayService.ShutdownTimeout)
+	timeout := g.Config.GatewayService.ShutdownTimeout
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	eg, ctx := errgroup.WithContext(ctx)
@@ -620,18 +690,24 @@ func (g *Gateway) shutdown() {
 			close(done)
 		}()
 
+		timer := time.NewTimer(grpcGracefulStopTimeout(timeout))
+		defer timer.Stop()
+
 		select {
+		case <-timer.C:
+			g.grpcServer.Stop()
+			return nil
 		case <-ctx.Done():
 			g.grpcServer.Stop()
-			return ctx.Err()
+			return nil
 		case <-done:
 			return nil
 		}
 	})
 
-	g.cancelFunc()
-
 	if err := eg.Wait(); err != nil {
-		log.Fatal().Err(err).Msg("failed to shutdown gateway")
+		log.Warn().Err(err).Msg("gateway shutdown completed with errors")
 	}
+
+	g.cancelFunc()
 }

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestDrainMiddlewareSetsConnectionCloseWhileDraining(t *testing.T) {
+	g := &Gateway{}
+	g.draining.Store(true)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	handler := g.drainMiddleware(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	if err := handler(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rec.Header().Get(echo.HeaderConnection); got != "close" {
+		t.Fatalf("Connection header = %q, want close", got)
+	}
+}
+
+func TestDrainMiddlewareSetsConnectionCloseWhenDrainStartsDuringRequest(t *testing.T) {
+	g := &Gateway{}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	handler := g.drainMiddleware(func(c echo.Context) error {
+		g.startDraining()
+		return c.String(http.StatusOK, "ok")
+	})
+	if err := handler(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rec.Header().Get(echo.HeaderConnection); got != "close" {
+		t.Fatalf("Connection header = %q, want close", got)
+	}
+}
+
+func TestStartDrainingMarksGatewayNotReady(t *testing.T) {
+	g := &Gateway{}
+
+	if !g.isReady() {
+		t.Fatal("new gateway should be ready")
+	}
+
+	g.startDraining()
+	if g.isReady() {
+		t.Fatal("draining gateway should not be ready")
+	}
+}
+
+func TestStartDrainingCancelsDrainContext(t *testing.T) {
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	g := &Gateway{drainCtx: drainCtx, drainCancelFunc: drainCancel}
+
+	g.startDraining()
+
+	select {
+	case <-drainCtx.Done():
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("drain context was not canceled")
+	}
+}
+
+func TestGRPCGracefulStopTimeout(t *testing.T) {
+	if got := grpcGracefulStopTimeout(0); got != gatewayGRPCShutdownMaxWait {
+		t.Fatalf("zero grpc shutdown timeout = %s, want %s", got, gatewayGRPCShutdownMaxWait)
+	}
+	if got := grpcGracefulStopTimeout(5 * time.Second); got != 5*time.Second {
+		t.Fatalf("short grpc shutdown timeout = %s, want caller timeout", got)
+	}
+	if got := grpcGracefulStopTimeout(gatewayGRPCShutdownMaxWait + time.Second); got != gatewayGRPCShutdownMaxWait {
+		t.Fatalf("long grpc shutdown timeout = %s, want %s", got, gatewayGRPCShutdownMaxWait)
+	}
+}

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.247"
+version = "0.1.248"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -1,6 +1,8 @@
 import inspect
 import json
+import math
 import os
+import re
 import threading
 from typing import Callable, Dict, List, Optional, Union
 
@@ -268,19 +270,34 @@ class RunnerAbstraction(BaseAbstraction):
         return res
 
     def parse_memory(self, memory_str: str) -> int:
+        """Parse memory strings into megabytes."""
         if not isinstance(memory_str, str):
             return memory_str
 
-        """Parse memory str (with units) to megabytes."""
-
-        if memory_str.lower().endswith("mi"):
-            return int(memory_str[:-2])
-        elif memory_str.lower().endswith("gb"):
-            return int(memory_str[:-2]) * 1000
-        elif memory_str.lower().endswith("gi"):
-            return int(memory_str[:-2]) * 1024
-        else:
+        memory = memory_str.strip().lower()
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)([a-z]*)", memory)
+        if not match:
             raise ValueError("Unsupported memory format")
+
+        amount = float(match.group(1))
+        unit = match.group(2) or "mb"
+        units = {
+            "m": 1,
+            "mb": 1,
+            "mi": 1,
+            "mib": 1,
+            "g": 1000,
+            "gb": 1000,
+            "gi": 1024,
+            "gib": 1024,
+        }
+        if unit not in units:
+            raise ValueError("Unsupported memory format")
+
+        memory_mb = math.ceil(amount * units[unit])
+        if memory_mb <= 0:
+            raise ValueError("memory must be greater than 0")
+        return memory_mb
 
     @property
     def gateway_stub(self) -> GatewayServiceStub:

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -420,7 +420,7 @@ class Image(BaseAbstraction):
             return image
 
         if not context_dir:
-            context_dir = os.path.dirname(path)
+            context_dir = os.path.dirname(path) or "."
 
         image.sync_files(context_dir)
 

--- a/sdk/src/beta9/abstractions/service.py
+++ b/sdk/src/beta9/abstractions/service.py
@@ -1,5 +1,6 @@
+import json
 import os
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ..type import GpuType, GpuTypeAlias, Pool, QueueDepthAutoscaler
 from .base.container import Container
@@ -9,16 +10,69 @@ from .pod import Pod, PodInstance
 DEFAULT_SERVICE_PORT = 8000
 
 
+def _strip_dockerfile_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for index, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == "#" and not in_single and not in_double:
+            if index == 0 or line[index - 1].isspace():
+                return line[:index].rstrip()
+
+    return line
+
+
+def dockerfile_instructions(dockerfile: str) -> List[Tuple[str, str]]:
+    instructions: List[Tuple[str, str]] = []
+    continued = ""
+
+    for raw_line in dockerfile.splitlines():
+        line = _strip_dockerfile_comment(raw_line.rstrip())
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+
+        if continued:
+            line = continued + line.lstrip()
+
+        if line.endswith("\\"):
+            continued = line[:-1].rstrip() + " "
+            continue
+
+        continued = ""
+        instruction, _, value = line.strip().partition(" ")
+        if instruction and value:
+            instructions.append((instruction.upper(), value.strip()))
+
+    if continued.strip():
+        instruction, _, value = continued.strip().partition(" ")
+        if instruction and value:
+            instructions.append((instruction.upper(), value.strip()))
+
+    return instructions
+
+
 def ports_from_dockerfile(image: Optional[Image]) -> List[int]:
     dockerfile = getattr(image, "dockerfile", "") or ""
     ports: List[int] = []
 
-    for raw_line in dockerfile.splitlines():
-        line = raw_line.split("#", 1)[0].strip()
-        if not line.upper().startswith("EXPOSE "):
+    for instruction, value in dockerfile_instructions(dockerfile):
+        if instruction != "EXPOSE":
             continue
 
-        for token in line.split()[1:]:
+        for token in value.split():
             port_text = token.split("/", 1)[0]
             if not port_text.isdigit():
                 continue
@@ -28,6 +82,41 @@ def ports_from_dockerfile(image: Optional[Image]) -> List[int]:
                 ports.append(port)
 
     return ports
+
+
+def _dockerfile_process_args(value: str) -> List[str]:
+    if value.startswith("["):
+        try:
+            parsed = json.loads(value)
+        except ValueError as exc:
+            raise ValueError(
+                "Dockerfile exec-form CMD/ENTRYPOINT must be a JSON string array"
+            ) from exc
+        if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+            raise ValueError("Dockerfile exec-form command must be a JSON string array")
+        return parsed
+
+    return ["sh", "-lc", value]
+
+
+def command_from_dockerfile(image: Optional[Image]) -> List[str]:
+    dockerfile = getattr(image, "dockerfile", "") or ""
+    entrypoint: List[str] = []
+    cmd: List[str] = []
+    entrypoint_shell_form = False
+
+    for instruction, value in dockerfile_instructions(dockerfile):
+        if instruction == "ENTRYPOINT":
+            entrypoint = _dockerfile_process_args(value)
+            entrypoint_shell_form = not value.startswith("[")
+        elif instruction == "CMD":
+            cmd = _dockerfile_process_args(value)
+
+    if entrypoint_shell_form:
+        return entrypoint
+    if entrypoint:
+        return entrypoint + cmd
+    return cmd
 
 
 def resolve_service_ports(
@@ -98,6 +187,10 @@ class Service(Pod):
         if command is not None and entrypoint:
             raise ValueError("Specify either command or entrypoint, not both.")
 
+        service_entrypoint = entrypoint
+        if command is None and not service_entrypoint:
+            service_entrypoint = command_from_dockerfile(image)
+
         service_ports = resolve_service_ports(
             port=port,
             ports=ports,
@@ -111,7 +204,7 @@ class Service(Pod):
 
         super().__init__(
             app=app,
-            entrypoint=entrypoint or self._command_to_entrypoint(command),
+            entrypoint=service_entrypoint or self._command_to_entrypoint(command),
             ports=service_ports,
             name=name,
             cpu=cpu,

--- a/sdk/src/beta9/cli/deployment.py
+++ b/sdk/src/beta9/cli/deployment.py
@@ -30,6 +30,7 @@ from .extraclick import (
     ClickManagementGroup,
     env_vars_to_dict,
     handle_config_override,
+    image_from_dockerfile_option,
     override_config_options,
 )
 
@@ -134,25 +135,34 @@ def _merge_port_options(kwargs: Dict) -> None:
     kwargs["ports"] = ports
 
 
-def _autodetect_dockerfile(kwargs: Dict) -> Optional[Image]:
+def _autodetect_dockerfile(kwargs: Dict) -> None:
     if kwargs.get("dockerfile") is not None or kwargs.get("image") is not None:
-        return None
+        return
 
     dockerfile = "Dockerfile"
     if not os.path.exists(dockerfile):
+        return
+
+    kwargs["dockerfile"] = dockerfile
+
+
+def _materialize_dockerfile_image(kwargs: Dict) -> Optional[Image]:
+    dockerfile = kwargs.get("dockerfile")
+    if dockerfile is None:
         return None
 
-    image = Image.from_dockerfile(dockerfile)
-    image.dockerfile_path = dockerfile
-    image.ignore_python = True
+    image = image_from_dockerfile_option(dockerfile)
     kwargs["dockerfile"] = image
     return image
 
 
 def _service_image_option(kwargs: Dict) -> Optional[Image]:
-    dockerfile = kwargs.get("dockerfile")
-    if dockerfile is not None:
-        return dockerfile
+    if kwargs.get("dockerfile") is not None and kwargs.get("image") is not None:
+        raise ValueError("Specify either --dockerfile or --image, not both.")
+
+    dockerfile_image = _materialize_dockerfile_image(kwargs)
+    if dockerfile_image is not None:
+        return dockerfile_image
     return kwargs.get("image")
 
 
@@ -164,19 +174,25 @@ def _generate_service_module(name: Optional[str], kwargs: Dict) -> Service:
         default=service_image is not None,
     )
     keep_warm_seconds = kwargs.get("keep_warm_seconds")
+    service_kwargs = {
+        "name": name or os.path.basename(os.getcwd()),
+        "entrypoint": kwargs.get("entrypoint"),
+        "ports": ports,
+        "image": service_image or Image(),
+        "env": env_vars_to_dict(kwargs.get("env")),
+        "keep_warm_seconds": 0 if keep_warm_seconds is None else keep_warm_seconds,
+        "min_replicas": kwargs.get("min_replicas") or 0,
+        "max_replicas": kwargs.get("max_replicas"),
+        "always_on": bool(kwargs.get("always_on")),
+        "pool": kwargs.get("pool"),
+        "tcp": bool(kwargs.get("tcp")),
+    }
+    for key in ("cpu", "memory", "gpu", "gpu_count", "secrets"):
+        value = kwargs.get(key)
+        if value is not None:
+            service_kwargs[key] = value
 
-    return Service(
-        name=name or os.path.basename(os.getcwd()),
-        entrypoint=kwargs.get("entrypoint") or [],
-        ports=ports,
-        image=service_image or Image(),
-        env=env_vars_to_dict(kwargs.get("env")),
-        keep_warm_seconds=0 if keep_warm_seconds is None else keep_warm_seconds,
-        min_replicas=kwargs.get("min_replicas") or 0,
-        max_replicas=kwargs.get("max_replicas"),
-        always_on=bool(kwargs.get("always_on")),
-        pool=kwargs.get("pool"),
-    )
+    return Service(**service_kwargs)
 
 
 def _release_deployment_grpc_refs(user_obj) -> None:
@@ -270,11 +286,19 @@ def create_deployment(
                     user_obj.set_handler(f"{module_name}:{obj_name}")
 
             else:
-                _autodetect_dockerfile(kwargs)
-                if entrypoint or _service_image_option(kwargs) is not None:
-                    user_obj = _generate_service_module(name, kwargs)
-                else:
-                    terminal.error("No handler, entrypoint, image, or Dockerfile specified")
+                try:
+                    _autodetect_dockerfile(kwargs)
+                    if (
+                        entrypoint
+                        or kwargs.get("dockerfile") is not None
+                        or kwargs.get("image") is not None
+                    ):
+                        user_obj = _generate_service_module(name, kwargs)
+                    else:
+                        terminal.error("No handler, entrypoint, image, or Dockerfile specified")
+                        return
+                except (OSError, ValueError) as exc:
+                    terminal.error(f"Invalid service configuration: {exc}")
                     return
 
             if not handle_config_override(user_obj, kwargs):

--- a/sdk/src/beta9/cli/extraclick.py
+++ b/sdk/src/beta9/cli/extraclick.py
@@ -14,6 +14,7 @@ from ..abstractions import base as base_abstraction
 from ..abstractions.image import Image
 from ..channel import ServiceClient, with_grpc_error_handling
 from ..clients.gateway import (
+    SecretVar,
     StringList,
 )
 from ..config import DEFAULT_CONTEXT_NAME, get_config_context
@@ -262,10 +263,17 @@ class DockerfileParser(click.ParamType):
             terminal.error(f"Dockerfile not found: {value}")
             return None
 
-        image = Image.from_dockerfile(value)
-        image.dockerfile_path = value
-        image.ignore_python = True
-        return image
+        return value
+
+
+def image_from_dockerfile_option(value) -> Image:
+    if isinstance(value, Image):
+        return value
+
+    image = Image.from_dockerfile(str(value))
+    image.dockerfile_path = str(value)
+    image.ignore_python = True
+    return image
 
 
 class ShlexParser(click.ParamType):
@@ -428,6 +436,15 @@ def handle_config_override(func, kwargs: Dict[str, str]) -> bool:
                     )
                     continue
 
+                if key == "secrets":
+                    secrets = [value] if isinstance(value, str) else value
+                    setattr(
+                        config_class_instance,
+                        "secrets",
+                        [SecretVar(name=str(secret)) for secret in secrets],
+                    )
+                    continue
+
                 if key == "pool" and hasattr(config_class_instance, "parse_pool"):
                     setattr(config_class_instance, "pool", value)
                     setattr(
@@ -453,7 +470,9 @@ def handle_config_override(func, kwargs: Dict[str, str]) -> bool:
             config_class_instance.configure_replicas(**replica_args)
 
         if kwargs.get("dockerfile") is not None:
-            config_class_instance.image = kwargs["dockerfile"]
+            image = image_from_dockerfile_option(kwargs["dockerfile"])
+            kwargs["dockerfile"] = image
+            config_class_instance.image = image
 
         return True
     except BaseException as e:

--- a/sdk/tests/test_service.py
+++ b/sdk/tests/test_service.py
@@ -1,14 +1,24 @@
+import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase, mock
-from pathlib import Path
 
 from beta9 import Image, Service
-from beta9.abstractions.service import ports_from_dockerfile, service_image_implies_default_port
+from beta9.abstractions.service import (
+    command_from_dockerfile,
+    ports_from_dockerfile,
+    service_image_implies_default_port,
+)
 from beta9.cli.deployment import (
     _generate_service_module,
     _merge_port_options,
+    _service_image_option,
 )
-from beta9.cli.extraclick import handle_config_override
+from beta9.cli.extraclick import (
+    DockerfileParser,
+    handle_config_override,
+    image_from_dockerfile_option,
+)
 
 
 class TestService(TestCase):
@@ -37,6 +47,22 @@ class TestService(TestCase):
 
         self.assertEqual(service.ports, [3000])
         self.assertIn("PORT=9000", service.env)
+
+    def test_bare_memory_string_is_megabytes(self):
+        service = Service(command="npm run start", port=3000, memory="512")
+
+        self.assertEqual(service.memory, 512)
+
+    def test_memory_string_accepts_common_units(self):
+        self.assertEqual(Service(command="x", memory="512MB").memory, 512)
+        self.assertEqual(Service(command="x", memory="512m").memory, 512)
+        self.assertEqual(Service(command="x", memory="512Mi").memory, 512)
+        self.assertEqual(Service(command="x", memory="512MiB").memory, 512)
+        self.assertEqual(Service(command="x", memory="0.5Gi").memory, 512)
+        self.assertEqual(Service(command="x", memory="1GB").memory, 1000)
+        self.assertEqual(Service(command="x", memory="1g").memory, 1000)
+        self.assertEqual(Service(command="x", memory="1Gi").memory, 1024)
+        self.assertEqual(Service(command="x", memory="1GiB").memory, 1024)
 
     def test_image_entrypoint_can_be_used_without_command(self):
         service = Service(image=Image.from_id("img-123"), ports=[8080])
@@ -127,6 +153,27 @@ class TestService(TestCase):
         self.assertEqual(service.ports, [8000])
         self.assertIn("PORT=8000", service.env)
 
+    def test_generate_service_module_applies_resource_options(self):
+        image = Image.from_id("img-123")
+        kwargs = {
+            "dockerfile": None,
+            "image": image,
+            "entrypoint": None,
+            "ports": [8080],
+            "env": (),
+            "cpu": 0.25,
+            "memory": "0.5Gi",
+            "secrets": ["API_TOKEN"],
+            "tcp": True,
+        }
+
+        service = _generate_service_module("image-app", kwargs)
+
+        self.assertEqual(service.cpu, 250)
+        self.assertEqual(service.memory, 512)
+        self.assertEqual([secret.name for secret in service.secrets], ["API_TOKEN"])
+        self.assertTrue(service.tcp)
+
     def test_empty_cli_port_override_preserves_inferred_service_port(self):
         image = Image.from_id("img-123")
         kwargs = {
@@ -152,6 +199,28 @@ class TestService(TestCase):
         self.assertEqual(service.autoscaler.min_containers, 2)
         self.assertEqual(service.autoscaler.max_containers, 3)
 
+    def test_cli_secret_override_keeps_gateway_secret_shape(self):
+        service = Service(image=Image.from_id("img-123"), ports=[8080])
+        kwargs = {"secrets": ["API_TOKEN"]}
+
+        self.assertTrue(handle_config_override(service, kwargs))
+
+        self.assertEqual([secret.name for secret in service.secrets], ["API_TOKEN"])
+
+    def test_cli_secret_override_accepts_single_secret_string(self):
+        service = Service(image=Image.from_id("img-123"), ports=[8080])
+        kwargs = {"secrets": "API_TOKEN"}
+
+        self.assertTrue(handle_config_override(service, kwargs))
+
+        self.assertEqual([secret.name for secret in service.secrets], ["API_TOKEN"])
+
+    def test_service_image_option_rejects_image_and_dockerfile_together(self):
+        kwargs = {"dockerfile": "Dockerfile", "image": Image.from_id("img-123")}
+
+        with self.assertRaisesRegex(ValueError, "either --dockerfile or --image"):
+            _service_image_option(kwargs)
+
     def test_generate_service_module_infers_dockerfile_exposed_port(self):
         image = Image()
         image.dockerfile = "FROM python:3.12-slim\nEXPOSE 5000/tcp 9000\n"
@@ -167,6 +236,91 @@ class TestService(TestCase):
 
         self.assertEqual(service.ports, [5000, 9000])
         self.assertIn("PORT=7000", service.env)
+
+    def test_service_infers_exec_form_dockerfile_cmd(self):
+        image = Image()
+        image.dockerfile = 'FROM node:20-alpine\nEXPOSE 8080\nCMD ["node", "server.js"]\n'
+
+        service = Service(image=image)
+
+        self.assertEqual(service.entrypoint, ["node", "server.js"])
+        self.assertEqual(service.ports, [8080])
+        self.assertIn("PORT=8080", service.env)
+
+    def test_service_infers_shell_form_dockerfile_cmd(self):
+        image = Image()
+        image.dockerfile = "FROM node:20-alpine\nCMD npm start\n"
+
+        service = Service(image=image)
+
+        self.assertEqual(service.entrypoint, ["sh", "-lc", "npm start"])
+
+    def test_dockerfile_entrypoint_and_cmd_are_combined(self):
+        image = Image()
+        image.dockerfile = 'ENTRYPOINT ["node"]\nCMD ["server.js"]\n'
+
+        self.assertEqual(command_from_dockerfile(image), ["node", "server.js"])
+
+    def test_dockerfile_exec_form_errors_are_actionable(self):
+        image = Image()
+        image.dockerfile = 'CMD ["node",]\n'
+
+        with self.assertRaisesRegex(ValueError, "JSON string array"):
+            command_from_dockerfile(image)
+
+    def test_dockerfile_command_parser_ignores_comments_outside_quotes(self):
+        image = Image()
+        image.dockerfile = 'CMD ["node", "server#prod.js"] # inline comment\n'
+
+        self.assertEqual(command_from_dockerfile(image), ["node", "server#prod.js"])
+
+    @mock.patch("beta9.abstractions.image.Image.sync_files")
+    def test_generate_service_module_materializes_dockerfile_path_and_infers_command(
+        self, sync_files_mock
+    ):
+        with TemporaryDirectory() as tmpdir:
+            dockerfile = Path(tmpdir) / "Dockerfile"
+            dockerfile.write_text('FROM node:20-alpine\nEXPOSE 8080\nCMD ["node", "server.js"]\n')
+            kwargs = {
+                "dockerfile": str(dockerfile),
+                "image": None,
+                "entrypoint": None,
+                "ports": [],
+                "env": (),
+            }
+
+            service = _generate_service_module("dockerfile-app", kwargs)
+
+        self.assertIsInstance(kwargs["dockerfile"], Image)
+        self.assertEqual(service.entrypoint, ["node", "server.js"])
+        self.assertEqual(service.ports, [8080])
+        self.assertIn("PORT=8080", service.env)
+        sync_files_mock.assert_called_once_with(str(Path(tmpdir)))
+
+    def test_dockerfile_parser_does_not_sync_during_click_parsing(self):
+        with TemporaryDirectory() as tmpdir:
+            dockerfile = Path(tmpdir) / "Dockerfile"
+            dockerfile.write_text("FROM node:20-alpine\n")
+
+            with mock.patch("beta9.abstractions.image.Image.from_dockerfile") as from_dockerfile:
+                parsed = DockerfileParser().convert(str(dockerfile), None, None)
+
+        self.assertEqual(parsed, str(dockerfile))
+        from_dockerfile.assert_not_called()
+
+    @mock.patch("beta9.abstractions.image.Image.sync_files")
+    def test_dockerfile_option_uses_current_directory_for_root_dockerfile(self, sync_files_mock):
+        with TemporaryDirectory() as tmpdir:
+            dockerfile = Path(tmpdir) / "Dockerfile"
+            dockerfile.write_text("FROM node:20-alpine\n")
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                image_from_dockerfile_option("Dockerfile")
+            finally:
+                os.chdir(previous_cwd)
+
+        sync_files_mock.assert_called_once_with(".")
 
     def test_ports_from_dockerfile_ignores_comments_and_protocols(self):
         image = Image()

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "beta9"
-version = "0.1.247"
+version = "0.1.248"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds graceful drain mode to the gateway and pod proxy to make rollouts safer, and improves SDK service inference from Dockerfiles and resource config. Requests are cleanly closed during drain, readiness is gated, and CLI/Dockerfile parsing is more robust.

- **New Features**
  - Gateway drain mode: sets `Connection: close`, gates readiness in `/api/v1/health`, adds `/api/v1/health/live`, and caps gRPC graceful-stop with a max wait.
  - Pod proxy is drain-aware: rejects new and queued HTTP/TCP requests with 503 “Service is draining,” and closes TCP connections during drain.
  - SDK service ergonomics:
    - Parse Dockerfile `EXPOSE`, `CMD`, and `ENTRYPOINT` (handles shell/exec forms, comments, and continuations) to infer ports and entrypoint.
    - Memory strings accept common units (`MB`, `MiB`, `GB`, `GiB`, bare numbers) and normalize to MB.
    - CLI: `--dockerfile` is materialized later (no build during click parsing), supports `--secrets`, and rejects `--dockerfile` + `--image` together.

- **Bug Fixes and Dependencies**
  - Set gateway/controller `terminationGracePeriodSeconds` to 195 to align with shutdown and readiness propagation.
  - Ensure `Connection: close` is sent on drain rejections to avoid keep-alives.
  - `Image.from_dockerfile` uses “.” when the Dockerfile path has no directory.
  - README updates “Fast Image Builds” to “Fast Cold Starts.”
  - Bump `beta9` SDK to 0.1.248.

<sup>Written for commit 130a6679b2c474988f948fc1d049202e337a73ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

