### PR TITLE
small worker repo fix

### DIFF
--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -139,27 +139,6 @@ end
 return requests
 `)
 
-var cleanupScheduledContainerRequestScript = redis.NewScript(`
-if ARGV[2] == "1" then
-	redis.call("LREM", KEYS[1], 1, ARGV[1])
-end
-
-redis.call("SREM", KEYS[2], KEYS[3])
-
-local assignment_id = redis.pcall("HGET", KEYS[3], "schedule_assignment_id")
-if type(assignment_id) == "table" and assignment_id.err then
-	return 1
-end
-local worker_id = redis.pcall("HGET", KEYS[3], "worker_id")
-if type(worker_id) == "table" and worker_id.err then
-	return 1
-end
-if assignment_id == ARGV[3] and worker_id == ARGV[4] then
-	redis.call("HDEL", KEYS[3], "worker_id", "machine_id", "schedule_assignment_id")
-end
-return 1
-`)
-
 func NewWorkerRedisRepository(r *common.RedisClient, config types.WorkerConfig) WorkerRepository {
 	lock := common.NewRedisLock(r)
 	return &WorkerRedisRepository{rdb: r, lock: lock, config: config}
@@ -1044,7 +1023,15 @@ func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, r
 	pipe.HSet(ctx, containerStateKey, "worker_id", currentWorker.Id, "machine_id", currentWorker.MachineId, schedulerAssignmentIDField, assignmentID)
 	pipe.SAdd(ctx, workerContainerIndexKey, containerStateKey)
 	if _, err := pipe.Exec(ctx); err != nil {
-		cleanupErr := r.cleanupScheduledContainerRequest(ctx, queueKey, requestJSON, pushCmd.Err() == nil, containerStateKey, workerContainerIndexKey, assignmentID, currentWorker.Id)
+		cleanupErr := r.cleanupScheduledContainerRequest(ctx, scheduleCleanup{
+			queue:   queueKey,
+			index:   workerContainerIndexKey,
+			state:   containerStateKey,
+			payload: requestJSON,
+			queued:  pushCmd.Err() == nil,
+			token:   assignmentID,
+			worker:  currentWorker.Id,
+		})
 		rollbackWorker := &types.Worker{}
 		if copyErr := common.CopyStruct(updatedWorker, rollbackWorker); copyErr != nil {
 			return errors.Join(fmt.Errorf("failed to push request: %w", err), cleanupErr, fmt.Errorf("failed to copy worker for queue push rollback: %w", copyErr))
@@ -1073,12 +1060,42 @@ func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, r
 	return nil
 }
 
-func (r *WorkerRedisRepository) cleanupScheduledContainerRequest(ctx context.Context, queueKey string, requestJSON []byte, removeQueued bool, containerStateKey, workerContainerIndexKey, assignmentID, workerID string) error {
+type scheduleCleanup struct {
+	queue, index, state string
+	payload             []byte
+	queued              bool
+	token, worker       string
+}
+
+var cleanupScheduledContainerRequestScript = redis.NewScript(`
+if ARGV[2] == "1" then
+	redis.call("LREM", KEYS[1], -1, ARGV[1])
+end
+
+local token = redis.pcall("HGET", KEYS[3], "schedule_assignment_id")
+local worker = redis.pcall("HGET", KEYS[3], "worker_id")
+if type(token) == "table" or type(worker) == "table" then
+	redis.call("SREM", KEYS[2], KEYS[3])
+	return 1
+end
+
+if worker == ARGV[4] and token ~= ARGV[3] then
+	return 1
+end
+
+redis.call("SREM", KEYS[2], KEYS[3])
+if worker == ARGV[4] then
+	redis.call("HDEL", KEYS[3], "worker_id", "machine_id", "schedule_assignment_id")
+end
+return 1
+`)
+
+func (r *WorkerRedisRepository) cleanupScheduledContainerRequest(ctx context.Context, cleanup scheduleCleanup) error {
 	removeQueuedArg := "0"
-	if removeQueued {
+	if cleanup.queued {
 		removeQueuedArg = "1"
 	}
-	if err := cleanupScheduledContainerRequestScript.Run(ctx, r.rdb, []string{queueKey, workerContainerIndexKey, containerStateKey}, string(requestJSON), removeQueuedArg, assignmentID, workerID).Err(); err != nil {
+	if err := cleanupScheduledContainerRequestScript.Run(ctx, r.rdb, []string{cleanup.queue, cleanup.index, cleanup.state}, string(cleanup.payload), removeQueuedArg, cleanup.token, cleanup.worker).Err(); err != nil {
 		return fmt.Errorf("failed to clean up scheduled container request: %w", err)
 	}
 	return nil

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -27,6 +27,7 @@ const (
 	schedulerWorkerLockTTL      = 10
 	schedulerWorkerLockRetries  = 20
 	schedulerWorkerLockInterval = 50 * time.Millisecond
+	schedulerAssignmentIDField  = "schedule_assignment_id"
 )
 
 var schedulerWorkerLockOptions = common.RedisLockOptions{
@@ -136,6 +137,27 @@ if #requests > 0 then
 	redis.call("DEL", KEYS[1])
 end
 return requests
+`)
+
+var cleanupScheduledContainerRequestScript = redis.NewScript(`
+if ARGV[2] == "1" then
+	redis.call("LREM", KEYS[1], 1, ARGV[1])
+end
+
+redis.call("SREM", KEYS[2], KEYS[3])
+
+local assignment_id = redis.pcall("HGET", KEYS[3], "schedule_assignment_id")
+if type(assignment_id) == "table" and assignment_id.err then
+	return 1
+end
+local worker_id = redis.pcall("HGET", KEYS[3], "worker_id")
+if type(worker_id) == "table" and worker_id.err then
+	return 1
+end
+if assignment_id == ARGV[3] and worker_id == ARGV[4] then
+	redis.call("HDEL", KEYS[3], "worker_id", "machine_id", "schedule_assignment_id")
+end
+return 1
 `)
 
 func NewWorkerRedisRepository(r *common.RedisClient, config types.WorkerConfig) WorkerRepository {
@@ -1013,15 +1035,16 @@ func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, r
 	containerStateKey := common.RedisKeys.SchedulerContainerState(request.ContainerId)
 	queueKey := common.RedisKeys.SchedulerWorkerRequests(worker.Id)
 	workerContainerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id)
