### PR TITLE
improve disk reconcile behavior for disks

### DIFF
--- a/pkg/repository/disk_postgres_test.go
+++ b/pkg/repository/disk_postgres_test.go
@@ -244,6 +244,52 @@ func TestUpdateDiskSnapshotFinalizesManifestReference(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetLatestDiskSnapshotOrdersByGeneration(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	postgresRepo := repo.(*PostgresBackendRepository)
+
+	now := time.Now()
+	mock.ExpectQuery("ORDER BY generation DESC, created_at DESC").
+		WithArgs(uint(7), "pg-data", types.DiskSnapshotStatusAvailable).
+		WillReturnRows(diskSnapshotRows().AddRow(
+			uint(2),
+			"snapshot-2",
+			uint(7),
+			uint(13),
+			"pg-data",
+			types.DiskSnapshotFormatDirV1,
+			types.DiskSnapshotStatusAvailable,
+			"",
+			"snapshot-1",
+			int64(2),
+			int64(10<<30),
+			"ext4",
+			types.DurableDiskDriverSnapshot,
+			"durable-disks/pg-data/snapshots/2/manifest.json",
+			"sha256:manifest-2",
+			int64(512),
+			int64(128),
+			int64(10<<30),
+			int64(3<<30),
+			"disk-bucket",
+			"durable-disks/pg-data/snapshots/2",
+			"default",
+			"worker-a",
+			"node-a",
+			now,
+			now,
+			now,
+			nil,
+		))
+
+	snapshot, err := postgresRepo.GetLatestDiskSnapshot(context.Background(), 7, "pg-data")
+
+	require.NoError(t, err)
+	require.Equal(t, "snapshot-2", snapshot.ExternalId)
+	require.Equal(t, int64(2), snapshot.Generation)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func diskSnapshotRows() *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
 		"id",

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -1666,7 +1666,7 @@ func mergeStubCacheRequiredContentRecord(merged map[string]types.CacheRequiredCo
 		if item.Kind == "" {
 			item.Kind = schema.Kind
 		}
-		merged[item.Hash+"\x00"+item.RoutingKey] = item
+		mergeStubCacheRequiredContentItem(merged, item)
 	}
 }
 
@@ -1676,6 +1676,80 @@ func stubCacheRequiredContentItems(merged map[string]types.CacheRequiredContentI
 		items = append(items, item)
 	}
 	return items
+}
+
+func mergeStubCacheRequiredContentItem(merged map[string]types.CacheRequiredContentItem, item types.CacheRequiredContentItem) {
+	item = normalizeStubCacheRequiredContentItem(item)
+	if item.Kind == types.CacheContentKindDiskSnapshot && item.DiskName != "" {
+		latest := latestDiskSnapshotContentGeneration(merged, item.DiskName)
+		if item.SnapshotGeneration < latest {
+			return
+		}
+		if item.SnapshotGeneration > latest {
+			pruneDiskSnapshotContentGenerationsBefore(merged, item.DiskName, item.SnapshotGeneration)
+		}
+	}
+	merged[stubCacheRequiredContentItemKey(item)] = item
+}
+
+func normalizeStubCacheRequiredContentItem(item types.CacheRequiredContentItem) types.CacheRequiredContentItem {
+	if item.Kind != types.CacheContentKindDiskSnapshot || (item.DiskName != "" && item.SnapshotGeneration > 0) {
+		return item
+	}
+	diskName, generation := diskSnapshotContentIdentity(item.Source)
+	if item.DiskName == "" {
+		item.DiskName = diskName
+	}
+	if item.SnapshotGeneration == 0 {
+		item.SnapshotGeneration = generation
+	}
+	return item
+}
+
+func stubCacheRequiredContentItemKey(item types.CacheRequiredContentItem) string {
+	if item.Kind == types.CacheContentKindDiskSnapshot && item.DiskName != "" {
+		return strings.Join([]string{
+			string(item.Kind),
+			item.DiskName,
+			strconv.FormatInt(item.SnapshotGeneration, 10),
+			item.Hash,
+			item.RoutingKey,
+		}, "\x00")
+	}
+	return item.Hash + "\x00" + item.RoutingKey
+}
+
+func latestDiskSnapshotContentGeneration(merged map[string]types.CacheRequiredContentItem, diskName string) int64 {
+	var latest int64
+	for _, item := range merged {
+		if item.Kind == types.CacheContentKindDiskSnapshot && item.DiskName == diskName && item.SnapshotGeneration > latest {
+			latest = item.SnapshotGeneration
+		}
+	}
+	return latest
+}
+
+func pruneDiskSnapshotContentGenerationsBefore(merged map[string]types.CacheRequiredContentItem, diskName string, generation int64) {
+	for key, item := range merged {
+		if item.Kind == types.CacheContentKindDiskSnapshot && item.DiskName == diskName && item.SnapshotGeneration < generation {
+			delete(merged, key)
+		}
+	}
+}
+
+func diskSnapshotContentIdentity(source string) (string, int64) {
+	parts := strings.Split(strings.Trim(source, "/"), "/")
+	if len(parts) < 3 || parts[0] != "durable-disks" {
+		return "", 0
+	}
+	if len(parts) >= 5 && parts[2] == "snapshots" {
+		generation, _ := strconv.ParseInt(parts[3], 10, 64)
+		return parts[1], generation
+	}
+	if parts[2] == "chunks" {
+		return parts[1], 0
+	}
+	return "", 0
 }
 
 func (r *S2EventRepository) containerLogStreamName(workspaceID, stubID, containerID string) s2.StreamName {

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -244,6 +245,80 @@ func TestMergeStubCacheRequiredContentRecordKeepsLatestItem(t *testing.T) {
 	}
 	if got, want := items[0].SizeBytes, int64(200); got != want {
 		t.Fatalf("unexpected size: got %d want %d", got, want)
+	}
+}
+
+func TestMergeStubCacheRequiredContentRecordKeepsLatestDiskSnapshotGeneration(t *testing.T) {
+	merged := map[string]types.CacheRequiredContentItem{}
+	writeRecord := func(items ...types.CacheRequiredContentItem) {
+		body, err := json.Marshal(struct {
+			Type string                                    `json:"type"`
+			Data types.EventStubCacheRequiredContentSchema `json:"data"`
+		}{
+			Type: types.EventStubCacheRequiredContent,
+			Data: types.EventStubCacheRequiredContentSchema{
+				Kind:  types.CacheContentKindDiskSnapshot,
+				Items: items,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mergeStubCacheRequiredContentRecord(merged, body)
+	}
+
+	writeRecord(
+		types.CacheRequiredContentItem{
+			Hash:               "old-manifest",
+			RoutingKey:         "old-manifest",
+			Source:             "durable-disks/redis-data/snapshots/1/manifest.json",
+			DiskName:           "redis-data",
+			SnapshotGeneration: 1,
+		},
+		types.CacheRequiredContentItem{
+			Hash:               "old-only-chunk",
+			RoutingKey:         "old-only-chunk",
+			Source:             "durable-disks/redis-data/chunks/old-only-chunk",
+			DiskName:           "redis-data",
+			SnapshotGeneration: 1,
+		},
+		types.CacheRequiredContentItem{
+			Hash:       "old-unversioned-chunk",
+			RoutingKey: "old-unversioned-chunk",
+			Source:     "durable-disks/redis-data/chunks/old-unversioned-chunk",
+		},
+	)
+	writeRecord(types.CacheRequiredContentItem{
+		Hash:               "new-manifest",
+		RoutingKey:         "new-manifest",
+		Source:             "durable-disks/redis-data/snapshots/2/manifest.json",
+		DiskName:           "redis-data",
+		SnapshotGeneration: 2,
+	})
+	writeRecord(types.CacheRequiredContentItem{
+		Hash:               "new-chunk",
+		RoutingKey:         "new-chunk",
+		Source:             "durable-disks/redis-data/chunks/new-chunk",
+		DiskName:           "redis-data",
+		SnapshotGeneration: 2,
+	})
+	writeRecord(types.CacheRequiredContentItem{
+		Hash:       "ignored-old-late",
+		RoutingKey: "ignored-old-late",
+		Source:     "durable-disks/redis-data/chunks/ignored-old-late",
+	})
+
+	items := stubCacheRequiredContentItems(merged)
+	if got, want := len(items), 2; got != want {
+		t.Fatalf("unexpected item count: got %d want %d: %#v", got, want, items)
+	}
+	for _, item := range items {
+		if got, want := item.SnapshotGeneration, int64(2); got != want {
+			t.Fatalf("unexpected snapshot generation: got %d want %d", got, want)
+		}
+		if strings.HasPrefix(item.Hash, "old") || strings.HasPrefix(item.Hash, "ignored") {
+			t.Fatalf("stale snapshot item kept: %#v", item)
+		}
 	}
 }
 

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -86,16 +86,18 @@ var EventPlatformCacheSchemaVersion = "1.0"
 // non-secret descriptor (OCI layer identity or workspace object path) used to
 // resolve an origin fetch; it never carries credentials.
 type CacheRequiredContentItem struct {
-	Hash         string           `json:"hash"`
-	RoutingKey   string           `json:"routing_key"`
-	SizeBytes    int64            `json:"size_bytes,omitempty"`
-	ExpectedHash string           `json:"expected_hash,omitempty"`
-	ImageID      string           `json:"image_id,omitempty"`
-	Source       string           `json:"source,omitempty"`
-	SourceBucket string           `json:"source_bucket,omitempty"`
-	Kind         CacheContentKind `json:"kind,omitempty"`
-	CheckpointID string           `json:"checkpoint_id,omitempty"`
-	Accelerator  string           `json:"accelerator,omitempty"`
+	Hash               string           `json:"hash"`
+	RoutingKey         string           `json:"routing_key"`
+	SizeBytes          int64            `json:"size_bytes,omitempty"`
+	ExpectedHash       string           `json:"expected_hash,omitempty"`
+	ImageID            string           `json:"image_id,omitempty"`
+	Source             string           `json:"source,omitempty"`
+	SourceBucket       string           `json:"source_bucket,omitempty"`
+	Kind               CacheContentKind `json:"kind,omitempty"`
+	CheckpointID       string           `json:"checkpoint_id,omitempty"`
+	Accelerator        string           `json:"accelerator,omitempty"`
+	DiskName           string           `json:"disk_name,omitempty"`
+	SnapshotGeneration int64            `json:"snapshot_generation,omitempty"`
 }
 
 // EventStubCacheRequiredContentSchema is the coalesced required-content report

--- a/pkg/worker/durable_disk.go
+++ b/pkg/worker/durable_disk.go
@@ -411,13 +411,15 @@ func durableDiskSnapshotRequiredContentItems(snapshot *types.DiskSnapshot, manif
 			return
 		}
 		items = append(items, types.CacheRequiredContentItem{
-			Hash:         hash,
-			RoutingKey:   hash,
-			ExpectedHash: hash,
-			SizeBytes:    size,
-			Source:       key,
-			SourceBucket: snapshot.BucketName,
-			Kind:         types.CacheContentKindDiskSnapshot,
+			Hash:               hash,
+			RoutingKey:         hash,
+			ExpectedHash:       hash,
+			SizeBytes:          size,
+			Source:             key,
+			SourceBucket:       snapshot.BucketName,
+			Kind:               types.CacheContentKindDiskSnapshot,
+			DiskName:           snapshot.DiskName,
+			SnapshotGeneration: snapshot.Generation,
 		})
 	}
 	add(snapshot.ManifestDigest, snapshot.ManifestKey, snapshot.ManifestSizeBytes)

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -303,6 +303,8 @@ func TestCreateDurableDiskDirectorySnapshotPreservesEmptyDirectory(t *testing.T)
 func TestDurableDiskSnapshotRequiredContentItems(t *testing.T) {
 	items := durableDiskSnapshotRequiredContentItems(&types.DiskSnapshot{
 		BucketName:        "disk-bucket",
+		DiskName:          "pg-data",
+		Generation:        7,
 		ManifestKey:       "durable-disks/pg-data/snapshots/7/manifest.json",
 		ManifestDigest:    "sha256:" + strings.Repeat("a", 64),
 		ManifestSizeBytes: 512,
@@ -324,8 +326,12 @@ func TestDurableDiskSnapshotRequiredContentItems(t *testing.T) {
 	require.Equal(t, "disk-bucket", items[0].SourceBucket)
 	require.Equal(t, "durable-disks/pg-data/snapshots/7/manifest.json", items[0].Source)
 	require.Equal(t, int64(512), items[0].SizeBytes)
+	require.Equal(t, "pg-data", items[0].DiskName)
+	require.Equal(t, int64(7), items[0].SnapshotGeneration)
 	require.Equal(t, strings.Repeat("b", 64), items[1].Hash)
 	require.Equal(t, "disk-bucket", items[1].SourceBucket)
+	require.Equal(t, "pg-data", items[1].DiskName)
+	require.Equal(t, int64(7), items[1].SnapshotGeneration)
 }
 
 func snapshotTestFile(manifest *types.DiskSnapshotManifest, name string) types.DiskSnapshotFile {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve disk snapshot reconcile to always use the latest snapshot generation and drop stale snapshot content from cache requirements. Also add disk metadata to cache events and ensure DB fetches prefer newer generations.

- **Bug Fixes**
  - Keep only the newest disk snapshot generation when merging required-content; prune older items and ignore late old entries.
  - Derive `disk_name` and `snapshot_generation` from `source` when missing.
  - Order latest snapshot lookup by generation DESC, then `created_at`.

- **New Features**
  - Add `disk_name` and `snapshot_generation` to `CacheRequiredContentItem`, and populate them in durable disk snapshot events.
  - Use a stable key for disk snapshot items that includes disk and generation to prevent cross-generation collisions.

<sup>Written for commit 872bdf05f03d435ffb914aa48748c30e37dab289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

