### PR TITLE
bump sdk

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.248"
+version = "0.1.249"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/cli/disk.py
+++ b/sdk/src/beta9/cli/disk.py
@@ -21,7 +21,7 @@ from .extraclick import ClickManagementGroup
 
 @click.group(
     name="disk",
-    help="Manage durable disks.",
+    help="Manage disks (durable, fixed-size block storage on local SSD/NVMe).",
     cls=ClickManagementGroup,
 )
 def management():
@@ -128,7 +128,7 @@ def _print_snapshot_table(snapshots: Iterable) -> None:
 
 @management.command(
     name="list",
-    help="List available durable disks.",
+    help="List available disks.",
 )
 @_format_option
 @extraclick.pass_service_client
@@ -148,7 +148,7 @@ def list_disks(service: ServiceClient, format: str):
 
 @management.command(
     name="create",
-    help="Create a new durable disk.",
+    help="Create a new disk.",
 )
 @click.argument(
     "name",
@@ -205,7 +205,7 @@ def create_disk(
 
 @management.command(
     name="delete",
-    help="Delete a durable disk.",
+    help="Delete a disk.",
 )
 @click.argument(
     "name",
@@ -235,7 +235,7 @@ def delete_disk(service: ServiceClient, name: str, yes: bool):
 
 @management.command(
     name="snapshots",
-    help="List snapshots for a durable disk.",
+    help="List snapshots for a disk.",
 )
 @click.argument(
     "name",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `beta9` SDK to 0.1.249 and clarify the disk CLI help. The disk group and its list, create, delete, and snapshots commands now say “disk” (not “durable disk”) and include a brief SSD/NVMe description.

<sup>Written for commit be3204c880d9fc65f7d58f32b6b3e4a059982eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

