### PR TITLE
Fix pod service scale reload convergence

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -557,9 +557,40 @@ func (c *InstanceController) Load(filter *types.DeploymentFilter) error {
 			log.Error().Str("instance_name", stub.Stub.ExternalId).Err(err).Msg("unable to sync instance")
 			continue
 		}
+		c.queuePostSyncScale(stub, instance)
 	}
 
 	return nil
+}
+
+func (c *InstanceController) queuePostSyncScale(stub types.DeploymentWithRelated, instance IAutoscaledInstance) {
+	// Manual scale changes update autoscaler bounds; queue a scale tick now so
+	// fixed replica counts converge without waiting for the next autoscaler sample.
+	instance.ConsumeScaleResult(&AutoscalerResult{DesiredContainers: c.postSyncDesiredContainers(stub.Stub), ResultValid: true})
+}
+
+func (c *InstanceController) postSyncDesiredContainers(stub types.Stub) int {
+	config, err := stub.UnmarshalConfig()
+	if err != nil || config == nil || config.Autoscaler == nil || config.Autoscaler.MinContainers > 0 {
+		return 0
+	}
+	if c.containerRepo == nil {
+		return 0
+	}
+
+	containers, err := c.containerRepo.GetActiveContainersByStubId(stub.ExternalId)
+	if err != nil {
+		log.Error().Str("stub_id", stub.ExternalId).Err(err).Msg("unable to count active containers")
+		return 0
+	}
+
+	count := 0
+	for _, container := range containers {
+		if container.Status == types.ContainerStatusRunning || container.Status == types.ContainerStatusPending {
+			count++
+		}
+	}
+	return count
 }
 
 func (c *InstanceController) deactivateInactiveDeployment(stub types.DeploymentWithRelated) error {

--- a/pkg/abstractions/common/instance_test.go
+++ b/pkg/abstractions/common/instance_test.go
@@ -237,6 +237,78 @@ func TestInstanceControllerDeactivatesExistingInactiveDeployment(t *testing.T) {
 	}
 }
 
