### PR TITLE
more cr edge case handling

### DIFF
--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -1736,6 +1736,11 @@ func normalizeStubCacheRequiredContentItem(item types.CacheRequiredContentItem) 
 }
 
 func stubCacheRequiredContentItemKey(item types.CacheRequiredContentItem) string {
+	// Keep only the checkpoint most recently reported by a stub. Explicit
+	// restores of older checkpoints still fetch their archive from origin.
+	if item.Kind == types.CacheContentKindCheckpoint {
+		return string(types.CacheContentKindCheckpoint)
+	}
 	if item.Kind == types.CacheContentKindDiskSnapshot && item.DiskName != "" {
 		return strings.Join([]string{
 			string(item.Kind),

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -249,6 +249,37 @@ func TestMergeStubCacheRequiredContentRecordKeepsLatestItem(t *testing.T) {
 	}
 }
 
+func TestMergeStubCacheRequiredContentRecordKeepsMostRecentlyReportedCheckpoint(t *testing.T) {
+	merged := map[string]types.CacheRequiredContentItem{}
+	writeRecord := func(item types.CacheRequiredContentItem) {
+		body, err := json.Marshal(struct {
+			Type string                                    `json:"type"`
+			Data types.EventStubCacheRequiredContentSchema `json:"data"`
+		}{
+			Type: types.EventStubCacheRequiredContent,
+			Data: types.EventStubCacheRequiredContentSchema{
+				Kind:  types.CacheContentKindCheckpoint,
+				Items: []types.CacheRequiredContentItem{item},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mergeStubCacheRequiredContentRecord(merged, body)
+	}
+
+	writeRecord(types.CacheRequiredContentItem{Hash: "old-hash", RoutingKey: "old-hash", CheckpointID: "old"})
+	writeRecord(types.CacheRequiredContentItem{Hash: "new-hash", RoutingKey: "new-hash", CheckpointID: "new"})
+
+	items := stubCacheRequiredContentItems(merged)
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("unexpected item count: got %d want %d", got, want)
+	}
+	if got, want := items[0].CheckpointID, "new"; got != want {
+		t.Fatalf("unexpected checkpoint: got %q want %q", got, want)
+	}
+}
+
 func TestMergeStubCacheRequiredContentRecordKeepsLatestDiskSnapshotGeneration(t *testing.T) {
 	merged := map[string]types.CacheRequiredContentItem{}
 	writeRecord := func(items ...types.CacheRequiredContentItem) {

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -101,6 +101,8 @@ type WorkerCacheManager struct {
 	reconcileFailures     map[string]time.Time
 	reconcileSuccessesMu  sync.Mutex
 	reconcileSuccesses    map[string]time.Time
+	checkpointLocksMu     sync.Mutex
+	checkpointLocks       map[string]*checkpointMaterializationLock
 	ownerLastLiveMu       sync.Mutex
 	ownerLastLive         map[string]time.Time
 	reconcilePausedAt     time.Time
@@ -117,6 +119,11 @@ type WorkerCacheManager struct {
 	wg                    sync.WaitGroup
 	drainOnce             sync.Once
 	drainErr              error
+}
+
+type checkpointMaterializationLock struct {
+	token chan struct{}
+	refs  int
 }
 
 func NewWorkerCacheManager(ctx context.Context, config types.AppConfig, poolConfig types.WorkerPoolConfig, workerRepo pb.WorkerRepositoryServiceClient, eventRepo repo.EventRepository, containerInstances *common.SafeMap[*ContainerInstance], workerID, poolName, podAddr string) *WorkerCacheManager {
@@ -313,6 +320,55 @@ func (m *WorkerCacheManager) CheckpointRoot() string {
 		return ""
 	}
 	return m.checkpointRoot
+}
+
+func (m *WorkerCacheManager) acquireCheckpointMaterialization(ctx context.Context, checkpointID string) (func(), error) {
+	if m == nil {
+		return nil, errors.New("cache manager is unavailable")
+	}
+	if checkpointID == "" {
+		return nil, errors.New("checkpoint ID is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.checkpointLocksMu.Lock()
+	if m.checkpointLocks == nil {
+		m.checkpointLocks = make(map[string]*checkpointMaterializationLock)
+	}
+	lock := m.checkpointLocks[checkpointID]
+	if lock == nil {
+		lock = &checkpointMaterializationLock{token: make(chan struct{}, 1)}
+		lock.token <- struct{}{}
+		m.checkpointLocks[checkpointID] = lock
+	}
+	lock.refs++
+	m.checkpointLocksMu.Unlock()
+
+	select {
+	case <-lock.token:
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				lock.token <- struct{}{}
+				m.releaseCheckpointMaterializationRef(checkpointID, lock)
+			})
+		}, nil
+	case <-ctx.Done():
+		m.releaseCheckpointMaterializationRef(checkpointID, lock)
+		return nil, ctx.Err()
+	}
+}
+
+func (m *WorkerCacheManager) releaseCheckpointMaterializationRef(checkpointID string, lock *checkpointMaterializationLock) {
+	m.checkpointLocksMu.Lock()
+	defer m.checkpointLocksMu.Unlock()
+
+	lock.refs--
+	if lock.refs == 0 && m.checkpointLocks[checkpointID] == lock {
+		delete(m.checkpointLocks, checkpointID)
+	}
 }
 
 func (m *WorkerCacheManager) requestReconcile() {

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -594,10 +594,10 @@ func protectedContentFromRecentStubs(stubs []recentStubContent, accelerator stri
 	activeCheckpointIDs := map[string]struct{}{}
 	for _, stub := range stubs {
 		for _, item := range stub.items {
-			if item.Hash != "" {
+			if item.Hash != "" && cacheContentAppliesToAccelerator(item, accelerator) {
 				protected[item.Hash] = struct{}{}
 			}
-			if item.Kind == types.CacheContentKindCheckpoint && item.CheckpointID != "" && (item.Accelerator == "" || strings.EqualFold(item.Accelerator, accelerator)) {
+			if item.Kind == types.CacheContentKindCheckpoint && item.CheckpointID != "" && cacheContentAppliesToAccelerator(item, accelerator) {
 				activeCheckpointIDs[item.CheckpointID] = struct{}{}
 			}
 		}
@@ -1463,13 +1463,18 @@ func (m *WorkerCacheManager) requiredContentComplete(server *cache.Server, item 
 	return server.HasCompleteContent(item.Hash, item.SizeBytes)
 }
 
-func (m *WorkerCacheManager) checkpointAcceleratorMatches(item types.CacheRequiredContentItem) bool {
-	return item.Accelerator == "" || strings.EqualFold(item.Accelerator, m.accelerator)
-}
-
 func (m *WorkerCacheManager) materializeCheckpoint(ctx context.Context, server *cache.Server, stub cache.RecentStub, item types.CacheRequiredContentItem, routingKey string) string {
 	if item.CheckpointID == "" || item.Hash == "" || item.SizeBytes <= 0 {
 		return types.CacheAuditStatusMiss
+	}
+	release, err := m.acquireCheckpointMaterialization(ctx, item.CheckpointID)
+	if err != nil {
+		log.Debug().Err(err).Str("checkpoint_id", item.CheckpointID).Msg("cache reconciliation checkpoint materialization canceled")
+		return types.CacheAuditStatusOriginFailure
+	}
+	defer release()
+	if m.requiredContentComplete(server, item, routingKey) {
+		return types.CacheAuditStatusMaterialized
 	}
 	if ok, err := m.client.MaterializeFromReplica(ctx, server, item.Hash, routingKey, item.SizeBytes); err != nil {
 		log.Debug().Err(err).Str("hash", item.Hash).Msg("cache reconciliation checkpoint replica copy failed")

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -1470,7 +1470,7 @@ func (m *WorkerCacheManager) materializeCheckpoint(ctx context.Context, server *
 	release, err := m.acquireCheckpointMaterialization(ctx, item.CheckpointID)
 	if err != nil {
 		log.Debug().Err(err).Str("checkpoint_id", item.CheckpointID).Msg("cache reconciliation checkpoint materialization canceled")
-		return types.CacheAuditStatusOriginFailure
+		return types.CacheAuditStatusSkipped
 	}
 	defer release()
 	if m.requiredContentComplete(server, item, routingKey) {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -62,7 +62,11 @@ func (f *fakeEventRepo) PushStubCacheRequiredContent(schema types.EventStubCache
 		if item.Kind == "" {
 			item.Kind = schema.Kind
 		}
-		bucket[item.Hash+"\x00"+item.RoutingKey] = item
+		key := item.Hash + "\x00" + item.RoutingKey
+		if item.Kind == types.CacheContentKindCheckpoint {
+			key = string(types.CacheContentKindCheckpoint)
+		}
+		bucket[key] = item
 	}
 	f.pushed = append(f.pushed, schema)
 	return nil
@@ -476,12 +480,24 @@ func TestCacheVolumeReportMinBytesDefaultAndOverride(t *testing.T) {
 	require.Equal(t, int64(64<<20), manager.cacheVolumeReportMinBytes())
 }
 
-func TestCheckpointAcceleratorMatch(t *testing.T) {
-	manager := &WorkerCacheManager{accelerator: "A10G"}
+func TestCacheContentAppliesToAccelerator(t *testing.T) {
+	require.True(t, cacheContentAppliesToAccelerator(types.CacheRequiredContentItem{Kind: types.CacheContentKindCheckpoint, Accelerator: "a10g"}, "A10G"))
+	require.True(t, cacheContentAppliesToAccelerator(types.CacheRequiredContentItem{Kind: types.CacheContentKindCheckpoint}, "A10G"))
+	require.False(t, cacheContentAppliesToAccelerator(types.CacheRequiredContentItem{Kind: types.CacheContentKindCheckpoint, Accelerator: "T4"}, "A10G"))
+	require.True(t, cacheContentAppliesToAccelerator(types.CacheRequiredContentItem{Kind: types.CacheContentKindVolume, Accelerator: "T4"}, "A10G"))
+}
 
-	require.True(t, manager.checkpointAcceleratorMatches(types.CacheRequiredContentItem{Accelerator: "a10g"}))
-	require.True(t, manager.checkpointAcceleratorMatches(types.CacheRequiredContentItem{}))
-	require.False(t, manager.checkpointAcceleratorMatches(types.CacheRequiredContentItem{Accelerator: "T4"}))
+func TestProtectedContentSkipsCheckpointForOtherAccelerator(t *testing.T) {
+	protected, checkpointIDs := protectedContentFromRecentStubs([]recentStubContent{{
+		items: []types.CacheRequiredContentItem{
+			{Hash: "checkpoint", Kind: types.CacheContentKindCheckpoint, CheckpointID: "checkpoint-a", Accelerator: "T4"},
+			{Hash: "volume", Kind: types.CacheContentKindVolume},
+		},
+	}}, "A10G")
+
+	require.NotContains(t, protected, "checkpoint")
+	require.Contains(t, protected, "volume")
+	require.Empty(t, checkpointIDs)
 }
 
 func TestReconcileBackoffIsBypassedByNewStubSighting(t *testing.T) {
@@ -839,6 +855,27 @@ func TestEnsureCheckpointMaterializedReportsMissingCheckpointDemand(t *testing.T
 	require.Equal(t, checkpoint.CacheHash, fake.pushed[0].Items[0].Hash)
 	require.Equal(t, checkpoint.CheckpointId, fake.pushed[0].Items[0].CheckpointID)
 	require.Equal(t, checkpoint.Accelerator, fake.pushed[0].Items[0].Accelerator)
+}
+
+func TestCheckpointMaterializationLockSerializesSameCheckpoint(t *testing.T) {
+	manager := &WorkerCacheManager{}
+	release, err := manager.acquireCheckpointMaterialization(context.Background(), "checkpoint-a")
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = manager.acquireCheckpointMaterialization(waitCtx, "checkpoint-a")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	releaseOther, err := manager.acquireCheckpointMaterialization(context.Background(), "checkpoint-b")
+	require.NoError(t, err)
+	releaseOther()
+
+	release()
+	releaseAgain, err := manager.acquireCheckpointMaterialization(context.Background(), "checkpoint-a")
+	require.NoError(t, err)
+	releaseAgain()
+	require.Empty(t, manager.checkpointLocks)
 }
 
 func TestEnsureCheckpointMaterializedReportsAlreadyLocalCheckpoint(t *testing.T) {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -878,6 +878,24 @@ func TestCheckpointMaterializationLockSerializesSameCheckpoint(t *testing.T) {
 	require.Empty(t, manager.checkpointLocks)
 }
 
+func TestCheckpointMaterializationLockCancellationIsSkipped(t *testing.T) {
+	manager := &WorkerCacheManager{}
+	release, err := manager.acquireCheckpointMaterialization(context.Background(), "checkpoint-a")
+	require.NoError(t, err)
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	status := manager.materializeCheckpoint(ctx, nil, cache.RecentStub{}, types.CacheRequiredContentItem{
+		CheckpointID: "checkpoint-a",
+		Hash:         "hash",
+		SizeBytes:    1,
+	}, "hash")
+
+	require.Equal(t, types.CacheAuditStatusSkipped, status)
+	require.False(t, reconcileStatusIsFailure(status))
+}
+
 func TestEnsureCheckpointMaterializedReportsAlreadyLocalCheckpoint(t *testing.T) {
 	fake := &fakeEventRepo{}
 	metadata := &claimedMetadataStore{}

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -261,12 +261,10 @@ func (s *Worker) attemptRestoreCheckpoint(ctx context.Context, request *types.Co
 		return -1, false, false, err
 	}
 
-	f, err := os.Create(filepath.Join(signalDir, checkpointCompleteFileName))
-	if err != nil {
+	if err := writeCheckpointCompleteMarker(request.ContainerId); err != nil {
 		log.Error().Str("container_id", request.ContainerId).Str("checkpoint_id", checkpoint.CheckpointId).Msgf("failed to create checkpoint complete file: %v", err)
 		return -1, false, false, err
 	}
-	defer f.Close()
 
 	instance, exists := s.containerInstances.Get(request.ContainerId)
 	if !exists {
@@ -468,10 +466,25 @@ type CreateCheckpointOpts struct {
 
 // Waits for the container to be ready to checkpoint at the desired point in execution, ie.
 // after all processes within a container have reached a checkpointable state
-func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpts) error {
+func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpts) (err error) {
+	if opts == nil || opts.Request == nil {
+		return errors.New("checkpoint request is required")
+	}
+
+	availableStateCreated := false
+	var persistedMetadata *checkpointCacheMetadata
+	defer func() {
+		if err != nil && !availableStateCreated {
+			s.markCheckpointFailed(opts, persistedMetadata)
+		}
+	}()
+
 	instance, exists := s.containerInstances.Get(opts.Request.ContainerId)
-	if !exists {
+	if !exists || instance == nil {
 		return fmt.Errorf("container instance not found")
+	}
+	if instance.Runtime == nil {
+		return fmt.Errorf("container runtime is unavailable")
 	}
 
 	if err := s.requireCRIUManager(); err != nil {
@@ -487,7 +500,6 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 			if opts.OutputLogger != nil {
 				opts.OutputLogger.Error(fmt.Sprintf("Failed to start checkpoint: %v", err))
 			}
-			s.markCheckpointFailed(opts)
 			return err
 		}
 		select {
@@ -513,9 +525,11 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 			if opts.OutputLogger != nil {
 				opts.OutputLogger.Error(fmt.Sprintf("Failed to wait for checkpoint readiness: %v", err))
 			}
-			s.markCheckpointFailed(opts)
 			return err
 		}
+	}
+	if instance.Overlay == nil {
+		return fmt.Errorf("container overlay is unavailable")
 	}
 
 	// Proceed to create the checkpoint
@@ -529,8 +543,6 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 		if errors.Is(checkpointCtx.Err(), context.DeadlineExceeded) {
 			err = fmt.Errorf("checkpoint snapshot timed out after %s: %w", defaultCheckpointCreateTTL, err)
 		}
-		s.markCheckpointFailed(opts)
-
 		if opts.OutputLogger != nil {
 			opts.OutputLogger.Error(fmt.Sprintf("Failed to create checkpoint: %v", err))
 		}
@@ -557,28 +569,28 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 	}
 	metadata, err := s.persistCheckpoint(ctx, opts.Request, opts.CheckpointId, checkpointPath)
 	if err != nil {
-		_ = s.createCheckpointState(opts.CheckpointId, opts.Request, types.CheckpointStatusCheckpointFailed, opts.ContainerIp)
 		log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to persist checkpoint: %v", err)
 		if opts.OutputLogger != nil {
 			opts.OutputLogger.Error(fmt.Sprintf("Failed to persist checkpoint: %v", err))
 		}
 		return err
 	}
+	persistedMetadata = metadata
 
 	if opts.WaitForSignal {
 		// Create a file accessible to the container to indicate that the checkpoint has been captured
-		_, err = os.Create(filepath.Join(checkpointSignalDir(opts.Request.ContainerId), checkpointCompleteFileName))
-		if err != nil {
+		if err = writeCheckpointCompleteMarker(opts.Request.ContainerId); err != nil {
 			log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to create checkpoint complete file: %v", err)
 			return err
 		}
 	}
 
-	err = s.createAvailableCheckpointState(opts.CheckpointId, opts.Request, opts.ContainerIp, metadata)
+	err = s.createCheckpointState(opts.CheckpointId, opts.Request, types.CheckpointStatusAvailable, opts.ContainerIp, metadata)
 	if err != nil {
 		log.Error().Str("container_id", opts.Request.ContainerId).Str("checkpoint_id", opts.CheckpointId).Msgf("failed to update checkpoint state: %v", err)
 		return err
 	}
+	availableStateCreated = true
 	s.reportCheckpointRequiredContent(opts.Request, opts.CheckpointId, metadata)
 
 	if opts.OutputLogger != nil {
@@ -589,8 +601,11 @@ func (s *Worker) createCheckpoint(ctx context.Context, opts *CreateCheckpointOpt
 	return nil
 }
 
-func (s *Worker) markCheckpointFailed(opts *CreateCheckpointOpts) {
-	if stateErr := s.createCheckpointState(opts.CheckpointId, opts.Request, types.CheckpointStatusCheckpointFailed, opts.ContainerIp); stateErr != nil {
+func (s *Worker) markCheckpointFailed(opts *CreateCheckpointOpts, metadata *checkpointCacheMetadata) {
+	if s == nil || s.backendRepoClient == nil || opts == nil || opts.Request == nil {
+		return
+	}
+	if stateErr := s.createCheckpointState(opts.CheckpointId, opts.Request, types.CheckpointStatusCheckpointFailed, opts.ContainerIp, metadata); stateErr != nil {
 		log.Error().
 			Str("container_id", opts.Request.ContainerId).
 			Str("checkpoint_id", opts.CheckpointId).
@@ -660,8 +675,7 @@ func (s *Worker) persistCheckpoint(ctx context.Context, request *types.Container
 		return nil, err
 	}
 	if err := f.Close(); err != nil {
-		_ = os.Remove(archivePath)
-		return nil, err
+		log.Warn().Err(err).Str("checkpoint_id", checkpointId).Msg("failed to close uploaded checkpoint archive")
 	}
 
 	metadata := &checkpointCacheMetadata{
@@ -671,12 +685,14 @@ func (s *Worker) persistCheckpoint(ctx context.Context, request *types.Container
 		locality:    s.cacheManager.locality,
 		accelerator: checkpointAccelerator(request),
 	}
-	s.storeCheckpointArchiveInCacheFromLocalFile(checkpointId, archivePath, originKey, hash)
+	s.cacheCheckpointArchiveAsync(checkpointId, archivePath, originKey, hash)
 
 	return metadata, nil
 }
 
-func (s *Worker) storeCheckpointArchiveInCacheFromLocalFile(checkpointId, archivePath, originKey, hash string) {
+// cacheCheckpointArchiveAsync takes ownership of archivePath and removes it
+// after the cache store completes or when no cache client is available.
+func (s *Worker) cacheCheckpointArchiveAsync(checkpointId, archivePath, originKey, hash string) {
 	if s.cacheManager == nil || s.cacheManager.client == nil {
 		_ = os.Remove(archivePath)
 		return
@@ -713,21 +729,40 @@ func (s *Worker) ensureCheckpointMaterialized(ctx context.Context, request *type
 	if !metadataComplete {
 		return "", fmt.Errorf("checkpoint cache metadata is incomplete")
 	}
+	release, err := s.cacheManager.acquireCheckpointMaterialization(ctx, checkpoint.CheckpointId)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+	if checkpointMaterialized(checkpointPath) {
+		return checkpointPath, nil
+	}
 	s.cacheManager.requestReconcile()
 
 	archivePath := s.checkpointArchivePath(checkpoint.CheckpointId)
 	if archivePath == "" {
 		return "", fmt.Errorf("checkpoint archive path is unavailable")
 	}
+	downloadedFromOrigin := false
 	if err := s.writeCheckpointArchiveFromCache(ctx, archivePath, checkpoint); err != nil {
 		if err := s.downloadCheckpointArchive(ctx, request, archivePath, checkpoint); err != nil {
 			return "", err
 		}
+		downloadedFromOrigin = true
 	}
-	defer os.Remove(archivePath)
+	removeArchive := true
+	defer func() {
+		if removeArchive {
+			_ = os.Remove(archivePath)
+		}
+	}()
 
 	if err := materializeCheckpointArchive(archivePath, checkpointPath, checkpoint.CheckpointId); err != nil {
 		return "", err
+	}
+	if downloadedFromOrigin {
+		removeArchive = false
+		s.cacheCheckpointArchiveAsync(checkpoint.CheckpointId, archivePath, checkpoint.OriginKey, checkpoint.CacheHash)
 	}
 	return checkpointPath, nil
 }
@@ -918,15 +953,11 @@ func (s *Worker) downloadCheckpointArchive(ctx context.Context, request *types.C
 	if err := os.Rename(tmpPath, archivePath); err != nil {
 		return err
 	}
-	if s.cacheManager != nil && s.cacheManager.client != nil {
-		if _, err := s.cacheManager.client.StoreContentFromLocalFile(cache.LocalContentSource{
-			Path:      archivePath,
-			CachePath: checkpoint.OriginKey,
-		}, cache.StoreContentOptions{RoutingKey: checkpoint.CacheHash, Lock: true}); err != nil {
-			log.Warn().Err(err).Str("checkpoint_id", checkpoint.CheckpointId).Msg("failed to cache restored checkpoint archive")
-		}
-	}
 	return nil
+}
+
+func writeCheckpointCompleteMarker(containerID string) error {
+	return os.WriteFile(filepath.Join(checkpointSignalDir(containerID), checkpointCompleteFileName), nil, 0644)
 }
 
 func fileSHA256(filePath string) (string, int64, error) {
@@ -1038,20 +1069,15 @@ func (s *Worker) requireCRIUManager() error {
 	return nil
 }
 
-func (s *Worker) createCheckpointState(checkpointId string, request *types.ContainerRequest, status types.CheckpointStatus, containerIp string) error {
+func (s *Worker) createCheckpointState(checkpointId string, request *types.ContainerRequest, status types.CheckpointStatus, containerIp string, metadata *checkpointCacheMetadata) error {
 	req := checkpointStateRequest(checkpointId, request, status, containerIp)
-	_, err := handleGRPCResponse(s.backendRepoClient.CreateCheckpoint(context.Background(), req))
-
-	return err
-}
-
-func (s *Worker) createAvailableCheckpointState(checkpointId string, request *types.ContainerRequest, containerIp string, metadata *checkpointCacheMetadata) error {
-	req := checkpointStateRequest(checkpointId, request, types.CheckpointStatusAvailable, containerIp)
-	req.CacheHash = metadata.hash
-	req.CacheSizeBytes = metadata.sizeBytes
-	req.OriginKey = metadata.originKey
-	req.Locality = metadata.locality
-	req.Accelerator = metadata.accelerator
+	if metadata != nil {
+		req.CacheHash = metadata.hash
+		req.CacheSizeBytes = metadata.sizeBytes
+		req.OriginKey = metadata.originKey
+		req.Locality = metadata.locality
+		req.Accelerator = metadata.accelerator
+	}
 	_, err := handleGRPCResponse(s.backendRepoClient.CreateCheckpoint(context.Background(), req))
 
 	return err

--- a/pkg/worker/criu_nvidia.go
+++ b/pkg/worker/criu_nvidia.go
@@ -168,7 +168,7 @@ func (c *NvidiaCRIUManager) RestoreCheckpoint(ctx context.Context, rt runtime.Ru
 		BundlePath:   bundlePath,      // Container bundle path
 		OutputWriter: outputWriter,    // Output writer for logs
 		Started:      opts.started,    // Channel to signal process start
-		AllowOpenTCP: preserveOpenTCP, // Preserve service-local TCP connections across restore
+		AllowOpenTCP: preserveOpenTCP, // Preserve pod TCP connections across restore
 		TCPClose:     !preserveOpenTCP,
 	})
 
@@ -198,7 +198,7 @@ func shouldPreservePodTCPOnRestore(opts *RestoreOpts) bool {
 		return false
 	}
 
-	return isPodServiceRequest(opts.request)
+	return isPodRequest(opts.request)
 }
 
 func restoreFailureError(runtimeName string, err error, stderr string) error {

--- a/pkg/worker/criu_test.go
+++ b/pkg/worker/criu_test.go
@@ -40,6 +40,22 @@ type MockRuntime struct {
 	capabilities     runtime.Capabilities
 }
 
+type staticCheckpointManager struct {
+	path string
+}
+
+func (m *staticCheckpointManager) Available() bool {
+	return true
+}
+
+func (m *staticCheckpointManager) CreateCheckpoint(context.Context, runtime.Runtime, string, *types.ContainerRequest) (string, error) {
+	return m.path, nil
+}
+
+func (m *staticCheckpointManager) RestoreCheckpoint(context.Context, runtime.Runtime, *RestoreOpts) (int, error) {
+	return -1, errors.New("not implemented")
+}
+
 func TestCheckpointRuntimeEnvironmentOverrides(t *testing.T) {
 	gpuRequest := &types.ContainerRequest{
 		CheckpointEnabled: true,
@@ -473,9 +489,12 @@ func TestNvidiaCRIUManager(t *testing.T) {
 				}
 			})
 
-			t.Run("RestoreCheckpoint", func(t *testing.T) {
+			t.Run("RestoreCheckpoint endpoint closes TCP", func(t *testing.T) {
 				request := &types.ContainerRequest{
 					ContainerId: fmt.Sprintf("%s-container-2", tc.runtimeName),
+					Stub: types.StubWithRelated{Stub: types.Stub{
+						Type: types.StubType(types.StubTypeEndpointDeployment),
+					}},
 				}
 
 				checkpoint := &types.Checkpoint{
@@ -511,7 +530,7 @@ func TestNvidiaCRIUManager(t *testing.T) {
 				}
 			})
 
-			t.Run("RestoreCheckpoint pod closes TCP", func(t *testing.T) {
+			t.Run("RestoreCheckpoint pod preserves open TCP", func(t *testing.T) {
 				mockRuntime.Reset()
 
 				request := &types.ContainerRequest{
@@ -539,8 +558,8 @@ func TestNvidiaCRIUManager(t *testing.T) {
 					t.Errorf("RestoreCheckpoint failed: %v", err)
 				}
 
-				if mockRuntime.restoreOpts == nil || mockRuntime.restoreOpts.AllowOpenTCP || !mockRuntime.restoreOpts.TCPClose {
-					t.Errorf("Expected pod NVIDIA restore to use tcp-close, got %+v", mockRuntime.restoreOpts)
+				if mockRuntime.restoreOpts == nil || !mockRuntime.restoreOpts.AllowOpenTCP || mockRuntime.restoreOpts.TCPClose {
+					t.Errorf("Expected pod NVIDIA restore to preserve open TCP without tcp-close, got %+v", mockRuntime.restoreOpts)
 				}
 
 				if exitCode != 0 {
@@ -760,6 +779,75 @@ func TestCreateCheckpointFailsWhenRuntimeStartSignalCloses(t *testing.T) {
 	}
 	if got := backendRepoClient.lastCreate.Status; got != string(types.CheckpointStatusCheckpointFailed) {
 		t.Fatalf("checkpoint status = %q, want %q", got, types.CheckpointStatusCheckpointFailed)
+	}
+}
+
+func TestCreateCheckpointMarksFilesystemCopyFailure(t *testing.T) {
+	root := t.TempDir()
+	containerID := "container-copy-failure"
+	request := &types.ContainerRequest{
+		ContainerId: containerID,
+		Stub: types.StubWithRelated{Stub: types.Stub{
+			ExternalId: "stub-copy-failure",
+		}},
+	}
+	checkpointPath := filepath.Join(root, "checkpoints", "checkpoint-copy-failure")
+	backendRepoClient := &fakeBackendRepoClient{}
+	worker := &Worker{
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		backendRepoClient:  backendRepoClient,
+		criuManager:        &staticCheckpointManager{path: checkpointPath},
+	}
+	worker.containerInstances.Set(containerID, &ContainerInstance{
+		Id:      containerID,
+		Runtime: NewMockRuntime("runc", runtime.Capabilities{CheckpointRestore: true}),
+		Overlay: common.NewContainerOverlay(
+			request,
+			filepath.Join(root, "overlay", "merged"),
+			filepath.Join(root, "overlay-storage"),
+		),
+	})
+
+	err := worker.createCheckpoint(context.Background(), &CreateCheckpointOpts{
+		Request:      request,
+		CheckpointId: "checkpoint-copy-failure",
+	})
+	if err == nil || !strings.Contains(err.Error(), "read source directory") {
+		t.Fatalf("createCheckpoint error = %v, want filesystem copy error", err)
+	}
+	if backendRepoClient.createCalls != 1 {
+		t.Fatalf("CreateCheckpoint calls = %d, want 1", backendRepoClient.createCalls)
+	}
+	if got := backendRepoClient.lastCreate.Status; got != string(types.CheckpointStatusCheckpointFailed) {
+		t.Fatalf("checkpoint status = %q, want %q", got, types.CheckpointStatusCheckpointFailed)
+	}
+}
+
+func TestMarkCheckpointFailedRetainsPersistedMetadata(t *testing.T) {
+	backendRepoClient := &fakeBackendRepoClient{}
+	worker := &Worker{backendRepoClient: backendRepoClient}
+	metadata := &checkpointCacheMetadata{
+		hash:        "checkpoint-hash",
+		sizeBytes:   42,
+		originKey:   "checkpoints/checkpoint-a.tar",
+		locality:    "locality-a",
+		accelerator: "A10G",
+	}
+
+	worker.markCheckpointFailed(&CreateCheckpointOpts{
+		Request: &types.ContainerRequest{
+			ContainerId: "container-a",
+			Stub:        types.StubWithRelated{Stub: types.Stub{ExternalId: "stub-a"}},
+		},
+		CheckpointId: "checkpoint-a",
+	}, metadata)
+
+	got := backendRepoClient.lastCreate
+	if got == nil || got.Status != string(types.CheckpointStatusCheckpointFailed) {
+		t.Fatalf("checkpoint state = %+v, want failed", got)
+	}
+	if got.CacheHash != metadata.hash || got.CacheSizeBytes != metadata.sizeBytes || got.OriginKey != metadata.originKey || got.Locality != metadata.locality || got.Accelerator != metadata.accelerator {
+		t.Fatalf("checkpoint metadata = %+v, want %+v", got, metadata)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened checkpoint/restore and cache reconciliation to prevent races, fix accelerator scoping, and keep only the latest checkpoint per stub. Improves checkpoint state reporting and re-caches archives when restored from origin.

- **Bug Fixes**
  - Serialize checkpoint materialization per ID (shared lock across reconcile/restore); early-exit if already local; re-cache archives after origin download and avoid premature deletion (`pkg/worker`).
  - Respect accelerator when protecting content and checkpoint IDs; skip checkpoints for other accelerators (`pkg/worker/cache_reconciler.go`).
  - Track only the most recent checkpoint per stub in cache-required events (`pkg/repository/events_s2.go`).
  - Mark failed checkpoints with metadata and add safer error paths and nil checks; pod restores now preserve open TCP while endpoints close TCP (`pkg/worker/criu*.go`).

- **Refactors**
  - Unified checkpoint state updates into `createCheckpointState` (accepts metadata) and removed the dedicated “available” variant (`pkg/worker/criu.go`).
  - Added `cacheCheckpointArchiveAsync` and `writeCheckpointCompleteMarker` helpers; expanded tests for edge cases across `events_s2_test.go`, `cache_reconciler_test.go`, and `criu_test.go`.

<sup>Written for commit 84271883e5f76749ee2ba817bf26f69d333dbb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

