### PR TITLE
more cr fixes

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -102,13 +102,14 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 
 	// If checkpoint/restore is enabled, we need to handle a few additional things to ensure dump/restore will work properly
 	if in.CheckpointEnabled {
-		err := gws.handleCheckpointEnabled(ctx, authInfo, in, gpus)
+		checkpointWarning, err := gws.handleCheckpointEnabled(ctx, authInfo, in, gpus)
 		if err != nil {
 			return &pb.GetOrCreateStubResponse{
 				Ok:     false,
 				ErrMsg: err.Error(),
 			}, nil
 		}
+		warning = appendWarning(warning, checkpointWarning)
 	}
 
 	var inputs *types.Schema = nil
@@ -232,7 +233,7 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		}
 
 		if len(lowCapacityGpus) > 0 {
-			warning = fmt.Sprintf("GPU capacity for %s is currently low.", strings.Join(lowCapacityGpus, ", "))
+			warning = appendWarning(warning, fmt.Sprintf("GPU capacity for %s is currently low.", strings.Join(lowCapacityGpus, ", ")))
 		}
 	}
 
@@ -565,32 +566,66 @@ func sanitizePoolSelector(value string) string {
 	return out
 }
 
-func (gws *GatewayService) handleCheckpointEnabled(ctx context.Context, authInfo *auth.AuthInfo, in *pb.GetOrCreateStubRequest, gpus []types.GpuType) error {
+// checkpointTriggerTypeHTTP mirrors the trigger type the worker uses to decide between
+// HTTP readiness polling and the runner signal file (see pkg/worker/criu.go)
+const checkpointTriggerTypeHTTP = "http"
+
+func appendWarning(existing, warning string) string {
+	if existing == "" {
+		return warning
+	}
+	if warning == "" {
+		return existing
+	}
+	return existing + " " + warning
+}
+
+func checkpointModelCacheVolumeName(in *pb.GetOrCreateStubRequest) string {
+	name := in.Name
+	if in.AppName != "" {
+		name = in.AppName
+	}
+	return types.CheckpointModelCacheVolumeName(name)
+}
+
+// handleCheckpointEnabled validates and configures a stub request that has checkpointing
+// enabled. It returns a user-facing warning message (empty if none) and an error.
+func (gws *GatewayService) handleCheckpointEnabled(ctx context.Context, authInfo *auth.AuthInfo, in *pb.GetOrCreateStubRequest, gpus []types.GpuType) (string, error) {
 	workspace := authInfo.Workspace
 
 	if in.GpuCount > 1 {
-		return fmt.Errorf("Checkpoints are yet not supported for multi-GPU")
+		return "", fmt.Errorf("Checkpoints are yet not supported for multi-GPU")
 	}
 
 	if len(gpus) > 1 {
-		return fmt.Errorf("Checkpoints are yet not supported between multiple GPUs")
+		return "", fmt.Errorf("Checkpoints are yet not supported between multiple GPUs")
 	}
 
-	// Disable checkpoint for serves
+	// Disable checkpoint for serves, but let the user know instead of failing silently
 	if types.StubType(in.StubType).IsServe() {
 		in.CheckpointEnabled = false
-		return nil
+		return "checkpointing is not supported for serve sessions; it has been disabled", nil
+	}
+
+	// Pods have no beta9 runner process to write the checkpoint readiness signal file,
+	// so automatic checkpoints require an HTTP readiness path. Sandboxes are exempt
+	// because they checkpoint via the manual snapshot APIs instead.
+	if types.StubType(in.StubType).Kind() == types.StubTypePod {
+		trigger := in.CheckpointTrigger
+		if trigger == nil || !strings.EqualFold(trigger.Type, checkpointTriggerTypeHTTP) || trigger.HttpPath == "" {
+			return "", fmt.Errorf("pods with checkpoint_enabled require checkpoint_readiness_path to be set (there is no runner to signal readiness)")
+		}
 	}
 
 	if !workspace.StorageAvailable() {
-		return fmt.Errorf("workspace storage is required for checkpoints")
+		return "", fmt.Errorf("workspace storage is required for checkpoints")
 	}
 
-	volumeName := types.CheckpointModelCacheVolumeName(in.Name)
+	volumeName := checkpointModelCacheVolumeName(in)
 	modelCachePath := fmt.Sprintf("/%s", volumeName)
 	volume, err := gws.backendRepo.GetOrCreateVolume(ctx, authInfo.Workspace.Id, volumeName)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Force set cache vars
@@ -605,7 +640,7 @@ func (gws *GatewayService) handleCheckpointEnabled(ctx context.Context, authInfo
 		MountPath: modelCachePath,
 	})
 
-	return nil
+	return "", nil
 }
 
 func (gws *GatewayService) DeployStub(ctx context.Context, in *pb.DeployStubRequest) (*pb.DeployStubResponse, error) {

--- a/pkg/gateway/services/stub_test.go
+++ b/pkg/gateway/services/stub_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
@@ -57,4 +58,74 @@ func TestConfigureDurableDiskPlacementAllowsReadOnlyDiskWithMultipleContainers(t
 	}
 
 	require.NoError(t, (&GatewayService{}).configureDurableDiskPlacement(context.Background(), nil, config))
+}
+
+func TestHandleCheckpointEnabledDisablesCheckpointForServesWithWarning(t *testing.T) {
+	authInfo := &auth.AuthInfo{Workspace: &types.Workspace{}}
+	in := &pb.GetOrCreateStubRequest{
+		StubType:          types.StubTypeEndpointServe,
+		CheckpointEnabled: true,
+	}
+
+	warning, err := (&GatewayService{}).handleCheckpointEnabled(context.Background(), authInfo, in, nil)
+	require.NoError(t, err)
+	require.Contains(t, warning, "checkpointing is not supported for serve sessions")
+	require.False(t, in.CheckpointEnabled)
+}
+
+func TestHandleCheckpointEnabledRequiresReadinessPathForPods(t *testing.T) {
+	authInfo := &auth.AuthInfo{Workspace: &types.Workspace{}}
+
+	for _, stubType := range []string{types.StubTypePod, types.StubTypePodDeployment, types.StubTypePodRun} {
+		t.Run(stubType, func(t *testing.T) {
+			// No trigger at all
+			in := &pb.GetOrCreateStubRequest{StubType: stubType, CheckpointEnabled: true}
+			_, err := (&GatewayService{}).handleCheckpointEnabled(context.Background(), authInfo, in, nil)
+			require.ErrorContains(t, err, "checkpoint_readiness_path")
+
+			// Trigger without an HTTP path
+			in = &pb.GetOrCreateStubRequest{
+				StubType:          stubType,
+				CheckpointEnabled: true,
+				CheckpointTrigger: &pb.CheckpointTrigger{Type: "http"},
+			}
+			_, err = (&GatewayService{}).handleCheckpointEnabled(context.Background(), authInfo, in, nil)
+			require.ErrorContains(t, err, "checkpoint_readiness_path")
+
+			// Valid HTTP trigger passes pod validation (fails later on workspace storage instead)
+			in = &pb.GetOrCreateStubRequest{
+				StubType:          stubType,
+				CheckpointEnabled: true,
+				CheckpointTrigger: &pb.CheckpointTrigger{Type: "http", HttpPath: "/ready"},
+			}
+			_, err = (&GatewayService{}).handleCheckpointEnabled(context.Background(), authInfo, in, nil)
+			require.ErrorContains(t, err, "workspace storage is required")
+		})
+	}
+}
+
+func TestHandleCheckpointEnabledExemptsSandboxesFromReadinessPath(t *testing.T) {
+	authInfo := &auth.AuthInfo{Workspace: &types.Workspace{}}
+	in := &pb.GetOrCreateStubRequest{
+		StubType:          types.StubTypeSandbox,
+		CheckpointEnabled: true,
+	}
+
+	// Sandboxes checkpoint via manual snapshot APIs, so no readiness path is required;
+	// validation proceeds to the workspace storage check instead.
+	_, err := (&GatewayService{}).handleCheckpointEnabled(context.Background(), authInfo, in, nil)
+	require.ErrorContains(t, err, "workspace storage is required")
+}
+
+func TestCheckpointModelCacheVolumeNamePrefersAppName(t *testing.T) {
+	in := &pb.GetOrCreateStubRequest{
+		Name:    types.StubTypePodDeployment,
+		AppName: "qwen",
+	}
+	require.Equal(t, "checkpoint-model-cache-qwen", checkpointModelCacheVolumeName(in))
+}
+
+func TestCheckpointModelCacheVolumeNameFallsBackToStubName(t *testing.T) {
+	in := &pb.GetOrCreateStubRequest{Name: "qwen/prod"}
+	require.Equal(t, "checkpoint-model-cache-qwen-prod", checkpointModelCacheVolumeName(in))
 }

