### PR TITLE
reachability fixes

### DIFF
--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -31,6 +33,7 @@ import (
 const (
 	gpuCntEnvKey               = types.WorkerGPUCountEnv
 	defaultCheckpointDeadline  = 10 * time.Minute
+	defaultCheckpointCreateTTL = 10 * time.Minute
 	readyLogRate               = 10
 	checkpointFsDir            = "filesystem"
 	checkpointArchiveExtension = ".tar"
@@ -362,7 +365,21 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 	}
 
 	if opts.CheckpointPIDChan != nil {
-		<-opts.CheckpointPIDChan
+		if opts.OutputLogger != nil {
+			opts.OutputLogger.Info("Waiting for container runtime to start before checkpoint")
+		}
+		select {
+		case pid, ok := <-opts.CheckpointPIDChan:
+			if !ok {
+				return fmt.Errorf("container runtime exited before checkpoint could start")
+			}
+			if pid <= 0 {
+				return fmt.Errorf("container runtime reported invalid PID %d before checkpoint", pid)
+			}
+			log.Info().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Int("pid", pid).Msg("container runtime started for checkpoint")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	log.Info().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msg("creating checkpoint")
@@ -371,39 +388,58 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 		err := s.waitForCheckpointTrigger(ctx, opts.Request, opts.OutputLogger)
 		if err != nil {
 			log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to wait for checkpoint signal: %v", err)
+			if opts.OutputLogger != nil {
+				opts.OutputLogger.Error(fmt.Sprintf("Failed to wait for checkpoint readiness: %v", err))
+			}
 			s.markCheckpointFailed(opts)
 			return err
 		}
 	}
 
 	// Proceed to create the checkpoint
-	checkpointPath, err := s.criuManager.CreateCheckpoint(ctx, instance.Runtime, opts.CheckpointId, opts.Request)
+	if opts.OutputLogger != nil {
+		opts.OutputLogger.Info("Creating container checkpoint snapshot")
+	}
+	checkpointCtx, checkpointCancel := context.WithTimeout(ctx, defaultCheckpointCreateTTL)
+	defer checkpointCancel()
+	checkpointPath, err := s.criuManager.CreateCheckpoint(checkpointCtx, instance.Runtime, opts.CheckpointId, opts.Request)
 	if err != nil {
+		if errors.Is(checkpointCtx.Err(), context.DeadlineExceeded) {
+			err = fmt.Errorf("checkpoint snapshot timed out after %s: %w", defaultCheckpointCreateTTL, err)
+		}
 		s.markCheckpointFailed(opts)
 
 		if opts.OutputLogger != nil {
-			opts.OutputLogger.Error("Failed to create checkpoint")
+			opts.OutputLogger.Error(fmt.Sprintf("Failed to create checkpoint: %v", err))
 		}
 
 		return err
 	}
-
 	parentDir := filepath.Dir(instance.Overlay.TopLayerPath())
 	upperDir := path.Join(parentDir, "upper")
 
 	err = copyDirectory(upperDir, path.Join(checkpointPath, checkpointFsDir), []string{"config.json", "outputs", "snapshot"})
 	if err != nil {
 		log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to copy upper directory: %v", err)
+		if opts.OutputLogger != nil {
+			opts.OutputLogger.Error(fmt.Sprintf("Failed to copy checkpoint filesystem state: %v", err))
+		}
 		return err
 	}
 	if !checkpointMaterialized(checkpointPath) {
 		return fmt.Errorf("checkpoint missing runtime or filesystem payload")
 	}
 
+	if opts.OutputLogger != nil {
+		opts.OutputLogger.Info("Persisting container checkpoint")
+	}
 	metadata, err := s.persistCheckpoint(ctx, opts.Request, opts.CheckpointId, checkpointPath)
 	if err != nil {
 		_ = s.createCheckpointState(opts.CheckpointId, opts.Request, types.CheckpointStatusCheckpointFailed, opts.ContainerIp)
 		log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to persist checkpoint: %v", err)
+		if opts.OutputLogger != nil {
+			opts.OutputLogger.Error(fmt.Sprintf("Failed to persist checkpoint: %v", err))
+		}
 		return err
 	}
 
@@ -425,9 +461,9 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 
 	if opts.OutputLogger != nil {
 		opts.OutputLogger.Info("Checkpoint created successfully")
+	} else {
+		log.Info().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msg("checkpoint created successfully")
 	}
-
-	log.Info().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msg("checkpoint created successfully")
 	return nil
 }
 
@@ -940,6 +976,14 @@ func (s *Worker) waitForCheckpointHTTPReadiness(ctx context.Context, request *ty
 		return fmt.Errorf("checkpoint HTTP readiness port is required")
 	}
 
+	readinessPath := trigger.HttpPath
+	if !strings.HasPrefix(readinessPath, "/") {
+		readinessPath = "/" + readinessPath
+	}
+	if outputLogger != nil {
+		outputLogger.Info(fmt.Sprintf("Waiting for container HTTP readiness before checkpoint (port %d, path %s)", port, readinessPath))
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -950,11 +994,13 @@ func (s *Worker) waitForCheckpointHTTPReadiness(ctx context.Context, request *ty
 	sampledLogger := log.Sample(&zerolog.BasicSampler{N: readyLogRate})
 
 	for {
-		if err := s.checkCheckpointHTTPReady(ctx, client, request, port, trigger.HttpPath); err == nil {
-			outputLogger.Info("Container HTTP readiness reached for checkpoint")
+		if err := s.checkCheckpointHTTPReady(ctx, client, request, port, readinessPath); err == nil {
+			if outputLogger != nil {
+				outputLogger.Info("Container HTTP readiness reached for checkpoint")
+			}
 			return nil
 		} else {
-			sampledLogger.Info().Str("container_id", request.ContainerId).Int32("port", port).Str("path", trigger.HttpPath).Err(err).Msg("container not ready for checkpoint")
+			sampledLogger.Info().Str("container_id", request.ContainerId).Int32("port", port).Str("path", readinessPath).Err(err).Msg("container not ready for checkpoint")
 		}
 
 		select {
@@ -971,29 +1017,86 @@ func (s *Worker) checkCheckpointHTTPReady(ctx context.Context, client *http.Clie
 		return fmt.Errorf("container instance not found yet")
 	}
 
-	address := instance.containerAddress(port)
-	if address == "" {
+	addresses := checkpointHTTPReadinessAddresses(instance, port)
+	if len(addresses) == 0 {
 		return fmt.Errorf("container address for port %d not registered yet", port)
 	}
 
 	if !strings.HasPrefix(readinessPath, "/") {
 		readinessPath = "/" + readinessPath
 	}
+
+	var firstErr error
+	for _, address := range addresses {
+		if err := checkCheckpointHTTPReadyAt(ctx, client, address, readinessPath); err == nil {
+			return nil
+		} else if firstErr == nil {
+			firstErr = fmt.Errorf("%s: %w", address, err)
+		}
+	}
+
+	return fmt.Errorf("checkpoint HTTP readiness failed at %w", firstErr)
+}
+
+func checkCheckpointHTTPReadyAt(ctx context.Context, client *http.Client, address, readinessPath string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+address+readinessPath, nil)
 	if err != nil {
 		return err
 	}
-
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("checkpoint HTTP readiness returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func checkpointHTTPReadinessAddresses(instance *ContainerInstance, port int32) []string {
+	if instance == nil {
+		return nil
+	}
+	portText := strconv.Itoa(int(port))
+	addresses := []string{}
+	addAddress := func(address string) {
+		if address == "" {
+			return
+		}
+		for _, existing := range addresses {
+			if existing == address {
+				return
+			}
+		}
+		addresses = append(addresses, address)
+	}
+	addHost := func(host string) {
+		if host != "" {
+			addAddress(net.JoinHostPort(host, portText))
+		}
+	}
+
+	addHost(instance.ContainerIp)
+	addHost(checkpointContainerIPv6(instance.ContainerIp))
+	addAddress(instance.containerAddress(port))
+	return addresses
+}
+
+func checkpointContainerIPv6(containerIP string) string {
+	ip := net.ParseIP(containerIP)
+	if ip == nil || ip.To4() == nil {
+		return ""
+	}
+	_, ipv6Net, err := net.ParseCIDR(containerSubnetIPv6)
+	if err != nil {
+		return ""
+	}
+	ipv6Address, err := containerIPv6Address(ip, ipv6Net)
+	if err != nil {
+		return ""
+	}
+	return ipv6Address.String()
 }
 
 func (s *Worker) waitForCheckpointSignal(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger) error {

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -368,17 +368,25 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 		if opts.OutputLogger != nil {
 			opts.OutputLogger.Info("Waiting for container runtime to start before checkpoint")
 		}
+		failBeforeRuntimeStart := func(err error) error {
+			log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Err(err).Msg("checkpoint failed before container runtime started")
+			if opts.OutputLogger != nil {
+				opts.OutputLogger.Error(fmt.Sprintf("Failed to start checkpoint: %v", err))
+			}
+			s.markCheckpointFailed(opts)
+			return err
+		}
 		select {
 		case pid, ok := <-opts.CheckpointPIDChan:
 			if !ok {
-				return fmt.Errorf("container runtime exited before checkpoint could start")
+				return failBeforeRuntimeStart(fmt.Errorf("container runtime exited before checkpoint could start"))
 			}
 			if pid <= 0 {
-				return fmt.Errorf("container runtime reported invalid PID %d before checkpoint", pid)
+				return failBeforeRuntimeStart(fmt.Errorf("container runtime reported invalid PID %d before checkpoint", pid))
 			}
 			log.Info().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Int("pid", pid).Msg("container runtime started for checkpoint")
 		case <-ctx.Done():
-			return ctx.Err()
+			return failBeforeRuntimeStart(ctx.Err())
 		}
 	}
 

--- a/pkg/worker/criu_test.go
+++ b/pkg/worker/criu_test.go
@@ -575,8 +575,10 @@ func TestCreateCheckpointRequiresCRIUManager(t *testing.T) {
 
 func TestCreateCheckpointFailsWhenRuntimeStartSignalCloses(t *testing.T) {
 	containerID := "container-no-runtime-start"
+	backendRepoClient := &fakeBackendRepoClient{}
 	worker := &Worker{
 		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		backendRepoClient:  backendRepoClient,
 		criuManager:        &NvidiaCRIUManager{checkpointRoot: t.TempDir(), available: true},
 	}
 	worker.containerInstances.Set(containerID, &ContainerInstance{
@@ -587,12 +589,18 @@ func TestCreateCheckpointFailsWhenRuntimeStartSignalCloses(t *testing.T) {
 	close(checkpointPIDChan)
 
 	err := worker.createCheckpoint(context.Background(), &CreateCheckpointOpts{
-		Request:           &types.ContainerRequest{ContainerId: containerID},
+		Request:           &types.ContainerRequest{ContainerId: containerID, Stub: types.StubWithRelated{Stub: types.Stub{ExternalId: "stub-no-runtime-start"}}},
 		CheckpointId:      "checkpoint-no-runtime-start",
 		CheckpointPIDChan: checkpointPIDChan,
 	})
 	if err == nil || !strings.Contains(err.Error(), "container runtime exited before checkpoint could start") {
 		t.Fatalf("createCheckpoint error = %v, want runtime start signal error", err)
+	}
+	if backendRepoClient.createCalls != 1 {
+		t.Fatalf("CreateCheckpoint calls = %d, want 1", backendRepoClient.createCalls)
+	}
+	if got := backendRepoClient.lastCreate.Status; got != string(types.CheckpointStatusCheckpointFailed) {
+		t.Fatalf("checkpoint status = %q, want %q", got, types.CheckpointStatusCheckpointFailed)
 	}
 }
 

--- a/pkg/worker/criu_test.go
+++ b/pkg/worker/criu_test.go
@@ -1,13 +1,18 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -43,7 +48,7 @@ func TestCheckpointHTTPReadinessRequiresStatusOK(t *testing.T) {
 	}))
 	defer server.Close()
 
-	address := strings.TrimPrefix(server.URL, "http://")
+	address := testHTTPServerAddress(t, server)
 	worker := &Worker{containerInstances: common.NewSafeMap[*ContainerInstance]()}
 	request := &types.ContainerRequest{ContainerId: "container-1"}
 	worker.containerInstances.Set(request.ContainerId, &ContainerInstance{
@@ -59,6 +64,134 @@ func TestCheckpointHTTPReadinessRequiresStatusOK(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected non-200 readiness response to fail")
 	}
+}
+
+func TestCheckpointHTTPReadinessPrefersContainerIP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, port := testHTTPServerHostPort(t, server)
+
+	worker := &Worker{containerInstances: common.NewSafeMap[*ContainerInstance]()}
+	request := &types.ContainerRequest{ContainerId: "container-direct-ip"}
+	worker.containerInstances.Set(request.ContainerId, &ContainerInstance{
+		ContainerIp:         host,
+		ContainerAddressMap: map[int32]string{port: "127.0.0.1:1"},
+	})
+
+	err := worker.checkCheckpointHTTPReady(context.Background(), server.Client(), request, port, "/ready")
+	if err != nil {
+		t.Fatalf("checkCheckpointHTTPReady returned error: %v", err)
+	}
+}
+
+func TestCheckpointHTTPReadinessAddresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *ContainerInstance
+		want     []string
+	}{
+		{
+			name: "container IPv4 before published route",
+			instance: &ContainerInstance{
+				ContainerIp:         "192.168.0.65",
+				ContainerAddressMap: map[int32]string{8000: "10.42.0.215:43131"},
+			},
+			want: []string{
+				"192.168.0.65:8000",
+				"[fd00:abcd::41]:8000",
+				"10.42.0.215:43131",
+			},
+		},
+		{
+			name: "container IPv6 before published route",
+			instance: &ContainerInstance{
+				ContainerIp:         "fd00:abcd::41",
+				ContainerAddressMap: map[int32]string{8000: "[2600:1f18::1]:43131"},
+			},
+			want: []string{
+				"[fd00:abcd::41]:8000",
+				"[2600:1f18::1]:43131",
+			},
+		},
+		{
+			name: "published route only",
+			instance: &ContainerInstance{
+				ContainerAddressMap: map[int32]string{8000: "10.42.0.215:43131"},
+			},
+			want: []string{"10.42.0.215:43131"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkpointHTTPReadinessAddresses(tt.instance, 8000)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("checkpoint readiness addresses = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForCheckpointHTTPReadinessLogsWaitingAndReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	address := testHTTPServerAddress(t, server)
+	worker := &Worker{containerInstances: common.NewSafeMap[*ContainerInstance]()}
+	request := &types.ContainerRequest{
+		ContainerId: "container-ready-log",
+		Ports:       []uint32{8000},
+	}
+	worker.containerInstances.Set(request.ContainerId, &ContainerInstance{
+		ContainerAddressMap: map[int32]string{8000: address},
+	})
+	trigger := &types.CheckpointTrigger{
+		Type:           checkpointTriggerHTTP,
+		HttpPath:       "v1/models",
+		TimeoutSeconds: 1,
+	}
+	var output bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&output, nil))
+
+	if err := worker.waitForCheckpointHTTPReadiness(context.Background(), request, trigger, logger); err != nil {
+		t.Fatalf("waitForCheckpointHTTPReadiness returned error: %v", err)
+	}
+
+	logs := output.String()
+	if !strings.Contains(logs, "Waiting for container HTTP readiness before checkpoint (port 8000, path /v1/models)") {
+		t.Fatalf("expected waiting log, got: %s", logs)
+	}
+	if !strings.Contains(logs, "Container HTTP readiness reached for checkpoint") {
+		t.Fatalf("expected ready log, got: %s", logs)
+	}
+}
+
+func testHTTPServerAddress(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	return strings.TrimPrefix(server.URL, "http://")
+}
+
+func testHTTPServerHostPort(t *testing.T, server *httptest.Server) (string, int32) {
+	t.Helper()
+
+	host, portText, err := net.SplitHostPort(testHTTPServerAddress(t, server))
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return host, int32(port)
 }
 
 func TestCheckpointCreateLockIsPerStub(t *testing.T) {
@@ -437,6 +570,29 @@ func TestCreateCheckpointRequiresCRIUManager(t *testing.T) {
 	})
 	if !errors.Is(err, errCRIUManagerUnavailable) {
 		t.Fatalf("createCheckpoint error = %v, want %v", err, errCRIUManagerUnavailable)
+	}
+}
+
+func TestCreateCheckpointFailsWhenRuntimeStartSignalCloses(t *testing.T) {
+	containerID := "container-no-runtime-start"
+	worker := &Worker{
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		criuManager:        &NvidiaCRIUManager{checkpointRoot: t.TempDir(), available: true},
+	}
+	worker.containerInstances.Set(containerID, &ContainerInstance{
+		Id:      containerID,
+		Runtime: NewMockRuntime("runc", runtime.Capabilities{CheckpointRestore: true}),
+	})
+	checkpointPIDChan := make(chan int)
+	close(checkpointPIDChan)
+
+	err := worker.createCheckpoint(context.Background(), &CreateCheckpointOpts{
+		Request:           &types.ContainerRequest{ContainerId: containerID},
+		CheckpointId:      "checkpoint-no-runtime-start",
+		CheckpointPIDChan: checkpointPIDChan,
+	})
+	if err == nil || !strings.Contains(err.Error(), "container runtime exited before checkpoint could start") {
+		t.Fatalf("createCheckpoint error = %v, want runtime start signal error", err)
 	}
 }
 

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -1856,6 +1856,8 @@ func (m *restoreFallbackRuntime) Run(ctx context.Context, containerID, bundlePat
 type fakeBackendRepoClient struct {
 	updateCalls int
 	lastUpdate  *pb.UpdateCheckpointRequest
+	createCalls int
+	lastCreate  *pb.CreateCheckpointRequest
 }
 
 func (f *fakeBackendRepoClient) GetCheckpointById(ctx context.Context, in *pb.GetCheckpointByIdRequest, opts ...grpc.CallOption) (*pb.GetCheckpointByIdResponse, error) {
@@ -1871,6 +1873,8 @@ func (f *fakeBackendRepoClient) ListCheckpoints(ctx context.Context, in *pb.List
 }
 
 func (f *fakeBackendRepoClient) CreateCheckpoint(ctx context.Context, in *pb.CreateCheckpointRequest, opts ...grpc.CallOption) (*pb.CreateCheckpointResponse, error) {
+	f.createCalls++
+	f.lastCreate = in
 	return &pb.CreateCheckpointResponse{Ok: true}, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves checkpoint reachability by preferring the container IP, trying derived IPv6, and normalizing HTTP paths. Adds a 10m snapshot timeout and waits for the runtime to start, with clearer logs end-to-end.

- **Bug Fixes**
  - HTTP readiness: normalize path; log wait with port/path; probe in order—`ContainerIp`, derived IPv6, then published route; return first failure clearly.
  - Runtime start: block on `CheckpointPIDChan`; fail on closed/invalid PID or context cancel; log PID when received.
  - Checkpoint creation: enforce 10m snapshot timeout; clearer errors and logs when creating, copying filesystem state, and persisting; log success even without `OutputLogger`.
  - Tests: cover address ordering (direct IP and IPv6), waiting/ready logs, PID channel closed, and status update on early failure.

<sup>Written for commit e719874ad46e36e727dd74ab963b65b1154e6091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

