### PR TITLE
fix some disk edge cases

### DIFF
--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -47,6 +47,9 @@ type AppWithLatestStubOrDeployment struct {
 	types.App
 	Stub              *types.StubWithRelated       `json:"stub,omitempty" serializer:"stub"`
 	Deployment        *types.DeploymentWithRelated `json:"deployment,omitempty" serializer:"deployment"`
+	URL               string                       `json:"url,omitempty" serializer:"url,omitempty"`
+	InvokeURL         string                       `json:"invoke_url,omitempty" serializer:"invoke_url,omitempty"`
+	ConnectionURL     string                       `json:"connection_url,omitempty" serializer:"connection_url,omitempty"`
 	PoolName          string                       `json:"pool_name" serializer:"pool_name"`
 	RunningContainers int                          `json:"running_containers" serializer:"running_containers"`
 	IsService         bool                         `json:"is_service" serializer:"is_service"`
@@ -109,10 +112,12 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 
 		if deployment, ok := deploymentsByApp[apps.Data[i].ExternalId]; ok {
 			deploymentCopy := deployment
-			enrichAppWithStubConfig(&appsWithLatest.Data[i], &deploymentCopy.Stub)
+			a.enrichAppWithStubConfig(ctx.Request().Context(), &workspace, &appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment)
 			if deploymentCopy.Stub.ExternalId != "" {
 				latestStubIndexes[deploymentCopy.Stub.ExternalId] = append(latestStubIndexes[deploymentCopy.Stub.ExternalId], i)
 			}
+			deploymentCopy.URL = appsWithLatest.Data[i].URL
+			deploymentCopy.InvokeURL = appsWithLatest.Data[i].InvokeURL
 			if err := deploymentCopy.Stub.SanitizeConfig(); err != nil {
 				return HTTPInternalServerError("Failed to sanitize stub config")
 			}
@@ -126,7 +131,7 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		}
 
 		stubCopy := stub
-		enrichAppWithStubConfig(&appsWithLatest.Data[i], &stubCopy.Stub)
+		a.enrichAppWithStubConfig(ctx.Request().Context(), &workspace, &appsWithLatest.Data[i], &stubCopy.Stub, nil)
 		if stubCopy.Stub.ExternalId != "" {
 			latestStubIndexes[stubCopy.Stub.ExternalId] = append(latestStubIndexes[stubCopy.Stub.ExternalId], i)
 		}
@@ -177,7 +182,7 @@ func countRunningContainersByStubID(containerRepo repository.ContainerRepository
 	return runningByStubID, nil
 }
 
-func enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, stub *types.Stub) {
+func (a *AppGroup) enrichAppWithStubConfig(ctx context.Context, workspace *types.Workspace, app *AppWithLatestStubOrDeployment, stub *types.Stub, deployment *types.Deployment) {
 	if stub == nil {
 		return
 	}
@@ -194,29 +199,87 @@ func enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, stub *types.Stu
 		}
 	}
 	app.IsService = config.IsService
-	app.Serving = config.EffectiveServingConfig()
+	app.Serving = cloneServingConfig(config.EffectiveServingConfig())
+	app.URL = a.appURL(stub, config, deployment)
+	app.InvokeURL = app.URL
+	if connectionURL := a.databaseConnectionURL(ctx, workspace, app.Serving); connectionURL != "" {
+		app.ConnectionURL = connectionURL
+		app.Serving.Database.ConnectionURL = connectionURL
+	}
 }
 