--- a/pkg/runtime/runsc.go
+++ b/pkg/runtime/runsc.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	runscRestoreStateTimeout      = 2 * time.Second
+	runscRestoreStateTimeout      = 30 * time.Second
 	runscRestoreStatePollInterval = 25 * time.Millisecond
 )
 
@@ -310,13 +310,11 @@ func (r *Runsc) Checkpoint(ctx context.Context, containerID string, opts *Checkp
 		return fmt.Errorf("checkpoint options cannot be nil")
 	}
 
-	// Freeze CUDA processes before checkpointing (non-fatal)
+	// Freeze CUDA processes before checkpointing. A failure here means GPU state
+	// cannot be captured, so fail the checkpoint instead of producing a broken image.
 	if r.nvproxyEnabled {
 		if err := r.cudaCheckpointProcesses(ctx, containerID, "checkpoint", opts.OutputWriter); err != nil {
-			// Log but don't fail - CUDA checkpoint is optional
-			if opts.OutputWriter != nil {
-				fmt.Fprintf(opts.OutputWriter, "Warning: CUDA checkpoint failed: %v\n", err)
-			}
+			return fmt.Errorf("cuda checkpoint failed: %w", err)
 		}
 	}
 
@@ -454,13 +452,12 @@ func (r *Runsc) Restore(ctx context.Context, containerID string, opts *RestoreOp
 		return -1, err
 	}
 