+	assignmentID := uuid.NewString()
 
 	// Push the serialized ContainerRequest and stamp the selected node together
 	// so container state can be correlated to the worker before runtime start.
 	pipe := r.rdb.TxPipeline()
 	pushCmd := pipe.RPush(ctx, queueKey, requestJSON)
-	pipe.HSet(ctx, containerStateKey, "worker_id", currentWorker.Id, "machine_id", currentWorker.MachineId)
+	pipe.HSet(ctx, containerStateKey, "worker_id", currentWorker.Id, "machine_id", currentWorker.MachineId, schedulerAssignmentIDField, assignmentID)
 	pipe.SAdd(ctx, workerContainerIndexKey, containerStateKey)
 	if _, err := pipe.Exec(ctx); err != nil {
-		cleanupErr := r.cleanupScheduledContainerRequest(ctx, queueKey, requestJSON, pushCmd.Err() == nil, containerStateKey, workerContainerIndexKey)
+		cleanupErr := r.cleanupScheduledContainerRequest(ctx, queueKey, requestJSON, pushCmd.Err() == nil, containerStateKey, workerContainerIndexKey, assignmentID, currentWorker.Id)
 		rollbackWorker := &types.Worker{}
 		if copyErr := common.CopyStruct(updatedWorker, rollbackWorker); copyErr != nil {
 			return errors.Join(fmt.Errorf("failed to push request: %w", err), cleanupErr, fmt.Errorf("failed to copy worker for queue push rollback: %w", copyErr))
@@ -1050,14 +1073,12 @@ func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, r
 	return nil
 }
 
-func (r *WorkerRedisRepository) cleanupScheduledContainerRequest(ctx context.Context, queueKey string, requestJSON []byte, removeQueued bool, containerStateKey, workerContainerIndexKey string) error {
-	pipe := r.rdb.Pipeline()
+func (r *WorkerRedisRepository) cleanupScheduledContainerRequest(ctx context.Context, queueKey string, requestJSON []byte, removeQueued bool, containerStateKey, workerContainerIndexKey, assignmentID, workerID string) error {
+	removeQueuedArg := "0"
 	if removeQueued {
-		pipe.LRem(ctx, queueKey, 1, requestJSON)
+		removeQueuedArg = "1"
 	}
-	pipe.SRem(ctx, workerContainerIndexKey, containerStateKey)
-	pipe.HDel(ctx, containerStateKey, "worker_id", "machine_id")
-	if _, err := pipe.Exec(ctx); err != nil {
+	if err := cleanupScheduledContainerRequestScript.Run(ctx, r.rdb, []string{queueKey, workerContainerIndexKey, containerStateKey}, string(requestJSON), removeQueuedArg, assignmentID, workerID).Err(); err != nil {
 		return fmt.Errorf("failed to clean up scheduled container request: %w", err)
 	}
 	return nil
@@ -1069,6 +1090,7 @@ func (r *WorkerRedisRepository) AddContainerToWorker(workerId string, containerI
 	ctx := context.TODO()
 	pipe := r.rdb.TxPipeline()
 	pipe.SAdd(ctx, common.RedisKeys.SchedulerContainerWorkerIndex(workerId), containerStateKey)
+	pipe.HDel(ctx, containerStateKey, schedulerAssignmentIDField)
 	if worker, err := r.getWorkerFromKey(common.RedisKeys.SchedulerWorkerState(workerId)); err == nil && worker != nil {
 		pipe.HSet(ctx, containerStateKey, "worker_id", worker.Id, "machine_id", worker.MachineId)
 	}

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -887,7 +887,15 @@ func TestCleanupScheduledContainerRequestPreservesNewerAssignment(t *testing.T) 
 	).Err()
 	assert.Nil(t, err)
 
-	err = repo.cleanupScheduledContainerRequest(context.TODO(), queueKey, requestJSON, true, containerStateKey, oldWorkerIndexKey, "assignment-old", "worker-old")
+	err = repo.cleanupScheduledContainerRequest(context.TODO(), scheduleCleanup{
+		queue:   queueKey,
+		index:   oldWorkerIndexKey,
+		state:   containerStateKey,
+		payload: requestJSON,
+		queued:  true,
+		token:   "assignment-old",
+		worker:  "worker-old",
+	})
 	assert.Nil(t, err)
 
 	queueDepth, err := rdb.LLen(context.TODO(), queueKey).Result()
@@ -904,6 +912,34 @@ func TestCleanupScheduledContainerRequestPreservesNewerAssignment(t *testing.T) 
 	assert.Equal(t, "worker-new", stateFields["worker_id"])
 	assert.Equal(t, "machine-new", stateFields["machine_id"])
 	assert.Equal(t, "assignment-old", stateFields["schedule_assignment_id"])
+
+	sameWorkerStateKey := common.RedisKeys.SchedulerContainerState("container-same-worker-newer-assignment")
+	sameWorkerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex("worker-same")
+	err = rdb.SAdd(context.TODO(), sameWorkerIndexKey, sameWorkerStateKey).Err()
+	assert.Nil(t, err)
+	err = rdb.HSet(context.TODO(), sameWorkerStateKey,
+		"worker_id", "worker-same",
+		"machine_id", "machine-same",
+		"schedule_assignment_id", "assignment-new",
+	).Err()
+	assert.Nil(t, err)
+
+	err = repo.cleanupScheduledContainerRequest(context.TODO(), scheduleCleanup{
+		index:  sameWorkerIndexKey,
+		state:  sameWorkerStateKey,
+		token:  "assignment-old",
+		worker: "worker-same",
+	})
+	assert.Nil(t, err)
+
+	indexedSameWorker, err := rdb.SIsMember(context.TODO(), sameWorkerIndexKey, sameWorkerStateKey).Result()
+	assert.Nil(t, err)
+	assert.True(t, indexedSameWorker)
+	sameWorkerFields, err := rdb.HGetAll(context.TODO(), sameWorkerStateKey).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, "worker-same", sameWorkerFields["worker_id"])
+	assert.Equal(t, "machine-same", sameWorkerFields["machine_id"])
+	assert.Equal(t, "assignment-new", sameWorkerFields["schedule_assignment_id"])
 }
 
 func TestScheduleContainerRequestRejectsDisabledWorker(t *testing.T) {

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -863,6 +863,49 @@ func TestScheduleContainerRequestRemovesQueuedRequestWhenMetadataWriteFails(t *t
 	assert.False(t, indexed)
 }
 
+func TestCleanupScheduledContainerRequestPreservesNewerAssignment(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb).(*WorkerRedisRepository)
+	containerStateKey := common.RedisKeys.SchedulerContainerState("container-newer-assignment")
+	oldWorkerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex("worker-old")
+	newWorkerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex("worker-new")
+	queueKey := common.RedisKeys.SchedulerWorkerRequests("worker-old")
+	requestJSON := []byte(`{"container_id":"container-newer-assignment"}`)
+	err = rdb.RPush(context.TODO(), queueKey, requestJSON).Err()
+	assert.Nil(t, err)
+	err = rdb.SAdd(context.TODO(), oldWorkerIndexKey, containerStateKey).Err()
+	assert.Nil(t, err)
+	err = rdb.SAdd(context.TODO(), newWorkerIndexKey, containerStateKey).Err()
+	assert.Nil(t, err)
+	err = rdb.HSet(context.TODO(), containerStateKey,
+		"worker_id", "worker-new",
+		"machine_id", "machine-new",
+		"schedule_assignment_id", "assignment-old",
+	).Err()
+	assert.Nil(t, err)
+
+	err = repo.cleanupScheduledContainerRequest(context.TODO(), queueKey, requestJSON, true, containerStateKey, oldWorkerIndexKey, "assignment-old", "worker-old")
+	assert.Nil(t, err)
+
+	queueDepth, err := rdb.LLen(context.TODO(), queueKey).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), queueDepth)
+	indexedOld, err := rdb.SIsMember(context.TODO(), oldWorkerIndexKey, containerStateKey).Result()
+	assert.Nil(t, err)
+	assert.False(t, indexedOld)
+	indexedNew, err := rdb.SIsMember(context.TODO(), newWorkerIndexKey, containerStateKey).Result()
+	assert.Nil(t, err)
+	assert.True(t, indexedNew)
+	stateFields, err := rdb.HGetAll(context.TODO(), containerStateKey).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, "worker-new", stateFields["worker_id"])
+	assert.Equal(t, "machine-new", stateFields["machine_id"])
+	assert.Equal(t, "assignment-old", stateFields["schedule_assignment_id"])
+}
+
 func TestScheduleContainerRequestRejectsDisabledWorker(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -1458,6 +1458,7 @@ func TestPruneStubCodeCacheRemovesExpiredAndTempEntries(t *testing.T) {
 	require.Equal(t, 2, pruned)
 	require.Positive(t, freed)
 	require.NoFileExists(t, oldReady)
+	require.NoDirExists(t, filepath.Dir(oldReady))
 	require.NoDirExists(t, tmpDir)
 	require.DirExists(t, activeTmpDir)
 	require.FileExists(t, recentReady)
@@ -1475,6 +1476,7 @@ func TestPressureEvictStubCodeCacheSkipsActiveTempEntries(t *testing.T) {
 	require.Equal(t, 1, evicted)
 	require.Positive(t, freed)
 	require.NoFileExists(t, oldReady)
+	require.NoDirExists(t, filepath.Dir(oldReady))
 	require.DirExists(t, activeTmpDir)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race in scheduler cleanup by tagging each scheduled container with an assignment ID and using an atomic Redis Lua script. Prevents older cleanups from wiping state after a container is re-assigned to a different worker.

- **Bug Fixes**
  - Add an assignment ID on schedule; store it with worker_id and machine_id on container state.
  - Replace multi-command cleanup with a single Lua script that:
    - Optionally removes the queued request.
    - Removes the old worker’s index entry, unless the same worker has a newer assignment.
    - Clears state only if assignment ID and worker_id match.
  - Clear the assignment ID when the container is added to a worker.
  - Tests: ensure newer assignments are preserved (same worker and new worker cases); assert parent dirs are removed in cache pruner tests.

<sup>Written for commit f03fc8d7b5b0654c35cd504c9b13a9eed38102d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

