### PR TITLE
rollout and concurrency fixes

### DIFF
--- a/pkg/gateway/services/rollout.go
+++ b/pkg/gateway/services/rollout.go
@@ -1,6 +1,7 @@
 package gatewayservices
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -39,7 +40,10 @@ func (gws *GatewayService) planDeploymentRollout(in deploymentRolloutInput) (dep
 	if in.latest != nil && in.stub != nil && in.stub.Type == types.StubType(types.StubTypeScheduledJobDeployment) {
 		return deploymentRolloutPlan{stopLatest: true}, nil
 	}
-	if mode == rolloutModeAuto || !deploymentRolloutApplies(in) {
+	if !deploymentRolloutTarget(in) {
+		return deploymentRolloutPlan{}, nil
+	}
+	if mode == rolloutModeAuto {
 		return deploymentRolloutPlan{}, nil
 	}
 
@@ -67,6 +71,38 @@ func (gws *GatewayService) planDeploymentRollout(in deploymentRolloutInput) (dep
 	}, nil
 }
 
+func (gws *GatewayService) activeDeploymentsForRollout(ctx context.Context, workspaceID uint, name, stubType string) ([]types.DeploymentWithRelated, error) {
+	active := true
+	deployments, err := gws.backendRepo.ListDeploymentsWithRelated(ctx, types.DeploymentFilter{
+		WorkspaceID: workspaceID,
+		StubType:    types.StringSlice{stubType},
+		Name:        name,
+		Active:      &active,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	activeDeployments := make([]types.DeploymentWithRelated, 0, len(deployments))
+	for _, deployment := range deployments {
+		if deployment.Active && deployment.Deployment.WorkspaceId == workspaceID && deployment.Name == name && deployment.StubType == stubType {
+			activeDeployments = append(activeDeployments, deployment)
+		}
+	}
+	return activeDeployments, nil
+}
+
+func latestActiveDeployment(deployments []types.DeploymentWithRelated) *types.DeploymentWithRelated {
+	var latest *types.DeploymentWithRelated
+	for i := range deployments {
+		deployment := deployments[i]
+		if latest == nil || deployment.Version > latest.Version {
+			latest = &deployment
+		}
+	}
+	return latest
+}
+
 func normalizeRolloutMode(mode string) string {
 	mode = strings.TrimSpace(strings.ToLower(mode))
 	if mode == "" {
@@ -85,13 +121,20 @@ func validRolloutMode(mode string) bool {
 }
 
 func deploymentRolloutApplies(in deploymentRolloutInput) bool {
+	if !deploymentRolloutTarget(in) {
+		return false
+	}
+	return alwaysOnDeploymentConfig(in.config) && latestAlwaysOnDeployment(in.latest)
+}
+
+func deploymentRolloutTarget(in deploymentRolloutInput) bool {
 	if in.stub == nil || in.config == nil || in.latest == nil || !in.latest.Active {
 		return false
 	}
 	if !in.stub.Type.IsDeployment() || !in.latest.Stub.Type.IsDeployment() {
 		return false
 	}
-	return alwaysOnDeploymentConfig(in.config) && latestAlwaysOnDeployment(in.latest)
+	return true
 }
 
 func latestAlwaysOnDeployment(deployment *types.DeploymentWithRelated) bool {

--- a/pkg/gateway/services/rollout_test.go
+++ b/pkg/gateway/services/rollout_test.go
@@ -1,9 +1,12 @@
 package gatewayservices
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/scheduler"
 	"github.com/beam-cloud/beta9/pkg/types"
 )
 
@@ -32,4 +35,128 @@ func TestDeploymentRolloutAppliesToAnyAlwaysOnDeployment(t *testing.T) {
 			t.Fatalf("expected rollout to apply to %s", stubType)
 		}
 	}
+}
+
+func TestExplicitReplaceRolloutStopsActiveWarmDeployment(t *testing.T) {
+	oldConfig := types.StubConfigV1{KeepWarmSeconds: 3600}
+	oldConfigBytes, err := json.Marshal(oldConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workerRepo := &rolloutWorkerRepo{workers: []*types.Worker{{
+		Id:            "worker-1",
+		PoolName:      "private-gpu",
+		Gpu:           string(types.GPU_B200),
+		TotalCpu:      16_000,
+		FreeCpu:       12_000,
+		TotalMemory:   64 * 1024,
+		FreeMemory:    48 * 1024,
+		TotalGpuCount: 8,
+		FreeGpuCount:  3,
+		Status:        types.WorkerStatusAvailable,
+	}}}
+	gws := &GatewayService{
+		scheduler: scheduler.NewSchedulerForCapacityChecks(workerRepo, nil, nil),
+		containerRepo: &rolloutContainerRepo{containers: []types.ContainerState{{
+			ContainerId: "old-container",
+			StubId:      "old-stub",
+			WorkerId:    "worker-1",
+			Cpu:         4_000,
+			Memory:      16 * 1024,
+			Gpu:         string(types.GPU_B200),
+			GpuCount:    5,
+			Status:      types.ContainerStatusRunning,
+		}}},
+	}
+
+	plan, err := gws.planDeploymentRollout(deploymentRolloutInput{
+		stub: &types.StubWithRelated{Stub: types.Stub{
+			ExternalId: "new-stub",
+			Type:       types.StubType(types.StubTypeEndpointDeployment),
+		}},
+		config: &types.StubConfigV1{
+			KeepWarmSeconds: 3600,
+			Runtime: types.Runtime{
+				Cpu:      4_000,
+				Memory:   16 * 1024,
+				Gpu:      types.GPU_B200,
+				GpuCount: 5,
+			},
+			Pool: &types.PoolConfig{Name: "private-gpu"},
+		},
+		latest: &types.DeploymentWithRelated{
+			Deployment: types.Deployment{Active: true},
+			Stub: types.Stub{
+				ExternalId: "old-stub",
+				Type:       types.StubType(types.StubTypeEndpointDeployment),
+				Config:     string(oldConfigBytes),
+			},
+		},
+		mode: rolloutModeReplace,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.stopLatest || plan.action != rolloutActionReplace {
+		t.Fatalf("plan = %+v, want replace with stopLatest", plan)
+	}
+}
+
+func TestActiveDeploymentsForRolloutUsesExactActiveMatches(t *testing.T) {
+	repo := &rolloutDeploymentRepo{deployments: []types.DeploymentWithRelated{
+		{Deployment: types.Deployment{ExternalId: "v1", WorkspaceId: 1, Name: "service", Active: true, StubType: string(types.StubTypeEndpointDeployment), Version: 1}},
+		{Deployment: types.Deployment{ExternalId: "v2", WorkspaceId: 1, Name: "service", Active: true, StubType: string(types.StubTypeEndpointDeployment), Version: 2}},
+		{Deployment: types.Deployment{ExternalId: "inactive", WorkspaceId: 1, Name: "service", Active: false, StubType: string(types.StubTypeEndpointDeployment), Version: 3}},
+		{Deployment: types.Deployment{ExternalId: "similar", WorkspaceId: 1, Name: "service-extra", Active: true, StubType: string(types.StubTypeEndpointDeployment), Version: 4}},
+		{Deployment: types.Deployment{ExternalId: "wrong-type", WorkspaceId: 1, Name: "service", Active: true, StubType: string(types.StubTypeFunctionDeployment), Version: 5}},
+		{Deployment: types.Deployment{ExternalId: "wrong-workspace", WorkspaceId: 2, Name: "service", Active: true, StubType: string(types.StubTypeEndpointDeployment), Version: 6}},
+	}}
+	gws := &GatewayService{backendRepo: repo}
+
+	active, err := gws.activeDeploymentsForRollout(context.Background(), 1, "service", string(types.StubTypeEndpointDeployment))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 2 {
+		t.Fatalf("active deployments = %d, want 2: %+v", len(active), active)
+	}
+
+	latest := latestActiveDeployment(active)
+	if latest == nil || latest.ExternalId != "v2" {
+		t.Fatalf("latest active = %+v, want v2", latest)
+	}
+}
+
+type rolloutWorkerRepo struct {
+	repository.WorkerRepository
+	workers []*types.Worker
+}
+
+func (r *rolloutWorkerRepo) GetAllWorkers() ([]*types.Worker, error) {
+	return r.workers, nil
+}
+
+type rolloutContainerRepo struct {
+	repository.ContainerRepository
+	containers []types.ContainerState
+}
+
+func (r *rolloutContainerRepo) GetActiveContainersByStubId(stubId string) ([]types.ContainerState, error) {
+	containers := make([]types.ContainerState, 0, len(r.containers))
+	for _, container := range r.containers {
+		if container.StubId == stubId {
+			containers = append(containers, container)
+		}
+	}
+	return containers, nil
+}
+
+type rolloutDeploymentRepo struct {
+	repository.BackendRepository
+	deployments []types.DeploymentWithRelated
+}
+
+func (r *rolloutDeploymentRepo) ListDeploymentsWithRelated(_ context.Context, _ types.DeploymentFilter) ([]types.DeploymentWithRelated, error) {
+	return r.deployments, nil
 }

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -830,6 +830,18 @@ func (gws *GatewayService) DeployStub(ctx context.Context, in *pb.DeployStubRequ
 		version = latestDeployment.Version + 1
 	}
 
+	activeDeployments, err := gws.activeDeploymentsForRollout(ctx, authInfo.Workspace.Id, in.Name, string(stub.Type))
+	if err != nil {
+		return &pb.DeployStubResponse{
+			Ok:     false,
+			ErrMsg: "Unable to check active deployments before rollout",
+		}, nil
+	}
+	rolloutLatestDeployment := latestDeployment
+	if rolloutLatestDeployment == nil || !rolloutLatestDeployment.Active {
+		rolloutLatestDeployment = latestActiveDeployment(activeDeployments)
+	}
+
 	var config types.StubConfigV1
 	if err := json.Unmarshal([]byte(stub.Config), &config); err != nil {
 		return &pb.DeployStubResponse{
@@ -842,7 +854,7 @@ func (gws *GatewayService) DeployStub(ctx context.Context, in *pb.DeployStubRequ
 		workspace: authInfo.Workspace,
 		stub:      stub,
 		config:    &config,
-		latest:    latestDeployment,
+		latest:    rolloutLatestDeployment,
 		mode:      normalizeRolloutMode(in.Rollout),
 	})
 	if err != nil {
@@ -852,7 +864,11 @@ func (gws *GatewayService) DeployStub(ctx context.Context, in *pb.DeployStubRequ
 		}, nil
 	}
 	if rolloutPlan.stopLatest {
-		if err := gws.stopDeployments([]types.DeploymentWithRelated{*latestDeployment}, ctx); err != nil {
+		deploymentsToStop := activeDeployments
+		if len(deploymentsToStop) == 0 && rolloutLatestDeployment != nil {
+			deploymentsToStop = []types.DeploymentWithRelated{*rolloutLatestDeployment}
+		}
+		if err := gws.stopDeployments(deploymentsToStop, ctx); err != nil {
 			return &pb.DeployStubResponse{
 				Ok:     false,
 				ErrMsg: "Unable to stop previous deployment before rollout",
@@ -874,7 +890,7 @@ func (gws *GatewayService) DeployStub(ctx context.Context, in *pb.DeployStubRequ
 		go gws.eventRepo.PushDeployStubEvent(authInfo.Workspace.ExternalId, &stub.Stub)
 	}
 
-	if config.Autoscaler.MinContainers > 0 {
+	if rolloutReplicas(&config) > 0 {
 		// Publish reload instance event
 		eventBus := common.NewEventBus(gws.redisClient)
 		eventBus.Send(&common.Event{Type: common.EventTypeReloadInstance, Retries: 3, LockAndDelete: false, Args: map[string]any{

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -335,15 +335,23 @@ func (s *Scheduler) getConcurrencyLimit(request *types.ContainerRequest) (*types
 }
 
 func (s *Scheduler) privatePoolQuotaExempt(request *types.ContainerRequest) bool {
-	if s == nil || request == nil || request.PoolSelector == "" || s.workerPoolManager == nil {
+	if s == nil || request == nil || s.workerPoolManager == nil {
 		return false
 	}
-	pool, ok := s.workerPoolManager.GetPool(request.PoolSelector)
-	if !ok || pool.Config.Mode != types.PoolModePrivate {
-		return false
-	}
+
 	stubConfig, err := request.Stub.UnmarshalConfig()
 	if err != nil || stubConfig == nil || stubConfig.Pool == nil {
+		return false
+	}
+	poolSelector := request.PoolSelector
+	if poolSelector == "" {
+		poolSelector = stubConfig.PoolSelector()
+	}
+	if poolSelector == "" {
+		return false
+	}
+	pool, ok := s.workerPoolManager.GetPool(poolSelector)
+	if !ok || pool.Config.Mode != types.PoolModePrivate {
 		return false
 	}
 	fallback := stubConfig.Pool.Fallback

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -111,6 +111,9 @@ func TestPrivatePoolRequestsBypassManagedQuotaLookup(t *testing.T) {
 		PoolSelector: "private-gpu-pool",
 		Stub:         types.StubWithRelated{Stub: types.Stub{Config: string(stubConfig)}},
 	}))
+	assert.True(t, scheduler.privatePoolQuotaExempt(&types.ContainerRequest{
+		Stub: types.StubWithRelated{Stub: types.Stub{Config: string(stubConfig)}},
+	}))
 	assert.False(t, scheduler.privatePoolQuotaExempt(&types.ContainerRequest{}))
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes rollout planning to correctly stop active deployments and trigger reloads for warm/replicated services, and fixes private pool concurrency checks to honor pool config even when no explicit selector is provided.

- Bug Fixes
  - Rollout: use latest active deployment if the "latest" is inactive, gate planning with a stricter target check, and stop all active same-name deployments during replace; adds `activeDeploymentsForRollout` and `latestActiveDeployment` with tests in `pkg/gateway/services/rollout_test.go`.
  - Reloads: switch to `rolloutReplicas` so keep-warm and autoscaled deployments correctly emit reload events.
  - Scheduler: `privatePoolQuotaExempt` now derives the pool from the stub config when `PoolSelector` is empty, ensuring private pools bypass managed quota as intended; tests updated in `pkg/scheduler/scheduler_test.go`.

<sup>Written for commit 263d4db1c999493c7873e20a91a04c4563f66e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