-	// Unfreeze CUDA processes after restore (non-fatal)
+	// Unfreeze CUDA processes after restore. A failure leaves GPU state frozen/broken,
+	// so propagate it and let the caller fall back to a cold boot (restore_failed path).
 	if r.nvproxyEnabled {
 		if err := r.cudaCheckpointProcesses(ctx, containerID, "restore", opts.OutputWriter); err != nil {
-			// Log but don't fail - CUDA restore is optional
-			if opts.OutputWriter != nil {
-				fmt.Fprintf(opts.OutputWriter, "Warning: CUDA restore failed: %v\n", err)
-			}
+			killRestoreProcess()
+			return -1, fmt.Errorf("cuda restore failed: %w", err)
 		}
 	}
 
@@ -550,8 +547,12 @@ func (r *Runsc) cudaCheckpointProcesses(ctx context.Context, containerID, action
 	}
 
 	pids, err := r.findCUDAProcesses(ctx, containerID)
-	if err != nil || len(pids) == 0 {
-		return nil // No CUDA processes, skip
+	if err != nil {
+		return err
+	}
+	if len(pids) == 0 {
+		// No CUDA processes is legitimate (e.g. GPU attached but not used yet)
+		return nil
 	}
 
 	for _, pid := range pids {
@@ -582,18 +583,15 @@ func (r *Runsc) findCUDAProcesses(ctx context.Context, containerID string) ([]in
 
 	output, err := exec.CommandContext(ctx, r.cfg.RunscPath, args...).Output()
 	if err != nil {
-		return []int{1}, nil // Fallback to PID 1
+		return nil, fmt.Errorf("failed to enumerate CUDA processes in container %s: %w", containerID, err)
 	}
 
+	// An empty result is valid - it means no processes have nvidia devices open
 	var pids []int
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		if pid, err := strconv.Atoi(strings.TrimSpace(line)); err == nil && pid > 0 {
 			pids = append(pids, pid)
 		}
-	}
-
-	if len(pids) == 0 {
-		return []int{1}, nil // Fallback to PID 1
 	}
 
 	return pids, nil

--- a/pkg/runtime/runsc.go
+++ b/pkg/runtime/runsc.go
@@ -581,17 +581,28 @@ func (r *Runsc) findCUDAProcesses(ctx context.Context, containerID string) ([]in
 			"[ -d \"$pid/fd\" ] && ls -l $pid/fd 2>/dev/null | grep -q nvidia && basename $pid; "+
 			"done")
 
-	output, err := exec.CommandContext(ctx, r.cfg.RunscPath, args...).Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to enumerate CUDA processes in container %s: %w", containerID, err)
-	}
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, r.cfg.RunscPath, args...)
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
 