-func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspaceID uint, app types.App) (AppWithLatestStubOrDeployment, error) {
+func cloneServingConfig(serving *types.ServingConfig) *types.ServingConfig {
+	if serving == nil {
+		return nil
+	}
+	clone := *serving
+	if serving.Database != nil {
+		database := *serving.Database
+		clone.Database = &database
+	}
+	if serving.LLM != nil {
+		llm := *serving.LLM
+		clone.LLM = &llm
+	}
+	return &clone
+}
+
+func (a *AppGroup) appURL(stub *types.Stub, config *types.StubConfigV1, deployment *types.Deployment) string {
+	stubWithRelated := &types.StubWithRelated{Stub: *stub}
+	if stub.Type.Kind() == types.StubTypePod || stub.Type.Kind() == types.StubTypeSandbox {
+		externalURL := a.config.GatewayService.HTTP.GetExternalURL()
+		urlType := a.config.GatewayService.InvokeURLType
+		if config.TCP {
+			externalURL = a.config.Abstractions.Pod.TCP.GetExternalURL()
+			urlType = common.InvokeUrlTypeHost
+		}
+		if deployment != nil {
+			return common.BuildPodDeploymentURL(externalURL, urlType, deployment, config)
+		}
+		return common.BuildPodURL(externalURL, urlType, stubWithRelated, config)
+	}
+	if deployment != nil {
+		return common.BuildDeploymentURL(a.config.GatewayService.HTTP.GetExternalURL(), a.config.GatewayService.InvokeURLType, stubWithRelated, deployment)
+	}
+	return common.BuildStubURL(a.config.GatewayService.HTTP.GetExternalURL(), a.config.GatewayService.InvokeURLType, stubWithRelated)
+}
+
+func (a *AppGroup) databaseConnectionURL(ctx context.Context, workspace *types.Workspace, serving *types.ServingConfig) string {
+	if workspace == nil || serving == nil || serving.Database == nil || serving.Database.ConnectionURLSecretName == "" {
+		return ""
+	}
+	secret, err := a.backendRepo.GetSecretByNameDecrypted(ctx, workspace, serving.Database.ConnectionURLSecretName)
+	if err != nil {
+		log.Warn().Err(err).Str("secret_name", serving.Database.ConnectionURLSecretName).Msg("failed to load database connection url")
+		return ""
+	}
+	return secret.Value
+}
+
+func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace *types.Workspace, app types.App) (AppWithLatestStubOrDeployment, error) {
 	appWithLatest := AppWithLatestStubOrDeployment{App: app}
 
-	deploymentsByApp, err := a.backendRepo.ListLatestDeploymentsByAppIDs(ctx, workspaceID, []string{app.ExternalId})
+	deploymentsByApp, err := a.backendRepo.ListLatestDeploymentsByAppIDs(ctx, workspace.Id, []string{app.ExternalId})
 	if err != nil {
 		return appWithLatest, err
 	}
 	if deployment, ok := deploymentsByApp[app.ExternalId]; ok {
 		deploymentCopy := deployment
-		enrichAppWithStubConfig(&appWithLatest, &deploymentCopy.Stub)
+		a.enrichAppWithStubConfig(ctx, workspace, &appWithLatest, &deploymentCopy.Stub, &deploymentCopy.Deployment)
+		deploymentCopy.URL = appWithLatest.URL
+		deploymentCopy.InvokeURL = appWithLatest.InvokeURL
+		appWithLatest.Deployment = &deploymentCopy
 		return appWithLatest, nil
 	}
 
-	stubsByApp, err := a.backendRepo.ListLatestStubsByAppIDs(ctx, workspaceID, []string{app.ExternalId})
+	stubsByApp, err := a.backendRepo.ListLatestStubsByAppIDs(ctx, workspace.Id, []string{app.ExternalId})
 	if err != nil {
 		return appWithLatest, err
 	}
 	if stub, ok := stubsByApp[app.ExternalId]; ok {
 		stubCopy := stub
-		enrichAppWithStubConfig(&appWithLatest, &stubCopy.Stub)
+		a.enrichAppWithStubConfig(ctx, workspace, &appWithLatest, &stubCopy.Stub, nil)
+		appWithLatest.Stub = &stubCopy
 	}
 
 	return appWithLatest, nil
@@ -283,7 +346,7 @@ func (a *AppGroup) RetrieveApp(ctx echo.Context) error {
 		return HTTPNotFound()
 	}
 
-	appWithLatest, err := a.appWithLatestStubOrDeployment(ctx.Request().Context(), workspace.Id, *app)
+	appWithLatest, err := a.appWithLatestStubOrDeployment(ctx.Request().Context(), &workspace, *app)
 	if err != nil {
 		return HTTPInternalServerError("Failed to get app metadata")
 	}

--- a/pkg/api/v1/app_test.go
+++ b/pkg/api/v1/app_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	repoCommon "github.com/beam-cloud/beta9/pkg/repository/common"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -22,6 +23,7 @@ type appBackendRepo struct {
 	apps             repoCommon.CursorPaginationInfo[types.App]
 	deploymentsByApp map[string][]types.DeploymentWithRelated
 	stubsByApp       map[string][]types.StubWithRelated
+	secrets          map[string]string
 }
 
 type appContainerRepo struct {
@@ -81,6 +83,17 @@ func (r *appBackendRepo) ListLatestStubsByAppIDs(_ context.Context, _ uint, appE
 		}
 	}
 	return stubs, nil
+}
+
+func (r *appBackendRepo) GetSecretByNameDecrypted(_ context.Context, workspace *types.Workspace, name string) (*types.Secret, error) {
+	if workspace == nil || r.workspace == nil || workspace.Id != r.workspace.Id {
+		return nil, errors.New("workspace not found")
+	}
+	value, ok := r.secrets[name]
+	if !ok {
+		return nil, errors.New("secret not found")
+	}
+	return &types.Secret{Name: name, Value: value, WorkspaceId: workspace.Id}, nil
 }
 
 func TestListAppWithLatestActivityAllowsAppsWithoutActivity(t *testing.T) {
@@ -327,13 +340,131 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 	}
 }
 
