### PR TITLE
fix small restore edge case

### DIFF
--- a/pkg/runtime/runc.go
+++ b/pkg/runtime/runc.go
@@ -245,8 +245,7 @@ func (r *Runc) Restore(ctx context.Context, containerID string, opts *RestoreOpt
 		}
 	}
 
-	finalResult := <-restoreDone
-	return finalResult.exitCode, finalResult.err
+	return 0, nil
 }
 
 func (r *Runc) runcCommand() string {
@@ -363,7 +362,7 @@ func runcWaitResult(err error) runcCommandResult {
 }
 
 func (r *Runc) RestoreWaitsForExit() bool {
-	return true
+	return false
 }
 
 func (r *Runc) Close() error {

--- a/pkg/runtime/runc_test.go
+++ b/pkg/runtime/runc_test.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -69,4 +71,78 @@ func TestPollRestoredContainerPIDFailsWhenStateUnavailable(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.Contains(t, err.Error(), "restore succeeded but restored container state was unavailable")
+}
+
+func TestRuncRestoreReturnsAfterStateRunning(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "runc.log")
+	readyPath := filepath.Join(dir, "restore-ready")
+	runcPath := filepath.Join(dir, "runc")
+	require.NoError(t, os.WriteFile(runcPath, []byte(`#!/bin/sh
+set -eu
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    restore|state)
+      cmd="$arg"
+      break
+      ;;
+  esac
+done
+case "$cmd" in
+  restore)
+    echo restore-start >> "$RUNC_FAKE_LOG"
+    touch "$RUNC_FAKE_READY"
+    sleep 1
+    echo restore-done >> "$RUNC_FAKE_LOG"
+    ;;
+  state)
+    echo state >> "$RUNC_FAKE_LOG"
+    if [ ! -f "$RUNC_FAKE_READY" ]; then
+      exit 1
+    fi
+    printf '{"id":"container-1","pid":4321,"status":"running"}'
+    ;;
+  *)
+    echo "unexpected args: $*" >&2
+    exit 1
+    ;;
+esac
+`), 0o755))
+	t.Setenv("RUNC_FAKE_LOG", logPath)
+	t.Setenv("RUNC_FAKE_READY", readyPath)
+
+	rt, err := NewRunc(Config{RuncPath: runcPath})
+	require.NoError(t, err)
+
+	started := make(chan int, 1)
+	result := make(chan error, 1)
+	go func() {
+		_, err := rt.Restore(context.Background(), "container-1", &RestoreOpts{
+			ImagePath:  filepath.Join(dir, "checkpoint"),
+			BundlePath: filepath.Join(dir, "bundle"),
+			Started:    started,
+		})
+		result <- err
+	}()
+
+	select {
+	case pid := <-started:
+		require.Equal(t, 4321, pid)
+	case <-time.After(time.Second):
+		t.Fatal("restore did not signal started from restored runtime state")
+	}
+
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("restore waited for the restored process to exit")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Contains(t, string(logData), "restore-start\n")
+	require.Contains(t, string(logData), "state\n")
+	require.NotContains(t, string(logData), "restore-done\n")
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `Runc.Restore` return once the restored container is running, instead of waiting for the process to exit. This fixes a blocking restore edge case and aligns with the expected start semantics.

- **Bug Fixes**
  - `Restore` now returns `(0, nil)` after the container reports `running`; it no longer waits on process exit.
  - `RestoreWaitsForExit()` now returns `false`.
  - Added `TestRuncRestoreReturnsAfterStateRunning` to verify PID is signaled and the call returns promptly.

<sup>Written for commit 5221696b4e76acc39d9921de30e6881b432ea0c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

