### PR TITLE
proxy idle timeout

### DIFF
--- a/pkg/abstractions/common/proxy.go
+++ b/pkg/abstractions/common/proxy.go
@@ -43,15 +43,21 @@ func SetConnOptions(conn net.Conn, keepAlive bool, keepAliveInterval time.Durati
 }
 
 type ConnIdleDeadline struct {
-	mu      sync.Mutex
 	timeout time.Duration
 	conns   []net.Conn
+	done    chan struct{}
+	active  chan struct{}
+	stop    sync.Once
 }
 
 // NewConnIdleDeadline applies one shared idle deadline to every connection.
 // Call Refresh whenever bytes move in either direction.
 func NewConnIdleDeadline(timeout time.Duration, conns ...net.Conn) *ConnIdleDeadline {
-	d := &ConnIdleDeadline{timeout: timeout}
+	d := &ConnIdleDeadline{
+		timeout: timeout,
+		done:    make(chan struct{}),
+		active:  make(chan struct{}, 1),
+	}
 	if timeout <= 0 {
 		return d
 	}
@@ -60,7 +66,8 @@ func NewConnIdleDeadline(timeout time.Duration, conns ...net.Conn) *ConnIdleDead
 			d.conns = append(d.conns, conn)
 		}
 	}
-	d.Refresh()
+	d.setDeadline(time.Now().Add(timeout))
+	go d.closeWhenIdle()
 	return d
 }
 
@@ -69,9 +76,43 @@ func (d *ConnIdleDeadline) Refresh() {
 	if d == nil || d.timeout <= 0 {
 		return
 	}
-	deadline := time.Now().Add(d.timeout)
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.setDeadline(time.Now().Add(d.timeout))
+	select {
+	case <-d.done:
+	case d.active <- struct{}{}:
+	default:
+	}
+}
+
+func (d *ConnIdleDeadline) closeWhenIdle() {
+	timer := time.NewTimer(d.timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-d.done:
+			return
+		case <-d.active:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(d.timeout)
+		case <-timer.C:
+			d.stop.Do(func() {
+				close(d.done)
+				for _, conn := range d.conns {
+					_ = conn.Close()
+				}
+			})
+			return
+		}
+	}
+}
+
+func (d *ConnIdleDeadline) setDeadline(deadline time.Time) {
 	for _, conn := range d.conns {
 		_ = conn.SetDeadline(deadline)
 	}
@@ -82,9 +123,8 @@ func (d *ConnIdleDeadline) Clear() {
 	if d == nil || d.timeout <= 0 {
 		return
 	}
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	for _, conn := range d.conns {
-		_ = conn.SetDeadline(time.Time{})
-	}
+	d.stop.Do(func() {
+		close(d.done)
+		d.setDeadline(time.Time{})
+	})
 }

--- a/pkg/abstractions/common/proxy_buffer_test.go
+++ b/pkg/abstractions/common/proxy_buffer_test.go
@@ -2,14 +2,13 @@ package abstractions
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"net"
 	"testing"
 	"time"
 )
 
-func TestConnIdleDeadlineAppliesToNonTCPConn(t *testing.T) {
+func TestConnIdleDeadlineClosesIdleConn(t *testing.T) {
 	client, server := net.Pipe()
 	defer client.Close()
 	defer server.Close()
@@ -19,11 +18,7 @@ func TestConnIdleDeadlineAppliesToNonTCPConn(t *testing.T) {
 
 	_, err := client.Read(make([]byte, 1))
 	if err == nil {
-		t.Fatal("expected idle read deadline to fire")
-	}
-	var netErr net.Error
-	if !errors.As(err, &netErr) || !netErr.Timeout() {
-		t.Fatalf("read error = %v, want timeout", err)
+		t.Fatal("expected idle connection to close")
 	}
 }
 
@@ -88,10 +83,6 @@ func TestCopyWithProxyBufferActivityReturnsIdleTimeout(t *testing.T) {
 
 	_, err := CopyWithProxyBufferActivity(io.Discard, src, idle.Refresh)
 	if err == nil {
-		t.Fatal("expected idle timeout")
-	}
-	var netErr net.Error
-	if !errors.As(err, &netErr) || !netErr.Timeout() {
-		t.Fatalf("copy error = %v, want timeout", err)
+		t.Fatal("expected idle connection to close")
 	}
 }

--- a/sdk/tests/test_cli.py
+++ b/sdk/tests/test_cli.py
@@ -29,7 +29,8 @@ def test_database_commands_are_nested_under_db():
 
     db = cli.common_group.get_command(None, "db")
     assert db is not None
-    assert sorted(db.commands) == ["postgres", "redis"]
+    assert sorted(db.commands) == ["list", "postgres", "redis"]
+    assert "list" in db.commands
     assert "create" in db.commands["postgres"].commands
     assert "create" in db.commands["redis"].commands
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Close idle proxy connections after a timeout to prevent hangs and leaks. Also updates CLI tests to include the `db list` subcommand.

- **Bug Fixes**
  - Replace deadline-only behavior with a timer-driven closer in `ConnIdleDeadline` using `active`/`done` channels and a single goroutine.
  - `Refresh` now resets both the timer and deadlines; `Clear` stops the closer and clears deadlines.
  - Tests updated to expect idle connections to be closed (works with non-TCP conns like `net.Pipe`).
  - CLI test fixed to include `list` in `db` commands.

<sup>Written for commit fb751933258b62037d75bbac183e45ac91710398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