+func TestListAppWithLatestActivityIncludesDatabaseURLs(t *testing.T) {
+	workspace := &types.Workspace{Id: 1, ExternalId: "workspace-1", Name: "Workspace 1"}
+	appWithDatabase := types.App{Id: 1, ExternalId: "app-db", Name: "App DB", WorkspaceId: workspace.Id}
+	connectionURL := "rediss://default:password@redis-a1b2c3d-latest-6379.svc.stage.beam.cloud:443/0"
+
+	appGroup := &AppGroup{
+		config: types.AppConfig{
+			GatewayService: types.GatewayServiceConfig{
+				InvokeURLType: common.InvokeUrlTypeHost,
+				HTTP: types.HTTPConfig{
+					TLS:          true,
+					ExternalHost: "app.stage.beam.cloud",
+					ExternalPort: 443,
+				},
+			},
+			Abstractions: types.AbstractionConfig{
+				Pod: types.PodConfig{
+					TCP: types.PodTCPConfig{
+						Enabled:      true,
+						ExternalHost: "svc.stage.beam.cloud",
+						ExternalPort: 443,
+					},
+				},
+			},
+		},
+		backendRepo: &appBackendRepo{
+			workspace: workspace,
+			apps: repoCommon.CursorPaginationInfo[types.App]{
+				Data: []types.App{appWithDatabase},
+				Next: "",
+			},
+			deploymentsByApp: map[string][]types.DeploymentWithRelated{
+				appWithDatabase.ExternalId: {
+					{
+						Deployment: types.Deployment{
+							ExternalId:  "deployment-db",
+							Name:        "luke-staging-redis",
+							Subdomain:   "redis-a1b2c3d",
+							Version:     1,
+							WorkspaceId: workspace.Id,
+							AppId:       appWithDatabase.Id,
+						},
+						Stub: types.Stub{
+							Id:          1,
+							ExternalId:  "stub-db",
+							Name:        "Stub DB",
+							Type:        types.StubType(types.StubTypePodDeployment),
+							Config:      `{"is_service":true,"tcp":true,"ports":[6379],"serving":{"app_kind":"database","serving_protocol":"redis","database":{"kind":"redis","port":6379,"connection_env_name":"REDIS_URL","connection_url_secret_name":"BETA9_REDIS_URL"}}}`,
+							WorkspaceId: workspace.Id,
+							AppId:       appWithDatabase.Id,
+						},
+						Workspace: *workspace,
+						App:       appWithDatabase,
+					},
+				},
+			},
+			secrets: map[string]string{
+				"BETA9_REDIS_URL": connectionURL,
+			},
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/workspace-1/latest", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("workspaceId")
+	ctx.SetParamValues(workspace.ExternalId)
+
+	err := appGroup.ListAppWithLatestActivity(&auth.HttpAuthContext{
+		Context: ctx,
+		AuthInfo: &auth.AuthInfo{
+			Workspace: workspace,
+			Token:     &types.Token{TokenType: types.TokenTypeWorkspacePrimary},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var response struct {
+		Data []struct {
+			ID            string `json:"id"`
+			URL           string `json:"url"`
+			InvokeURL     string `json:"invoke_url"`
+			ConnectionURL string `json:"connection_url"`
+			Deployment    struct {
+				URL       string `json:"url"`
+				InvokeURL string `json:"invoke_url"`
+			} `json:"deployment"`
+			Serving struct {
+				Database struct {
+					ConnectionURL string `json:"connection_url"`
+				} `json:"database"`
+			} `json:"serving"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(response.Data) != 1 {
+		t.Fatalf("expected one app, got %d", len(response.Data))
+	}
+
+	app := response.Data[0]
+	expectedURL := "https://redis-a1b2c3d-latest-6379.svc.stage.beam.cloud"
+	if app.URL != expectedURL || app.InvokeURL != expectedURL || app.Deployment.URL != expectedURL || app.Deployment.InvokeURL != expectedURL {
+		t.Fatalf("unexpected urls: %+v", app)
+	}
+	if app.ConnectionURL != connectionURL || app.Serving.Database.ConnectionURL != connectionURL {
+		t.Fatalf("unexpected connection url: %+v", app)
+	}
+}
+
 func TestEnrichAppWithStubConfigHidesDefaultPool(t *testing.T) {
 	app := AppWithLatestStubOrDeployment{}
 	stub := &types.Stub{
 		Config: `{"pool":{"name":"default"},"is_service":true}`,
 	}
 
-	enrichAppWithStubConfig(&app, stub)
+	appGroup := &AppGroup{}
+	appGroup.enrichAppWithStubConfig(context.Background(), nil, &app, stub, nil)
 
 	if app.PoolName != "" {
 		t.Fatalf("expected default pool to be hidden, got %q", app.PoolName)

--- a/pkg/api/v1/deployment.go
+++ b/pkg/api/v1/deployment.go
@@ -402,7 +402,12 @@ func (g *DeploymentGroup) GetURL(ctx echo.Context) error {
 			return HTTPNotFound()
 		}
 
-		invokeUrl := common.BuildStubURL(g.config.GatewayService.HTTP.GetExternalURL(), g.config.GatewayService.InvokeURLType, stub)
+		if stubConfig.Pricing != nil {
+			invokeUrl := common.BuildStubURL(g.config.GatewayService.HTTP.GetExternalURL(), g.config.GatewayService.InvokeURLType, stub)
+			return ctx.JSON(http.StatusOK, map[string]string{"url": invokeUrl})
+		}
+
+		invokeUrl := g.deploymentURL(stub, &deployment.Deployment, stubConfig)
 		return ctx.JSON(http.StatusOK, map[string]string{"url": invokeUrl})
 	}
 
@@ -438,6 +443,19 @@ func (g *DeploymentGroup) GetURL(ctx echo.Context) error {
 		return ctx.JSON(http.StatusOK, map[string]string{"url": invokeUrl})
 	}
 
-	invokeUrl := common.BuildDeploymentURL(g.config.GatewayService.HTTP.GetExternalURL(), g.config.GatewayService.InvokeURLType, stub, &deployment.Deployment)
+	invokeUrl := g.deploymentURL(stub, &deployment.Deployment, stubConfig)
 	return ctx.JSON(http.StatusOK, map[string]string{"url": invokeUrl})
+}
+
+func (g *DeploymentGroup) deploymentURL(stub *types.StubWithRelated, deployment *types.Deployment, stubConfig *types.StubConfigV1) string {
+	if stub.Type.Kind() == types.StubTypePod || stub.Type.Kind() == types.StubTypeSandbox {
+		externalURL := g.config.GatewayService.HTTP.GetExternalURL()
+		urlType := g.config.GatewayService.InvokeURLType
+		if stubConfig.TCP {
+			externalURL = g.config.Abstractions.Pod.TCP.GetExternalURL()
+			urlType = common.InvokeUrlTypeHost
+		}
+		return common.BuildPodDeploymentURL(externalURL, urlType, deployment, stubConfig)
+	}
+	return common.BuildDeploymentURL(g.config.GatewayService.HTTP.GetExternalURL(), g.config.GatewayService.InvokeURLType, stub, deployment)
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -439,7 +439,7 @@ func (g *Gateway) registerServices() error {
 	pb.RegisterVolumeServiceServer(g.grpcServer, vs)
 
 	// Register disk service
-	ds, err := disk.NewGlobalDiskService(g.BackendRepo, g.WorkspaceRepo, g.rootRouteGroup)
+	ds, err := disk.NewGlobalDiskService(g.BackendRepo, g.WorkspaceRepo, g.baseRouteGroup)
 	if err != nil {
 		return err
 	}

--- a/pkg/repository/disk_postgres.go
+++ b/pkg/repository/disk_postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -164,16 +165,23 @@ func (r *PostgresBackendRepository) CreateDiskSnapshot(ctx context.Context, snap
 	if snapshot.Status == "" {
 		snapshot.Status = types.DiskSnapshotStatusPending
 	}
+	var completedAt any
+	if snapshot.CompletedAt.Valid {
+		completedAt = snapshot.CompletedAt.Time
+	} else if diskSnapshotStatusTerminal(snapshot.Status) {
+		completedAt = time.Now()
+	}
 
 	query := fmt.Sprintf(`
 		INSERT INTO disk_snapshot (
 			workspace_id, stub_id, disk_name, format, status, reason, parent_snapshot_id,
 			generation, size_bytes, filesystem, driver, manifest_key, manifest_digest,
 			manifest_size_bytes, chunk_count, logical_size_bytes, stored_size_bytes,
-			bucket_name, object_prefix, source_pool, source_worker_id, source_storage_node_id
+			bucket_name, object_prefix, source_pool, source_worker_id, source_storage_node_id,
+			completed_at
 		) VALUES (
 			$1, NULLIF($2, 0), $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-			$13, $14, $15, $16, $17, $18, $19, $20, $21, $22
+			$13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
 		)
 		RETURNING %s;`, diskSnapshotColumns(""))
 
@@ -201,6 +209,7 @@ func (r *PostgresBackendRepository) CreateDiskSnapshot(ctx context.Context, snap
 		snapshot.SourcePool,
 		snapshot.SourceWorkerId,
 		snapshot.SourceStorageNodeId,
+		completedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/repository/disk_postgres_test.go
+++ b/pkg/repository/disk_postgres_test.go
@@ -39,6 +39,7 @@ func TestCreateDiskSnapshotStoresManifestReference(t *testing.T) {
 			"private-pool",
 			"worker-a",
 			"node-a",
+			nil,
 		).
 		WillReturnRows(diskSnapshotRows().AddRow(
 			uint(1),
@@ -90,6 +91,97 @@ func TestCreateDiskSnapshotStoresManifestReference(t *testing.T) {
 	require.Equal(t, "snapshot-1", snapshot.ExternalId)
 	require.Equal(t, types.DiskSnapshotStatusPending, snapshot.Status)
 	require.Equal(t, "snapshots/workspace/pg-data/snap-1", snapshot.ObjectPrefix)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateDiskSnapshotSetsCompletedAtForTerminalStatus(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	postgresRepo := repo.(*PostgresBackendRepository)
+
+	now := time.Now()
+	mock.ExpectQuery("INSERT INTO disk_snapshot").
+		WithArgs(
+			uint(7),
+			uint(13),
+			"pg-data",
+			types.DiskSnapshotFormatDirV1,
+			types.DiskSnapshotStatusAvailable,
+			"",
+			"",
+			int64(42),
+			int64(10<<30),
+			"ext4",
+			types.DurableDiskDriverSnapshot,
+			"snapshots/workspace/pg-data/snap-1/manifest.json",
+			"sha256:manifest",
+			int64(512),
+			int64(128),
+			int64(10<<30),
+			int64(3<<30),
+			"beta9-workspace-disk-pg-data",
+			"snapshots/workspace/pg-data/snap-1",
+			"private-pool",
+			"worker-a",
+			"node-a",
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(diskSnapshotRows().AddRow(
+			uint(1),
+			"snapshot-1",
+			uint(7),
+			uint(13),
+			"pg-data",
+			types.DiskSnapshotFormatDirV1,
+			types.DiskSnapshotStatusAvailable,
+			"",
+			"",
+			int64(42),
+			int64(10<<30),
+			"ext4",
+			types.DurableDiskDriverSnapshot,
+			"snapshots/workspace/pg-data/snap-1/manifest.json",
+			"sha256:manifest",
+			int64(512),
+			int64(128),
+			int64(10<<30),
+			int64(3<<30),
+			"beta9-workspace-disk-pg-data",
+			"snapshots/workspace/pg-data/snap-1",
+			"private-pool",
+			"worker-a",
+			"node-a",
+			now,
+			now,
+			now,
+			nil,
+		))
+
+	snapshot, err := postgresRepo.CreateDiskSnapshot(context.Background(), &types.DiskSnapshot{
+		WorkspaceId:         7,
+		StubId:              13,
+		DiskName:            "pg-data",
+		Format:              types.DiskSnapshotFormatDirV1,
+		Status:              types.DiskSnapshotStatusAvailable,
+		Generation:          42,
+		SizeBytes:           10 << 30,
+		Filesystem:          "ext4",
+		Driver:              types.DurableDiskDriverSnapshot,
+		ManifestKey:         "snapshots/workspace/pg-data/snap-1/manifest.json",
+		ManifestDigest:      "sha256:manifest",
+		ManifestSizeBytes:   512,
+		ChunkCount:          128,
+		LogicalSizeBytes:    10 << 30,
+		StoredSizeBytes:     3 << 30,
+		ObjectPrefix:        "snapshots/workspace/pg-data/snap-1",
+		SourcePool:          "private-pool",
+		BucketName:          "beta9-workspace-disk-pg-data",
+		SourceWorkerId:      "worker-a",
+		SourceStorageNodeId: "node-a",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, types.DiskSnapshotStatusAvailable, snapshot.Status)
+	require.True(t, snapshot.CompletedAt.Valid)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -293,6 +293,8 @@ type DeploymentWithRelated struct {
 	StubId      string    `serializer:"stub_id,source:stub.id"`
 	AppId       string    `serializer:"app_id,source:app.id"`
 	WorkspaceId string    `serializer:"workspace_id,source:workspace.id"`
+	URL         string    `db:"-" json:"url,omitempty" serializer:"url,omitempty"`
+	InvokeURL   string    `db:"-" json:"invoke_url,omitempty" serializer:"invoke_url,omitempty"`
 }
 
 // @go2proto
@@ -559,6 +561,7 @@ type DatabaseServingConfig struct {
 	Port                    uint32   `json:"port,omitempty" serializer:"port,omitempty"`
 	ReadinessProbe          string   `json:"readiness_probe,omitempty" serializer:"readiness_probe,omitempty"`
 	ConnectionEnvName       string   `json:"connection_env_name,omitempty" serializer:"connection_env_name,omitempty"`
+	ConnectionURL           string   `json:"connection_url,omitempty" serializer:"connection_url,omitempty"`
 	CredentialSecretNames   []string `json:"credential_secret_names,omitempty" serializer:"credential_secret_names,omitempty"`
 	DurabilityMode          string   `json:"durability_mode,omitempty" serializer:"durability_mode,omitempty"`
 	UsernameSecretName      string   `json:"username_secret_name,omitempty" serializer:"username_secret_name,omitempty"`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose accurate app/deployment URLs and database connection URLs, and fix disk snapshot completion handling. Also correct URL generation for TCP/Pod services and register the disk service on the right route group.

- **New Features**
  - Add `url` and `invoke_url` to app and deployment payloads, computed per stub/deployment (includes TCP/Pod host URLs).
  - Surface database `connection_url` by resolving the secret; also include it under `serving.database.connection_url`.

- **Bug Fixes**
  - Set `completed_at` automatically when creating disk snapshots in a terminal status.
  - Fix deployment URL resolution for pods/sandboxes and TCP services in `GetURL` (keep stub URL when pricing is present).
  - Register disk service on `baseRouteGroup` to ensure routes mount correctly.

<sup>Written for commit 0250054351fc3f55c406871b257d66df6c66be1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

