### PR TITLE
fix: remove triton cache dir

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -570,6 +570,8 @@ func sanitizePoolSelector(value string) string {
 // HTTP readiness polling and the runner signal file (see pkg/worker/criu.go)
 const checkpointTriggerTypeHTTP = "http"
 
+const checkpointCompileCacheRoot = "/tmp/beam-checkpoint-compile-cache"
+
 func appendWarning(existing, warning string) string {
 	if existing == "" {
 		return warning
@@ -586,6 +588,43 @@ func checkpointModelCacheVolumeName(in *pb.GetOrCreateStubRequest) string {
 		name = in.AppName
 	}
 	return types.CheckpointModelCacheVolumeName(name)
+}
+
+func checkpointCacheEnv(modelCachePath string) []string {
+	// Persist model files across checkpoint boots, but keep compiler/JIT artifacts on
+	// local disk so Triton/TorchInductor can compile before the checkpoint is created.
+	return []string{
+		fmt.Sprintf("HF_HOME=%s", modelCachePath),
+		fmt.Sprintf("HF_HUB_CACHE=%s/hub", modelCachePath),
+		fmt.Sprintf("TRANSFORMERS_CACHE=%s", modelCachePath),
+		fmt.Sprintf("TRITON_CACHE_DIR=%s/triton", checkpointCompileCacheRoot),
+		fmt.Sprintf("TORCHINDUCTOR_CACHE_DIR=%s/torchinductor", checkpointCompileCacheRoot),
+		fmt.Sprintf("VLLM_CACHE_ROOT=%s/vllm", checkpointCompileCacheRoot),
+		fmt.Sprintf("CUDA_CACHE_PATH=%s/cuda", checkpointCompileCacheRoot),
+		"HF_HUB_DISABLE_XET=1",
+		"HF_HUB_ENABLE_HF_TRANSFER=0",
+	}
+}
+
+func upsertCheckpointEnv(env []string, updates []string) []string {
+	for _, update := range updates {
+		name, _, ok := strings.Cut(update, "=")
+		if !ok {
+			continue
+		}
+		replaced := false
+		for i, existing := range env {
+			existingName, _, ok := strings.Cut(existing, "=")
+			if ok && existingName == name {
+				env[i] = update
+				replaced = true
+			}
+		}
+		if !replaced {
+			env = append(env, update)
+		}
+	}
+	return env
 }
 
 // handleCheckpointEnabled validates and configures a stub request that has checkpointing
@@ -628,12 +667,7 @@ func (gws *GatewayService) handleCheckpointEnabled(ctx context.Context, authInfo
 		return "", err
 	}
 
-	// Force set cache vars
-	in.Env = append(in.Env, fmt.Sprintf("TRITON_CACHE_DIR=%s", modelCachePath))
-	in.Env = append(in.Env, fmt.Sprintf("TRANSFORMERS_CACHE=%s", modelCachePath))
-	in.Env = append(in.Env, fmt.Sprintf("HF_HOME=%s", modelCachePath))
-	in.Env = append(in.Env, "HF_HUB_DISABLE_XET=1")
-	in.Env = append(in.Env, "HF_HUB_ENABLE_HF_TRANSFER=0")
+	in.Env = upsertCheckpointEnv(in.Env, checkpointCacheEnv(modelCachePath))
 
 	in.Volumes = append(in.Volumes, &pb.Volume{
 		Id:        volume.ExternalId,

--- a/pkg/gateway/services/stub_test.go
+++ b/pkg/gateway/services/stub_test.go
@@ -5,10 +5,19 @@ import (
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
 )
+
+type checkpointVolumeBackendRepo struct {
+	repository.BackendRepository
+}
+
+func (r *checkpointVolumeBackendRepo) GetOrCreateVolume(ctx context.Context, workspaceId uint, name string) (*types.Volume, error) {
+	return &types.Volume{ExternalId: "volume-123", WorkspaceId: workspaceId, Name: name}, nil
+}
 
 func TestConfigureDurableDiskPlacementDefaultsSnapshotDriver(t *testing.T) {
 	config := &types.StubConfigV1{
@@ -128,4 +137,40 @@ func TestCheckpointModelCacheVolumeNamePrefersAppName(t *testing.T) {
 func TestCheckpointModelCacheVolumeNameFallsBackToStubName(t *testing.T) {
 	in := &pb.GetOrCreateStubRequest{Name: "qwen/prod"}
 	require.Equal(t, "checkpoint-model-cache-qwen-prod", checkpointModelCacheVolumeName(in))
+}
+
+func TestHandleCheckpointEnabledSplitsModelAndCompilerCaches(t *testing.T) {
+	storageId := uint(1)
+	authInfo := &auth.AuthInfo{Workspace: &types.Workspace{
+		Id:        7,
+		StorageId: &storageId,
+		Storage:   &types.WorkspaceStorage{Id: &storageId},
+	}}
+	in := &pb.GetOrCreateStubRequest{
+		Name:              "qwen",
+		StubType:          types.StubTypePodDeployment,
+		CheckpointEnabled: true,
+		CheckpointTrigger: &pb.CheckpointTrigger{Type: "http", HttpPath: "/v1/models"},
+		Env:               []string{"TRITON_CACHE_DIR=/bad", "HF_HOME=/bad", "USER_ENV=1"},
+	}
+
+	warning, err := (&GatewayService{backendRepo: &checkpointVolumeBackendRepo{}}).handleCheckpointEnabled(context.Background(), authInfo, in, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, warning)
+	require.ElementsMatch(t, []string{
+		"HF_HOME=/checkpoint-model-cache-qwen",
+		"HF_HUB_CACHE=/checkpoint-model-cache-qwen/hub",
+		"TRANSFORMERS_CACHE=/checkpoint-model-cache-qwen",
+		"TRITON_CACHE_DIR=/tmp/beam-checkpoint-compile-cache/triton",
+		"TORCHINDUCTOR_CACHE_DIR=/tmp/beam-checkpoint-compile-cache/torchinductor",
+		"VLLM_CACHE_ROOT=/tmp/beam-checkpoint-compile-cache/vllm",
+		"CUDA_CACHE_PATH=/tmp/beam-checkpoint-compile-cache/cuda",
+		"HF_HUB_DISABLE_XET=1",
+		"HF_HUB_ENABLE_HF_TRANSFER=0",
+		"USER_ENV=1",
+	}, in.Env)
+	require.Len(t, in.Volumes, 1)
+	require.Equal(t, "volume-123", in.Volumes[0].Id)
+	require.Equal(t, "/checkpoint-model-cache-qwen", in.Volumes[0].MountPath)
 }

--- a/pkg/worker/mount_test.go
+++ b/pkg/worker/mount_test.go
@@ -167,6 +167,48 @@ func TestSetupContainerMountsPrefersDirectWorkspaceStorageForStubCode(t *testing
 	require.Equal(t, "direct\n", string(workspaceBytes))
 }
 
+func TestSetupContainerMountsUsesWorkspaceStorageForCheckpointModelCacheVolume(t *testing.T) {
+	workspace := "workspace-checkpoint"
+	volumeID := "volume-123"
+	storageID := uint(1)
+	storageRoot := t.TempDir()
+	manager := NewContainerMountManager(types.AppConfig{
+		Storage: types.StorageConfig{
+			WorkspaceStorage: types.WorkspaceStorageConfig{
+				BaseMountPath: storageRoot,
+			},
+		},
+	})
+	cacheVolumeName := types.CheckpointModelCacheVolumeName("qwen")
+	legacyVolumePath := filepath.Join(types.DefaultVolumesPath, workspace, volumeID)
+	request := &types.ContainerRequest{
+		ContainerId: "container-checkpoint-volume",
+		Workspace: types.Workspace{
+			Name:    workspace,
+			Storage: &types.WorkspaceStorage{Id: &storageID},
+		},
+		Mounts: []types.Mount{
+			{
+				LocalPath: legacyVolumePath,
+				MountPath: filepath.Join(types.WorkerContainerVolumePath, cacheVolumeName),
+			},
+			{
+				LocalPath: legacyVolumePath,
+				MountPath: "/" + cacheVolumeName,
+			},
+		},
+	}
+
+	require.True(t, manager.RequiresWorkspaceStorageMount(request))
+	require.NoError(t, manager.SetupContainerMounts(context.Background(), request, discardLogger()))
+
+	expectedWorkspaceVolumePath := filepath.Join(storageRoot, workspace, types.DefaultVolumesPrefix, volumeID)
+	require.Equal(t, expectedWorkspaceVolumePath, request.Mounts[0].LocalPath)
+	require.Equal(t, expectedWorkspaceVolumePath, request.Mounts[1].LocalPath)
+	require.NotContains(t, request.Mounts[0].LocalPath, types.DefaultVolumesPath)
+	require.NotContains(t, request.Mounts[1].LocalPath, types.DefaultVolumesPath)
+}
+
 func TestStubCodeCacheRootUsesDiskCacheWhenEnabled(t *testing.T) {
 	cacheRoot := t.TempDir()
 	config := types.AppConfig{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split model and compiler caches for checkpointed stubs. HF model files persist on the volume, while Triton/TorchInductor/vLLM/CUDA caches now write to `/tmp/beam-checkpoint-compile-cache`.

- **Bug Fixes**
  - Set env in `handleCheckpointEnabled` via `checkpointCacheEnv` + `upsertCheckpointEnv`: HF caches to the model cache volume; compiler/JIT caches to `/tmp/beam-checkpoint-compile-cache`.
  - Preserve user-defined env and replace only conflicts.
  - Ensure worker mounts route the checkpoint model cache volume to workspace storage (new tests cover env and mount behavior).

<sup>Written for commit 572450eea55c2811b8f69ddba3b7b01d17e1b5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

