### PR TITLE
fix snapshot test

### DIFF
--- a/pkg/worker/durable_disk_snapshot.go
+++ b/pkg/worker/durable_disk_snapshot.go
@@ -231,18 +231,12 @@ func createDurableDiskDirectorySnapshot(ctx context.Context, store durableDiskSn
 			if durableDiskSnapshotFileReusable(previousFile, file) {
 				file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
 			} else if durableDiskSnapshotAppendOnlyFile(manifest.Format, file.Path) && durableDiskSnapshotFileAppendReusable(previousFile, file) {
-				reusePrefix := durableDiskSnapshotSameIdentity(previousFile, file)
+				reusePrefix, err := durableDiskSnapshotFileChunksReusable(name, previousFile)
+				if err != nil {
+					return err
+				}
 				if reusePrefix {
 					file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
-				} else {
-					var err error
-					reusePrefix, err = durableDiskSnapshotFileChunksReusable(name, previousFile)
-					if err != nil {
-						return err
-					}
-					if reusePrefix {
-						file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
-					}
 				}
 				if err := snapshotDurableDiskFile(ctx, store, name, chunkPrefix, buffer, seen, &file); err != nil {
 					return err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes snapshot test failures by simplifying append-only file chunk reuse logic. Uses `durableDiskSnapshotFileChunksReusable` directly and removes the redundant identity branch to ensure consistent chunk reuse.

<sup>Written for commit 05ed1c85e06d13d37f1730471eb9bd42ba55fdd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

