### PR TITLE
fix: disk snapshot fixes

### DIFF
--- a/pkg/types/storage.go
+++ b/pkg/types/storage.go
@@ -136,6 +136,9 @@ type DiskSnapshotFile struct {
 	Gid             int                 `json:"gid,omitempty"`
 	SizeBytes       int64               `json:"size_bytes,omitempty"`
 	ModTimeUnixNano int64               `json:"mtime_unix_nano,omitempty"`
+	ChangeUnixNano  int64               `json:"ctime_unix_nano,omitempty"`
+	DeviceId        uint64              `json:"device_id,omitempty"`
+	Inode           uint64              `json:"inode,omitempty"`
 	LinkName        string              `json:"link_name,omitempty"`
 	Chunks          []DiskSnapshotChunk `json:"chunks,omitempty"`
 }

--- a/pkg/worker/durable_disk.go
+++ b/pkg/worker/durable_disk.go
@@ -21,7 +21,18 @@ const (
 	durableDiskMarkerFile = ".beta9-durable-disk"
 	durableDiskLockDir    = ".beta9-durable-disk-locks"
 	durableDiskLockWait   = 10 * time.Minute
+
+	durableDiskStateClean = "clean"
+	durableDiskStateDirty = "dirty"
 )
+
+type durableDiskMarker struct {
+	Driver         string
+	State          string
+	SnapshotID     string
+	ManifestDigest string
+	Generation     int64
+}
 
 func (s *Worker) prepareDurableDiskMount(request *types.ContainerRequest, mount *types.Mount) error {
 	if mount == nil || mount.DurableDisk == nil {
@@ -40,7 +51,20 @@ func (s *Worker) prepareDurableDiskMount(request *types.ContainerRequest, mount 
 					return err
 				}
 			}
-			return prepareSnapshotDurableDiskMount(mount)
+			if err := prepareSnapshotDurableDiskMount(mount); err != nil {
+				return err
+			}
+			if mount.ReadOnly {
+				return nil
+			}
+			marker := readDurableDiskMarker(mount.LocalPath)
+			return writeDurableDiskMarker(mount.LocalPath, durableDiskMarker{
+				Driver:         types.DurableDiskDriverSnapshot,
+				State:          durableDiskStateDirty,
+				Generation:     marker.Generation,
+				SnapshotID:     marker.SnapshotID,
+				ManifestDigest: marker.ManifestDigest,
+			})
 		})
 	default:
 		return fmt.Errorf("durable disk %q requested unsupported driver %q", mount.DurableDisk.Name, driver)
