### PR TITLE
fix: cleanup app api

### DIFF
--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -112,13 +112,13 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 
 		if deployment, ok := deploymentsByApp[apps.Data[i].ExternalId]; ok {
 			deploymentCopy := deployment
-			a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment)
+			a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment, false)
 			if deploymentCopy.Stub.ExternalId != "" {
 				latestStubIndexes[deploymentCopy.Stub.ExternalId] = append(latestStubIndexes[deploymentCopy.Stub.ExternalId], i)
 			}
 			deploymentCopy.URL = appsWithLatest.Data[i].URL
 			deploymentCopy.InvokeURL = appsWithLatest.Data[i].InvokeURL
-			if err := deploymentCopy.Stub.SanitizeConfig(); err != nil {
+			if err := sanitizeDeploymentWithRelated(&deploymentCopy); err != nil {
 				return HTTPInternalServerError("Failed to sanitize stub config")
 			}
 			appsWithLatest.Data[i].Deployment = &deploymentCopy
@@ -131,12 +131,12 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		}
 
 		stubCopy := stub
-		a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &stubCopy.Stub, nil)
+		a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &stubCopy.Stub, nil, false)
 		if stubCopy.Stub.ExternalId != "" {
 			latestStubIndexes[stubCopy.Stub.ExternalId] = append(latestStubIndexes[stubCopy.Stub.ExternalId], i)
 		}
 		appsWithLatest.Data[i].Stub = &stubCopy
-		if err := appsWithLatest.Data[i].Stub.SanitizeConfig(); err != nil {
+		if err := sanitizeStubWithRelated(appsWithLatest.Data[i].Stub); err != nil {
 			return HTTPInternalServerError("Failed to sanitize stub config")
 		}
 	}
@@ -184,7 +184,7 @@ func countRunningContainersForStubs(containerRepo repository.ContainerRepository
 	return runningByStubID, nil
 }
 
-func (a *AppGroup) enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, stub *types.Stub, deployment *types.Deployment) {
+func (a *AppGroup) enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, stub *types.Stub, deployment *types.Deployment, includeDatabaseSecretNames bool) {
 	if stub == nil {
 		return
 	}
@@ -202,6 +202,9 @@ func (a *AppGroup) enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, s
 	}
 	app.IsService = config.IsService
 	app.Serving = cloneServingConfig(config.EffectiveServingConfig())
+	if !includeDatabaseSecretNames {
+		clearDatabaseSecretNames(app.Serving)
+	}
 	app.URL = a.appURL(stub, config, deployment)
 	app.InvokeURL = app.URL
 }
@@ -220,6 +223,23 @@ func cloneServingConfig(serving *types.ServingConfig) *types.ServingConfig {
 		clone.LLM = &llm
 	}
 	return &clone
