### PR TITLE
more copy fixes

### DIFF
--- a/pkg/worker/util.go
+++ b/pkg/worker/util.go
@@ -112,7 +112,21 @@ func copyDirectory(src, dst string, excludePaths []string) error {
 	return nil
 }
 
+func normalizedCopyExcludePaths(excludePaths []string) map[string]struct{} {
+	excludes := map[string]struct{}{}
+	for _, excludePath := range excludePaths {
+		cleanPath := filepath.ToSlash(filepath.Clean(excludePath))
+		if cleanPath == "." || cleanPath == "" {
+			continue
+		}
+		excludes[cleanPath] = struct{}{}
+	}
+	return excludes
+}
+
 func copyDirectoryWalk(src, dst string, excludePaths []string) error {
+	excludes := normalizedCopyExcludePaths(excludePaths)
+
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -125,14 +139,13 @@ func copyDirectoryWalk(src, dst string, excludePaths []string) error {
 		if relPath == "." {
 			return nil
 		}
+		relPath = filepath.ToSlash(relPath)
 
-		for _, excludePath := range excludePaths {
-			if relPath == excludePath {
-				if info.IsDir() {
-					return filepath.SkipDir
-				}
-				return nil
+		if _, excluded := excludes[relPath]; excluded {
+			if info.IsDir() {
+				return filepath.SkipDir
 			}
+			return nil
 		}
 
 		dstPath := filepath.Join(dst, relPath)

--- a/pkg/worker/util.go
+++ b/pkg/worker/util.go
@@ -1,16 +1,27 @@
 package worker
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+func tarCommandError(action string, err error, stderr bytes.Buffer) error {
+	message := stderr.String()
+	if message == "" {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return fmt.Errorf("%s: %w: %s", action, err, message)
+}
 
 // Creates a symlink, but will remove any existing symlinks, files, or directories
 // before doing so.
@@ -28,19 +39,89 @@ func forceSymlink(source, link string) error {
 }
 
 func copyDirectory(src, dst string, excludePaths []string) error {
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return fmt.Errorf("create destination directory %s: %w", dst, err)
+	}
+
+	rootExcludes := map[string]struct{}{}
+	for _, excludePath := range excludePaths {
+		cleanPath := filepath.ToSlash(filepath.Clean(excludePath))
+		if cleanPath == "." || cleanPath == "" {
+			continue
+		}
+		if strings.Contains(cleanPath, "/") {
+			return copyDirectoryWalk(src, dst, excludePaths)
+		}
+		rootExcludes[cleanPath] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("read source directory %s: %w", src, err)
+	}
+
+	tarArgs := []string{"-cf", "-", "-C", src, "--"}
+	for _, entry := range entries {
+		if _, excluded := rootExcludes[entry.Name()]; excluded {
+			continue
+		}
+		tarArgs = append(tarArgs, "./"+entry.Name())
+	}
+	if len(tarArgs) == 5 {
+		return nil
+	}
+
+	reader, writer := io.Pipe()
+	archiveCmd := exec.Command("tar", tarArgs...)
+	extractCmd := exec.Command("tar", "-xf", "-", "-C", dst)
+	var archiveStderr, extractStderr bytes.Buffer
+	archiveCmd.Stdout = writer
+	archiveCmd.Stderr = &archiveStderr
+	extractCmd.Stdin = reader
+	extractCmd.Stderr = &extractStderr
+
+	if err := extractCmd.Start(); err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		return fmt.Errorf("start directory extraction: %w", err)
+	}
+	if err := archiveCmd.Start(); err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		_ = extractCmd.Wait()
+		return fmt.Errorf("start directory archive: %w", err)
+	}
+
+	archiveDone := make(chan error, 1)
+	go func() {
+		err := archiveCmd.Wait()
+		_ = writer.CloseWithError(err)
+		archiveDone <- err
+	}()
+
+	extractErr := extractCmd.Wait()
+	_ = reader.Close()
+	archiveErr := <-archiveDone
+
+	if archiveErr != nil {
+		return tarCommandError(fmt.Sprintf("archive directory %s", src), archiveErr, archiveStderr)
+	}
+	if extractErr != nil {
+		return tarCommandError(fmt.Sprintf("extract directory to %s", dst), extractErr, extractStderr)
+	}
+	return nil
+}
+
+func copyDirectoryWalk(src, dst string, excludePaths []string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Compute the relative path from src
 		relPath, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
 		}
-
-		// When src is like "/snapshot", relPath == "." means this is the source folder itself.
-		// So we skip it to ensure we copy only its contents.
 		if relPath == "." {
 			return nil
 		}
@@ -55,19 +136,61 @@ func copyDirectory(src, dst string, excludePaths []string) error {
 		}
 
 		dstPath := filepath.Join(dst, relPath)
-
 		if info.IsDir() {
 			return os.MkdirAll(dstPath, info.Mode())
 		}
-
+		if info.Mode()&os.ModeSocket != 0 {
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("read symlink %s: %w", path, err)
+			}
+			if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+				return fmt.Errorf("create symlink parent %s: %w", filepath.Dir(dstPath), err)
+			}
+			_ = os.Remove(dstPath)
+			return os.Symlink(linkTarget, dstPath)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
 		return copyFile(path, dstPath)
 	})
 }
 
 func copyFile(src, dst string) error {
-	cmd := exec.Command("cp", src, dst)
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source file %s: %w", src, err)
+	}
+	defer srcFile.Close()
+
+	info, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source file %s: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("create destination parent %s: %w", filepath.Dir(dst), err)
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("open destination file %s: %w", dst, err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	closeErr := dstFile.Close()
+	if copyErr != nil {
+		return fmt.Errorf("copy %s to %s: %w", src, dst, copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close destination file %s: %w", dst, closeErr)
+	}
+
+	return nil
 }
 
 func createTar(srcDir, destTar string) error {

--- a/pkg/worker/util_test.go
+++ b/pkg/worker/util_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,4 +28,54 @@ func TestForceSymlinkCreatesParentAndReplacesExistingLink(t *testing.T) {
 	target, err = os.Readlink(link)
 	require.NoError(t, err)
 	require.Equal(t, nextSource, target)
+}
+
+func TestCopyDirectorySkipsUnixSockets(t *testing.T) {
+	src, err := os.MkdirTemp("/tmp", "copydir-src-")
+	require.NoError(t, err)
+	defer os.RemoveAll(src)
+	dst, err := os.MkdirTemp("/tmp", "copydir-dst-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dst)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "tmp"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "tmp", "regular.txt"), []byte("ok"), 0644))
+	require.NoError(t, os.Symlink("regular.txt", filepath.Join(src, "tmp", "regular-link")))
+
+	socketPath := filepath.Join(src, "tmp", "runtime.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	require.NoError(t, err)
+	defer listener.Close()
+
+	require.NoError(t, copyDirectory(src, dst, nil))
+
+	data, err := os.ReadFile(filepath.Join(dst, "tmp", "regular.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(data))
+
+	linkTarget, err := os.Readlink(filepath.Join(dst, "tmp", "regular-link"))
+	require.NoError(t, err)
+	require.Equal(t, "regular.txt", linkTarget)
+
+	_, err = os.Lstat(filepath.Join(dst, "tmp", "runtime.sock"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestCopyDirectoryExcludesOnlyRootPaths(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "outputs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "outputs", "root.txt"), []byte("drop"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "workspace", "outputs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "workspace", "outputs", "nested.txt"), []byte("keep"), 0644))
+
+	require.NoError(t, copyDirectory(src, dst, []string{"outputs"}))
+
+	_, err := os.Stat(filepath.Join(dst, "outputs", "root.txt"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	data, err := os.ReadFile(filepath.Join(dst, "workspace", "outputs", "nested.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "keep", string(data))
 }

--- a/pkg/worker/util_test.go
+++ b/pkg/worker/util_test.go
@@ -79,3 +79,22 @@ func TestCopyDirectoryExcludesOnlyRootPaths(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "keep", string(data))
 }
+
+func TestCopyDirectoryNormalizesNestedExcludePaths(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "workspace", "outputs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "workspace", "outputs", "drop.txt"), []byte("drop"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "workspace", "data"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "workspace", "data", "keep.txt"), []byte("keep"), 0644))
+
+	require.NoError(t, copyDirectory(src, dst, []string{"./workspace/outputs/"}))
+
+	_, err := os.Stat(filepath.Join(dst, "workspace", "outputs", "drop.txt"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	data, err := os.ReadFile(filepath.Join(dst, "workspace", "data", "keep.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "keep", string(data))
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened the worker directory copy: preserve symlinks, skip Unix sockets, normalize exclude paths, and add a fast path for root-level excludes via a `tar` stream. Added tests and clearer error messages.

- **Bug Fixes**
  - Fast path: stream selected root entries via `tar`; walker used for nested excludes; return early when nothing to copy.
  - File types: skip Unix sockets, preserve symlinks, copy regular files with perms; create destination dir and parent dirs.
  - Robustness: replace `cp` with Go I/O; normalize exclude paths (./, trailing slashes); surface `tar` stderr in errors; add tests for sockets, root excludes, and nested exclude normalization.

<sup>Written for commit fcb081cc5e13d2b5763e778b3b34b12cc1f7e930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