@@ -67,7 +91,10 @@ func prepareSnapshotDurableDiskMount(mount *types.Mount) error {
 	if err := os.MkdirAll(mount.LocalPath, 0755); err != nil {
 		return fmt.Errorf("create durable disk path %s: %w", mount.LocalPath, err)
 	}
-	return writeDurableDiskMarker(mount.LocalPath)
+	if _, err := os.Stat(filepath.Join(mount.LocalPath, durableDiskMarkerFile)); os.IsNotExist(err) {
+		return writeDurableDiskMarker(mount.LocalPath, durableDiskMarker{Driver: types.DurableDiskDriverSnapshot, State: durableDiskStateClean})
+	}
+	return nil
 }
 
 func (s *Worker) syncDurableDiskMounts(request *types.ContainerRequest) error {
@@ -133,13 +160,10 @@ func (s *Worker) snapshotDurableDiskMount(request *types.ContainerRequest, mount
 	if s == nil || s.backendRepoClient == nil || request == nil || mount == nil || mount.DurableDisk == nil {
 		return nil
 	}
-	if !durableDiskHasPayload(mount.LocalPath) {
-		return nil
-	}
 	if err := cleanDurableDiskRuntimeFiles(mount, mount.LocalPath); err != nil {
 		return err
 	}
-	if !durableDiskHasRestorablePayload(mount, mount.LocalPath) {
+	if durableDiskHasPayload(mount.LocalPath) && !durableDiskHasRestorablePayload(mount, mount.LocalPath) {
 		return fmt.Errorf("durable disk %q is not ready to snapshot", mount.DurableDisk.Name)
 	}
 
@@ -187,12 +211,25 @@ func (s *Worker) snapshotDurableDiskMount(request *types.ContainerRequest, mount
 		return err
 	}
 
-	_, err = handleGRPCResponse(s.backendRepoClient.CreateDiskSnapshot(ctx, &pb.CreateDiskSnapshotRequest{
+	resp, err := handleGRPCResponse(s.backendRepoClient.CreateDiskSnapshot(ctx, &pb.CreateDiskSnapshotRequest{
 		WorkspaceId: cacheRequestWorkspaceID(request),
 		StubId:      cacheRequestStubID(request),
 		Snapshot:    durableDiskSnapshotToProto(snapshot),
 	}))
 	if err != nil {
+		return err
+	}
+	if created := durableDiskSnapshotFromProto(resp.Snapshot); created != nil {
+		snapshot = created
+	}
+
+	if err := writeDurableDiskMarker(mount.LocalPath, durableDiskMarker{
+		Driver:         types.DurableDiskDriverSnapshot,
+		State:          durableDiskStateClean,
+		SnapshotID:     snapshot.ExternalId,
+		ManifestDigest: snapshot.ManifestDigest,
+		Generation:     snapshot.Generation,
+	}); err != nil {
 		return err
 	}
 
@@ -227,13 +264,6 @@ func (s *Worker) restoreDurableDiskSnapshot(request *types.ContainerRequest, mou
 	if s == nil || s.backendRepoClient == nil || request == nil || mount == nil || mount.DurableDisk == nil {
 		return nil
 	}
-	if durableDiskHasRestorablePayload(mount, mount.LocalPath) {
-		return nil
-	}
-	if durableDiskHasPayload(mount.LocalPath) {
-		return fmt.Errorf("durable disk %q has an active or incomplete local payload", mount.DurableDisk.Name)
-	}
-
 	ctx := s.ctx
 	if ctx == nil {
 		ctx = context.Background()
@@ -254,24 +284,44 @@ func (s *Worker) restoreDurableDiskSnapshot(request *types.ContainerRequest, mou
 	}
 	snapshot := durableDiskSnapshotFromProto(resp.Snapshot)
 	if snapshot == nil || snapshot.ManifestKey == "" {
+		if durableDiskHasRestorablePayload(mount, mount.LocalPath) {
+			return nil
+		}
+		if durableDiskHasPayload(mount.LocalPath) {
+			return fmt.Errorf("durable disk %q has an active or incomplete local payload", mount.DurableDisk.Name)
+		}
 		return nil
 	}
 	if !types.IsDiskSnapshotFilesystemFormat(snapshot.Format) {
 		return fmt.Errorf("durable disk snapshot %s has unsupported filesystem format %q", snapshot.ExternalId, snapshot.Format)
+	}
+	if durableDiskHasRestorablePayload(mount, mount.LocalPath) {
+		if durableDiskShouldKeepLocalPayload(readDurableDiskMarker(mount.LocalPath), snapshot) {
+			return nil
+		}
+	} else if durableDiskHasPayload(mount.LocalPath) {
+		return fmt.Errorf("durable disk %q has an active or incomplete local payload", mount.DurableDisk.Name)
 	}
 
 	store, err := newDurableDiskSnapshotBucketStore(ctx, request, mount.DurableDisk.Name, snapshot.BucketName, false)
 	if err != nil {
 		return err
 	}
-	if _, err := restoreDurableDiskDirectorySnapshotWithCache(ctx, store, s.durableDiskSnapshotCacheReader(), snapshot.ManifestKey, snapshot.ManifestDigest, snapshot.ManifestSizeBytes, mount.LocalPath); err != nil {
+	manifest, err := restoreDurableDiskDirectorySnapshotWithCache(ctx, store, s.durableDiskSnapshotCacheReader(), snapshot.ManifestKey, snapshot.ManifestDigest, snapshot.ManifestSizeBytes, mount.LocalPath)
+	if err != nil {
 		return fmt.Errorf("restore durable disk snapshot %s: %w", snapshot.ExternalId, err)
 	}
-	if !durableDiskHasRestorablePayload(mount, mount.LocalPath) {
+	if len(manifest.Files) > 0 && !durableDiskHasRestorablePayload(mount, mount.LocalPath) {
 		_ = os.RemoveAll(mount.LocalPath)
 		return fmt.Errorf("restore durable disk snapshot %s produced an invalid payload", snapshot.ExternalId)
 	}
-	return nil
+	return writeDurableDiskMarker(mount.LocalPath, durableDiskMarker{
+		Driver:         types.DurableDiskDriverSnapshot,
+		State:          durableDiskStateClean,
+		SnapshotID:     snapshot.ExternalId,
+		ManifestDigest: snapshot.ManifestDigest,
+		Generation:     snapshot.Generation,
+	})
 }
 
 func (s *Worker) ensureDurableDiskSnapshotStorage(ctx context.Context, request *types.ContainerRequest) error {
@@ -425,8 +475,60 @@ func cleanDurableDiskRuntimeFiles(mount *types.Mount, diskPath string) error {
 	return nil
 }
 
-func writeDurableDiskMarker(path string) error {
-	if err := os.WriteFile(filepath.Join(path, durableDiskMarkerFile), []byte("driver=snapshot\n"), 0644); err != nil {
+func readDurableDiskMarker(path string) durableDiskMarker {
+	data, err := os.ReadFile(filepath.Join(path, durableDiskMarkerFile))
+	if err != nil {
+		return durableDiskMarker{}
+	}
+	marker := durableDiskMarker{}
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "driver":
+			marker.Driver = value
+		case "state":
+			marker.State = value
+		case "snapshot_id":
+			marker.SnapshotID = value
+		case "manifest_digest":
+			marker.ManifestDigest = value
+		case "generation":
+			marker.Generation, _ = strconv.ParseInt(value, 10, 64)
+		}
+	}
+	return marker
+}
+
+func durableDiskShouldKeepLocalPayload(marker durableDiskMarker, snapshot *types.DiskSnapshot) bool {
+	if snapshot == nil {
+		return true
+	}
+	switch marker.State {
+	case durableDiskStateDirty:
+		return marker.Generation >= snapshot.Generation
+	case durableDiskStateClean:
+		return marker.Generation == snapshot.Generation && marker.ManifestDigest == snapshot.ManifestDigest
+	default:
+		return false
+	}
+}
+
+func writeDurableDiskMarker(path string, marker durableDiskMarker) error {
+	if marker.Driver == "" {
+		marker.Driver = types.DurableDiskDriverSnapshot
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "driver=%s\nstate=%s\ngeneration=%d\n", marker.Driver, marker.State, marker.Generation)
+	if marker.SnapshotID != "" {
+		fmt.Fprintf(&b, "snapshot_id=%s\n", marker.SnapshotID)
+	}
+	if marker.ManifestDigest != "" {
+		fmt.Fprintf(&b, "manifest_digest=%s\n", marker.ManifestDigest)
+	}
+	if err := os.WriteFile(filepath.Join(path, durableDiskMarkerFile), []byte(b.String()), 0644); err != nil {
 		return fmt.Errorf("write durable disk marker %s: %w", path, err)
 	}
 	return nil

--- a/pkg/worker/durable_disk_snapshot.go
+++ b/pkg/worker/durable_disk_snapshot.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"syscall"
@@ -157,9 +158,6 @@ func loadDurableDiskSnapshotManifest(ctx context.Context, store durableDiskSnaps
 }
 
 func createDurableDiskDirectorySnapshot(ctx context.Context, store durableDiskSnapshotStore, sourceDir, objectPrefix string, snapshot types.DiskSnapshot, chunkSize int64, previous *types.DiskSnapshotManifest) (*types.DiskSnapshot, *types.DiskSnapshotManifest, error) {
-	if !durableDiskHasPayload(sourceDir) {
-		return nil, nil, fmt.Errorf("durable disk directory %s has no payload", sourceDir)
-	}
 	if store == nil {
 		return nil, nil, fmt.Errorf("durable disk snapshot store is nil")
 	}
@@ -213,6 +211,9 @@ func createDurableDiskDirectorySnapshot(ctx context.Context, store durableDiskSn
 			return err
 		}
 		rel = filepath.ToSlash(rel)
+		if rel == durableDiskMarkerFile {
+			return nil
+		}
 		file := durableDiskSnapshotFile(rel, info)
 
 		switch {
@@ -230,7 +231,19 @@ func createDurableDiskDirectorySnapshot(ctx context.Context, store durableDiskSn
 			if durableDiskSnapshotFileReusable(previousFile, file) {
 				file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
 			} else if durableDiskSnapshotAppendOnlyFile(manifest.Format, file.Path) && durableDiskSnapshotFileAppendReusable(previousFile, file) {
-				file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
+				reusePrefix := durableDiskSnapshotSameIdentity(previousFile, file)
+				if reusePrefix {
+					file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
+				} else {
+					var err error
+					reusePrefix, err = durableDiskSnapshotFileChunksReusable(name, previousFile)
+					if err != nil {
+						return err
+					}
+					if reusePrefix {
+						file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
+					}
+				}
 				if err := snapshotDurableDiskFile(ctx, store, name, chunkPrefix, buffer, seen, &file); err != nil {
 					return err
 				}
@@ -317,6 +330,9 @@ func durableDiskSnapshotFile(name string, info os.FileInfo) types.DiskSnapshotFi
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		file.Uid = int(stat.Uid)
 		file.Gid = int(stat.Gid)
+		file.ChangeUnixNano = durableDiskSnapshotChangeTimeUnixNano(stat)
+		file.DeviceId = uint64(stat.Dev)
+		file.Inode = uint64(stat.Ino)
 	}
 	return file
 }
@@ -328,7 +344,35 @@ func durableDiskSnapshotFileReusable(previous, current types.DiskSnapshotFile) b
 		previous.Gid == current.Gid &&
 		previous.SizeBytes == current.SizeBytes &&
 		previous.ModTimeUnixNano == current.ModTimeUnixNano &&
+		previous.ChangeUnixNano == current.ChangeUnixNano &&
+		durableDiskSnapshotSameIdentity(previous, current) &&
 		len(previous.Chunks) > 0
+}
+
+func durableDiskSnapshotSameIdentity(previous, current types.DiskSnapshotFile) bool {
+	return previous.DeviceId != 0 &&
+		previous.Inode != 0 &&
+		previous.DeviceId == current.DeviceId &&
+		previous.Inode == current.Inode
+}
+
+func durableDiskSnapshotChangeTimeUnixNano(stat *syscall.Stat_t) int64 {
+	if stat == nil {
+		return 0
+	}
+	value := reflect.ValueOf(*stat)
+	for _, name := range []string{"Ctim", "Ctimespec"} {
+		field := value.FieldByName(name)
+		if !field.IsValid() {
+			continue
+		}
+		sec := field.FieldByName("Sec")
+		nsec := field.FieldByName("Nsec")
+		if sec.IsValid() && nsec.IsValid() {
+			return sec.Int()*int64(time.Second) + nsec.Int()
+		}
+	}
+	return 0
 }
 
 func durableDiskSnapshotFileAppendReusable(previous, current types.DiskSnapshotFile) bool {
@@ -346,6 +390,32 @@ func durableDiskSnapshotFileAppendReusable(previous, current types.DiskSnapshotF
 		end += chunk.SizeBytes
 	}
 	return end == previous.SizeBytes
+}
+
+func durableDiskSnapshotFileChunksReusable(filename string, previous types.DiskSnapshotFile) (bool, error) {
+	in, err := os.Open(filename)
+	if err != nil {
+		return false, err
+	}
+	defer in.Close()
+
+	for _, chunk := range previous.Chunks {
+		if chunk.SizeBytes <= 0 || chunk.Digest == "" {
+			return false, nil
+		}
+		if _, err := in.Seek(chunk.OffsetBytes, io.SeekStart); err != nil {
+			return false, err
+		}
+
+		sum := sha256.New()
+		if n, err := io.CopyN(sum, in, chunk.SizeBytes); err != nil || n != chunk.SizeBytes {
+			return false, nil
+		}
+		if "sha256:"+hex.EncodeToString(sum.Sum(nil)) != chunk.Digest {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func durableDiskSnapshotAppendOnlyFile(format, name string) bool {
@@ -453,9 +523,6 @@ func restoreDurableDiskDirectorySnapshotWithCache(ctx context.Context, store dur
 	})
 	if err != nil {
 		return nil, fmt.Errorf("download durable disk snapshot manifest %s: %w", manifestKey, err)
-	}
-	if len(manifest.Files) == 0 {
-		return nil, fmt.Errorf("durable disk directory snapshot %s has no files", manifestKey)
 	}
 	return manifest, restoreDurableDiskDirectoryManifest(ctx, store, cacheReader, manifest, targetDir)
 }

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -63,6 +64,29 @@ func TestAddRequestMountsPreparesDurableDisk(t *testing.T) {
 	require.Equal(t, localPath, spec.Mounts[0].Source)
 	require.Equal(t, request.Mounts[0].MountPath, spec.Mounts[0].Destination)
 	require.Equal(t, []string{"rbind", "rw"}, spec.Mounts[0].Options)
+}
+
+func TestDurableDiskShouldKeepLocalPayload(t *testing.T) {
+	snapshot := &types.DiskSnapshot{Generation: 2, ManifestDigest: "sha256:new"}
+
+	require.False(t, durableDiskShouldKeepLocalPayload(durableDiskMarker{
+		State:      durableDiskStateDirty,
+		Generation: 1,
+	}, snapshot))
+	require.True(t, durableDiskShouldKeepLocalPayload(durableDiskMarker{
+		State:      durableDiskStateDirty,
+		Generation: 2,
+	}, snapshot))
+	require.True(t, durableDiskShouldKeepLocalPayload(durableDiskMarker{
+		State:          durableDiskStateClean,
+		Generation:     2,
+		ManifestDigest: "sha256:new",
+	}, snapshot))
+	require.False(t, durableDiskShouldKeepLocalPayload(durableDiskMarker{
+		State:          durableDiskStateClean,
+		Generation:     2,
+		ManifestDigest: "sha256:old",
+	}, snapshot))
 }
 
 func TestCreateDurableDiskDirectorySnapshotDedupesChunks(t *testing.T) {
@@ -168,6 +192,112 @@ func TestCreateDurableDiskDirectorySnapshotReusesAppendOnlyTail(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(restored, "appendonlydir", "appendonly.aof.1.incr.aof"))
 	require.NoError(t, err)
 	require.Equal(t, "aaaabbbbcccc", string(data))
+}
+
+func TestCreateDurableDiskDirectorySnapshotRejectsRecreatedAppendOnlyPrefix(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "redis-data")
+	aof := filepath.Join(source, "appendonlydir", "appendonly.aof.1.incr.aof")
+	require.NoError(t, os.MkdirAll(filepath.Dir(aof), 0o700))
+	require.NoError(t, os.WriteFile(aof, []byte("aaaabbbb"), 0o600))
+
+	store := &fakeDurableDiskSnapshotStore{}
+	_, firstManifest, err := createDurableDiskDirectorySnapshot(ctx, store, source, "durable-disks/redis-data/snapshots/1", types.DiskSnapshot{
+		DiskName:   "redis-data",
+		Format:     types.DiskSnapshotFormatRedisAOFV1,
+		Filesystem: "ext4",
+		Generation: 1,
+	}, 4, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(aof))
+	require.NoError(t, os.WriteFile(aof, []byte("xxxxbbbbcccc"), 0o600))
+	second, _, err := createDurableDiskDirectorySnapshot(ctx, store, source, "durable-disks/redis-data/snapshots/2", types.DiskSnapshot{
+		DiskName:   "redis-data",
+		Format:     types.DiskSnapshotFormatRedisAOFV1,
+		Filesystem: "ext4",
+		Generation: 2,
+	}, 4, firstManifest)
+	require.NoError(t, err)
+
+	restored := filepath.Join(t.TempDir(), "restored")
+	_, err = restoreDurableDiskDirectorySnapshotWithCache(ctx, store, nil, second.ManifestKey, second.ManifestDigest, second.ManifestSizeBytes, restored)
+	require.NoError(t, err)
+	data, err := os.ReadFile(filepath.Join(restored, "appendonlydir", "appendonly.aof.1.incr.aof"))
+	require.NoError(t, err)
+	require.Equal(t, "xxxxbbbbcccc", string(data))
+}
+
+func TestCreateDurableDiskDirectorySnapshotRejectsSameMetadataRewrite(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "data")
+	file := filepath.Join(source, "dbfile")
+	require.NoError(t, os.MkdirAll(source, 0o700))
+	require.NoError(t, os.WriteFile(file, []byte("aaaabbbb"), 0o600))
+
+	store := &fakeDurableDiskSnapshotStore{}
+	_, firstManifest, err := createDurableDiskDirectorySnapshot(ctx, store, source, "durable-disks/data/snapshots/1", types.DiskSnapshot{
+		DiskName:   "data",
+		Format:     types.DiskSnapshotFormatDirV1,
+		Filesystem: "ext4",
+		Generation: 1,
+	}, 4, nil)
+	require.NoError(t, err)
+	firstFile := snapshotTestFile(firstManifest, "dbfile")
+	require.NotEmpty(t, firstFile.Chunks)
+
+	modTime := time.Unix(0, firstFile.ModTimeUnixNano)
+	require.NoError(t, os.WriteFile(file, []byte("xxxxbbbb"), 0o600))
+	require.NoError(t, os.Chtimes(file, modTime, modTime))
+
+	second, _, err := createDurableDiskDirectorySnapshot(ctx, store, source, "durable-disks/data/snapshots/2", types.DiskSnapshot{
+		DiskName:   "data",
+		Format:     types.DiskSnapshotFormatDirV1,
+		Filesystem: "ext4",
+		Generation: 2,
+	}, 4, firstManifest)
+	require.NoError(t, err)
+
+	restored := filepath.Join(t.TempDir(), "restored")
+	_, err = restoreDurableDiskDirectorySnapshotWithCache(ctx, store, nil, second.ManifestKey, second.ManifestDigest, second.ManifestSizeBytes, restored)
+	require.NoError(t, err)
+	data, err := os.ReadFile(filepath.Join(restored, "dbfile"))
+	require.NoError(t, err)
+	require.Equal(t, "xxxxbbbb", string(data))
+}
+
+func TestCreateDurableDiskDirectorySnapshotPreservesEmptyDirectory(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "data")
+	require.NoError(t, os.MkdirAll(source, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "value"), []byte("present"), 0o600))
+
+	store := &fakeDurableDiskSnapshotStore{}
+	_, firstManifest, err := createDurableDiskDirectorySnapshot(ctx, store, source, "durable-disks/data/snapshots/1", types.DiskSnapshot{
+		DiskName:   "data",
+		Format:     types.DiskSnapshotFormatDirV1,
+		Filesystem: "ext4",
+		Generation: 1,
+	}, 4, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstManifest.Files)
+
+	require.NoError(t, os.Remove(filepath.Join(source, "value")))
+	second, secondManifest, err := createDurableDiskDirectorySnapshot(ctx, store, source, "durable-disks/data/snapshots/2", types.DiskSnapshot{
+		DiskName:   "data",
+		Format:     types.DiskSnapshotFormatDirV1,
+		Filesystem: "ext4",
+		Generation: 2,
+	}, 4, firstManifest)
+	require.NoError(t, err)
+	require.Empty(t, secondManifest.Files)
+
+	restored := filepath.Join(t.TempDir(), "restored")
+	_, err = restoreDurableDiskDirectorySnapshotWithCache(ctx, store, nil, second.ManifestKey, second.ManifestDigest, second.ManifestSizeBytes, restored)
+	require.NoError(t, err)
+	entries, err := os.ReadDir(restored)
+	require.NoError(t, err)
+	require.Empty(t, entries)
 }
 
 func TestDurableDiskSnapshotRequiredContentItems(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens durable disk snapshots and restores. Adds a disk marker with clean/dirty state and snapshot metadata, tracks file identity (ctime, device, inode), validates append-only reuse, prevents restoring over newer local data, and supports empty-directory snapshots.

- **Bug Fixes**
  - Do not restore over newer or dirty local payloads; keep local when marker indicates it.
  - Exclude the marker file from snapshots; allow empty manifests (empty dir) without error.
  - Verify append-only prefix by hash to avoid corruption; reject recreated prefixes and same-mtime rewrites.
  - Enforce restorable payload after restore; otherwise fail and clean.

- **New Features**
  - Read/write durable disk marker with `driver`, `state`, `generation`, `snapshot_id`, `manifest_digest`; mark dirty on writeable mount and clean after successful snapshot/restore.
  - Track per-file `ctime`, `device_id`, and `inode` for safe reuse and identity checks.
  - Expanded tests cover append-only reuse, prefix rejection, metadata rewrite, and empty-directory snapshots.

<sup>Written for commit 1edf520c074d0311c0665afe4c6f9ac87ebfa542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

