### PR TITLE
use workspace buckets instead of a new bucket for each snapshot dir

### DIFF
--- a/pkg/abstractions/common/durable_disk.go
+++ b/pkg/abstractions/common/durable_disk.go
@@ -110,15 +110,8 @@ func configureDurableDiskSnapshotFallback(ctx context.Context, repos DurableDisk
 	if poolName == "" || !durableDiskSnapshotFallbackSupported(stubConfig.Disks) {
 		return fmt.Errorf("durable disk snapshot fallback is not available for pool %q", poolName)
 	}
-	if err := ensureDurableDiskSnapshotsAvailable(ctx, repos, workspace, stubConfig.Disks); err != nil {
+	if _, err := latestRestorableDurableDiskSnapshots(ctx, repos, workspace, stubConfig.Disks); err != nil {
 		return err
-	}
-	allowed, err := privatePoolSnapshotFallbackAllowed(ctx, repos, workspace, poolName)
-	if err != nil {
-		return err
-	}
-	if !allowed {
-		return fmt.Errorf("durable disk snapshot fallback is only enabled for private pools")
 	}
 
 	stubConfig.Pool = nil
@@ -145,42 +138,33 @@ func durableDiskSnapshotFallbackNeeded(ctx context.Context, repos DurableDiskPla
 	if poolName == "" || !durableDiskSnapshotFallbackSupported(disks) || privatePoolHasAvailableWorkers(ctx, repos, poolName) {
 		return false, nil
 	}
-	allowed, err := privatePoolSnapshotFallbackAllowed(ctx, repos, workspace, poolName)
-	return allowed, err
+	_, err := latestRestorableDurableDiskSnapshots(ctx, repos, workspace, disks)
+	return err == nil, err
 }
 
-func privatePoolSnapshotFallbackAllowed(ctx context.Context, repos DurableDiskPlacementRepos, workspace *types.Workspace, poolName string) (bool, error) {
-	if repos.ComputeRepo == nil || workspace == nil {
-		return false, nil
-	}
-	state, err := repos.ComputeRepo.GetPoolState(ctx, workspace.ExternalId, poolName)
-	if err != nil {
-		return false, err
-	}
-	return state != nil && state.Mode == string(types.PoolModePrivate), nil
-}
-
-func ensureDurableDiskSnapshotsAvailable(ctx context.Context, repos DurableDiskPlacementRepos, workspace *types.Workspace, disks []*pb.DurableDisk) error {
+func latestRestorableDurableDiskSnapshots(ctx context.Context, repos DurableDiskPlacementRepos, workspace *types.Workspace, disks []*pb.DurableDisk) ([]*types.DiskSnapshot, error) {
 	if repos.BackendRepo == nil || workspace == nil {
-		return fmt.Errorf("durable disk snapshot fallback requires workspace metadata")
+		return nil, fmt.Errorf("durable disk snapshot fallback requires workspace metadata")
 	}
 	workspaceID, err := durableDiskSnapshotWorkspaceID(ctx, repos, workspace)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	snapshots := make([]*types.DiskSnapshot, 0, len(disks))
 	for _, disk := range disks {
 		if disk == nil || disk.Name == "" {
 			continue
 		}
 		snapshot, err := repos.BackendRepo.GetLatestDiskSnapshot(ctx, workspaceID, disk.Name)
 		if err != nil {
-			return fmt.Errorf("durable disk %q has no restorable snapshot: %w", disk.Name, err)
+			return nil, fmt.Errorf("durable disk %q has no restorable snapshot: %w", disk.Name, err)
 		}
 		if snapshot == nil || snapshot.ManifestKey == "" || !types.IsDiskSnapshotFilesystemFormat(snapshot.Format) {
-			return fmt.Errorf("durable disk %q has no restorable filesystem snapshot", disk.Name)
+			return nil, fmt.Errorf("durable disk %q has no restorable filesystem snapshot", disk.Name)
 		}
+		snapshots = append(snapshots, snapshot)
 	}
-	return nil
+	return snapshots, nil
 }
 
 func durableDiskSnapshotWorkspaceID(ctx context.Context, repos DurableDiskPlacementRepos, workspace *types.Workspace) (uint, error) {

--- a/pkg/abstractions/pod/instance.go
+++ b/pkg/abstractions/pod/instance.go
@@ -48,8 +48,14 @@ func (i *podInstance) ensureReadyForRequest() error {
 }
 
 func (i *podInstance) startContainers(containersToRun int) error {
+	poolSelector := i.StubConfig.PoolSelector()
 	if err := abstractions.ConfigureDurableDiskPlacement(i.Ctx, i.durableDiskPlacementRepos, i.Workspace, i.StubConfig); err != nil {
 		return err
+	}
+	if poolSelector != i.StubConfig.PoolSelector() && i.Stub != nil && i.BackendRepo != nil {
+		if err := i.BackendRepo.UpdateStubConfig(i.Ctx, i.Stub.Id, i.StubConfig); err != nil {
+			return err
+		}
 	}
 
 	secrets, err := abstractions.ConfigureContainerRequestSecrets(i.Workspace, *i.StubConfig)

--- a/pkg/gateway/services/deployment_test.go
+++ b/pkg/gateway/services/deployment_test.go
@@ -302,6 +302,42 @@ func TestScalePodDeploymentRestoresDurableDiskToRegularPoolWhenPrivatePoolGone(t
 	require.Equal(t, types.DurableDiskDriverSnapshot, backend.stubConfigs[20].Disks[0].Driver)
 }
 
+func TestScalePodDeploymentRestoresDurableDiskWhenPrivatePoolRecordIsGone(t *testing.T) {
+	gws, backend := newDeploymentLifecycleGateway(t)
+	gws.computeRepo = &deploymentLifecycleComputeRepo{states: map[string]*compute.PoolState{}}
+	backend.snapshots["pg-data"] = &types.DiskSnapshot{
+		WorkspaceId:    1,
+		DiskName:       "pg-data",
+		Format:         types.DiskSnapshotFormatPostgresWalV1,
+		Status:         types.DiskSnapshotStatusAvailable,
+		ManifestKey:    "durable-disks/pg-data/snapshots/1/manifest.json",
+		SourceWorkerId: "worker-a",
+	}
+
+	setDeploymentStubConfig(t, backend, types.StubConfigV1{
+		Pool: &types.PoolConfig{Name: "pool-a"},
+		Autoscaler: &types.Autoscaler{
+			Type:              types.QueueDepthAutoscaler,
+			MinContainers:     0,
+			MaxContainers:     1,
+			TasksPerContainer: 1,
+		},
+		Disks: []*pb.DurableDisk{{
+			Name:   "pg-data",
+			Driver: types.DurableDiskDriverSnapshot,
+		}},
+	})
+
+	resp, err := gws.ScaleDeployment(deploymentLifecycleContext(types.TokenTypeWorkspace), &pb.ScaleDeploymentRequest{
+		Id:         "deployment-id",
+		Containers: 1,
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Ok, resp.ErrMsg)
+	require.Nil(t, backend.stubConfigs[20].Pool)
+}
+
 func TestScalePodDeploymentClearsUnavailablePrivatePoolWithoutDisks(t *testing.T) {
 	gws, backend := newDeploymentLifecycleGateway(t)
 

--- a/pkg/worker/durable_disk_snapshot.go
+++ b/pkg/worker/durable_disk_snapshot.go
@@ -41,7 +41,7 @@ type durableDiskSnapshotBucketStore struct {
 	bucket string
 }
 
-func newDurableDiskSnapshotBucketStore(ctx context.Context, request *types.ContainerRequest, diskName, bucketName string, create bool) (*durableDiskSnapshotBucketStore, error) {
+func newDurableDiskSnapshotBucketStore(ctx context.Context, request *types.ContainerRequest, _ string, bucketName string, create bool) (*durableDiskSnapshotBucketStore, error) {
 	if request == nil || request.Workspace.Name == "" || !workspaceStorageDownloadAvailable(request.Workspace.Storage) {
 		return nil, fmt.Errorf("workspace storage credentials are required for durable disk snapshots")
 	}
@@ -51,10 +51,14 @@ func newDurableDiskSnapshotBucketStore(ctx context.Context, request *types.Conta
 		return nil, fmt.Errorf("create durable disk snapshot storage client: %w", err)
 	}
 	if bucketName == "" {
-		bucketName = durableDiskSnapshotBucketName(client.BucketName(), diskName)
+		bucketName = client.BucketName()
 	}
 	if create {
-		if err := client.StorageClient.EnsureBucket(ctx, bucketName); err != nil {
+		if bucketName == client.BucketName() {
+			if err := client.EnsureLocalBucket(ctx); err != nil {
+				return nil, fmt.Errorf("ensure durable disk snapshot bucket %s: %w", bucketName, err)
+			}
+		} else if err := client.StorageClient.EnsureBucket(ctx, bucketName); err != nil {
 			return nil, fmt.Errorf("ensure durable disk snapshot bucket %s: %w", bucketName, err)
 		}
 	}
@@ -75,38 +79,6 @@ func (s *durableDiskSnapshotBucketStore) UploadWithReader(ctx context.Context, k
 
 func (s *durableDiskSnapshotBucketStore) DownloadWithReader(ctx context.Context, key string) (io.ReadCloser, error) {
 	return s.client.StorageClient.DownloadWithReader(ctx, key, s.bucket)
-}
-
-func durableDiskSnapshotBucketName(workspaceBucket, diskName string) string {
-	sum := sha256.Sum256([]byte(workspaceBucket + "/" + diskName))
-	suffix := hex.EncodeToString(sum[:])[:12]
-	prefix := durableDiskBucketPart(workspaceBucket + "-disk-" + diskName)
-	if len(prefix) > 50 {
-		prefix = strings.Trim(prefix[:50], "-")
-	}
-	if prefix == "" {
-		prefix = "beta9-disk"
-	}
-	return strings.Trim(prefix+"-"+suffix, "-")
-}
-
-func durableDiskBucketPart(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	var b strings.Builder
-	lastDash := false
-	for _, r := range value {
-		ok := r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
-		if !ok {
-			if !lastDash {
-				b.WriteByte('-')
-				lastDash = true
-			}
-			continue
-		}
-		b.WriteRune(r)
-		lastDash = false
-	}
-	return strings.Trim(b.String(), "-")
 }
 
 func uploadDurableDiskSnapshotManifest(ctx context.Context, store durableDiskSnapshotStore, manifestKey string, manifest *types.DiskSnapshotManifest) (string, int64, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch durable disk snapshots to the workspace bucket (no per‑disk buckets) and simplify snapshot fallback to rely on the latest restorable snapshot, independent of private pool records. Persist pool selector changes to the stub config when placement updates it.

- **Refactors**
  - Store snapshots in the workspace’s bucket; stop creating per‑disk buckets.
  - Remove bucket name hashing/slug helpers and use `EnsureLocalBucket` when using the workspace bucket.

- **Bug Fixes**
  - Fallback no longer requires a private pool; it triggers when a restorable snapshot exists.
  - Persist stub config when the pool selector changes during placement.
  - Add test to restore disks when the private pool record is gone and clear the `Pool` field.

<sup>Written for commit d16cb3faea0bfe307065cb01ffe7ac305bec469a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

