### PR TITLE
more durable disk cleanup

### DIFF
--- a/pkg/worker/durable_disk.go
+++ b/pkg/worker/durable_disk.go
@@ -178,7 +178,7 @@ func (s *Worker) snapshotDurableDiskMount(request *types.ContainerRequest, mount
 		return err
 	}
 
-	store, err := newDurableDiskSnapshotBucketStore(ctx, request, mount.DurableDisk.Name, "", true)
+	store, err := newDurableDiskSnapshotWriteStore(ctx, request)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ func (s *Worker) restoreDurableDiskSnapshot(request *types.ContainerRequest, mou
 		return fmt.Errorf("durable disk %q has an active or incomplete local payload", mount.DurableDisk.Name)
 	}
 
-	store, err := newDurableDiskSnapshotBucketStore(ctx, request, mount.DurableDisk.Name, snapshot.BucketName, false)
+	store, err := newDurableDiskSnapshotReadStore(ctx, request, snapshot.BucketName)
 	if err != nil {
 		return err
 	}

--- a/pkg/worker/durable_disk_snapshot.go
+++ b/pkg/worker/durable_disk_snapshot.go
@@ -41,7 +41,31 @@ type durableDiskSnapshotBucketStore struct {
 	bucket string
 }
 
-func newDurableDiskSnapshotBucketStore(ctx context.Context, request *types.ContainerRequest, _ string, bucketName string, create bool) (*durableDiskSnapshotBucketStore, error) {
+func newDurableDiskSnapshotWriteStore(ctx context.Context, request *types.ContainerRequest) (*durableDiskSnapshotBucketStore, error) {
+	client, err := newDurableDiskSnapshotStorageClient(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketName := client.BucketName()
+	if err := client.EnsureLocalBucket(ctx); err != nil {
+		return nil, fmt.Errorf("ensure durable disk snapshot bucket %s: %w", bucketName, err)
+	}
+	return &durableDiskSnapshotBucketStore{client: client, bucket: bucketName}, nil
+}
+
+func newDurableDiskSnapshotReadStore(ctx context.Context, request *types.ContainerRequest, bucketName string) (*durableDiskSnapshotBucketStore, error) {
+	client, err := newDurableDiskSnapshotStorageClient(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if bucketName == "" {
+		bucketName = client.BucketName()
+	}
+	return &durableDiskSnapshotBucketStore{client: client, bucket: bucketName}, nil
+}
+
+func newDurableDiskSnapshotStorageClient(ctx context.Context, request *types.ContainerRequest) (*clients.WorkspaceStorageClient, error) {
 	if request == nil || request.Workspace.Name == "" || !workspaceStorageDownloadAvailable(request.Workspace.Storage) {
 		return nil, fmt.Errorf("workspace storage credentials are required for durable disk snapshots")
 	}
@@ -50,19 +74,7 @@ func newDurableDiskSnapshotBucketStore(ctx context.Context, request *types.Conta
 	if err != nil {
 		return nil, fmt.Errorf("create durable disk snapshot storage client: %w", err)
 	}
-	if bucketName == "" {
-		bucketName = client.BucketName()
-	}
-	if create {
-		if bucketName == client.BucketName() {
-			if err := client.EnsureLocalBucket(ctx); err != nil {
-				return nil, fmt.Errorf("ensure durable disk snapshot bucket %s: %w", bucketName, err)
-			}
-		} else if err := client.StorageClient.EnsureBucket(ctx, bucketName); err != nil {
-			return nil, fmt.Errorf("ensure durable disk snapshot bucket %s: %w", bucketName, err)
-		}
-	}
-	return &durableDiskSnapshotBucketStore{client: client, bucket: bucketName}, nil
+	return client, nil
 }
 
 func (s *durableDiskSnapshotBucketStore) Exists(ctx context.Context, key string) (bool, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make durable disk snapshot cleanup safer by splitting read/write code paths and only creating the local bucket on writes. This prevents accidental remote bucket creation and improves snapshot restore reliability.

- **Refactors**
  - Replaced `newDurableDiskSnapshotBucketStore` with `newDurableDiskSnapshotWriteStore` and `newDurableDiskSnapshotReadStore`.
  - Added `newDurableDiskSnapshotStorageClient` for shared client setup and validation.
  - Updated `snapshotDurableDiskMount` to use the write store and `restoreDurableDiskSnapshot` to use the read store.

<sup>Written for commit 4f196681784cad165f9cdb3208f1d28900c36972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