-	// An empty result is valid - it means no processes have nvidia devices open
 	var pids []int
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		if pid, err := strconv.Atoi(strings.TrimSpace(line)); err == nil && pid > 0 {
 			pids = append(pids, pid)
 		}
+	}
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			if len(pids) > 0 || (strings.TrimSpace(string(output)) == "" && strings.TrimSpace(stderr.String()) == "") {
+				return pids, nil
+			}
+		}
+
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return nil, fmt.Errorf("failed to enumerate CUDA processes in container %s: %w (output: %s)", containerID, err, message)
+		}
+		return nil, fmt.Errorf("failed to enumerate CUDA processes in container %s: %w", containerID, err)
 	}
 
 	return pids, nil

--- a/pkg/runtime/runsc_test.go
+++ b/pkg/runtime/runsc_test.go
@@ -113,6 +113,7 @@ set -u
 for arg in "$@"; do
   if [ "$arg" = "exec" ]; then
 `+execBody+`
+    exit 0
   fi
 done
 echo "unexpected args: $*" >&2
@@ -124,11 +125,19 @@ exit 1
 
 func TestFindCUDAProcessesReturnsPIDs(t *testing.T) {
 	rt := newFakeRunsc(t, `    printf '12\n345\n'
-    exit 0`)
+	    exit 0`)
 
 	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
 	require.NoError(t, err)
 	require.Equal(t, []int{12, 345}, pids)
+}
+
+func TestFindCUDAProcessesExecBodyMayFallThrough(t *testing.T) {
+	rt := newFakeRunsc(t, `    printf '7\n'`)
+
+	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
+	require.NoError(t, err)
+	require.Equal(t, []int{7}, pids)
 }
 
 func TestFindCUDAProcessesEmptyOutputIsNotAnError(t *testing.T) {
@@ -139,11 +148,30 @@ func TestFindCUDAProcessesEmptyOutputIsNotAnError(t *testing.T) {
 	require.Empty(t, pids)
 }
 
-func TestFindCUDAProcessesExecFailureReturnsError(t *testing.T) {
+func TestFindCUDAProcessesNoMatchExitOneIsNotAnError(t *testing.T) {
 	rt := newFakeRunsc(t, `    exit 1`)
+
+	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
+	require.NoError(t, err)
+	require.Empty(t, pids)
+}
+
+func TestFindCUDAProcessesExitOneWithPIDsReturnsPIDs(t *testing.T) {
+	rt := newFakeRunsc(t, `    printf '12\n'
+	    exit 1`)
+
+	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
+	require.NoError(t, err)
+	require.Equal(t, []int{12}, pids)
+}
+
+func TestFindCUDAProcessesExecFailureReturnsError(t *testing.T) {
+	rt := newFakeRunsc(t, `    echo boom >&2
+	    exit 1`)
 
 	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to enumerate CUDA processes")
+	require.ErrorContains(t, err, "boom")
 	require.Nil(t, pids)
 }

--- a/pkg/runtime/runsc_test.go
+++ b/pkg/runtime/runsc_test.go
@@ -100,3 +100,50 @@ esac
 	require.Contains(t, string(logData), "restore-ready\n")
 	require.NotContains(t, string(logData), "restore-done\n")
 }
+
+// newFakeRunsc writes a fake runsc script whose `exec` subcommand runs the given
+// shell body, and returns a Runsc wired to it.
+func newFakeRunsc(t *testing.T, execBody string) *Runsc {
+	t.Helper()
+
+	dir := t.TempDir()
+	runscPath := filepath.Join(dir, "runsc")
+	require.NoError(t, os.WriteFile(runscPath, []byte(`#!/bin/sh
+set -u
+for arg in "$@"; do
+  if [ "$arg" = "exec" ]; then
+`+execBody+`
+  fi
+done
+echo "unexpected args: $*" >&2
+exit 1
+`), 0o755))
+
+	return &Runsc{cfg: Config{RunscPath: runscPath, RunscRoot: filepath.Join(dir, "root")}}
+}
+
+func TestFindCUDAProcessesReturnsPIDs(t *testing.T) {
+	rt := newFakeRunsc(t, `    printf '12\n345\n'
+    exit 0`)
+
+	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
+	require.NoError(t, err)
+	require.Equal(t, []int{12, 345}, pids)
+}
+
+func TestFindCUDAProcessesEmptyOutputIsNotAnError(t *testing.T) {
+	rt := newFakeRunsc(t, `    exit 0`)
+
+	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
+	require.NoError(t, err)
+	require.Empty(t, pids)
+}
+
+func TestFindCUDAProcessesExecFailureReturnsError(t *testing.T) {
+	rt := newFakeRunsc(t, `    exit 1`)
+
+	pids, err := rt.findCUDAProcesses(context.Background(), "container-1")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to enumerate CUDA processes")
+	require.Nil(t, pids)
+}

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -273,16 +273,6 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 
 	caps := s.runtime.Capabilities()
 
-	// Gate features based on runtime capabilities
-	if request.CheckpointEnabled && !caps.CheckpointRestore {
-		log.Info().Str("container_id", containerId).
-			Str("runtime", s.runtime.Name()).
-			Msg("disabling checkpoint for runtime without CRIU support")
-
-		request.CheckpointEnabled = false
-		request.Checkpoint = nil
-	}
-
 	if request.RequiresGPU() && !caps.GPU {
 		return fmt.Errorf("runtime %s does not support GPU workloads", s.runtime.Name())
 	}
@@ -326,6 +316,17 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 
 	// Handle stdout/stderr
 	go s.containerLogger.CaptureLogs(request, logChan)
+
+	// Gate checkpointing based on runtime capabilities, and let the user know if it was disabled
+	if request.CheckpointEnabled && !caps.CheckpointRestore {
+		log.Info().Str("container_id", containerId).
+			Str("runtime", s.runtime.Name()).
+			Msg("disabling checkpoint for runtime without CRIU support")
+		outputLogger.Info("Checkpointing is enabled for this container, but the runtime on this worker does not support checkpoint/restore - disabling checkpointing\n")
+
+		request.CheckpointEnabled = false
+		request.Checkpoint = nil
+	}
 
 	_, imageLoaded, err := s.loadContainerImage(ctx, request, outputLogger)
 	if err != nil {

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.253"
+version = "0.1.254"
 description = ""
 
 [project.scripts]

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "beta9"
-version = "0.1.253"
+version = "0.1.254"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves checkpoint/restore reliability and clarity: stricter validation with user-visible warnings in the gateway, fatal CUDA CR errors in the runtime, longer restore readiness wait, and a clear notice when a worker disables checkpointing. Also bumps the Python `beta9` SDK to 0.1.254.

- **Bug Fixes**
  - `pkg/gateway`: require `checkpoint_readiness_path` (HTTP trigger) for pod-based stubs; auto-disable checkpointing for serve sessions with a warning; prefer `AppName` for model cache volume naming; aggregate multiple warnings in responses.
  - `pkg/runtime`: increase `runsc` restore readiness wait to 30s; make CUDA checkpoint/restore failures fatal and propagate errors from CUDA process discovery; remove PID 1 fallback.
  - `pkg/worker`: when CR is unsupported, emit a user-visible message to container output and disable checkpointing.

- **Migration**
  - For pods with checkpointing, set `checkpoint_trigger` type `http` and a valid `checkpoint_readiness_path`.
  - Do not enable checkpointing for serve stubs; it will be disabled with a warning.
  - Ensure workspace storage is enabled to use checkpoints.

<sup>Written for commit c304ce6a9c2c61c61b4ac520b3fcb4a9b53adc22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

