### PR TITLE
add vllm fixes for cr

### DIFF
--- a/pkg/worker/container_environment.go
+++ b/pkg/worker/container_environment.go
@@ -45,6 +45,8 @@ func (s *Worker) getContainerEnvironment(request *types.ContainerRequest, option
 }
 
 func (s *Worker) applyRuntimeEnvironmentOverrides(env []string, request *types.ContainerRequest) []string {
+	env = applyCheckpointRuntimeEnvironmentOverrides(env, request)
+
 	if request == nil || !request.RequiresGPU() || s == nil || s.runtime == nil {
 		return env
 	}

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -25,6 +25,7 @@ import (
 	types "github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/google/uuid"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -41,7 +42,67 @@ const (
 	checkpointTriggerHTTP      = "http"
 )
 
+var checkpointRuntimeEnvOverrides = []string{
+	"UV_USE_IO_URING=0",
+	"TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL=1",
+}
+
+var checkpointDisabledIOUringSyscalls = []string{
+	"io_uring_setup",
+	"io_uring_enter",
+	"io_uring_register",
+}
+
 var errCRIUManagerUnavailable = errors.New("checkpoint/restore unavailable: CRIU manager is not initialized")
+
+func applyCheckpointRuntimeEnvironmentOverrides(env []string, request *types.ContainerRequest) []string {
+	if request == nil || !request.CheckpointEnabled {
+		return env
+	}
+	return upsertEnvVars(env, checkpointRuntimeEnvOverrides)
+}
+
+func disableIOUringForCheckpoint(spec *specs.Spec) {
+	if spec == nil {
+		return
+	}
+	if spec.Linux == nil {
+		spec.Linux = &specs.Linux{}
+	}
+	if spec.Linux.Seccomp == nil {
+		spec.Linux.Seccomp = &specs.LinuxSeccomp{DefaultAction: specs.ActAllow}
+	}
+	if spec.Linux.Seccomp.DefaultAction == "" {
+		spec.Linux.Seccomp.DefaultAction = specs.ActAllow
+	}
+
+	blocked := make(map[string]struct{}, len(checkpointDisabledIOUringSyscalls))
+	for _, name := range checkpointDisabledIOUringSyscalls {
+		blocked[name] = struct{}{}
+	}
+
+	syscalls := spec.Linux.Seccomp.Syscalls[:0]
+	for _, syscallRule := range spec.Linux.Seccomp.Syscalls {
+		names := syscallRule.Names[:0]
+		for _, name := range syscallRule.Names {
+			if _, ok := blocked[name]; !ok {
+				names = append(names, name)
+			}
+		}
+		if len(names) == 0 {
+			continue
+		}
+		syscallRule.Names = names
+		syscalls = append(syscalls, syscallRule)
+	}
+
+	errno := uint(syscall.ENOSYS)
+	spec.Linux.Seccomp.Syscalls = append([]specs.LinuxSyscall{{
+		Names:    append([]string(nil), checkpointDisabledIOUringSyscalls...),
+		Action:   specs.ActErrno,
+		ErrnoRet: &errno,
+	}}, syscalls...)
+}
 
 type checkpointCacheMetadata struct {
 	hash        string

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -771,6 +771,8 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 
 	// We need to include the checkpoint signal files in the container spec
 	if s.IsCRIUAvailable(request.GpuCount) && request.CheckpointEnabled {
+		disableIOUringForCheckpoint(spec)
+
 		err = os.MkdirAll(checkpointSignalDir(request.ContainerId), os.ModePerm) // Add a mount point for the checkpoint signal file
 		if err != nil {
 			return nil, err

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -222,6 +222,31 @@ func TestApplyRuntimeEnvironmentOverridesLeavesRuncNvidiaCapabilities(t *testing
 	require.Equal(t, "all", envMap["NVIDIA_DRIVER_CAPABILITIES"])
 }
 
+func TestApplyRuntimeEnvironmentOverridesDisablesLibuvIOUringForCheckpoints(t *testing.T) {
+	worker := &Worker{runtime: &mockRuntime{name: types.ContainerRuntimeRunc.String()}}
+	env := worker.applyRuntimeEnvironmentOverrides(
+		[]string{"UV_USE_IO_URING=1", "TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL=0", "OTHER=value"},
+		&types.ContainerRequest{CheckpointEnabled: true},
+	)
+	envMap := envListToMap(env)
+
+	require.Equal(t, "0", envMap["UV_USE_IO_URING"])
+	require.Equal(t, "1", envMap["TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL"])
+	require.Equal(t, "value", envMap["OTHER"])
+}
+
+func TestApplyRuntimeEnvironmentOverridesLeavesCheckpointEnvWithoutCheckpoints(t *testing.T) {
+	worker := &Worker{runtime: &mockRuntime{name: types.ContainerRuntimeRunc.String()}}
+	env := worker.applyRuntimeEnvironmentOverrides(
+		[]string{"UV_USE_IO_URING=1", "TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL=0"},
+		&types.ContainerRequest{},
+	)
+	envMap := envListToMap(env)
+
+	require.Equal(t, "1", envMap["UV_USE_IO_URING"])
+	require.Equal(t, "0", envMap["TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL"])
+}
+
 func TestRegisterContainerPortsUsesNetworkManagerAddresses(t *testing.T) {
 	containerID := "container-route"
 	repoClient := &fakeContainerRepoClient{}
@@ -533,6 +558,93 @@ func TestSpecFromRequestRejectsRunnerStubWithoutRunnerEnv(t *testing.T) {
 
 	require.Nil(t, spec)
 	require.ErrorContains(t, err, "empty process args")
+}
+
+func TestSpecFromRequestDisablesIOUringForCheckpoints(t *testing.T) {
+	t.Setenv(types.WorkerPoolEnv, "default")
+
+	worker := &Worker{
+		config: types.AppConfig{Worker: types.WorkerConfig{Pools: map[string]types.WorkerPoolConfig{
+			"default": {CRIUEnabled: true},
+		}}},
+		podAddr:     "127.0.0.1",
+		runtime:     &mockRuntime{name: types.ContainerRuntimeRunc.String()},
+		criuManager: &startedCRIUManager{},
+	}
+
+	spec, err := worker.specFromRequest(&types.ContainerRequest{
+		ContainerId:       "container-checkpoint",
+		EntryPoint:        []string{"python", "app.py"},
+		CheckpointEnabled: true,
+		Stub: types.StubWithRelated{Stub: types.Stub{
+			Type: types.StubType(types.StubTypeFunction),
+		}},
+	}, &ContainerOptions{BindPorts: []int{8001}, HostBindPort: 30001})
+
+	require.NoError(t, err)
+	require.NotNil(t, spec.Linux)
+	require.NotNil(t, spec.Linux.Seccomp)
+
+	rule := findSeccompRule(t, spec.Linux.Seccomp, checkpointDisabledIOUringSyscalls)
+	require.Equal(t, specs.ActErrno, rule.Action)
+	require.NotNil(t, rule.ErrnoRet)
+	require.Equal(t, uint(syscall.ENOSYS), *rule.ErrnoRet)
+}
+
+func TestDisableIOUringForCheckpointPreservesExistingSeccompRules(t *testing.T) {
+	spec := &specs.Spec{Linux: &specs.Linux{Seccomp: &specs.LinuxSeccomp{
+		DefaultAction: specs.ActErrno,
+		Syscalls: []specs.LinuxSyscall{
+			{Names: []string{"read", "io_uring_setup", "write"}, Action: specs.ActAllow},
+			{Names: []string{"io_uring_enter"}, Action: specs.ActAllow},
+		},
+	}}}
+
+	disableIOUringForCheckpoint(spec)
+
+	blockRule := findSeccompRule(t, spec.Linux.Seccomp, checkpointDisabledIOUringSyscalls)
+	require.Equal(t, specs.ActErrno, blockRule.Action)
+	require.NotNil(t, blockRule.ErrnoRet)
+	require.Equal(t, uint(syscall.ENOSYS), *blockRule.ErrnoRet)
+
+	allowRule := findSeccompRule(t, spec.Linux.Seccomp, []string{"read", "write"})
+	require.Equal(t, specs.ActAllow, allowRule.Action)
+	for _, syscallRule := range spec.Linux.Seccomp.Syscalls {
+		if syscallRule.Action == specs.ActAllow {
+			require.NotContains(t, syscallRule.Names, "io_uring_setup")
+			require.NotContains(t, syscallRule.Names, "io_uring_enter")
+			require.NotContains(t, syscallRule.Names, "io_uring_register")
+		}
+	}
+}
+
+func findSeccompRule(t *testing.T, seccomp *specs.LinuxSeccomp, names []string) specs.LinuxSyscall {
+	t.Helper()
+	require.NotNil(t, seccomp)
+	for _, rule := range seccomp.Syscalls {
+		if sameStringSet(rule.Names, names) {
+			return rule
+		}
+	}
+	t.Fatalf("seccomp rule for %v not found in %#v", names, seccomp.Syscalls)
+	return specs.LinuxSyscall{}
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, value := range a {
+		seen[value]++
+	}
+	for _, value := range b {
+		seen[value]--
+		if seen[value] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func TestSpecFromRequestDefersSandboxCPUThrottleWhenRuntimeCanUpdate(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes CRIU checkpoint/restore for vLLM by disabling io_uring and enforcing safe runtime env when checkpoints are enabled. This prevents CRIU failures and preserves existing seccomp rules.

- **Bug Fixes**
  - Runtime env overrides for checkpoints: set UV_USE_IO_URING=0 and TORCHINDUCTOR_QUIESCE_ASYNC_COMPILE_POOL=1, integrated into `applyRuntimeEnvironmentOverrides`.
  - Seccomp hardening during checkpoint: in `specFromRequest`, block io_uring syscalls (`io_uring_setup`, `io_uring_enter`, `io_uring_register`) with ActErrno (ENOSYS) while keeping other allow rules intact; added tests for both behaviors.

<sup>Written for commit b03a1ba4160319aba7e72cd224aa03e6dfac6223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

