### PR TITLE
Bump CLIP for timestamp sanitization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0
-	github.com/beam-cloud/clip v0.0.0-20260622205455-9f3db21c0c89
+	github.com/beam-cloud/clip v0.0.0-20260630181046-c83059e7c84a
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.12
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/beam-cloud/clip v0.0.0-20260612152219-fc12eb359a11 h1:03G4HcFrvMfM2xT
 github.com/beam-cloud/clip v0.0.0-20260612152219-fc12eb359a11/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
 github.com/beam-cloud/clip v0.0.0-20260622205455-9f3db21c0c89 h1:/nnGCYESqzVf7USxuQj5zPsjVs1yY7YS8KPVJSsNftg=
 github.com/beam-cloud/clip v0.0.0-20260622205455-9f3db21c0c89/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
+github.com/beam-cloud/clip v0.0.0-20260630181046-c83059e7c84a h1:Z1ixftRB6UQ/IxhHAvS+mtWnerEYWHmYiAcl2j723N4=
+github.com/beam-cloud/clip v0.0.0-20260630181046-c83059e7c84a/go.mod h1:GdrBOVFiqr/qox9C923iDfyfi41bpeoW+fMetSl+Z4w=
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd h1:qdvWIpwFIHK4yhLV27r7D2HZj80Umq/h3tHGITpgM6g=
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `github.com/beam-cloud/clip` to v0.0.0-20260630181046-c83059e7c84a to enable timestamp sanitization. This prevents malformed timestamps from being emitted and reduces downstream parsing errors.

<sup>Written for commit f08d73c1f9c9fdc1945067683d04222f50b9d2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

