### PR TITLE
fix private pool fallback

### DIFF
--- a/pkg/scheduler/private_pool_fallback.go
+++ b/pkg/scheduler/private_pool_fallback.go
@@ -20,6 +20,17 @@ func (a *schedulingAttempt) tryPrivatePoolFallback() bool {
 		Msg("falling back from private pool to regular pools")
 
 	fallback := newSchedulingAttempt(a.scheduler, fallbackRequest, a.workers)
+	if !fallback.hasManagedFallbackPath() {
+		return false
+	}
+	if err := fallback.reserveManagedFallbackQuota(); err != nil {
+		requestLog(log.Error(), fallbackRequest).
+			Err(err).
+			Msg("private pool fallback blocked by managed concurrency limit")
+		a.fail("managed_fallback_concurrency_limit")
+		return true
+	}
+
 	if fallback.scheduleOnAvailableWorker() {
 		return true
 	}
@@ -27,7 +38,10 @@ func (a *schedulingAttempt) tryPrivatePoolFallback() bool {
 		return true
 	}
 	if !fallback.canProvisionWorker() {
-		return false
+		requestLog(log.Error(), fallbackRequest).
+			Msg("private pool fallback has no managed capacity path")
+		a.fail("managed_fallback_no_capacity")
+		return true
 	}
 
 	fallback.provisionWorker()
@@ -41,6 +55,9 @@ func (a *schedulingAttempt) privatePoolFallbackRequest() (*types.ContainerReques
 	if a.request.HasDurableDiskMount() {
 		// Durable disk fallback is handled before scheduling so snapshot
 		// availability is checked before the pool selector is cleared.
+		return nil, "", false
+	}
+	if !a.privatePoolAllowsManagedFallback() {
 		return nil, "", false
 	}
 
@@ -75,6 +92,36 @@ func (a *schedulingAttempt) privatePoolFallbackRequest() (*types.ContainerReques
 	}
 	fallback.PoolSelector = ""
 	return fallback, pool.Name, true
+}
+
+func (a *schedulingAttempt) hasManagedFallbackPath() bool {
+	if worker, err := a.scheduler.selectWorkerFromWorkers(a.workers, a.request); err == nil && worker != nil {
+		return true
+	}
+	if worker, err := a.scheduler.selectWorkerFromWorkersByStatus(a.workers, a.request, types.WorkerStatusPending); err == nil && worker != nil {
+		return true
+	}
+	return a.canProvisionWorker()
+}
+
+func (a *schedulingAttempt) privatePoolAllowsManagedFallback() bool {
+	stubConfig, err := a.request.Stub.UnmarshalConfig()
+	if err != nil || stubConfig == nil || stubConfig.Pool == nil {
+		return true
+	}
+	fallback := stubConfig.Pool.Fallback
+	return fallback == "" || fallback == types.PrivatePoolFallbackInternal
+}
+
+func (a *schedulingAttempt) reserveManagedFallbackQuota() error {
+	if a == nil || a.scheduler == nil || a.request == nil {
+		return nil
+	}
+	quota, err := a.scheduler.managedConcurrencyLimit(a.request)
+	if err != nil {
+		return err
+	}
+	return a.scheduler.containerRepo.SetContainerStateWithConcurrencyLimit(quota, a.request)
 }
 
 func (a *schedulingAttempt) selectedPrivatePool() (*WorkerPool, bool) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -309,6 +309,10 @@ func (s *Scheduler) getConcurrencyLimit(request *types.ContainerRequest) (*types
 		return nil, nil
 	}
 
+	return s.managedConcurrencyLimit(request)
+}
+
+func (s *Scheduler) managedConcurrencyLimit(request *types.ContainerRequest) (*types.ConcurrencyLimit, error) {
 	// First try to get the cached quota
 	var quota *types.ConcurrencyLimit
 	quota, err := s.workspaceRepo.GetConcurrencyLimitByWorkspaceId(request.WorkspaceId)
@@ -339,12 +343,12 @@ func (s *Scheduler) privatePoolQuotaExempt(request *types.ContainerRequest) bool
 		return false
 	}
 
-	stubConfig, err := request.Stub.UnmarshalConfig()
-	if err != nil || stubConfig == nil || stubConfig.Pool == nil {
-		return false
-	}
 	poolSelector := request.PoolSelector
 	if poolSelector == "" {
+		stubConfig, err := request.Stub.UnmarshalConfig()
+		if err != nil || stubConfig == nil {
+			return false
+		}
 		poolSelector = stubConfig.PoolSelector()
 	}
 	if poolSelector == "" {
@@ -354,8 +358,7 @@ func (s *Scheduler) privatePoolQuotaExempt(request *types.ContainerRequest) bool
 	if !ok || pool.Config.Mode != types.PoolModePrivate {
 		return false
 	}
-	fallback := stubConfig.Pool.Fallback
-	return fallback == types.PrivatePoolFallbackFail || fallback == types.PrivatePoolFallbackWait
+	return true
 }
 
 func (s *Scheduler) CheckConcurrencyLimit(request *types.ContainerRequest) error {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -103,10 +103,11 @@ func TestPrivatePoolRequestsBypassManagedQuotaLookup(t *testing.T) {
 	manager.SetPool("private-gpu-pool", types.WorkerPoolConfig{Mode: types.PoolModePrivate}, nil)
 	scheduler := &Scheduler{workerPoolManager: manager}
 	stubConfig, err := json.Marshal(types.StubConfigV1{
-		Pool: &types.PoolConfig{Name: "private-gpu-pool", Selector: "private-gpu-pool", Fallback: types.PrivatePoolFallbackFail},
+		Pool: &types.PoolConfig{Name: "private-gpu-pool", Selector: "private-gpu-pool", Fallback: types.PrivatePoolFallbackInternal},
 	})
 	assert.NoError(t, err)
 
+	assert.True(t, scheduler.privatePoolQuotaExempt(&types.ContainerRequest{PoolSelector: "private-gpu-pool"}))
 	assert.True(t, scheduler.privatePoolQuotaExempt(&types.ContainerRequest{
 		PoolSelector: "private-gpu-pool",
 		Stub:         types.StubWithRelated{Stub: types.Stub{Config: string(stubConfig)}},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes private pool fallback to managed pools by enforcing concurrency limits and honoring pool fallback settings. Adds early capacity checks and clear failure reasons to avoid silent failures.

- **Bug Fixes**
  - Allow managed fallback only when `Pool.Fallback` is empty or `internal` (`privatePoolAllowsManagedFallback`).
  - Reserve managed quota before scheduling via `managedConcurrencyLimit`; fail with `managed_fallback_concurrency_limit` when blocked.
  - Check for an available/pending/provisionable managed path (`hasManagedFallbackPath`); fail with `managed_fallback_no_capacity` if none exists.
  - Treat any private pool as quota-exempt in `privatePoolQuotaExempt`; tests updated accordingly.

- **Refactors**
  - Extracted `managedConcurrencyLimit` from `getConcurrencyLimit` for reuse in fallback quota checks.

<sup>Written for commit 75952ae6ebf4cb6a131c5dd81663b27b8eef6db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