+func TestInstanceControllerSyncsActiveDeploymentAndQueuesScale(t *testing.T) {
+	controller, _ := newTestInstanceController(t, types.DeploymentWithRelated{
+		Deployment: types.Deployment{Active: true},
+		Stub:       types.Stub{ExternalId: "stub-active", Type: types.StubType(types.StubTypePodDeployment)},
+	})
+
+	if err := controller.Load(&types.DeploymentFilter{ShowDeleted: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	if controller.created != 1 {
+		t.Fatalf("created instances = %d, want 1", controller.created)
+	}
+
+	instance := controller.instances["stub-active"]
+	if instance.syncs != 1 {
+		t.Fatalf("syncs = %d, want 1", instance.syncs)
+	}
+	if len(instance.scaleResults) != 1 || instance.scaleResults[0] != 0 {
+		t.Fatalf("scale results = %v, want [0]", instance.scaleResults)
+	}
+}
+
+func TestInstanceControllerScaleToZeroPreservesRunningDeploymentContainers(t *testing.T) {
+	config := &types.StubConfigV1{
+		Autoscaler: &types.Autoscaler{
+			Type:              types.QueueDepthAutoscaler,
+			MinContainers:     0,
+			MaxContainers:     2,
+			TasksPerContainer: 1,
+		},
+	}
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controller, containerRepo := newTestInstanceController(t, types.DeploymentWithRelated{
+		Deployment: types.Deployment{Active: true},
+		Stub: types.Stub{
+			ExternalId: "stub-scale-to-zero",
+			Type:       types.StubType(types.StubTypePodDeployment),
+			Config:     string(configBytes),
+		},
+	})
+
+	for _, containerID := range []string{"pod-stub-scale-to-zero-00000000", "pod-stub-scale-to-zero-11111111"} {
+		state := &types.ContainerState{
+			ContainerId: containerID,
+			StubId:      "stub-scale-to-zero",
+			WorkspaceId: "workspace",
+			Status:      types.ContainerStatusRunning,
+			ScheduledAt: time.Now().Unix(),
+			StartedAt:   time.Now().Unix(),
+			Cpu:         100,
+			Memory:      128,
+		}
+		if err := containerRepo.SetContainerState(state.ContainerId, state); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := controller.Load(&types.DeploymentFilter{ShowDeleted: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := controller.instances["stub-scale-to-zero"]
+	if len(instance.scaleResults) != 1 || instance.scaleResults[0] != 2 {
+		t.Fatalf("scale results = %v, want [2]", instance.scaleResults)
+	}
+}
+
 func TestInstanceControllerCreatesInactiveDeploymentOnlyForStaleContainers(t *testing.T) {
 	controller, containerRepo := newTestInstanceController(t, types.DeploymentWithRelated{
 		Deployment: types.Deployment{Active: false},
@@ -367,10 +439,13 @@ func (r *testInstanceControllerBackendRepo) ListDeploymentsWithRelated(ctx conte
 
 type testAutoscaledInstance struct {
 	syncs         int
+	scaleResults  []int
 	scalingEvents []int
 }
 
-func (i *testAutoscaledInstance) ConsumeScaleResult(*AutoscalerResult) {}
+func (i *testAutoscaledInstance) ConsumeScaleResult(result *AutoscalerResult) {
+	i.scaleResults = append(i.scaleResults, result.DesiredContainers)
+}
 
 func (i *testAutoscaledInstance) ConsumeContainerEvent(types.ContainerEvent) {}
 

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -559,7 +559,7 @@ func TestScaleStubEnablesScaleToZeroAndReloads(t *testing.T) {
 	mock.ExpectExec("UPDATE stub").WithArgs(stubConfigJSONArg{check: func(config *types.StubConfigV1) bool {
 		return config.Autoscaler != nil &&
 			config.Autoscaler.MinContainers == 0 &&
-			config.Autoscaler.MaxContainers == 1
+			config.Autoscaler.MaxContainers == 2
 	}}, 11).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	body, _ := json.Marshal(ScaleStubRequest{Containers: 0})

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -730,7 +730,9 @@ func (c *StubConfigV1) SetReplicaCount(containers uint) {
 	}
 	if containers == 0 {
 		c.Autoscaler.MinContainers = 0
-		c.Autoscaler.MaxContainers = 1
+		if c.Autoscaler.MaxContainers == 0 {
+			c.Autoscaler.MaxContainers = 1
+		}
 		return
 	}
 	c.Autoscaler.MinContainers = containers

--- a/pkg/types/backend_test.go
+++ b/pkg/types/backend_test.go
@@ -181,3 +181,20 @@ func TestStubConfigSetReplicaCountPreservesAutoscalerType(t *testing.T) {
 		t.Fatalf("replica bounds = %d/%d, want 2/2", config.Autoscaler.MinContainers, config.Autoscaler.MaxContainers)
 	}
 }
+
+func TestStubConfigSetReplicaCountZeroPreservesAutoscalerCeiling(t *testing.T) {
+	config := &StubConfigV1{
+		Autoscaler: &Autoscaler{
+			Type:              QueueDepthAutoscaler,
+			MinContainers:     2,
+			MaxContainers:     4,
+			TasksPerContainer: 1,
+		},
+	}
+
+	config.SetReplicaCount(0)
+
+	if config.Autoscaler.MinContainers != 0 || config.Autoscaler.MaxContainers != 4 {
+		t.Fatalf("replica bounds = %d/%d, want 0/4", config.Autoscaler.MinContainers, config.Autoscaler.MaxContainers)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make pod service scale converge immediately on reload by queuing a post-sync scale tick and preserving running pods when scaling to zero. Also keep the autoscaler ceiling when setting replicas to zero.

- **Bug Fixes**
  - Queue a post-sync scale evaluation after instance sync so manual scale bounds apply right away.
  - For scale-to-zero, set desired replicas to the count of running/pending containers to avoid dropping live pods on reload.
  - In `SetReplicaCount(0)`, preserve `Autoscaler.MaxContainers` (only default to 1 if it was 0); tests updated accordingly.

<sup>Written for commit 53f2560cc56fe7a5c0901da17e4b1c9ea5fdc74b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