+}
+
+func clearDatabaseSecretNames(serving *types.ServingConfig) {
+	if serving == nil || serving.Database == nil {
+		return
+	}
+	serving.Database.ClearSecretNames()
+}
+
+func sanitizeDeploymentWithRelated(deployment *types.DeploymentWithRelated) error {
+	deployment.Workspace = deployment.Workspace.WithoutPrivateCredentials()
+	return deployment.Stub.SanitizeConfig()
+}
+
+func sanitizeStubWithRelated(stub *types.StubWithRelated) error {
+	stub.Workspace = stub.Workspace.WithoutPrivateCredentials()
+	return stub.SanitizeConfig()
 }
 
 func (a *AppGroup) appURL(stub *types.Stub, config *types.StubConfigV1, deployment *types.Deployment) string {
@@ -243,7 +263,12 @@ func (a *AppGroup) appURL(stub *types.Stub, config *types.StubConfigV1, deployme
 }
 
 func (a *AppGroup) hydrateDatabaseConnectionURL(ctx context.Context, workspace *types.Workspace, app *AppWithLatestStubOrDeployment) {
-	if workspace == nil || workspace.SigningKey == nil || app == nil || app.Serving == nil || app.Serving.Database == nil {
+	if app == nil {
+		return
+	}
+	defer clearDatabaseSecretNames(app.Serving)
+
+	if workspace == nil || workspace.SigningKey == nil || app.Serving == nil || app.Serving.Database == nil {
 		return
 	}
 
@@ -274,9 +299,12 @@ func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace 
 	}
 	if deployment, ok := deploymentsByApp[app.ExternalId]; ok {
 		deploymentCopy := deployment
-		a.enrichAppWithStubConfig(&appWithLatest, &deploymentCopy.Stub, &deploymentCopy.Deployment)
+		a.enrichAppWithStubConfig(&appWithLatest, &deploymentCopy.Stub, &deploymentCopy.Deployment, true)
 		deploymentCopy.URL = appWithLatest.URL
 		deploymentCopy.InvokeURL = appWithLatest.InvokeURL
+		if err := sanitizeDeploymentWithRelated(&deploymentCopy); err != nil {
+			return appWithLatest, err
+		}
 		appWithLatest.Deployment = &deploymentCopy
 		return appWithLatest, nil
 	}
@@ -287,7 +315,10 @@ func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace 
 	}
 	if stub, ok := stubsByApp[app.ExternalId]; ok {
 		stubCopy := stub
-		a.enrichAppWithStubConfig(&appWithLatest, &stubCopy.Stub, nil)
+		a.enrichAppWithStubConfig(&appWithLatest, &stubCopy.Stub, nil, true)
+		if err := sanitizeStubWithRelated(&stubCopy); err != nil {
+			return appWithLatest, err
+		}
 		appWithLatest.Stub = &stubCopy
 	}
 

--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -112,7 +112,7 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 
 		if deployment, ok := deploymentsByApp[apps.Data[i].ExternalId]; ok {
 			deploymentCopy := deployment
-			a.enrichAppWithStubConfig(ctx.Request().Context(), &workspace, &appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment)
+			a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment)
 			if deploymentCopy.Stub.ExternalId != "" {
 				latestStubIndexes[deploymentCopy.Stub.ExternalId] = append(latestStubIndexes[deploymentCopy.Stub.ExternalId], i)
 			}
@@ -131,7 +131,7 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		}
 
 		stubCopy := stub
-		a.enrichAppWithStubConfig(ctx.Request().Context(), &workspace, &appsWithLatest.Data[i], &stubCopy.Stub, nil)
+		a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &stubCopy.Stub, nil)
 		if stubCopy.Stub.ExternalId != "" {
 			latestStubIndexes[stubCopy.Stub.ExternalId] = append(latestStubIndexes[stubCopy.Stub.ExternalId], i)
 		}
@@ -142,7 +142,7 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 	}
 
 	if a.containerRepo != nil && len(latestStubIndexes) > 0 {
-		runningByStubID, err := countRunningContainersByStubID(a.containerRepo, latestStubIndexes)
+		runningByStubID, err := countRunningContainersForStubs(a.containerRepo, workspaceID, latestStubIndexes)
 		if err != nil {
 			return HTTPInternalServerError("Failed to get running containers")
 		}
@@ -165,24 +165,26 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 	)
 }
 
-func countRunningContainersByStubID(containerRepo repository.ContainerRepository, latestStubIndexes map[string][]int) (map[string]int, error) {
+func countRunningContainersForStubs(containerRepo repository.ContainerRepository, workspaceID string, latestStubIndexes map[string][]int) (map[string]int, error) {
 	runningByStubID := make(map[string]int, len(latestStubIndexes))
-	for stubID := range latestStubIndexes {
-		containers, err := containerRepo.GetActiveContainersByStubId(stubID)
-		if err != nil {
-			return nil, err
-		}
+	containers, err := containerRepo.GetActiveContainersByWorkspaceId(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 
-		for _, container := range containers {
-			if container.Status == types.ContainerStatusRunning {
-				runningByStubID[stubID]++
-			}
+	for _, container := range containers {
+		if container.Status != types.ContainerStatusRunning {
+			continue
+		}
+		if _, ok := latestStubIndexes[container.StubId]; ok {
+			runningByStubID[container.StubId]++
 		}
 	}
+
 	return runningByStubID, nil
 }
 
-func (a *AppGroup) enrichAppWithStubConfig(ctx context.Context, workspace *types.Workspace, app *AppWithLatestStubOrDeployment, stub *types.Stub, deployment *types.Deployment) {
+func (a *AppGroup) enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, stub *types.Stub, deployment *types.Deployment) {
 	if stub == nil {
 		return
 	}
@@ -202,10 +204,6 @@ func (a *AppGroup) enrichAppWithStubConfig(ctx context.Context, workspace *types
 	app.Serving = cloneServingConfig(config.EffectiveServingConfig())
 	app.URL = a.appURL(stub, config, deployment)
 	app.InvokeURL = app.URL
-	if connectionURL := a.databaseConnectionURL(ctx, workspace, app.Serving); connectionURL != "" {
-		app.ConnectionURL = connectionURL
-		app.Serving.Database.ConnectionURL = connectionURL
-	}
 }
 
 func cloneServingConfig(serving *types.ServingConfig) *types.ServingConfig {
@@ -244,16 +242,27 @@ func (a *AppGroup) appURL(stub *types.Stub, config *types.StubConfigV1, deployme
 	return common.BuildStubURL(a.config.GatewayService.HTTP.GetExternalURL(), a.config.GatewayService.InvokeURLType, stubWithRelated)
 }
 
-func (a *AppGroup) databaseConnectionURL(ctx context.Context, workspace *types.Workspace, serving *types.ServingConfig) string {
-	if workspace == nil || serving == nil || serving.Database == nil || serving.Database.ConnectionURLSecretName == "" {
-		return ""
+func (a *AppGroup) hydrateDatabaseConnectionURL(ctx context.Context, workspace *types.Workspace, app *AppWithLatestStubOrDeployment) {
+	if workspace == nil || workspace.SigningKey == nil || app == nil || app.Serving == nil || app.Serving.Database == nil {
+		return
 	}
-	secret, err := a.backendRepo.GetSecretByNameDecrypted(ctx, workspace, serving.Database.ConnectionURLSecretName)
+
+	name := app.Serving.Database.ConnectionURLSecretName
+	if name == "" {
+		return
+	}
+
+	secrets, err := a.backendRepo.GetSecretsByNameDecrypted(ctx, workspace, []string{name})
 	if err != nil {
-		log.Warn().Err(err).Str("secret_name", serving.Database.ConnectionURLSecretName).Msg("failed to load database connection url")
-		return ""
+		log.Warn().Err(err).Str("secret_name", name).Msg("failed to load database connection url")
+		return
 	}
-	return secret.Value
+	if len(secrets) == 0 {
+		return
+	}
+
+	app.ConnectionURL = secrets[0].Value
+	app.Serving.Database.ConnectionURL = secrets[0].Value
 }
 
 func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace *types.Workspace, app types.App) (AppWithLatestStubOrDeployment, error) {
@@ -265,7 +274,7 @@ func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace 
 	}
 	if deployment, ok := deploymentsByApp[app.ExternalId]; ok {
 		deploymentCopy := deployment
-		a.enrichAppWithStubConfig(ctx, workspace, &appWithLatest, &deploymentCopy.Stub, &deploymentCopy.Deployment)
+		a.enrichAppWithStubConfig(&appWithLatest, &deploymentCopy.Stub, &deploymentCopy.Deployment)
 		deploymentCopy.URL = appWithLatest.URL
 		deploymentCopy.InvokeURL = appWithLatest.InvokeURL
 		appWithLatest.Deployment = &deploymentCopy
@@ -278,7 +287,7 @@ func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace 
 	}
 	if stub, ok := stubsByApp[app.ExternalId]; ok {
 		stubCopy := stub
-		a.enrichAppWithStubConfig(ctx, workspace, &appWithLatest, &stubCopy.Stub, nil)
+		a.enrichAppWithStubConfig(&appWithLatest, &stubCopy.Stub, nil)
 		appWithLatest.Stub = &stubCopy
 	}
 
@@ -328,7 +337,7 @@ func (a *AppGroup) RetrieveApp(ctx echo.Context) error {
 		return HTTPNotFound()
 	}
 
-	workspace, err := a.backendRepo.GetWorkspaceByExternalId(ctx.Request().Context(), workspaceID)
+	workspace, err := a.backendRepo.GetWorkspaceByExternalIdWithSigningKey(ctx.Request().Context(), workspaceID)
 	if err != nil {
 		return HTTPBadRequest("Failed to retrieve workspace")
 	}
@@ -350,6 +359,7 @@ func (a *AppGroup) RetrieveApp(ctx echo.Context) error {
 	if err != nil {
 		return HTTPInternalServerError("Failed to get app metadata")
 	}
+	a.hydrateDatabaseConnectionURL(ctx.Request().Context(), &workspace, &appWithLatest)
 
 	serializedApp, err := serializer.Serialize(appWithLatest)
 	if err != nil {

--- a/pkg/api/v1/app_test.go
+++ b/pkg/api/v1/app_test.go
@@ -432,6 +432,7 @@ func TestDatabaseAppListOmitsConnectionURLAndRetrieveIncludesIt(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
 	}
+	listBody := rec.Body.String()
 
 	var listResponse struct {
 		Data []struct {
@@ -466,7 +467,10 @@ func TestDatabaseAppListOmitsConnectionURLAndRetrieveIncludesIt(t *testing.T) {
 		t.Fatalf("failed to parse raw response: %v", err)
 	}
 	if _, ok := rawList.Data[0]["connection_url"]; ok {
-		t.Fatalf("list response should not include connection_url: %s", rec.Body.String())
+		t.Fatalf("list response should not include connection_url: %s", listBody)
+	}
+	if strings.Contains(listBody, "connection_url_secret_name") || strings.Contains(listBody, "password_secret_name") {
+		t.Fatalf("list response should not include database secret names: %s", listBody)
 	}
 	if servingRaw, ok := rawList.Data[0]["serving"]; ok {
 		var serving map[string]json.RawMessage
@@ -479,7 +483,7 @@ func TestDatabaseAppListOmitsConnectionURLAndRetrieveIncludesIt(t *testing.T) {
 				t.Fatalf("failed to parse database response: %v", err)
 			}
 			if _, ok := database["connection_url"]; ok {
-				t.Fatalf("list serving response should not include connection_url: %s", rec.Body.String())
+				t.Fatalf("list serving response should not include connection_url: %s", listBody)
 			}
 		}
 	}
@@ -503,8 +507,12 @@ func TestDatabaseAppListOmitsConnectionURLAndRetrieveIncludesIt(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
 	}
+	detailBody := rec.Body.String()
 	if backendRepo.secretLookups != 1 {
 		t.Fatalf("retrieve endpoint should load one secret batch, got %d lookups", backendRepo.secretLookups)
+	}
+	if strings.Contains(detailBody, "connection_url_secret_name") || strings.Contains(detailBody, "password_secret_name") {
+		t.Fatalf("retrieve response should not include database secret names: %s", detailBody)
 	}
 
 	var detailResponse struct {
@@ -535,7 +543,7 @@ func TestEnrichAppWithStubConfigHidesDefaultPool(t *testing.T) {
 	}
 
 	appGroup := &AppGroup{}
-	appGroup.enrichAppWithStubConfig(&app, stub, nil)
+	appGroup.enrichAppWithStubConfig(&app, stub, nil, false)
 
 	if app.PoolName != "" {
 		t.Fatalf("expected default pool to be hidden, got %q", app.PoolName)

--- a/pkg/api/v1/app_test.go
+++ b/pkg/api/v1/app_test.go
@@ -24,6 +24,7 @@ type appBackendRepo struct {
 	deploymentsByApp map[string][]types.DeploymentWithRelated
 	stubsByApp       map[string][]types.StubWithRelated
 	secrets          map[string]string
+	secretLookups    int
 }
 
 type appContainerRepo struct {
@@ -35,16 +36,6 @@ func (r *appContainerRepo) GetActiveContainersByWorkspaceId(_ string) ([]types.C
 	return r.states, nil
 }
 
-func (r *appContainerRepo) GetActiveContainersByStubId(stubId string) ([]types.ContainerState, error) {
-	states := make([]types.ContainerState, 0)
-	for _, state := range r.states {
-		if state.StubId == stubId {
-			states = append(states, state)
-		}
-	}
-	return states, nil
-}
-
 func (r *appBackendRepo) GetWorkspaceByExternalId(_ context.Context, externalId string) (types.Workspace, error) {
 	if r.workspace == nil || r.workspace.ExternalId != externalId {
 		return types.Workspace{}, errors.New("workspace not found")
@@ -53,8 +44,22 @@ func (r *appBackendRepo) GetWorkspaceByExternalId(_ context.Context, externalId 
 	return *r.workspace, nil
 }
 
+func (r *appBackendRepo) GetWorkspaceByExternalIdWithSigningKey(_ context.Context, externalId string) (types.Workspace, error) {
+	return r.GetWorkspaceByExternalId(context.Background(), externalId)
+}
+
 func (r *appBackendRepo) ListAppsPaginated(_ context.Context, _ uint, _ types.AppFilter) (repoCommon.CursorPaginationInfo[types.App], error) {
 	return r.apps, nil
+}
+
+func (r *appBackendRepo) RetrieveApp(_ context.Context, workspaceID uint, appID string) (*types.App, error) {
+	for i := range r.apps.Data {
+		app := r.apps.Data[i]
+		if app.WorkspaceId == workspaceID && app.ExternalId == appID {
+			return &app, nil
+		}
+	}
+	return nil, nil
 }
 
 func (r *appBackendRepo) ListDeploymentsWithRelated(_ context.Context, filters types.DeploymentFilter) ([]types.DeploymentWithRelated, error) {
@@ -85,15 +90,18 @@ func (r *appBackendRepo) ListLatestStubsByAppIDs(_ context.Context, _ uint, appE
 	return stubs, nil
 }
 
-func (r *appBackendRepo) GetSecretByNameDecrypted(_ context.Context, workspace *types.Workspace, name string) (*types.Secret, error) {
+func (r *appBackendRepo) GetSecretsByNameDecrypted(_ context.Context, workspace *types.Workspace, names []string) ([]types.Secret, error) {
+	r.secretLookups++
 	if workspace == nil || r.workspace == nil || workspace.Id != r.workspace.Id {
 		return nil, errors.New("workspace not found")
 	}
-	value, ok := r.secrets[name]
-	if !ok {
-		return nil, errors.New("secret not found")
+	secrets := make([]types.Secret, 0, len(names))
+	for _, name := range names {
+		if value, ok := r.secrets[name]; ok {
+			secrets = append(secrets, types.Secret{Name: name, Value: value, WorkspaceId: workspace.Id})
+		}
 	}
-	return &types.Secret{Name: name, Value: value, WorkspaceId: workspace.Id}, nil
+	return secrets, nil
 }
 
 func TestListAppWithLatestActivityAllowsAppsWithoutActivity(t *testing.T) {
@@ -340,11 +348,47 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 	}
 }
 
-func TestListAppWithLatestActivityIncludesDatabaseURLs(t *testing.T) {
-	workspace := &types.Workspace{Id: 1, ExternalId: "workspace-1", Name: "Workspace 1"}
+func TestDatabaseAppListOmitsConnectionURLAndRetrieveIncludesIt(t *testing.T) {
+	signingKey := "test-signing-key"
+	workspace := &types.Workspace{Id: 1, ExternalId: "workspace-1", Name: "Workspace 1", SigningKey: &signingKey}
 	appWithDatabase := types.App{Id: 1, ExternalId: "app-db", Name: "App DB", WorkspaceId: workspace.Id}
 	connectionURL := "rediss://default:password@redis-a1b2c3d-latest-6379.svc.stage.beam.cloud:443/0"
 
+	backendRepo := &appBackendRepo{
+		workspace: workspace,
+		apps: repoCommon.CursorPaginationInfo[types.App]{
+			Data: []types.App{appWithDatabase},
+			Next: "",
+		},
+		deploymentsByApp: map[string][]types.DeploymentWithRelated{
+			appWithDatabase.ExternalId: {
+				{
+					Deployment: types.Deployment{
+						ExternalId:  "deployment-db",
+						Name:        "luke-staging-redis",
+						Subdomain:   "redis-a1b2c3d",
+						Version:     1,
+						WorkspaceId: workspace.Id,
+						AppId:       appWithDatabase.Id,
+					},
+					Stub: types.Stub{
+						Id:          1,
+						ExternalId:  "stub-db",
+						Name:        "Stub DB",
+						Type:        types.StubType(types.StubTypePodDeployment),
+						Config:      `{"is_service":true,"tcp":true,"ports":[6379],"serving":{"app_kind":"database","serving_protocol":"redis","database":{"kind":"redis","port":6379,"connection_env_name":"REDIS_URL","connection_url_secret_name":"BETA9_REDIS_URL"}}}`,
+						WorkspaceId: workspace.Id,
+						AppId:       appWithDatabase.Id,
+					},
+					Workspace: *workspace,
+					App:       appWithDatabase,
+				},
+			},
+		},
+		secrets: map[string]string{
+			"BETA9_REDIS_URL": connectionURL,
+		},
+	}
 	appGroup := &AppGroup{
 		config: types.AppConfig{
 			GatewayService: types.GatewayServiceConfig{
@@ -365,41 +409,7 @@ func TestListAppWithLatestActivityIncludesDatabaseURLs(t *testing.T) {
 				},
 			},
 		},
-		backendRepo: &appBackendRepo{
-			workspace: workspace,
-			apps: repoCommon.CursorPaginationInfo[types.App]{
-				Data: []types.App{appWithDatabase},
-				Next: "",
-			},
-			deploymentsByApp: map[string][]types.DeploymentWithRelated{
-				appWithDatabase.ExternalId: {
-					{
-						Deployment: types.Deployment{
-							ExternalId:  "deployment-db",
-							Name:        "luke-staging-redis",
-							Subdomain:   "redis-a1b2c3d",
-							Version:     1,
-							WorkspaceId: workspace.Id,
-							AppId:       appWithDatabase.Id,
-						},
-						Stub: types.Stub{
-							Id:          1,
-							ExternalId:  "stub-db",
-							Name:        "Stub DB",
-							Type:        types.StubType(types.StubTypePodDeployment),
-							Config:      `{"is_service":true,"tcp":true,"ports":[6379],"serving":{"app_kind":"database","serving_protocol":"redis","database":{"kind":"redis","port":6379,"connection_env_name":"REDIS_URL","connection_url_secret_name":"BETA9_REDIS_URL"}}}`,
-							WorkspaceId: workspace.Id,
-							AppId:       appWithDatabase.Id,
-						},
-						Workspace: *workspace,
-						App:       appWithDatabase,
-					},
-				},
-			},
-			secrets: map[string]string{
-				"BETA9_REDIS_URL": connectionURL,
-			},
-		},
+		backendRepo: backendRepo,
 	}
 
 	e := echo.New()
@@ -423,37 +433,98 @@ func TestListAppWithLatestActivityIncludesDatabaseURLs(t *testing.T) {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
 	}
 
-	var response struct {
+	var listResponse struct {
 		Data []struct {
-			ID            string `json:"id"`
-			URL           string `json:"url"`
-			InvokeURL     string `json:"invoke_url"`
-			ConnectionURL string `json:"connection_url"`
-			Deployment    struct {
+			ID         string `json:"id"`
+			URL        string `json:"url"`
+			InvokeURL  string `json:"invoke_url"`
+			Deployment struct {
 				URL       string `json:"url"`
 				InvokeURL string `json:"invoke_url"`
 			} `json:"deployment"`
-			Serving struct {
-				Database struct {
-					ConnectionURL string `json:"connection_url"`
-				} `json:"database"`
-			} `json:"serving"`
 		} `json:"data"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+	if err := json.Unmarshal(rec.Body.Bytes(), &listResponse); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	if len(response.Data) != 1 {
-		t.Fatalf("expected one app, got %d", len(response.Data))
+	if len(listResponse.Data) != 1 {
+		t.Fatalf("expected one app, got %d", len(listResponse.Data))
 	}
 
-	app := response.Data[0]
+	app := listResponse.Data[0]
 	expectedURL := "https://redis-a1b2c3d-latest-6379.svc.stage.beam.cloud"
 	if app.URL != expectedURL || app.InvokeURL != expectedURL || app.Deployment.URL != expectedURL || app.Deployment.InvokeURL != expectedURL {
 		t.Fatalf("unexpected urls: %+v", app)
 	}
-	if app.ConnectionURL != connectionURL || app.Serving.Database.ConnectionURL != connectionURL {
-		t.Fatalf("unexpected connection url: %+v", app)
+	if backendRepo.secretLookups != 0 {
+		t.Fatalf("list endpoint should not load secrets, got %d lookups", backendRepo.secretLookups)
+	}
+	var rawList struct {
+		Data []map[string]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &rawList); err != nil {
+		t.Fatalf("failed to parse raw response: %v", err)
+	}
+	if _, ok := rawList.Data[0]["connection_url"]; ok {
+		t.Fatalf("list response should not include connection_url: %s", rec.Body.String())
+	}
+	if servingRaw, ok := rawList.Data[0]["serving"]; ok {
+		var serving map[string]json.RawMessage
+		if err := json.Unmarshal(servingRaw, &serving); err != nil {
+			t.Fatalf("failed to parse serving response: %v", err)
+		}
+		if databaseRaw, ok := serving["database"]; ok {
+			var database map[string]json.RawMessage
+			if err := json.Unmarshal(databaseRaw, &database); err != nil {
+				t.Fatalf("failed to parse database response: %v", err)
+			}
+			if _, ok := database["connection_url"]; ok {
+				t.Fatalf("list serving response should not include connection_url: %s", rec.Body.String())
+			}
+		}
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/workspace-1/app-db", nil)
+	rec = httptest.NewRecorder()
+	ctx = e.NewContext(req, rec)
+	ctx.SetParamNames("workspaceId", "appId")
+	ctx.SetParamValues(workspace.ExternalId, appWithDatabase.ExternalId)
+
+	err = appGroup.RetrieveApp(&auth.HttpAuthContext{
+		Context: ctx,
+		AuthInfo: &auth.AuthInfo{
+			Workspace: workspace,
+			Token:     &types.Token{TokenType: types.TokenTypeWorkspacePrimary},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if backendRepo.secretLookups != 1 {
+		t.Fatalf("retrieve endpoint should load one secret batch, got %d lookups", backendRepo.secretLookups)
+	}
+
+	var detailResponse struct {
+		URL           string `json:"url"`
+		InvokeURL     string `json:"invoke_url"`
+		ConnectionURL string `json:"connection_url"`
+		Serving       struct {
+			Database struct {
+				ConnectionURL string `json:"connection_url"`
+			} `json:"database"`
+		} `json:"serving"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &detailResponse); err != nil {
+		t.Fatalf("failed to parse retrieve response: %v", err)
+	}
+	if detailResponse.URL != expectedURL || detailResponse.InvokeURL != expectedURL {
+		t.Fatalf("unexpected retrieve urls: %+v", detailResponse)
+	}
+	if detailResponse.ConnectionURL != connectionURL || detailResponse.Serving.Database.ConnectionURL != connectionURL {
+		t.Fatalf("unexpected retrieve connection url: %+v", detailResponse)
 	}
 }
 
@@ -464,7 +535,7 @@ func TestEnrichAppWithStubConfigHidesDefaultPool(t *testing.T) {
 	}
 
 	appGroup := &AppGroup{}
-	appGroup.enrichAppWithStubConfig(context.Background(), nil, &app, stub, nil)
+	appGroup.enrichAppWithStubConfig(&app, stub, nil)
 
 	if app.PoolName != "" {
 		t.Fatalf("expected default pool to be hidden, got %q", app.PoolName)

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -570,6 +570,17 @@ type DatabaseServingConfig struct {
 	ConnectionURLSecretName string   `json:"connection_url_secret_name,omitempty" serializer:"connection_url_secret_name,omitempty"`
 }
 
+func (d *DatabaseServingConfig) ClearSecretNames() {
+	if d == nil {
+		return
+	}
+	d.CredentialSecretNames = nil
+	d.UsernameSecretName = ""
+	d.PasswordSecretName = ""
+	d.DatabaseSecretName = ""
+	d.ConnectionURLSecretName = ""
+}
+
 const (
 	DatabaseKindPostgres      = "postgres"
 	DatabaseKindPostgresAlias = "postgresql"
@@ -902,6 +913,9 @@ func (s *Stub) SanitizeConfig() error {
 	// Remove secret values from config
 	for i := range config.Secrets {
 		config.Secrets[i].Value = ""
+	}
+	if config.Serving != nil {
+		config.Serving.Database.ClearSecretNames()
 	}
 
 	data, err := json.Marshal(config)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up the app API to avoid leaking database secrets or secret names, hydrate the database URL only on app detail, and reduce container lookups by aggregating running states per workspace.

- **Bug Fixes**
  - `ListAppWithLatestActivity` no longer returns `connection_url`, loads secrets, or exposes database secret names.
  - `RetrieveApp` hydrates the database `connection_url` via `hydrateDatabaseConnectionURL` using `GetSecretsByNameDecrypted` and `GetWorkspaceByExternalIdWithSigningKey`, and clears secret names from the response.
  - Added `sanitizeStubWithRelated`/`sanitizeDeploymentWithRelated` to strip workspace private credentials and sanitize configs.

- **Refactors**
  - Replaced per-stub container queries with workspace-wide `GetActiveContainersByWorkspaceId` and aggregation in `countRunningContainersForStubs`.
  - Simplified `enrichAppWithStubConfig` to set serving and URLs only; clears database secret names by default.
  - Updated tests to assert secret omission on list, hydration (single batched lookup) on retrieve, and workspace-level container queries.

<sup>Written for commit b2cc7ef7aad37837f47dd431c77dc07662915dfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

