### PR TITLE
feat: pricing versions

### DIFF
--- a/pkg/clients/container_cost.go
+++ b/pkg/clients/container_cost.go
@@ -20,8 +20,7 @@ import (
 const (
 	containerCostRequestTimeout = 5 * time.Second
 	containerCostQuoteRefresh   = 5 * time.Minute
-	containerCostRetryInitial   = 5 * time.Second
-	containerCostRetryMax       = time.Minute
+	containerCostRetryDelay     = 5 * time.Second
 	containerCostResponseLimit  = 1 << 20
 	containerCostErrorLimit     = 4 << 10
 )
@@ -43,35 +42,6 @@ type ContainerCostQuote struct {
 	Valid          bool
 }
 
-type containerCostCacheEntry struct {
-	quote        ContainerCostQuote
-	refreshAt    time.Time
-	retryAt      time.Time
-	failures     uint8
-	refreshError error
-}
-
-type containerCostRefreshOwner struct {
-	marker byte
-}
-
-type containerCostLookupResult struct {
-	quote        ContainerCostQuote
-	refreshError error
-	owner        *containerCostRefreshOwner
-}
-
-type ContainerCostClient struct {
-	client   *http.Client
-	endpoint string
-	token    string
-
-	mu           sync.RWMutex
-	quotes       map[ContainerCostRequest]containerCostCacheEntry
-	refreshGroup singleflight.Group
-	now          func() time.Time
-}
-
 type ContainerCostRequest struct {
 	Cpu      int64  `json:"cpu"`
 	Memory   int64  `json:"memory"`
@@ -79,11 +49,32 @@ type ContainerCostRequest struct {
 	GpuCount uint32 `json:"gpu_count"`
 }
 
+type containerCostCacheEntry struct {
+	quote     ContainerCostQuote
+	refreshAt time.Time
+	retryAt   time.Time
+}
+
+type containerCostResult struct {
+	quote ContainerCostQuote
+	err   error
+}
+
+type ContainerCostClient struct {
+	client   *http.Client
+	endpoint string
+	token    string
+
+	mu      sync.RWMutex
+	quotes  map[ContainerCostRequest]containerCostCacheEntry
+	refresh singleflight.Group
+	now     func() time.Time
+}
+
 func NewContainerCostClient(config types.ContainerCostHookConfig) *ContainerCostClient {
 	if config.Endpoint == "" || config.Token == "" {
 		return nil
 	}
-
 	return &ContainerCostClient{
 		client:   &http.Client{Timeout: containerCostRequestTimeout},
 		endpoint: config.Endpoint,
@@ -93,10 +84,8 @@ func NewContainerCostClient(config types.ContainerCostHookConfig) *ContainerCost
 	}
 }
 
-// GetContainerCostQuote returns a resource-keyed cached quote. Quotes are
-// refreshed every five minutes, or sooner when valid_until says they expire.
-// If a refresh fails, the last validated quote is returned together with the
-// refresh error so callers can continue metering and surface the stale state.
+// GetContainerCostQuote caches by resources for five minutes (or valid_until).
+// A failed refresh returns the last good quote and retries on a later lookup.
 func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request *types.ContainerRequest) (ContainerCostQuote, error) {
 	if c == nil {
 		return ContainerCostQuote{}, fmt.Errorf("container cost client is not configured")
@@ -109,75 +98,72 @@ func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request
 	}
 
 	key := ContainerCostRequest{
-		Cpu:      request.Cpu,
-		Memory:   request.Memory,
-		Gpu:      strings.TrimSpace(request.Gpu),
-		GpuCount: request.GpuCount,
+		Cpu: request.Cpu, Memory: request.Memory,
+		Gpu: strings.TrimSpace(request.Gpu), GpuCount: request.GpuCount,
 	}
-	if quote, ok := c.cachedResult(key, c.now()); ok {
+	if quote, ok := c.cached(key); ok {
 		return quote, nil
 	}
 
-	owner := &containerCostRefreshOwner{marker: 1}
-	result, err, _ := c.refreshGroup.Do(key.singleflightKey(), func() (interface{}, error) {
-		now := c.now()
-		if quote, ok := c.cachedResult(key, now); ok {
-			return containerCostLookupResult{quote: quote}, nil
+	result := c.refresh.DoChan(key.cacheKey(), func() (any, error) {
+		if quote, ok := c.cached(key); ok {
+			return containerCostResult{quote: quote}, nil
 		}
 
-		quote, refreshAt, fetchErr := c.fetchQuote(ctx, key)
-		if fetchErr != nil {
-			quote, refreshErr := c.cacheFailure(key, c.now(), fetchErr)
-			return containerCostLookupResult{quote: quote, refreshError: refreshErr, owner: owner}, nil
+		refreshCtx, cancel := context.WithTimeout(context.Background(), containerCostRequestTimeout)
+		defer cancel()
+		quote, refreshAt, err := c.fetch(refreshCtx, key)
+		if err != nil {
+			stale := c.rememberFailure(key)
+			if stale.Valid {
+				err = fmt.Errorf("refreshing container cost quote: %w", err)
+			}
+			return containerCostResult{quote: stale, err: err}, nil
 		}
 
 		c.mu.Lock()
 		c.quotes[key] = containerCostCacheEntry{quote: quote, refreshAt: refreshAt}
 		c.mu.Unlock()
-		return containerCostLookupResult{quote: quote}, nil
+		return containerCostResult{quote: quote}, nil
 	})
-	if err != nil {
-		return ContainerCostQuote{}, err
+	select {
+	case <-ctx.Done():
+		return c.lastGood(key), ctx.Err()
+	case call := <-result:
+		if call.Err != nil {
+			return ContainerCostQuote{}, call.Err
+		}
+		value, ok := call.Val.(containerCostResult)
+		if !ok {
+			return ContainerCostQuote{}, fmt.Errorf("invalid container cost lookup result")
+		}
+		return value.quote, value.err
 	}
-
-	lookup, ok := result.(containerCostLookupResult)
-	if !ok {
-		return ContainerCostQuote{}, fmt.Errorf("invalid container cost lookup result")
-	}
-	if lookup.owner == owner {
-		return lookup.quote, lookup.refreshError
-	}
-	return lookup.quote, nil
 }
 
-// GetContainerCostPerMs is kept for callers that only need the legacy scalar
-// response. New metering code should retain the quote metadata as well.
+// GetContainerCostPerMs keeps the scalar interface used by older callers.
 func (c *ContainerCostClient) GetContainerCostPerMs(request *types.ContainerRequest) (float64, error) {
 	quote, err := c.GetContainerCostQuote(context.Background(), request)
-	if !quote.Valid {
+	if !quote.Valid || !quote.ValidUntil.IsZero() && !quote.ValidUntil.After(c.now()) {
 		if err == nil {
-			err = fmt.Errorf("container cost quote is unavailable")
+			err = fmt.Errorf("container cost quote is unavailable or expired")
 		}
 		return 0, err
 	}
 	return quote.CostPerMs, err
 }
 
-func (c *ContainerCostClient) fetchQuote(ctx context.Context, request ContainerCostRequest) (ContainerCostQuote, time.Time, error) {
-	var requestBody bytes.Buffer
-	if err := json.NewEncoder(&requestBody).Encode(request); err != nil {
+func (c *ContainerCostClient) fetch(ctx context.Context, request ContainerCostRequest) (ContainerCostQuote, time.Time, error) {
+	body, err := json.Marshal(request)
+	if err != nil {
 		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("encoding container cost request: %w", err)
 	}
-
-	requestCtx, cancel := context.WithTimeout(ctx, containerCostRequestTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, c.endpoint, &requestBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("creating container cost request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	req.Header.Set("Authorization", "Bearer "+c.token)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -186,15 +172,22 @@ func (c *ContainerCostClient) fetchQuote(ctx context.Context, request ContainerC
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		detail, _ := io.ReadAll(io.LimitReader(resp.Body, containerCostErrorLimit))
-		detailText := strings.TrimSpace(string(detail))
-		if detailText != "" {
-			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("requesting container cost quote: unexpected HTTP status %s: %q", resp.Status, detailText)
+		if text := strings.TrimSpace(string(detail)); text != "" {
+			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("requesting container cost quote: unexpected HTTP status %s: %q", resp.Status, text)
 		}
 		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("requesting container cost quote: unexpected HTTP status %s", resp.Status)
 	}
 
+	body, err = io.ReadAll(io.LimitReader(resp.Body, containerCostResponseLimit+1))
+	if err != nil {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("reading container cost quote: %w", err)
+	}
+	if len(body) > containerCostResponseLimit {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("container cost quote exceeds %d bytes", containerCostResponseLimit)
+	}
 	var response ContainerCostResponse
-	decoder := json.NewDecoder(io.LimitReader(resp.Body, containerCostResponseLimit))
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&response); err != nil {
 		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("decoding container cost quote: %w", err)
 	}
@@ -202,97 +195,83 @@ func (c *ContainerCostClient) fetchQuote(ctx context.Context, request ContainerC
 		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("decoding container cost quote: %w", err)
 	}
 
-	costPerMs, err := strconv.ParseFloat(response.CostPerMs, 64)
-	if err != nil {
-		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("parsing cost_per_ms: %w", err)
-	}
-	if math.IsNaN(costPerMs) || math.IsInf(costPerMs, 0) || costPerMs < 0 {
+	cost, err := strconv.ParseFloat(response.CostPerMs, 64)
+	if err != nil || math.IsNaN(cost) || math.IsInf(cost, 0) || cost < 0 {
 		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("invalid cost_per_ms %q: must be finite and nonnegative", response.CostPerMs)
 	}
-
-	quote := ContainerCostQuote{
-		CostPerMs:      costPerMs,
-		PricingVersion: response.PricingVersion,
-		Valid:          true,
+	effectiveAt, err := optionalTime(response.EffectiveAt, "effective_at")
+	if err != nil {
+		return ContainerCostQuote{}, time.Time{}, err
 	}
-	validatedAt := c.now()
-	refreshAt := validatedAt.Add(containerCostQuoteRefresh)
-	if response.EffectiveAt != "" {
-		effectiveAt, err := time.Parse(time.RFC3339Nano, response.EffectiveAt)
-		if err != nil {
-			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("parsing effective_at: %w", err)
-		}
-		quote.EffectiveAt = effectiveAt
-	}
-	if response.ValidUntil != "" {
-		validUntil, err := time.Parse(time.RFC3339Nano, response.ValidUntil)
-		if err != nil {
-			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("parsing valid_until: %w", err)
-		}
-		if !validUntil.After(validatedAt) {
-			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("invalid valid_until %q: must be in the future", response.ValidUntil)
-		}
-		quote.ValidUntil = validUntil
-		if validUntil.Before(refreshAt) {
-			refreshAt = validUntil
-		}
+	validUntil, err := optionalTime(response.ValidUntil, "valid_until")
+	if err != nil {
+		return ContainerCostQuote{}, time.Time{}, err
 	}
 
-	return quote, refreshAt, nil
+	now := c.now()
+	if !validUntil.IsZero() && !validUntil.After(now) {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("invalid valid_until %q: must be in the future", response.ValidUntil)
+	}
+	if !effectiveAt.IsZero() && !validUntil.IsZero() && !validUntil.After(effectiveAt) {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("invalid quote interval: valid_until must follow effective_at")
+	}
+	refreshAt := now.Add(containerCostQuoteRefresh)
+	if !validUntil.IsZero() && validUntil.Before(refreshAt) {
+		refreshAt = validUntil
+	}
+	return ContainerCostQuote{
+		CostPerMs: cost, PricingVersion: response.PricingVersion,
+		EffectiveAt: effectiveAt, ValidUntil: validUntil, Valid: true,
+	}, refreshAt, nil
 }
 
-func (c *ContainerCostClient) cachedResult(key ContainerCostRequest, now time.Time) (ContainerCostQuote, bool) {
+func (c *ContainerCostClient) cached(key ContainerCostRequest) (ContainerCostQuote, bool) {
 	c.mu.RLock()
 	entry, ok := c.quotes[key]
 	c.mu.RUnlock()
 	if !ok {
 		return ContainerCostQuote{}, false
 	}
-	if entry.refreshError != nil && now.Before(entry.retryAt) {
-		return entry.quote, true
-	}
-	if entry.quote.Valid && now.Before(entry.refreshAt) {
+	now := c.now()
+	if now.Before(entry.retryAt) || entry.quote.Valid && now.Before(entry.refreshAt) {
 		return entry.quote, true
 	}
 	return ContainerCostQuote{}, false
 }
 
-func (c *ContainerCostClient) cacheFailure(key ContainerCostRequest, failedAt time.Time, refreshErr error) (ContainerCostQuote, error) {
+func (c *ContainerCostClient) rememberFailure(key ContainerCostRequest) ContainerCostQuote {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
 	entry := c.quotes[key]
-	if entry.failures < ^uint8(0) {
-		entry.failures++
-	}
-	if entry.quote.Valid {
-		refreshErr = fmt.Errorf("refreshing container cost quote: %w", refreshErr)
-	}
-	entry.refreshError = refreshErr
-	entry.retryAt = failedAt.Add(containerCostRetryDelay(entry.failures))
+	entry.retryAt = c.now().Add(containerCostRetryDelay)
 	c.quotes[key] = entry
-	return entry.quote, refreshErr
+	return entry.quote
 }
 
-func containerCostRetryDelay(failures uint8) time.Duration {
-	delay := containerCostRetryInitial
-	for attempt := uint8(1); attempt < failures && delay < containerCostRetryMax; attempt++ {
-		delay *= 2
-		if delay > containerCostRetryMax {
-			return containerCostRetryMax
-		}
+func (c *ContainerCostClient) lastGood(key ContainerCostRequest) ContainerCostQuote {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.quotes[key].quote
+}
+
+func (r ContainerCostRequest) cacheKey() string {
+	return strconv.FormatInt(r.Cpu, 10) + "\x00" + strconv.FormatInt(r.Memory, 10) +
+		"\x00" + r.Gpu + "\x00" + strconv.FormatUint(uint64(r.GpuCount), 10)
+}
+
+func optionalTime(value, name string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
 	}
-	return delay
-}
-
-func (r ContainerCostRequest) singleflightKey() string {
-	return strconv.FormatInt(r.Cpu, 10) + "\x00" +
-		strconv.FormatInt(r.Memory, 10) + "\x00" + r.Gpu + "\x00" +
-		strconv.FormatUint(uint64(r.GpuCount), 10)
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return parsed, nil
 }
 
 func ensureJSONEOF(decoder *json.Decoder) error {
-	var trailing interface{}
+	var trailing any
 	if err := decoder.Decode(&trailing); err != io.EOF {
 		if err == nil {
 			return fmt.Errorf("multiple JSON values in response")

--- a/pkg/clients/container_cost.go
+++ b/pkg/clients/container_cost.go
@@ -2,22 +2,74 @@ package clients
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
 	"net/http"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/types"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	containerCostRequestTimeout = 5 * time.Second
+	containerCostQuoteRefresh   = 5 * time.Minute
+	containerCostRetryInitial   = 5 * time.Second
+	containerCostRetryMax       = time.Minute
+	containerCostResponseLimit  = 1 << 20
+	containerCostErrorLimit     = 4 << 10
 )
 
 type ContainerCostResponse struct {
-	CostPerMs string `json:"cost_per_ms"`
+	CostPerMs      string `json:"cost_per_ms"`
+	PricingVersion string `json:"pricing_version,omitempty"`
+	EffectiveAt    string `json:"effective_at,omitempty"`
+	ValidUntil     string `json:"valid_until,omitempty"`
+}
+
+// ContainerCostQuote is a validated quote returned by the billing service.
+// Valid distinguishes a real zero-cost quote from the absence of a quote.
+type ContainerCostQuote struct {
+	CostPerMs      float64
+	PricingVersion string
+	EffectiveAt    time.Time
+	ValidUntil     time.Time
+	Valid          bool
+}
+
+type containerCostCacheEntry struct {
+	quote        ContainerCostQuote
+	refreshAt    time.Time
+	retryAt      time.Time
+	failures     uint8
+	refreshError error
+}
+
+type containerCostRefreshOwner struct {
+	marker byte
+}
+
+type containerCostLookupResult struct {
+	quote        ContainerCostQuote
+	refreshError error
+	owner        *containerCostRefreshOwner
 }
 
 type ContainerCostClient struct {
 	client   *http.Client
 	endpoint string
 	token    string
+
+	mu           sync.RWMutex
+	quotes       map[ContainerCostRequest]containerCostCacheEntry
+	refreshGroup singleflight.Group
+	now          func() time.Time
 }
 
 type ContainerCostRequest struct {
@@ -33,28 +85,95 @@ func NewContainerCostClient(config types.ContainerCostHookConfig) *ContainerCost
 	}
 
 	return &ContainerCostClient{
-		client:   &http.Client{},
+		client:   &http.Client{Timeout: containerCostRequestTimeout},
 		endpoint: config.Endpoint,
 		token:    config.Token,
+		quotes:   make(map[ContainerCostRequest]containerCostCacheEntry),
+		now:      time.Now,
 	}
 }
 
-func (c *ContainerCostClient) GetContainerCostPerMs(request *types.ContainerRequest) (float64, error) {
-	containerCostRequest := &ContainerCostRequest{
+// GetContainerCostQuote returns a resource-keyed cached quote. Quotes are
+// refreshed every five minutes, or sooner when valid_until says they expire.
+// If a refresh fails, the last validated quote is returned together with the
+// refresh error so callers can continue metering and surface the stale state.
+func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request *types.ContainerRequest) (ContainerCostQuote, error) {
+	if c == nil {
+		return ContainerCostQuote{}, fmt.Errorf("container cost client is not configured")
+	}
+	if request == nil {
+		return ContainerCostQuote{}, fmt.Errorf("container cost request is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	key := ContainerCostRequest{
 		Cpu:      request.Cpu,
 		Memory:   request.Memory,
-		Gpu:      request.Gpu,
+		Gpu:      strings.TrimSpace(request.Gpu),
 		GpuCount: request.GpuCount,
 	}
-
-	var requestBody bytes.Buffer
-	if err := json.NewEncoder(&requestBody).Encode(containerCostRequest); err != nil {
-		return 0, err
+	if quote, ok := c.cachedResult(key, c.now()); ok {
+		return quote, nil
 	}
 
-	req, err := http.NewRequest("POST", c.endpoint, &requestBody)
+	owner := &containerCostRefreshOwner{marker: 1}
+	result, err, _ := c.refreshGroup.Do(key.singleflightKey(), func() (interface{}, error) {
+		now := c.now()
+		if quote, ok := c.cachedResult(key, now); ok {
+			return containerCostLookupResult{quote: quote}, nil
+		}
+
+		quote, refreshAt, fetchErr := c.fetchQuote(ctx, key)
+		if fetchErr != nil {
+			quote, refreshErr := c.cacheFailure(key, c.now(), fetchErr)
+			return containerCostLookupResult{quote: quote, refreshError: refreshErr, owner: owner}, nil
+		}
+
+		c.mu.Lock()
+		c.quotes[key] = containerCostCacheEntry{quote: quote, refreshAt: refreshAt}
+		c.mu.Unlock()
+		return containerCostLookupResult{quote: quote}, nil
+	})
 	if err != nil {
+		return ContainerCostQuote{}, err
+	}
+
+	lookup, ok := result.(containerCostLookupResult)
+	if !ok {
+		return ContainerCostQuote{}, fmt.Errorf("invalid container cost lookup result")
+	}
+	if lookup.owner == owner {
+		return lookup.quote, lookup.refreshError
+	}
+	return lookup.quote, nil
+}
+
+// GetContainerCostPerMs is kept for callers that only need the legacy scalar
+// response. New metering code should retain the quote metadata as well.
+func (c *ContainerCostClient) GetContainerCostPerMs(request *types.ContainerRequest) (float64, error) {
+	quote, err := c.GetContainerCostQuote(context.Background(), request)
+	if !quote.Valid {
+		if err == nil {
+			err = fmt.Errorf("container cost quote is unavailable")
+		}
 		return 0, err
+	}
+	return quote.CostPerMs, err
+}
+
+func (c *ContainerCostClient) fetchQuote(ctx context.Context, request ContainerCostRequest) (ContainerCostQuote, time.Time, error) {
+	var requestBody bytes.Buffer
+	if err := json.NewEncoder(&requestBody).Encode(request); err != nil {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("encoding container cost request: %w", err)
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, containerCostRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, c.endpoint, &requestBody)
+	if err != nil {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("creating container cost request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -62,19 +181,123 @@ func (c *ContainerCostClient) GetContainerCostPerMs(request *types.ContainerRequ
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return 0, err
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("requesting container cost quote: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, containerCostErrorLimit))
+		detailText := strings.TrimSpace(string(detail))
+		if detailText != "" {
+			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("requesting container cost quote: unexpected HTTP status %s: %q", resp.Status, detailText)
+		}
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("requesting container cost quote: unexpected HTTP status %s", resp.Status)
+	}
 
 	var response ContainerCostResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return 0, err
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, containerCostResponseLimit))
+	if err := decoder.Decode(&response); err != nil {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("decoding container cost quote: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("decoding container cost quote: %w", err)
 	}
 
 	costPerMs, err := strconv.ParseFloat(response.CostPerMs, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse cost_per_ms as float: %v", err)
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("parsing cost_per_ms: %w", err)
+	}
+	if math.IsNaN(costPerMs) || math.IsInf(costPerMs, 0) || costPerMs < 0 {
+		return ContainerCostQuote{}, time.Time{}, fmt.Errorf("invalid cost_per_ms %q: must be finite and nonnegative", response.CostPerMs)
 	}
 
-	return costPerMs, nil
+	quote := ContainerCostQuote{
+		CostPerMs:      costPerMs,
+		PricingVersion: response.PricingVersion,
+		Valid:          true,
+	}
+	validatedAt := c.now()
+	refreshAt := validatedAt.Add(containerCostQuoteRefresh)
+	if response.EffectiveAt != "" {
+		effectiveAt, err := time.Parse(time.RFC3339Nano, response.EffectiveAt)
+		if err != nil {
+			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("parsing effective_at: %w", err)
+		}
+		quote.EffectiveAt = effectiveAt
+	}
+	if response.ValidUntil != "" {
+		validUntil, err := time.Parse(time.RFC3339Nano, response.ValidUntil)
+		if err != nil {
+			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("parsing valid_until: %w", err)
+		}
+		if !validUntil.After(validatedAt) {
+			return ContainerCostQuote{}, time.Time{}, fmt.Errorf("invalid valid_until %q: must be in the future", response.ValidUntil)
+		}
+		quote.ValidUntil = validUntil
+		if validUntil.Before(refreshAt) {
+			refreshAt = validUntil
+		}
+	}
+
+	return quote, refreshAt, nil
+}
+
+func (c *ContainerCostClient) cachedResult(key ContainerCostRequest, now time.Time) (ContainerCostQuote, bool) {
+	c.mu.RLock()
+	entry, ok := c.quotes[key]
+	c.mu.RUnlock()
+	if !ok {
+		return ContainerCostQuote{}, false
+	}
+	if entry.refreshError != nil && now.Before(entry.retryAt) {
+		return entry.quote, true
+	}
+	if entry.quote.Valid && now.Before(entry.refreshAt) {
+		return entry.quote, true
+	}
+	return ContainerCostQuote{}, false
+}
+
+func (c *ContainerCostClient) cacheFailure(key ContainerCostRequest, failedAt time.Time, refreshErr error) (ContainerCostQuote, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry := c.quotes[key]
+	if entry.failures < ^uint8(0) {
+		entry.failures++
+	}
+	if entry.quote.Valid {
+		refreshErr = fmt.Errorf("refreshing container cost quote: %w", refreshErr)
+	}
+	entry.refreshError = refreshErr
+	entry.retryAt = failedAt.Add(containerCostRetryDelay(entry.failures))
+	c.quotes[key] = entry
+	return entry.quote, refreshErr
+}
+
+func containerCostRetryDelay(failures uint8) time.Duration {
+	delay := containerCostRetryInitial
+	for attempt := uint8(1); attempt < failures && delay < containerCostRetryMax; attempt++ {
+		delay *= 2
+		if delay > containerCostRetryMax {
+			return containerCostRetryMax
+		}
+	}
+	return delay
+}
+
+func (r ContainerCostRequest) singleflightKey() string {
+	return strconv.FormatInt(r.Cpu, 10) + "\x00" +
+		strconv.FormatInt(r.Memory, 10) + "\x00" + r.Gpu + "\x00" +
+		strconv.FormatUint(uint64(r.GpuCount), 10)
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values in response")
+		}
+		return err
+	}
+	return nil
 }

--- a/pkg/clients/container_cost.go
+++ b/pkg/clients/container_cost.go
@@ -104,6 +104,9 @@ func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request
 	if quote, ok := c.cached(key); ok {
 		return quote, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return c.lastGood(key), err
+	}
 
 	result := c.refresh.DoChan(key.cacheKey(), func() (any, error) {
 		if quote, ok := c.cached(key); ok {

--- a/pkg/clients/container_cost_test.go
+++ b/pkg/clients/container_cost_test.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +32,7 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 		_ = json.NewEncoder(w).Encode(ContainerCostResponse{
 			CostPerMs:      "0.0000017",
 			PricingVersion: "cpu-only-202607",
+			EffectiveAt:    now.Add(-time.Hour).Format(time.RFC3339Nano),
 			ValidUntil:     now.Add(time.Minute).Format(time.RFC3339Nano),
 		})
 	}))
@@ -44,7 +46,7 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	if err != nil {
 		t.Fatalf("initial quote: %v", err)
 	}
-	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "cpu-only-202607" {
+	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "cpu-only-202607" || !quote.EffectiveAt.Equal(now.Add(-time.Hour)) {
 		t.Fatalf("initial quote = %+v", quote)
 	}
 
@@ -74,11 +76,14 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	if cached, err := client.GetContainerCostQuote(context.Background(), request); err != nil || !cached.Valid {
 		t.Fatalf("cached stale quote = %+v, err = %v; want quiet last-good hit", cached, err)
 	}
+	if _, err := client.GetContainerCostPerMs(request); err == nil {
+		t.Fatal("scalar lookup accepted an expired stale quote")
+	}
 	if calls != 2 {
 		t.Fatalf("quote calls = %d, want failed-refresh backoff", calls)
 	}
 
-	now = now.Add(containerCostRetryInitial - time.Millisecond)
+	now = now.Add(containerCostRetryDelay - time.Millisecond)
 	if cached, err := client.GetContainerCostQuote(context.Background(), request); err != nil || !cached.Valid {
 		t.Fatalf("backed-off stale quote = %+v, err = %v; want quiet hit", cached, err)
 	}
@@ -96,7 +101,7 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	}
 
 	fail = false
-	now = now.Add(2 * containerCostRetryInitial)
+	now = now.Add(2 * containerCostRetryDelay)
 	recovered, err := client.GetContainerCostQuote(context.Background(), request)
 	if err != nil || !recovered.Valid {
 		t.Fatalf("recovered quote = %+v, err = %v", recovered, err)
@@ -144,7 +149,7 @@ func TestContainerCostClientRetriesWhenNoQuoteWasCached(t *testing.T) {
 		t.Fatalf("quote calls = %d after legacy cached lookup, want 1", calls)
 	}
 
-	now = now.Add(containerCostRetryInitial)
+	now = now.Add(containerCostRetryDelay)
 	quote, err = client.GetContainerCostQuote(context.Background(), request)
 	if err != nil || !quote.Valid || quote.CostPerMs != 0.25 {
 		t.Fatalf("retried quote = %+v, err = %v", quote, err)
@@ -202,7 +207,7 @@ func TestContainerCostClientCoalescesConcurrentRefreshes(t *testing.T) {
 	}
 }
 
-func TestContainerCostClientSurfacesRefreshFailureOnlyToOwner(t *testing.T) {
+func TestContainerCostClientCoalescesFailedRefresh(t *testing.T) {
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		calls.Add(1)
@@ -246,8 +251,8 @@ func TestContainerCostClientSurfacesRefreshFailureOnlyToOwner(t *testing.T) {
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("HTTP refreshes = %d, want one coalesced failed attempt", got)
 	}
-	if surfaced != 1 {
-		t.Fatalf("surfaced refresh errors = %d, want only the refresh owner", surfaced)
+	if surfaced == 0 {
+		t.Fatal("coalesced refresh did not surface its error")
 	}
 }
 
@@ -261,7 +266,9 @@ func TestContainerCostClientRejectsInvalidResponses(t *testing.T) {
 		{name: "not a number", status: http.StatusOK, body: `{"cost_per_ms":"NaN"}`},
 		{name: "infinity", status: http.StatusOK, body: `{"cost_per_ms":"+Inf"}`},
 		{name: "negative", status: http.StatusOK, body: `{"cost_per_ms":"-0.1"}`},
+		{name: "invalid effective time", status: http.StatusOK, body: `{"cost_per_ms":"1","effective_at":"yesterday"}`},
 		{name: "invalid expiry", status: http.StatusOK, body: `{"cost_per_ms":"1","valid_until":"tomorrow"}`},
+		{name: "unexpected field", status: http.StatusOK, body: `{"cost_per_ms":"1","extra":true}`},
 		{name: "trailing JSON", status: http.StatusOK, body: `{"cost_per_ms":"1"} {"extra":true}`},
 	}
 
@@ -303,11 +310,42 @@ func TestContainerCostClientUsesBoundedHTTPTimeout(t *testing.T) {
 	}
 }
 
-func TestContainerCostRetryDelayIsBounded(t *testing.T) {
-	if got := containerCostRetryDelay(1); got != containerCostRetryInitial {
-		t.Fatalf("first retry delay = %v, want %v", got, containerCostRetryInitial)
+func TestContainerCostClientWaitersCancelIndependently(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		close(requestStarted)
+		<-releaseRequest
+		_, _ = w.Write([]byte(`{"cost_per_ms":"0.125"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	ctx, cancel := context.WithCancel(context.Background())
+	first := make(chan error, 1)
+	go func() {
+		_, err := client.GetContainerCostQuote(ctx, &types.ContainerRequest{Cpu: 1_000})
+		first <- err
+	}()
+	<-requestStarted
+	cancel()
+	if err := <-first; !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled waiter error = %v, want context.Canceled", err)
 	}
-	if got := containerCostRetryDelay(^uint8(0)); got != containerCostRetryMax {
-		t.Fatalf("maximum retry delay = %v, want %v", got, containerCostRetryMax)
+
+	second := make(chan containerCostResult, 1)
+	go func() {
+		quote, err := client.GetContainerCostQuote(context.Background(), &types.ContainerRequest{Cpu: 1_000})
+		second <- containerCostResult{quote: quote, err: err}
+	}()
+	close(releaseRequest)
+	result := <-second
+	if result.err != nil || !result.quote.Valid || result.quote.CostPerMs != 0.125 {
+		t.Fatalf("healthy waiter quote = %+v, err = %v", result.quote, result.err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("HTTP calls = %d, want one shared refresh", calls.Load())
 	}
 }

--- a/pkg/clients/container_cost_test.go
+++ b/pkg/clients/container_cost_test.go
@@ -16,19 +16,38 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 )
 
+type atomicTestClock struct {
+	nanos atomic.Int64
+}
+
+func newAtomicTestClock(now time.Time) *atomicTestClock {
+	clock := &atomicTestClock{}
+	clock.nanos.Store(now.UnixNano())
+	return clock
+}
+
+func (c *atomicTestClock) Now() time.Time {
+	return time.Unix(0, c.nanos.Load()).UTC()
+}
+
+func (c *atomicTestClock) Add(duration time.Duration) {
+	c.nanos.Add(duration.Nanoseconds())
+}
+
 func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *testing.T) {
-	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	var calls int
-	fail := false
+	clock := newAtomicTestClock(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC))
+	var calls atomic.Int32
+	var fail atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			t.Errorf("authorization = %q, want bearer token", r.Header.Get("Authorization"))
 		}
-		if fail {
+		if fail.Load() {
 			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
 			return
 		}
+		now := clock.Now()
 		_ = json.NewEncoder(w).Encode(ContainerCostResponse{
 			CostPerMs:      "0.0000017",
 			PricingVersion: "cpu-only-202607",
@@ -39,14 +58,14 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	t.Cleanup(server.Close)
 
 	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
-	client.now = func() time.Time { return now }
+	client.now = clock.Now
 	request := &types.ContainerRequest{ContainerId: "container-1", Cpu: 1_000, Memory: 1_024}
 
 	quote, err := client.GetContainerCostQuote(context.Background(), request)
 	if err != nil {
 		t.Fatalf("initial quote: %v", err)
 	}
-	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "cpu-only-202607" || !quote.EffectiveAt.Equal(now.Add(-time.Hour)) {
+	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "cpu-only-202607" || !quote.EffectiveAt.Equal(clock.Now().Add(-time.Hour)) {
 		t.Fatalf("initial quote = %+v", quote)
 	}
 
@@ -55,12 +74,12 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	if _, err := client.GetContainerCostQuote(context.Background(), request); err != nil {
 		t.Fatalf("cached quote: %v", err)
 	}
-	if calls != 1 {
-		t.Fatalf("quote calls = %d, want one shared resource-keyed call", calls)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("quote calls = %d, want one shared resource-keyed call", got)
 	}
 
-	now = now.Add(2 * time.Minute)
-	fail = true
+	clock.Add(2 * time.Minute)
+	fail.Store(true)
 	surfacedErrors := 0
 	stale, err := client.GetContainerCostQuote(context.Background(), request)
 	if err == nil {
@@ -70,8 +89,8 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	if !stale.Valid || stale.CostPerMs != quote.CostPerMs || stale.PricingVersion != quote.PricingVersion {
 		t.Fatalf("stale quote = %+v, want last good %+v", stale, quote)
 	}
-	if calls != 2 {
-		t.Fatalf("quote calls = %d, want refresh after valid_until", calls)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("quote calls = %d, want refresh after valid_until", got)
 	}
 	if cached, err := client.GetContainerCostQuote(context.Background(), request); err != nil || !cached.Valid {
 		t.Fatalf("cached stale quote = %+v, err = %v; want quiet last-good hit", cached, err)
@@ -79,35 +98,35 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	if _, err := client.GetContainerCostPerMs(request); err == nil {
 		t.Fatal("scalar lookup accepted an expired stale quote")
 	}
-	if calls != 2 {
-		t.Fatalf("quote calls = %d, want failed-refresh backoff", calls)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("quote calls = %d, want failed-refresh backoff", got)
 	}
 
-	now = now.Add(containerCostRetryDelay - time.Millisecond)
+	clock.Add(containerCostRetryDelay - time.Millisecond)
 	if cached, err := client.GetContainerCostQuote(context.Background(), request); err != nil || !cached.Valid {
 		t.Fatalf("backed-off stale quote = %+v, err = %v; want quiet hit", cached, err)
 	}
-	if calls != 2 {
-		t.Fatalf("quote calls = %d before retry deadline, want 2", calls)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("quote calls = %d before retry deadline, want 2", got)
 	}
 
-	now = now.Add(time.Millisecond)
+	clock.Add(time.Millisecond)
 	if _, err := client.GetContainerCostQuote(context.Background(), request); err == nil {
 		t.Fatal("second stale refresh error = nil")
 	}
 	surfacedErrors++
-	if calls != 3 {
-		t.Fatalf("quote calls = %d at retry deadline, want 3", calls)
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("quote calls = %d at retry deadline, want 3", got)
 	}
 
-	fail = false
-	now = now.Add(2 * containerCostRetryDelay)
+	fail.Store(false)
+	clock.Add(2 * containerCostRetryDelay)
 	recovered, err := client.GetContainerCostQuote(context.Background(), request)
 	if err != nil || !recovered.Valid {
 		t.Fatalf("recovered quote = %+v, err = %v", recovered, err)
 	}
-	if calls != 4 {
-		t.Fatalf("quote calls = %d after bounded exponential backoff, want 4", calls)
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("quote calls = %d after bounded exponential backoff, want 4", got)
 	}
 	if surfacedErrors != 2 {
 		t.Fatalf("surfaced refresh errors = %d, want one per failed HTTP refresh", surfacedErrors)
@@ -115,11 +134,10 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 }
 
 func TestContainerCostClientRetriesWhenNoQuoteWasCached(t *testing.T) {
-	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	var calls int
+	clock := newAtomicTestClock(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC))
+	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls++
-		if calls == 1 {
+		if calls.Add(1) == 1 {
 			http.Error(w, "try again", http.StatusServiceUnavailable)
 			return
 		}
@@ -128,7 +146,7 @@ func TestContainerCostClientRetriesWhenNoQuoteWasCached(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
-	client.now = func() time.Time { return now }
+	client.now = clock.Now
 	request := &types.ContainerRequest{Cpu: 1_000, Memory: 1_024}
 	if quote, err := client.GetContainerCostQuote(context.Background(), request); err == nil || quote.Valid {
 		t.Fatalf("first quote = %+v, err = %v; want missing quote", quote, err)
@@ -139,23 +157,23 @@ func TestContainerCostClientRetriesWhenNoQuoteWasCached(t *testing.T) {
 	if err != nil || quote.Valid {
 		t.Fatalf("negative cached quote = %+v, err = %v; want quiet unavailable hit", quote, err)
 	}
-	if calls != 1 {
-		t.Fatalf("quote calls = %d during negative-cache window, want 1", calls)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("quote calls = %d during negative-cache window, want 1", got)
 	}
 	if _, err := client.GetContainerCostPerMs(request); err == nil {
 		t.Fatal("legacy scalar lookup error = nil for unavailable cached quote")
 	}
-	if calls != 1 {
-		t.Fatalf("quote calls = %d after legacy cached lookup, want 1", calls)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("quote calls = %d after legacy cached lookup, want 1", got)
 	}
 
-	now = now.Add(containerCostRetryDelay)
+	clock.Add(containerCostRetryDelay)
 	quote, err = client.GetContainerCostQuote(context.Background(), request)
 	if err != nil || !quote.Valid || quote.CostPerMs != 0.25 {
 		t.Fatalf("retried quote = %+v, err = %v", quote, err)
 	}
-	if calls != 2 {
-		t.Fatalf("quote calls = %d, want retry on next lookup", calls)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("quote calls = %d, want retry on next lookup", got)
 	}
 }
 
@@ -347,5 +365,40 @@ func TestContainerCostClientWaitersCancelIndependently(t *testing.T) {
 	}
 	if calls.Load() != 1 {
 		t.Fatalf("HTTP calls = %d, want one shared refresh", calls.Load())
+	}
+}
+
+func TestContainerCostClientCanceledLookupUsesCacheWithoutRefreshing(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(`{"cost_per_ms":"0.125"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	cachedRequest := &types.ContainerRequest{Cpu: 1_000}
+	quote, err := client.GetContainerCostQuote(context.Background(), cachedRequest)
+	if err != nil || !quote.Valid {
+		t.Fatalf("priming quote = %+v, err = %v", quote, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	quote, err = client.GetContainerCostQuote(ctx, cachedRequest)
+	if err != nil || !quote.Valid {
+		t.Fatalf("cached canceled lookup = %+v, err = %v; want cached quote", quote, err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("HTTP calls after cached lookup = %d, want 1", got)
+	}
+
+	quote, err = client.GetContainerCostQuote(ctx, &types.ContainerRequest{Cpu: 2_000})
+	if !errors.Is(err, context.Canceled) || quote.Valid {
+		t.Fatalf("uncached canceled lookup = %+v, err = %v; want context.Canceled", quote, err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("HTTP calls after uncached canceled lookup = %d, want 1", got)
 	}
 }

--- a/pkg/clients/container_cost_test.go
+++ b/pkg/clients/container_cost_test.go
@@ -1,0 +1,313 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	var calls int
+	fail := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("authorization = %q, want bearer token", r.Header.Get("Authorization"))
+		}
+		if fail {
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ContainerCostResponse{
+			CostPerMs:      "0.0000017",
+			PricingVersion: "cpu-only-202607",
+			ValidUntil:     now.Add(time.Minute).Format(time.RFC3339Nano),
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	client.now = func() time.Time { return now }
+	request := &types.ContainerRequest{ContainerId: "container-1", Cpu: 1_000, Memory: 1_024}
+
+	quote, err := client.GetContainerCostQuote(context.Background(), request)
+	if err != nil {
+		t.Fatalf("initial quote: %v", err)
+	}
+	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "cpu-only-202607" {
+		t.Fatalf("initial quote = %+v", quote)
+	}
+
+	// Container identity is deliberately absent from the cache key.
+	request.ContainerId = "container-2"
+	if _, err := client.GetContainerCostQuote(context.Background(), request); err != nil {
+		t.Fatalf("cached quote: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("quote calls = %d, want one shared resource-keyed call", calls)
+	}
+
+	now = now.Add(2 * time.Minute)
+	fail = true
+	surfacedErrors := 0
+	stale, err := client.GetContainerCostQuote(context.Background(), request)
+	if err == nil {
+		t.Fatal("stale refresh error = nil")
+	}
+	surfacedErrors++
+	if !stale.Valid || stale.CostPerMs != quote.CostPerMs || stale.PricingVersion != quote.PricingVersion {
+		t.Fatalf("stale quote = %+v, want last good %+v", stale, quote)
+	}
+	if calls != 2 {
+		t.Fatalf("quote calls = %d, want refresh after valid_until", calls)
+	}
+	if cached, err := client.GetContainerCostQuote(context.Background(), request); err != nil || !cached.Valid {
+		t.Fatalf("cached stale quote = %+v, err = %v; want quiet last-good hit", cached, err)
+	}
+	if calls != 2 {
+		t.Fatalf("quote calls = %d, want failed-refresh backoff", calls)
+	}
+
+	now = now.Add(containerCostRetryInitial - time.Millisecond)
+	if cached, err := client.GetContainerCostQuote(context.Background(), request); err != nil || !cached.Valid {
+		t.Fatalf("backed-off stale quote = %+v, err = %v; want quiet hit", cached, err)
+	}
+	if calls != 2 {
+		t.Fatalf("quote calls = %d before retry deadline, want 2", calls)
+	}
+
+	now = now.Add(time.Millisecond)
+	if _, err := client.GetContainerCostQuote(context.Background(), request); err == nil {
+		t.Fatal("second stale refresh error = nil")
+	}
+	surfacedErrors++
+	if calls != 3 {
+		t.Fatalf("quote calls = %d at retry deadline, want 3", calls)
+	}
+
+	fail = false
+	now = now.Add(2 * containerCostRetryInitial)
+	recovered, err := client.GetContainerCostQuote(context.Background(), request)
+	if err != nil || !recovered.Valid {
+		t.Fatalf("recovered quote = %+v, err = %v", recovered, err)
+	}
+	if calls != 4 {
+		t.Fatalf("quote calls = %d after bounded exponential backoff, want 4", calls)
+	}
+	if surfacedErrors != 2 {
+		t.Fatalf("surfaced refresh errors = %d, want one per failed HTTP refresh", surfacedErrors)
+	}
+}
+
+func TestContainerCostClientRetriesWhenNoQuoteWasCached(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"cost_per_ms":"0.25","pricing_version":"legacy"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	client.now = func() time.Time { return now }
+	request := &types.ContainerRequest{Cpu: 1_000, Memory: 1_024}
+	if quote, err := client.GetContainerCostQuote(context.Background(), request); err == nil || quote.Valid {
+		t.Fatalf("first quote = %+v, err = %v; want missing quote", quote, err)
+	} else if !strings.Contains(err.Error(), "try again") {
+		t.Fatalf("first quote error = %q, want bounded server detail", err)
+	}
+	quote, err := client.GetContainerCostQuote(context.Background(), request)
+	if err != nil || quote.Valid {
+		t.Fatalf("negative cached quote = %+v, err = %v; want quiet unavailable hit", quote, err)
+	}
+	if calls != 1 {
+		t.Fatalf("quote calls = %d during negative-cache window, want 1", calls)
+	}
+	if _, err := client.GetContainerCostPerMs(request); err == nil {
+		t.Fatal("legacy scalar lookup error = nil for unavailable cached quote")
+	}
+	if calls != 1 {
+		t.Fatalf("quote calls = %d after legacy cached lookup, want 1", calls)
+	}
+
+	now = now.Add(containerCostRetryInitial)
+	quote, err = client.GetContainerCostQuote(context.Background(), request)
+	if err != nil || !quote.Valid || quote.CostPerMs != 0.25 {
+		t.Fatalf("retried quote = %+v, err = %v", quote, err)
+	}
+	if calls != 2 {
+		t.Fatalf("quote calls = %d, want retry on next lookup", calls)
+	}
+}
+
+func TestContainerCostClientCoalescesConcurrentRefreshes(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"cost_per_ms":"0.125"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	request := &types.ContainerRequest{Cpu: 2_000, Memory: 4_096, Gpu: " T4 ", GpuCount: 1}
+
+	const goroutines = 12
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			quote, err := client.GetContainerCostQuote(context.Background(), request)
+			if err == nil && (!quote.Valid || quote.CostPerMs != 0.125) {
+				err = fmt.Errorf("unexpected quote %+v", quote)
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("quote calls = %d, want one coalesced refresh", got)
+	}
+	request.Gpu = "T4"
+	if _, err := client.GetContainerCostQuote(context.Background(), request); err != nil {
+		t.Fatalf("trimmed GPU cache lookup: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("quote calls after normalized GPU lookup = %d, want one", got)
+	}
+}
+
+func TestContainerCostClientSurfacesRefreshFailureOnlyToOwner(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	client.now = func() time.Time { return time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC) }
+	request := &types.ContainerRequest{Cpu: 1_000, Memory: 1_024}
+
+	const goroutines = 32
+	start := make(chan struct{})
+	errorsSeen := make(chan bool, goroutines)
+	var ready, done sync.WaitGroup
+	ready.Add(goroutines)
+	done.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			<-start
+			quote, err := client.GetContainerCostQuote(context.Background(), request)
+			if quote.Valid {
+				t.Errorf("failed lookup returned valid quote %+v", quote)
+			}
+			errorsSeen <- err != nil
+		}()
+	}
+	ready.Wait()
+	close(start)
+	done.Wait()
+	close(errorsSeen)
+
+	var surfaced int
+	for seen := range errorsSeen {
+		if seen {
+			surfaced++
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("HTTP refreshes = %d, want one coalesced failed attempt", got)
+	}
+	if surfaced != 1 {
+		t.Fatalf("surfaced refresh errors = %d, want only the refresh owner", surfaced)
+	}
+}
+
+func TestContainerCostClientRejectsInvalidResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "redirect", status: http.StatusFound, body: `{"cost_per_ms":"1"}`},
+		{name: "not a number", status: http.StatusOK, body: `{"cost_per_ms":"NaN"}`},
+		{name: "infinity", status: http.StatusOK, body: `{"cost_per_ms":"+Inf"}`},
+		{name: "negative", status: http.StatusOK, body: `{"cost_per_ms":"-0.1"}`},
+		{name: "invalid expiry", status: http.StatusOK, body: `{"cost_per_ms":"1","valid_until":"tomorrow"}`},
+		{name: "trailing JSON", status: http.StatusOK, body: `{"cost_per_ms":"1"} {"extra":true}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+			quote, err := client.GetContainerCostQuote(context.Background(), &types.ContainerRequest{Cpu: 1_000})
+			if err == nil || quote.Valid {
+				t.Fatalf("quote = %+v, err = %v; want rejected response", quote, err)
+			}
+		})
+	}
+}
+
+func TestContainerCostClientUsesBoundedHTTPTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(100 * time.Millisecond):
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	client.client.Timeout = 20 * time.Millisecond
+	started := time.Now()
+	quote, err := client.GetContainerCostQuote(context.Background(), &types.ContainerRequest{Cpu: 1_000})
+	if err == nil || quote.Valid {
+		t.Fatalf("quote = %+v, err = %v; want timeout", quote, err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("timeout took %v, want bounded request", elapsed)
+	}
+}
+
+func TestContainerCostRetryDelayIsBounded(t *testing.T) {
+	if got := containerCostRetryDelay(1); got != containerCostRetryInitial {
+		t.Fatalf("first retry delay = %v, want %v", got, containerCostRetryInitial)
+	}
+	if got := containerCostRetryDelay(^uint8(0)); got != containerCostRetryMax {
+		t.Fatalf("maximum retry delay = %v, want %v", got, containerCostRetryMax)
+	}
+}

--- a/pkg/clients/managed_compute_usage.go
+++ b/pkg/clients/managed_compute_usage.go
@@ -56,30 +56,35 @@ func NewManagedComputeUsageRecorder(config types.ManagedComputeConfig, worker Wo
 	}
 }
 
-func (r *ManagedComputeUsageRecorder) RecordContainerUsage(ctx context.Context, request *types.ContainerRequest, start, end time.Time, costCents float64) error {
-	return r.client.Record(ctx, MarketplaceUsageRequest{
-		BuyerWorkspaceID:          request.WorkspaceId,
-		SellerWorkspaceID:         r.config.SellerWorkspaceID,
-		ListingID:                 r.config.MarketplaceListingID,
-		MachineID:                 r.worker.MachineID,
-		ContainerID:               request.ContainerId,
-		StubID:                    request.StubId,
-		AppID:                     request.AppId,
-		UsageKind:                 usageKind(request),
-		Runtime:                   r.worker.Runtime,
-		GPU:                       request.Gpu,
-		GPUCount:                  request.GpuCount,
-		DurationSeconds:           end.Sub(start).Seconds(),
-		BuyerCostCents:            costCents,
-		SellerPayoutEstimateCents: math.Max(0, costCents*r.payoutRate),
-		StartAt:                   start.UTC(),
-		EndAt:                     end.UTC(),
-		ContainerType:             request.Stub.Type.Kind(),
+func (r *ManagedComputeUsageRecorder) RecordContainerUsage(ctx context.Context, request *types.ContainerRequest, start, end time.Time, costCents *float64) error {
+	usage := MarketplaceUsageRequest{
+		BuyerWorkspaceID:  request.WorkspaceId,
+		SellerWorkspaceID: r.config.SellerWorkspaceID,
+		ListingID:         r.config.MarketplaceListingID,
+		MachineID:         r.worker.MachineID,
+		ContainerID:       request.ContainerId,
+		StubID:            request.StubId,
+		AppID:             request.AppId,
+		UsageKind:         usageKind(request),
+		Runtime:           r.worker.Runtime,
+		GPU:               request.Gpu,
+		GPUCount:          request.GpuCount,
+		DurationSeconds:   end.Sub(start).Seconds(),
+		StartAt:           start.UTC(),
+		EndAt:             end.UTC(),
+		ContainerType:     request.Stub.Type.Kind(),
 		RuntimeMetadata: map[string]interface{}{
 			"worker_id": r.worker.WorkerID,
 			"pool_name": r.worker.PoolName,
 		},
-	})
+	}
+	if costCents != nil {
+		usage.BuyerCostCents = *costCents
+		usage.SellerPayoutEstimateCents = math.Max(0, *costCents*r.payoutRate)
+	} else {
+		usage.OmitPrice = true
+	}
+	return r.client.Record(ctx, usage)
 }
 
 func usageKind(request *types.ContainerRequest) string {

--- a/pkg/clients/managed_compute_usage_test.go
+++ b/pkg/clients/managed_compute_usage_test.go
@@ -75,7 +75,8 @@ func TestManagedComputeUsageRecorderAttributesFromConfig(t *testing.T) {
 		GpuCount:    1,
 		Stub:        types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeFunction)}},
 	}
-	if err := recorder.RecordContainerUsage(context.Background(), request, start, end, 100); err != nil {
+	cost := 100.0
+	if err := recorder.RecordContainerUsage(context.Background(), request, start, end, &cost); err != nil {
 		t.Fatalf("RecordContainerUsage() error = %v", err)
 	}
 
@@ -87,5 +88,44 @@ func TestManagedComputeUsageRecorderAttributesFromConfig(t *testing.T) {
 	}
 	if got.BuyerCostCents != 100 || got.SellerPayoutEstimateCents != 90 {
 		t.Fatalf("cost/payout = %v/%v, want 100/90 with 10%% margin", got.BuyerCostCents, got.SellerPayoutEstimateCents)
+	}
+}
+
+func TestManagedComputeUsageRecorderKeepsDurationWithoutPrice(t *testing.T) {
+	var got map[string]json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode usage request: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	recorder := NewManagedComputeUsageRecorder(types.ManagedComputeConfig{
+		Billing:              types.ManagedComputeBillingConfig{Endpoint: server.URL},
+		MarketplaceListingID: "listing-1",
+		SellerWorkspaceID:    "seller-1",
+	}, WorkerIdentity{WorkerID: "worker-1", MachineID: "machine-1"})
+	if recorder == nil {
+		t.Fatal("recorder = nil, want configured recorder")
+	}
+
+	start := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Second)
+	if err := recorder.RecordContainerUsage(context.Background(), &types.ContainerRequest{
+		ContainerId: "container-1",
+		WorkspaceId: "buyer-1",
+	}, start, end, nil); err != nil {
+		t.Fatalf("RecordContainerUsage() error = %v", err)
+	}
+
+	if _, ok := got["duration_seconds"]; !ok {
+		t.Fatal("duration_seconds omitted from unpriced usage")
+	}
+	if _, ok := got["buyer_cost_cents"]; ok {
+		t.Fatal("buyer_cost_cents present without a valid quote")
+	}
+	if _, ok := got["seller_payout_estimate_cents"]; ok {
+		t.Fatal("seller_payout_estimate_cents present without a valid quote")
 	}
 }

--- a/pkg/clients/marketplace_usage.go
+++ b/pkg/clients/marketplace_usage.go
@@ -46,6 +46,25 @@ type MarketplaceUsageRequest struct {
 	EndAt                     time.Time              `json:"end_at"`
 	ContainerType             string                 `json:"container_type"`
 	RuntimeMetadata           map[string]interface{} `json:"runtime_metadata"`
+	OmitPrice                 bool                   `json:"-"`
+}
+
+func (u MarketplaceUsageRequest) MarshalJSON() ([]byte, error) {
+	type alias MarketplaceUsageRequest
+	var buyerCost, sellerPayout *float64
+	if !u.OmitPrice {
+		buyerCost = &u.BuyerCostCents
+		sellerPayout = &u.SellerPayoutEstimateCents
+	}
+	return json.Marshal(struct {
+		alias
+		BuyerCostCents            *float64 `json:"buyer_cost_cents,omitempty"`
+		SellerPayoutEstimateCents *float64 `json:"seller_payout_estimate_cents,omitempty"`
+	}{
+		alias:                     alias(u),
+		BuyerCostCents:            buyerCost,
+		SellerPayoutEstimateCents: sellerPayout,
+	})
 }
 
 type marketplaceUsageResponse struct {

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -359,7 +359,7 @@ func (r *PostgresBackendRepository) RetrieveActiveToken(ctx context.Context, wor
 
 func (r *PostgresBackendRepository) ListTokens(ctx context.Context, workspaceId uint) ([]types.Token, error) {
 	query := `
-    SELECT id, external_id, key, created_at, updated_at, active, token_type, reusable, workspace_id
+    SELECT id, external_id, key, created_at, updated_at, active, disabled_by_cluster_admin, token_type, reusable, workspace_id
     FROM token
     WHERE workspace_id = $1
 	AND token_type != 'worker'

--- a/pkg/repository/usage/usage_openmeter.go
+++ b/pkg/repository/usage/usage_openmeter.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -72,7 +74,6 @@ func (o *OpenMeterUsageMetricsRepository) sendEvent(name string, data map[string
 		subjectId = workspaceId
 	}
 
-	e.SetID(uuid.New().String())
 	e.SetSource(o.source)
 	e.SetType(name)
 	e.SetSubject(subjectId)
@@ -80,6 +81,7 @@ func (o *OpenMeterUsageMetricsRepository) sendEvent(name string, data map[string
 	if err := e.SetData("application/json", data); err != nil {
 		return fmt.Errorf("failed to encode OpenMeter event: %w", err)
 	}
+	e.SetID(openMeterEventID(o.source, name, data))
 	if err := e.Validate(); err != nil {
 		return fmt.Errorf("invalid OpenMeter event: %w", err)
 	}
@@ -116,6 +118,28 @@ func (o *OpenMeterUsageMetricsRepository) sendEvent(name string, data map[string
 	}
 
 	return lastErr
+}
+
+// Interval usage is safe to replay above the HTTP retry layer. Worker and
+// pricing metadata are deliberately excluded: neither changes the logical
+// resource usage if the same container interval is emitted again.
+func openMeterEventID(source, name string, data map[string]interface{}) string {
+	start, startOK := data["interval_start"].(string)
+	if !startOK {
+		return uuid.New().String()
+	}
+	end, endOK := data["interval_end"].(string)
+	if !endOK {
+		return uuid.New().String()
+	}
+	identity, _ := json.Marshal([]interface{}{
+		source, name,
+		data["container_id"], data["workspace_id"], data["stub_id"], data["app_id"],
+		data["cpu_millicores"], data["mem_mb"], data["gpu"], data["gpu_count"],
+		start, end, data["value"],
+	})
+	sum := sha256.Sum256(identity)
+	return fmt.Sprintf("%x", sum)
 }
 
 func eventData(metadata map[string]interface{}, value float64) map[string]interface{} {

--- a/pkg/repository/usage/usage_openmeter.go
+++ b/pkg/repository/usage/usage_openmeter.go
@@ -2,7 +2,10 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,6 +14,12 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 	cloudevents "github.com/cloudevents/sdk-go/v2/event"
 	openmeter "github.com/openmeterio/openmeter/api/client/go"
+)
+
+const (
+	openMeterRequestTimeout = 5 * time.Second
+	openMeterSendAttempts   = 3
+	openMeterRetryDelay     = 100 * time.Millisecond
 )
 
 type OpenMeterUsageMetricsRepository struct {
@@ -27,7 +36,11 @@ func NewOpenMeterUsageMetricsRepository(omConfig types.OpenMeterConfig) reposito
 }
 
 func (o *OpenMeterUsageMetricsRepository) Init(source string) error {
-	om, err := openmeter.NewAuthClientWithResponses(o.config.ServerUrl, o.config.ApiKey)
+	om, err := openmeter.NewAuthClientWithResponses(
+		o.config.ServerUrl,
+		o.config.ApiKey,
+		openmeter.WithHTTPClient(&http.Client{Timeout: openMeterRequestTimeout}),
+	)
 	if err != nil {
 		return err
 	}
@@ -51,7 +64,7 @@ func (o *OpenMeterUsageMetricsRepository) sendEvent(name string, data map[string
 	data = eventData(data, value)
 
 	e := cloudevents.New()
-	t := time.Now()
+	t := openMeterEventTime(data)
 
 	subjectId := o.source
 	workspaceId, ok := data["workspace_id"].(string)
@@ -64,17 +77,45 @@ func (o *OpenMeterUsageMetricsRepository) sendEvent(name string, data map[string
 	e.SetType(name)
 	e.SetSubject(subjectId)
 	e.SetTime(t)
-	e.SetData("application/json", data)
-
-	resp, err := o.client.IngestEventWithResponse(context.Background(), e)
-	if err != nil {
-		return fmt.Errorf("failed to increment counter: %w", err)
+	if err := e.SetData("application/json", data); err != nil {
+		return fmt.Errorf("failed to encode OpenMeter event: %w", err)
 	}
-	if resp.StatusCode() > 399 {
-		return fmt.Errorf("failed to increment counter: %w", err)
+	if err := e.Validate(); err != nil {
+		return fmt.Errorf("invalid OpenMeter event: %w", err)
 	}
 
-	return nil
+	// Build the CloudEvent once and reuse it across bounded retries. OpenMeter
+	// deduplicates on source+id, so an ambiguous network failure cannot turn a
+	// retry into duplicate billable usage.
+	var lastErr error
+	for attempt := 1; attempt <= openMeterSendAttempts; attempt++ {
+		requestCtx, cancel := context.WithTimeout(context.Background(), openMeterRequestTimeout)
+		resp, err := o.client.IngestEventWithResponse(requestCtx, e)
+		cancel()
+
+		if err == nil && resp != nil && resp.StatusCode() >= http.StatusOK && resp.StatusCode() < http.StatusMultipleChoices {
+			return nil
+		}
+
+		retry := false
+		if err != nil {
+			lastErr = fmt.Errorf("sending OpenMeter event %s: %w", e.ID(), err)
+			retry = isRetryableOpenMeterError(err)
+		} else if resp == nil {
+			lastErr = fmt.Errorf("sending OpenMeter event %s: empty response", e.ID())
+			retry = true
+		} else {
+			lastErr = fmt.Errorf("sending OpenMeter event %s: unexpected HTTP status %s", e.ID(), resp.Status())
+			retry = isRetryableOpenMeterStatus(resp.StatusCode())
+		}
+
+		if !retry || attempt == openMeterSendAttempts {
+			return lastErr
+		}
+		time.Sleep(time.Duration(attempt) * openMeterRetryDelay)
+	}
+
+	return lastErr
 }
 
 func eventData(metadata map[string]interface{}, value float64) map[string]interface{} {
@@ -84,4 +125,28 @@ func eventData(metadata map[string]interface{}, value float64) map[string]interf
 	}
 	data["value"] = value
 	return data
+}
+
+func isRetryableOpenMeterStatus(status int) bool {
+	return status == http.StatusRequestTimeout ||
+		status == http.StatusTooEarly ||
+		status == http.StatusTooManyRequests ||
+		status >= http.StatusInternalServerError
+}
+
+func isRetryableOpenMeterError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func openMeterEventTime(data map[string]interface{}) time.Time {
+	if value, ok := data["interval_start"].(string); ok {
+		if intervalStart, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return intervalStart
+		}
+	}
+	return time.Now()
 }

--- a/pkg/repository/usage/usage_openmeter_test.go
+++ b/pkg/repository/usage/usage_openmeter_test.go
@@ -1,11 +1,13 @@
 package metrics
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 )
@@ -23,6 +25,95 @@ func TestOpenMeterEventDataUsesRepositoryValue(t *testing.T) {
 	}
 	if metadata["value"] != 1 {
 		t.Fatalf("eventData mutated caller metadata value = %v", metadata["value"])
+	}
+}
+
+func TestOpenMeterEventTimeUsesIntervalStart(t *testing.T) {
+	start := time.Date(2026, 7, 10, 23, 59, 59, 0, time.UTC)
+	transition := start.Add(time.Second)
+	preTransition := openMeterEventTime(map[string]interface{}{
+		"interval_start": start.Format(time.RFC3339Nano),
+	})
+	postTransition := openMeterEventTime(map[string]interface{}{
+		"interval_start": transition.Format(time.RFC3339Nano),
+	})
+	if !preTransition.Equal(start) || !preTransition.Before(transition) {
+		t.Fatalf("pre-transition event time = %v, want %v before transition", preTransition, start)
+	}
+	if !postTransition.Equal(transition) || postTransition.Before(transition) {
+		t.Fatalf("post-transition event time = %v, want transition %v", postTransition, transition)
+	}
+}
+
+func TestOpenMeterIntervalEventIDIsIdempotent(t *testing.T) {
+	type event struct {
+		ID string `json:"id"`
+	}
+	var events []event
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got event
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode event: %v", err)
+		}
+		events = append(events, got)
+		if len(events) == 1 {
+			http.Error(w, "retry", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	repository := &OpenMeterUsageMetricsRepository{config: types.OpenMeterConfig{
+		ServerUrl: server.URL,
+		ApiKey:    "test-key",
+	}}
+	if err := repository.Init("worker"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	interval := map[string]interface{}{
+		"container_id":    "container-1",
+		"worker_id":       "worker-1",
+		"cpu_millicores":  int64(1_000),
+		"pricing_version": "price-1",
+		"interval_start":  "2026-07-10T12:00:00Z",
+		"interval_end":    "2026-07-10T12:00:05Z",
+	}
+	emit := func(name string, labels map[string]interface{}, value float64) {
+		t.Helper()
+		if err := repository.IncrementCounter(name, labels, value); err != nil {
+			t.Fatalf("IncrementCounter: %v", err)
+		}
+	}
+
+	emit("container_duration_milliseconds", interval, 5_000)
+	replayed := make(map[string]interface{}, len(interval))
+	for key, value := range interval {
+		replayed[key] = value
+	}
+	replayed["worker_id"] = "worker-2"
+	replayed["pricing_version"] = "price-2"
+	emit("container_duration_milliseconds", replayed, 5_000)
+
+	differentResource := make(map[string]interface{}, len(interval))
+	for key, value := range interval {
+		differentResource[key] = value
+	}
+	differentResource["cpu_millicores"] = int64(2_000)
+	emit("container_duration_milliseconds", differentResource, 5_000)
+	emit("container_duration_milliseconds", interval, 4_000)
+	emit("container_cost_cents", interval, 1)
+
+	if len(events) != 6 {
+		t.Fatalf("events = %d, want retry plus five logical sends", len(events))
+	}
+	if events[0].ID == "" || events[0].ID != events[1].ID || events[0].ID != events[2].ID {
+		t.Fatalf("same interval IDs = %q/%q/%q, want one stable ID", events[0].ID, events[1].ID, events[2].ID)
+	}
+	for index, got := range events[3:] {
+		if got.ID == events[0].ID {
+			t.Fatalf("distinct event %d reused interval ID %q", index, got.ID)
+		}
 	}
 }
 

--- a/pkg/repository/usage/usage_openmeter_test.go
+++ b/pkg/repository/usage/usage_openmeter_test.go
@@ -1,6 +1,14 @@
 package metrics
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/types"
+)
 
 func TestOpenMeterEventDataUsesRepositoryValue(t *testing.T) {
 	metadata := map[string]interface{}{
@@ -15,5 +23,31 @@ func TestOpenMeterEventDataUsesRepositoryValue(t *testing.T) {
 	}
 	if metadata["value"] != 1 {
 		t.Fatalf("eventData mutated caller metadata value = %v", metadata["value"])
+	}
+}
+
+func TestOpenMeterRejectsNon2xxWithoutRetryingPermanentStatus(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	repository := &OpenMeterUsageMetricsRepository{config: types.OpenMeterConfig{
+		ServerUrl: server.URL,
+		ApiKey:    "test-key",
+	}}
+	if err := repository.Init("worker"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	err := repository.IncrementCounter("container_duration_milliseconds", map[string]interface{}{
+		"workspace_id": "workspace-1",
+	}, 1)
+	if err == nil || !strings.Contains(err.Error(), "302 Found") {
+		t.Fatalf("IncrementCounter error = %v, want strict non-2xx status", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("OpenMeter calls = %d, want no retry for permanent 3xx", got)
 	}
 }

--- a/pkg/worker/usage.go
+++ b/pkg/worker/usage.go
@@ -113,6 +113,13 @@ func (wm *WorkerUsageMetrics) EmitContainerUsage(ctx context.Context, request *t
 		// Resolve after freezing end. Quote latency can delay cost delivery, but
 		// it can never lengthen the interval or hold its duration event.
 		nextQuote := wm.getContainerCostQuote(&requestSnapshot)
+		if nextQuote.Valid && nextQuote.EffectiveAt.IsZero() {
+			nextQuote.EffectiveAt = currentQuote.EffectiveAt
+			if !samePricing(nextQuote, currentQuote) {
+				// Changed undated pricing is prospective; it cannot reprice elapsed usage.
+				nextQuote.EffectiveAt = end.UTC()
+			}
+		}
 		wm.emitContainerPriceSegments(requestSnapshot, start, end, currentQuote, nextQuote)
 		if final {
 			return
@@ -162,7 +169,7 @@ func containerUsageSegments(request types.ContainerRequest, start, end time.Time
 }
 
 func (wm *WorkerUsageMetrics) emitContainerDurationSegments(request types.ContainerRequest, start, end time.Time, quote clients.ContainerCostQuote) {
-	for _, interval := range containerUsageSegments(request, start, end) {
+	for _, interval := range containerUsageSegments(request, start, end, quote.EffectiveAt, quote.ValidUntil) {
 		interval.quote = quoteAt(quote, clients.ContainerCostQuote{}, interval.start)
 		wm.metricsContainerDuration(interval)
 	}
@@ -193,6 +200,10 @@ func quoteAt(preferred, fallback clients.ContainerCostQuote, at time.Time) clien
 		return fallback
 	}
 	return clients.ContainerCostQuote{}
+}
+
+func samePricing(a, b clients.ContainerCostQuote) bool {
+	return a.Valid && b.Valid && a.CostPerMs == b.CostPerMs && a.PricingVersion == b.PricingVersion
 }
 
 func quoteCovers(quote clients.ContainerCostQuote, at time.Time) bool {

--- a/pkg/worker/usage.go
+++ b/pkg/worker/usage.go
@@ -18,7 +18,7 @@ const usageRecordTimeout = 5 * time.Second
 // system. Implementations carry their own attribution (who is billed, who is
 // paid out); the worker only supplies the container and the interval.
 type ContainerUsageRecorder interface {
-	RecordContainerUsage(ctx context.Context, request *types.ContainerRequest, start, end time.Time, costCents float64) error
+	RecordContainerUsage(ctx context.Context, request *types.ContainerRequest, start, end time.Time, costCents *float64) error
 }
 
 type WorkerUsageMetrics struct {
@@ -29,6 +29,32 @@ type WorkerUsageMetrics struct {
 	usageRecorder       ContainerUsageRecorder
 	gpuType             string
 	poolMode            types.PoolMode
+	openMeterMetadata   bool
+	now                 func() time.Time
+	newTicker           func(time.Duration) (<-chan time.Time, func())
+	newBoundaryTimer    func(time.Time) (<-chan time.Time, func())
+	quoteProvider       func(context.Context, *types.ContainerRequest) (clients.ContainerCostQuote, error)
+}
+
+type containerUsageInterval struct {
+	request  types.ContainerRequest
+	start    time.Time
+	end      time.Time
+	duration time.Duration
+	quote    clients.ContainerCostQuote
+	cost     *float64
+}
+
+type activeContainerUsageInterval struct {
+	request      types.ContainerRequest
+	start        time.Time
+	quote        clients.ContainerCostQuote
+	quoteResult  <-chan clients.ContainerCostQuote
+	cancelQuote  context.CancelFunc
+	boundary     <-chan time.Time
+	boundaryAt   time.Time
+	stopBoundary func()
+	nextQuote    *clients.ContainerCostQuote
 }
 
 func NewWorkerUsageMetrics(
@@ -52,104 +78,358 @@ func NewWorkerUsageMetrics(
 		metricsRepo:         metricsRepo,
 		containerCostClient: clients.NewContainerCostClient(config.Monitoring.ContainerCostHookConfig),
 		usageRecorder:       usageRecorder,
+		openMeterMetadata:   config.Monitoring.MetricsCollector == string(types.MetricsCollectorOpenMeter),
+		now:                 time.Now,
+		newTicker:           usageTicker,
+		newBoundaryTimer:    usageBoundaryTimer,
 	}, nil
 }
 
-func (wm *WorkerUsageMetrics) metricsContainerDuration(request *types.ContainerRequest, duration time.Duration) {
-	wm.metricsRepo.IncrementCounter(
+func (wm *WorkerUsageMetrics) metricsContainerDuration(interval containerUsageInterval) {
+	if err := wm.metricsRepo.IncrementCounter(
 		types.UsageMetricsWorkerContainerDuration,
-		wm.containerMetricLabels(request, duration),
-		float64(duration.Milliseconds()),
-	)
+		wm.containerMetricLabels(interval),
+		float64(interval.duration.Milliseconds()),
+	); err != nil {
+		log.Warn().Err(err).Str("container_id", interval.request.ContainerId).Msg("failed to emit container duration")
+	}
 }
 
-func (wm *WorkerUsageMetrics) metricsContainerCost(request *types.ContainerRequest, duration time.Duration) {
-	cost := request.CostPerMs * float64(duration.Milliseconds())
-	labels := wm.containerMetricLabels(request, duration)
-	labels["cost_per_ms"] = request.CostPerMs
-	labels["cost_for_duration"] = cost
-	wm.metricsRepo.IncrementCounter(
+func (wm *WorkerUsageMetrics) metricsContainerCost(interval containerUsageInterval) {
+	labels := wm.containerMetricLabels(interval)
+	labels["cost_per_ms"] = interval.quote.CostPerMs
+	labels["cost_for_duration"] = *interval.cost
+	if err := wm.metricsRepo.IncrementCounter(
 		types.UsageMetricsWorkerContainerCost,
 		labels,
-		cost,
-	)
+		*interval.cost,
+	); err != nil {
+		log.Warn().Err(err).Str("container_id", interval.request.ContainerId).Msg("failed to emit container cost")
+	}
 }
 
 // Periodically send metrics to track container duration
 func (wm *WorkerUsageMetrics) EmitContainerUsage(ctx context.Context, request *types.ContainerRequest) {
-	if wm == nil || wm.poolMode == types.PoolModePrivate {
+	if wm == nil || request == nil || wm.poolMode == types.PoolModePrivate {
 		return
 	}
-	cursorTime := time.Now()
-	ticker := time.NewTicker(types.ContainerDurationEmissionInterval)
-	defer ticker.Stop()
+	cursorTime := wm.currentTime()
+	ticker, stopTicker := wm.usageTicker(types.ContainerDurationEmissionInterval)
+	defer stopTicker()
+	interval := wm.startContainerUsageInterval(request, cursorTime, nil)
 
-	request.Gpu = wm.gpuType
-	request.CostPerMs = wm.getContainerCostPerMs(request)
+	// Capture cancellation independently of quote/event delivery. Otherwise a
+	// slow synchronous retry can postpone observing ctx.Done and inflate the
+	// final authoritative duration by the retry latency.
+	cancelledAt := make(chan time.Time, 1)
+	go func() {
+		<-ctx.Done()
+		cancelledAt <- wm.currentTime()
+	}()
 
 	for {
 		select {
-		case <-ticker.C:
-			end := time.Now()
-			wm.emitContainerUsageInterval(request, cursorTime, end)
+		case quote := <-interval.quoteResult:
+			interval.quoteResult = nil
+			interval.stopQuoteResolution()
+			wm.bindContainerCostQuote(&interval, quote)
+		case <-interval.boundary:
+			end := interval.boundaryAt
+			nextQuote := interval.nextQuote
+			interval.stopBoundaryTimer()
+			interval.stopQuoteResolution()
+			wm.flushActiveContainerUsageInterval(interval, end)
+			interval = wm.startContainerUsageInterval(request, end, nextQuote)
+		case end := <-ticker:
+			// If cancellation raced with a buffered tick, prefer the captured
+			// cancellation boundary and finish without billing past it.
+			if ctx.Err() != nil {
+				end = <-cancelledAt
+				wm.bindReadyContainerCostQuote(&interval)
+				interval.stopQuoteResolution()
+				wm.flushActiveContainerUsageIntervalThrough(request, interval, end)
+				return
+			}
+			wm.bindReadyContainerCostQuote(&interval)
+			wm.flushActiveContainerUsageIntervalThrough(request, interval, end)
 			cursorTime = end
-		case <-ctx.Done():
+			interval = wm.startContainerUsageInterval(request, cursorTime, nil)
+		case end := <-cancelledAt:
 			// Consolidate any remaining time
-			wm.emitContainerUsageInterval(request, cursorTime, time.Now())
+			wm.bindReadyContainerCostQuote(&interval)
+			interval.stopQuoteResolution()
+			wm.flushActiveContainerUsageIntervalThrough(request, interval, end)
 			return
 		}
 	}
+}
+
+func (wm *WorkerUsageMetrics) currentTime() time.Time {
+	if wm.now != nil {
+		return wm.now()
+	}
+	return time.Now()
+}
+
+func (wm *WorkerUsageMetrics) usageTicker(interval time.Duration) (<-chan time.Time, func()) {
+	if wm.newTicker != nil {
+		return wm.newTicker(interval)
+	}
+	return usageTicker(interval)
+}
+
+func usageTicker(interval time.Duration) (<-chan time.Time, func()) {
+	ticker := time.NewTicker(interval)
+	return ticker.C, ticker.Stop
+}
+
+func (wm *WorkerUsageMetrics) boundaryTimer(at time.Time) (<-chan time.Time, func()) {
+	if wm.newBoundaryTimer != nil {
+		return wm.newBoundaryTimer(at)
+	}
+	return usageBoundaryTimer(at)
+}
+
+func usageBoundaryTimer(at time.Time) (<-chan time.Time, func()) {
+	delay := time.Until(at)
+	if delay < 0 {
+		delay = 0
+	}
+	timer := time.NewTimer(delay)
+	return timer.C, func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}
+}
+
+func (wm *WorkerUsageMetrics) newActiveContainerUsageInterval(request *types.ContainerRequest, start time.Time) activeContainerUsageInterval {
+	requestSnapshot := *request
+	requestSnapshot.Gpu = wm.gpuType
+	requestSnapshot.CostPerMs = 0
+	return activeContainerUsageInterval{request: requestSnapshot, start: start}
+}
+
+func (wm *WorkerUsageMetrics) startContainerUsageInterval(request *types.ContainerRequest, start time.Time, quote *clients.ContainerCostQuote) activeContainerUsageInterval {
+	interval := wm.newActiveContainerUsageInterval(request, start)
+	if quote != nil {
+		wm.bindContainerCostQuote(&interval, *quote)
+		return interval
+	}
+
+	result := make(chan clients.ContainerCostQuote, 1)
+	interval.quoteResult = result
+	ctx := wm.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	quoteCtx, cancel := context.WithCancel(ctx)
+	interval.cancelQuote = cancel
+	go func(request types.ContainerRequest) {
+		result <- wm.getContainerCostQuoteWithContext(quoteCtx, &request, true)
+	}(interval.request)
+	return interval
+}
+
+func (wm *WorkerUsageMetrics) bindReadyContainerCostQuote(interval *activeContainerUsageInterval) {
+	if interval.quoteResult == nil {
+		return
+	}
+	select {
+	case quote := <-interval.quoteResult:
+		interval.quoteResult = nil
+		interval.stopQuoteResolution()
+		wm.bindContainerCostQuote(interval, quote)
+	default:
+	}
+}
+
+func (wm *WorkerUsageMetrics) bindContainerCostQuote(interval *activeContainerUsageInterval, quote clients.ContainerCostQuote) {
+	if !quote.Valid {
+		return
+	}
+
+	if !quote.EffectiveAt.IsZero() && quote.EffectiveAt.After(interval.start) {
+		nextQuote := quote
+		interval.nextQuote = &nextQuote
+		interval.setBoundaryTimer(wm, quote.EffectiveAt)
+		return
+	}
+
+	interval.quote = quote
+	if quote.ValidUntil.After(interval.start) {
+		interval.setBoundaryTimer(wm, quote.ValidUntil)
+	}
+}
+
+func (interval *activeContainerUsageInterval) setBoundaryTimer(wm *WorkerUsageMetrics, at time.Time) {
+	if !interval.boundaryAt.IsZero() && !at.Before(interval.boundaryAt) {
+		return
+	}
+	interval.stopBoundaryTimer()
+	interval.boundaryAt = at
+	interval.boundary, interval.stopBoundary = wm.boundaryTimer(at)
+}
+
+func (interval *activeContainerUsageInterval) stopBoundaryTimer() {
+	if interval.stopBoundary != nil {
+		interval.stopBoundary()
+	}
+	interval.boundary = nil
+	interval.stopBoundary = nil
+}
+
+func (interval *activeContainerUsageInterval) stopQuoteResolution() {
+	if interval.cancelQuote != nil {
+		interval.cancelQuote()
+	}
+	interval.cancelQuote = nil
+	interval.quoteResult = nil
+}
+
+func (wm *WorkerUsageMetrics) flushActiveContainerUsageInterval(interval activeContainerUsageInterval, end time.Time) {
+	if end.Before(interval.start) {
+		return
+	}
+	completed := containerUsageInterval{
+		request:  interval.request,
+		start:    interval.start.UTC(),
+		end:      end.UTC(),
+		duration: end.Sub(interval.start),
+		quote:    interval.quote,
+	}
+	wm.emitCompletedContainerUsageInterval(completed)
+}
+
+func (wm *WorkerUsageMetrics) flushActiveContainerUsageIntervalThrough(request *types.ContainerRequest, interval activeContainerUsageInterval, end time.Time) {
+	for !interval.boundaryAt.IsZero() && !interval.boundaryAt.After(end) {
+		boundary := interval.boundaryAt
+		nextQuote := interval.nextQuote
+		interval.stopBoundaryTimer()
+		wm.flushActiveContainerUsageInterval(interval, boundary)
+
+		interval = wm.newActiveContainerUsageInterval(request, boundary)
+		if nextQuote != nil {
+			wm.bindContainerCostQuote(&interval, *nextQuote)
+		}
+	}
+	interval.stopBoundaryTimer()
+	wm.flushActiveContainerUsageInterval(interval, end)
 }
 
 func (wm *WorkerUsageMetrics) emitContainerUsageInterval(request *types.ContainerRequest, start, end time.Time) {
 	if request == nil || end.Before(start) {
 		return
 	}
-	duration := end.Sub(start)
-	wm.metricsContainerDuration(request, duration)
-	wm.metricsContainerCost(request, duration)
-	wm.recordExternalUsage(request, start, end, duration)
+
+	// Freeze all resource and timing fields before resolving the quote so both
+	// emitted events (and the optional external recorder) describe one exact
+	// interval even if the scheduler-owned request is changed concurrently.
+	requestSnapshot := *request
+	requestSnapshot.Gpu = wm.gpuType
+	requestSnapshot.CostPerMs = 0
+	interval := containerUsageInterval{
+		request:  requestSnapshot,
+		start:    start.UTC(),
+		end:      end.UTC(),
+		duration: end.Sub(start),
+	}
+
+	// Duration is authoritative: send it before any quote HTTP request or
+	// price-derived work can delay the signal.
+	wm.metricsContainerDuration(interval)
+	interval.quote = wm.getContainerCostQuote(&requestSnapshot)
+	wm.emitPriceAndExternalUsage(interval)
+}
+
+func (wm *WorkerUsageMetrics) emitCompletedContainerUsageInterval(interval containerUsageInterval) {
+	wm.metricsContainerDuration(interval)
+	wm.emitPriceAndExternalUsage(interval)
+}
+
+func (wm *WorkerUsageMetrics) emitPriceAndExternalUsage(interval containerUsageInterval) {
+	if interval.quote.Valid {
+		interval.request.CostPerMs = interval.quote.CostPerMs
+		cost := interval.quote.CostPerMs * float64(interval.duration.Milliseconds())
+		interval.cost = &cost
+		wm.metricsContainerCost(interval)
+	}
+	wm.recordExternalUsage(interval)
 }
 
 // recordExternalUsage forwards the interval to the configured usage recorder,
 // if any. Attribution is the recorder's concern, not the worker's.
-func (wm *WorkerUsageMetrics) recordExternalUsage(request *types.ContainerRequest, start, end time.Time, duration time.Duration) {
+func (wm *WorkerUsageMetrics) recordExternalUsage(interval containerUsageInterval) {
 	if wm.usageRecorder == nil {
 		return
 	}
 
-	cost := request.CostPerMs * float64(duration.Milliseconds())
 	recordCtx, cancel := context.WithTimeout(context.Background(), usageRecordTimeout)
 	defer cancel()
-	if err := wm.usageRecorder.RecordContainerUsage(recordCtx, request, start, end, cost); err != nil {
-		log.Warn().Err(err).Str("container_id", request.ContainerId).Msg("failed to record container usage")
+	if err := wm.usageRecorder.RecordContainerUsage(recordCtx, &interval.request, interval.start, interval.end, interval.cost); err != nil {
+		log.Warn().Err(err).Str("container_id", interval.request.ContainerId).Msg("failed to record container usage")
 	}
 }
 
-func (wm *WorkerUsageMetrics) containerMetricLabels(request *types.ContainerRequest, duration time.Duration) map[string]interface{} {
-	return map[string]interface{}{
-		"container_id":   request.ContainerId,
-		"worker_id":      wm.workerId,
-		"stub_id":        request.StubId,
-		"app_id":         request.AppId,
-		"workspace_id":   request.WorkspaceId,
-		"cpu_millicores": request.Cpu,
-		"mem_mb":         request.Memory,
-		"gpu":            request.Gpu,
-		"gpu_count":      request.GpuCount,
-		"duration_ms":    duration.Milliseconds(),
+func (wm *WorkerUsageMetrics) containerMetricLabels(interval containerUsageInterval) map[string]interface{} {
+	labels := map[string]interface{}{
+		"container_id":    interval.request.ContainerId,
+		"worker_id":       wm.workerId,
+		"stub_id":         interval.request.StubId,
+		"app_id":          interval.request.AppId,
+		"workspace_id":    interval.request.WorkspaceId,
+		"cpu_millicores":  interval.request.Cpu,
+		"mem_mb":          interval.request.Memory,
+		"gpu":             interval.request.Gpu,
+		"gpu_count":       interval.request.GpuCount,
+		"duration_ms":     interval.duration.Milliseconds(),
+		"pricing_version": interval.quote.PricingVersion,
 	}
+	// Exact interval timestamps are useful OpenMeter event metadata, but would
+	// be unbounded Prometheus label values when that collector is selected.
+	if wm.openMeterMetadata {
+		labels["interval_start"] = interval.start.Format(time.RFC3339Nano)
+		labels["interval_end"] = interval.end.Format(time.RFC3339Nano)
+		if !interval.quote.EffectiveAt.IsZero() {
+			labels["pricing_effective_at"] = interval.quote.EffectiveAt.Format(time.RFC3339Nano)
+		}
+		if !interval.quote.ValidUntil.IsZero() {
+			labels["pricing_valid_until"] = interval.quote.ValidUntil.Format(time.RFC3339Nano)
+		}
+	}
+	return labels
 }
 
-func (wm *WorkerUsageMetrics) getContainerCostPerMs(request *types.ContainerRequest) float64 {
-	if wm.containerCostClient == nil {
-		return 0
+func (wm *WorkerUsageMetrics) getContainerCostQuote(request *types.ContainerRequest) clients.ContainerCostQuote {
+	ctx := wm.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return wm.getContainerCostQuoteWithContext(ctx, request, false)
+}
+
+func (wm *WorkerUsageMetrics) getContainerCostQuoteWithContext(ctx context.Context, request *types.ContainerRequest, suppressCanceled bool) clients.ContainerCostQuote {
+	if wm.containerCostClient == nil && wm.quoteProvider == nil {
+		return clients.ContainerCostQuote{}
 	}
 
-	costPerMs, err := wm.containerCostClient.GetContainerCostPerMs(request)
-	if err != nil {
-		log.Error().Str("container_id", request.ContainerId).Err(err).Msg("unable to get container cost per ms")
+	var quote clients.ContainerCostQuote
+	var err error
+	if wm.quoteProvider != nil {
+		quote, err = wm.quoteProvider(ctx, request)
+	} else {
+		quote, err = wm.containerCostClient.GetContainerCostQuote(ctx, request)
+	}
+	if err != nil && !(suppressCanceled && ctx.Err() != nil) {
+		logger := log.Error()
+		if quote.Valid {
+			logger = log.Warn()
+		}
+		logger.Str("container_id", request.ContainerId).Err(err).Msg("unable to refresh container cost quote")
 	}
 
-	return costPerMs
+	return quote
 }

--- a/pkg/worker/usage.go
+++ b/pkg/worker/usage.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/clients"
@@ -15,8 +16,8 @@ import (
 const usageRecordTimeout = 5 * time.Second
 
 // ContainerUsageRecorder reports billable container usage to an external
-// system. Implementations carry their own attribution (who is billed, who is
-// paid out); the worker only supplies the container and the interval.
+// system. Implementations carry their own attribution; the worker supplies
+// the frozen container interval and an optional quoted cost.
 type ContainerUsageRecorder interface {
 	RecordContainerUsage(ctx context.Context, request *types.ContainerRequest, start, end time.Time, costCents *float64) error
 }
@@ -32,7 +33,6 @@ type WorkerUsageMetrics struct {
 	openMeterMetadata   bool
 	now                 func() time.Time
 	newTicker           func(time.Duration) (<-chan time.Time, func())
-	newBoundaryTimer    func(time.Time) (<-chan time.Time, func())
 	quoteProvider       func(context.Context, *types.ContainerRequest) (clients.ContainerCostQuote, error)
 }
 
@@ -43,18 +43,6 @@ type containerUsageInterval struct {
 	duration time.Duration
 	quote    clients.ContainerCostQuote
 	cost     *float64
-}
-
-type activeContainerUsageInterval struct {
-	request      types.ContainerRequest
-	start        time.Time
-	quote        clients.ContainerCostQuote
-	quoteResult  <-chan clients.ContainerCostQuote
-	cancelQuote  context.CancelFunc
-	boundary     <-chan time.Time
-	boundaryAt   time.Time
-	stopBoundary func()
-	nextQuote    *clients.ContainerCostQuote
 }
 
 func NewWorkerUsageMetrics(
@@ -81,8 +69,142 @@ func NewWorkerUsageMetrics(
 		openMeterMetadata:   config.Monitoring.MetricsCollector == string(types.MetricsCollectorOpenMeter),
 		now:                 time.Now,
 		newTicker:           usageTicker,
-		newBoundaryTimer:    usageBoundaryTimer,
 	}, nil
+}
+
+// EmitContainerUsage binds a quote to each interval start. Once an end is
+// captured, a bounded quote refresh cannot change the accounted duration.
+// Any effective-date boundary inside [start,end) becomes a separate segment.
+func (wm *WorkerUsageMetrics) EmitContainerUsage(ctx context.Context, request *types.ContainerRequest) {
+	if wm == nil || request == nil || wm.poolMode == types.PoolModePrivate {
+		return
+	}
+
+	requestSnapshot := *request
+	requestSnapshot.Gpu = wm.gpuType
+	requestSnapshot.CostPerMs = 0
+	start := wm.currentTime()
+	ticker, stopTicker := wm.usageTicker(types.ContainerDurationEmissionInterval)
+	defer stopTicker()
+
+	cancelledAt := make(chan time.Time, 1)
+	go func() {
+		<-ctx.Done()
+		cancelledAt <- wm.currentTime()
+	}()
+
+	currentQuote := wm.getContainerCostQuote(&requestSnapshot)
+	for {
+		var end time.Time
+		final := false
+		select {
+		case end = <-ticker:
+			if ctx.Err() != nil {
+				end = <-cancelledAt
+				final = true
+			}
+		case end = <-cancelledAt:
+			final = true
+		}
+
+		// Duration is authoritative and never waits on the optional quote.
+		wm.emitContainerDurationSegments(requestSnapshot, start, end, currentQuote)
+
+		// Resolve after freezing end. Quote latency can delay cost delivery, but
+		// it can never lengthen the interval or hold its duration event.
+		nextQuote := wm.getContainerCostQuote(&requestSnapshot)
+		wm.emitContainerPriceSegments(requestSnapshot, start, end, currentQuote, nextQuote)
+		if final {
+			return
+		}
+		currentQuote = quoteAt(nextQuote, currentQuote, end)
+		start = end
+	}
+}
+
+func containerUsageSegments(request types.ContainerRequest, start, end time.Time, extraBoundaries ...time.Time) []containerUsageInterval {
+	if !end.After(start) {
+		return nil
+	}
+	boundaries := []time.Time{start, end}
+	addBoundary := func(at time.Time) {
+		if at.After(start) && at.Before(end) {
+			boundaries = append(boundaries, at)
+		}
+	}
+	for _, boundary := range extraBoundaries {
+		addBoundary(boundary)
+	}
+	for midnight := nextUTCMidnight(start); midnight.Before(end); midnight = midnight.AddDate(0, 0, 1) {
+		addBoundary(midnight)
+	}
+
+	sort.Slice(boundaries, func(i, j int) bool { return boundaries[i].Before(boundaries[j]) })
+	remainingMs := end.Sub(start).Milliseconds()
+	segments := make([]containerUsageInterval, 0, len(boundaries)-1)
+	for i := 1; i < len(boundaries); i++ {
+		if boundaries[i].Equal(boundaries[i-1]) {
+			continue
+		}
+		durationMs := boundaries[i].Sub(boundaries[i-1]).Milliseconds()
+		if i == len(boundaries)-1 {
+			durationMs = remainingMs
+		}
+		remainingMs -= durationMs
+		segments = append(segments, containerUsageInterval{
+			request:  request,
+			start:    boundaries[i-1].UTC(),
+			end:      boundaries[i].UTC(),
+			duration: time.Duration(durationMs) * time.Millisecond,
+		})
+	}
+	return segments
+}
+
+func (wm *WorkerUsageMetrics) emitContainerDurationSegments(request types.ContainerRequest, start, end time.Time, quote clients.ContainerCostQuote) {
+	for _, interval := range containerUsageSegments(request, start, end) {
+		interval.quote = quoteAt(quote, clients.ContainerCostQuote{}, interval.start)
+		wm.metricsContainerDuration(interval)
+	}
+}
+
+func (wm *WorkerUsageMetrics) emitContainerPriceSegments(request types.ContainerRequest, start, end time.Time, current, next clients.ContainerCostQuote) {
+	boundaries := []time.Time{
+		current.EffectiveAt, current.ValidUntil,
+		next.EffectiveAt, next.ValidUntil,
+	}
+	for _, interval := range containerUsageSegments(request, start, end, boundaries...) {
+		interval.quote = quoteAt(next, current, interval.start)
+		if interval.quote.Valid {
+			interval.request.CostPerMs = interval.quote.CostPerMs
+			cost := interval.quote.CostPerMs * float64(interval.duration.Milliseconds())
+			interval.cost = &cost
+			wm.metricsContainerCost(interval)
+		}
+		wm.recordExternalUsage(interval)
+	}
+}
+
+func quoteAt(preferred, fallback clients.ContainerCostQuote, at time.Time) clients.ContainerCostQuote {
+	if quoteCovers(preferred, at) {
+		return preferred
+	}
+	if quoteCovers(fallback, at) {
+		return fallback
+	}
+	return clients.ContainerCostQuote{}
+}
+
+func quoteCovers(quote clients.ContainerCostQuote, at time.Time) bool {
+	if !quote.Valid || (!quote.EffectiveAt.IsZero() && quote.EffectiveAt.After(at)) {
+		return false
+	}
+	return quote.ValidUntil.IsZero() || quote.ValidUntil.After(at)
+}
+
+func nextUTCMidnight(at time.Time) time.Time {
+	at = at.UTC()
+	return time.Date(at.Year(), at.Month(), at.Day()+1, 0, 0, 0, 0, time.UTC)
 }
 
 func (wm *WorkerUsageMetrics) metricsContainerDuration(interval containerUsageInterval) {
@@ -99,274 +221,15 @@ func (wm *WorkerUsageMetrics) metricsContainerCost(interval containerUsageInterv
 	labels := wm.containerMetricLabels(interval)
 	labels["cost_per_ms"] = interval.quote.CostPerMs
 	labels["cost_for_duration"] = *interval.cost
-	if err := wm.metricsRepo.IncrementCounter(
-		types.UsageMetricsWorkerContainerCost,
-		labels,
-		*interval.cost,
-	); err != nil {
+	if err := wm.metricsRepo.IncrementCounter(types.UsageMetricsWorkerContainerCost, labels, *interval.cost); err != nil {
 		log.Warn().Err(err).Str("container_id", interval.request.ContainerId).Msg("failed to emit container cost")
 	}
 }
 
-// Periodically send metrics to track container duration
-func (wm *WorkerUsageMetrics) EmitContainerUsage(ctx context.Context, request *types.ContainerRequest) {
-	if wm == nil || request == nil || wm.poolMode == types.PoolModePrivate {
-		return
-	}
-	cursorTime := wm.currentTime()
-	ticker, stopTicker := wm.usageTicker(types.ContainerDurationEmissionInterval)
-	defer stopTicker()
-	interval := wm.startContainerUsageInterval(request, cursorTime, nil)
-
-	// Capture cancellation independently of quote/event delivery. Otherwise a
-	// slow synchronous retry can postpone observing ctx.Done and inflate the
-	// final authoritative duration by the retry latency.
-	cancelledAt := make(chan time.Time, 1)
-	go func() {
-		<-ctx.Done()
-		cancelledAt <- wm.currentTime()
-	}()
-
-	for {
-		select {
-		case quote := <-interval.quoteResult:
-			interval.quoteResult = nil
-			interval.stopQuoteResolution()
-			wm.bindContainerCostQuote(&interval, quote)
-		case <-interval.boundary:
-			end := interval.boundaryAt
-			nextQuote := interval.nextQuote
-			interval.stopBoundaryTimer()
-			interval.stopQuoteResolution()
-			wm.flushActiveContainerUsageInterval(interval, end)
-			interval = wm.startContainerUsageInterval(request, end, nextQuote)
-		case end := <-ticker:
-			// If cancellation raced with a buffered tick, prefer the captured
-			// cancellation boundary and finish without billing past it.
-			if ctx.Err() != nil {
-				end = <-cancelledAt
-				wm.bindReadyContainerCostQuote(&interval)
-				interval.stopQuoteResolution()
-				wm.flushActiveContainerUsageIntervalThrough(request, interval, end)
-				return
-			}
-			wm.bindReadyContainerCostQuote(&interval)
-			wm.flushActiveContainerUsageIntervalThrough(request, interval, end)
-			cursorTime = end
-			interval = wm.startContainerUsageInterval(request, cursorTime, nil)
-		case end := <-cancelledAt:
-			// Consolidate any remaining time
-			wm.bindReadyContainerCostQuote(&interval)
-			interval.stopQuoteResolution()
-			wm.flushActiveContainerUsageIntervalThrough(request, interval, end)
-			return
-		}
-	}
-}
-
-func (wm *WorkerUsageMetrics) currentTime() time.Time {
-	if wm.now != nil {
-		return wm.now()
-	}
-	return time.Now()
-}
-
-func (wm *WorkerUsageMetrics) usageTicker(interval time.Duration) (<-chan time.Time, func()) {
-	if wm.newTicker != nil {
-		return wm.newTicker(interval)
-	}
-	return usageTicker(interval)
-}
-
-func usageTicker(interval time.Duration) (<-chan time.Time, func()) {
-	ticker := time.NewTicker(interval)
-	return ticker.C, ticker.Stop
-}
-
-func (wm *WorkerUsageMetrics) boundaryTimer(at time.Time) (<-chan time.Time, func()) {
-	if wm.newBoundaryTimer != nil {
-		return wm.newBoundaryTimer(at)
-	}
-	return usageBoundaryTimer(at)
-}
-
-func usageBoundaryTimer(at time.Time) (<-chan time.Time, func()) {
-	delay := time.Until(at)
-	if delay < 0 {
-		delay = 0
-	}
-	timer := time.NewTimer(delay)
-	return timer.C, func() {
-		if !timer.Stop() {
-			select {
-			case <-timer.C:
-			default:
-			}
-		}
-	}
-}
-
-func (wm *WorkerUsageMetrics) newActiveContainerUsageInterval(request *types.ContainerRequest, start time.Time) activeContainerUsageInterval {
-	requestSnapshot := *request
-	requestSnapshot.Gpu = wm.gpuType
-	requestSnapshot.CostPerMs = 0
-	return activeContainerUsageInterval{request: requestSnapshot, start: start}
-}
-
-func (wm *WorkerUsageMetrics) startContainerUsageInterval(request *types.ContainerRequest, start time.Time, quote *clients.ContainerCostQuote) activeContainerUsageInterval {
-	interval := wm.newActiveContainerUsageInterval(request, start)
-	if quote != nil {
-		wm.bindContainerCostQuote(&interval, *quote)
-		return interval
-	}
-
-	result := make(chan clients.ContainerCostQuote, 1)
-	interval.quoteResult = result
-	ctx := wm.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	quoteCtx, cancel := context.WithCancel(ctx)
-	interval.cancelQuote = cancel
-	go func(request types.ContainerRequest) {
-		result <- wm.getContainerCostQuoteWithContext(quoteCtx, &request, true)
-	}(interval.request)
-	return interval
-}
-
-func (wm *WorkerUsageMetrics) bindReadyContainerCostQuote(interval *activeContainerUsageInterval) {
-	if interval.quoteResult == nil {
-		return
-	}
-	select {
-	case quote := <-interval.quoteResult:
-		interval.quoteResult = nil
-		interval.stopQuoteResolution()
-		wm.bindContainerCostQuote(interval, quote)
-	default:
-	}
-}
-
-func (wm *WorkerUsageMetrics) bindContainerCostQuote(interval *activeContainerUsageInterval, quote clients.ContainerCostQuote) {
-	if !quote.Valid {
-		return
-	}
-
-	if !quote.EffectiveAt.IsZero() && quote.EffectiveAt.After(interval.start) {
-		nextQuote := quote
-		interval.nextQuote = &nextQuote
-		interval.setBoundaryTimer(wm, quote.EffectiveAt)
-		return
-	}
-
-	interval.quote = quote
-	if quote.ValidUntil.After(interval.start) {
-		interval.setBoundaryTimer(wm, quote.ValidUntil)
-	}
-}
-
-func (interval *activeContainerUsageInterval) setBoundaryTimer(wm *WorkerUsageMetrics, at time.Time) {
-	if !interval.boundaryAt.IsZero() && !at.Before(interval.boundaryAt) {
-		return
-	}
-	interval.stopBoundaryTimer()
-	interval.boundaryAt = at
-	interval.boundary, interval.stopBoundary = wm.boundaryTimer(at)
-}
-
-func (interval *activeContainerUsageInterval) stopBoundaryTimer() {
-	if interval.stopBoundary != nil {
-		interval.stopBoundary()
-	}
-	interval.boundary = nil
-	interval.stopBoundary = nil
-}
-
-func (interval *activeContainerUsageInterval) stopQuoteResolution() {
-	if interval.cancelQuote != nil {
-		interval.cancelQuote()
-	}
-	interval.cancelQuote = nil
-	interval.quoteResult = nil
-}
-
-func (wm *WorkerUsageMetrics) flushActiveContainerUsageInterval(interval activeContainerUsageInterval, end time.Time) {
-	if end.Before(interval.start) {
-		return
-	}
-	completed := containerUsageInterval{
-		request:  interval.request,
-		start:    interval.start.UTC(),
-		end:      end.UTC(),
-		duration: end.Sub(interval.start),
-		quote:    interval.quote,
-	}
-	wm.emitCompletedContainerUsageInterval(completed)
-}
-
-func (wm *WorkerUsageMetrics) flushActiveContainerUsageIntervalThrough(request *types.ContainerRequest, interval activeContainerUsageInterval, end time.Time) {
-	for !interval.boundaryAt.IsZero() && !interval.boundaryAt.After(end) {
-		boundary := interval.boundaryAt
-		nextQuote := interval.nextQuote
-		interval.stopBoundaryTimer()
-		wm.flushActiveContainerUsageInterval(interval, boundary)
-
-		interval = wm.newActiveContainerUsageInterval(request, boundary)
-		if nextQuote != nil {
-			wm.bindContainerCostQuote(&interval, *nextQuote)
-		}
-	}
-	interval.stopBoundaryTimer()
-	wm.flushActiveContainerUsageInterval(interval, end)
-}
-
-func (wm *WorkerUsageMetrics) emitContainerUsageInterval(request *types.ContainerRequest, start, end time.Time) {
-	if request == nil || end.Before(start) {
-		return
-	}
-
-	// Freeze all resource and timing fields before resolving the quote so both
-	// emitted events (and the optional external recorder) describe one exact
-	// interval even if the scheduler-owned request is changed concurrently.
-	requestSnapshot := *request
-	requestSnapshot.Gpu = wm.gpuType
-	requestSnapshot.CostPerMs = 0
-	interval := containerUsageInterval{
-		request:  requestSnapshot,
-		start:    start.UTC(),
-		end:      end.UTC(),
-		duration: end.Sub(start),
-	}
-
-	// Duration is authoritative: send it before any quote HTTP request or
-	// price-derived work can delay the signal.
-	wm.metricsContainerDuration(interval)
-	interval.quote = wm.getContainerCostQuote(&requestSnapshot)
-	wm.emitPriceAndExternalUsage(interval)
-}
-
-func (wm *WorkerUsageMetrics) emitCompletedContainerUsageInterval(interval containerUsageInterval) {
-	wm.metricsContainerDuration(interval)
-	wm.emitPriceAndExternalUsage(interval)
-}
-
-func (wm *WorkerUsageMetrics) emitPriceAndExternalUsage(interval containerUsageInterval) {
-	if interval.quote.Valid {
-		interval.request.CostPerMs = interval.quote.CostPerMs
-		cost := interval.quote.CostPerMs * float64(interval.duration.Milliseconds())
-		interval.cost = &cost
-		wm.metricsContainerCost(interval)
-	}
-	wm.recordExternalUsage(interval)
-}
-
-// recordExternalUsage forwards the interval to the configured usage recorder,
-// if any. Attribution is the recorder's concern, not the worker's.
 func (wm *WorkerUsageMetrics) recordExternalUsage(interval containerUsageInterval) {
 	if wm.usageRecorder == nil {
 		return
 	}
-
 	recordCtx, cancel := context.WithTimeout(context.Background(), usageRecordTimeout)
 	defer cancel()
 	if err := wm.usageRecorder.RecordContainerUsage(recordCtx, &interval.request, interval.start, interval.end, interval.cost); err != nil {
@@ -388,8 +251,6 @@ func (wm *WorkerUsageMetrics) containerMetricLabels(interval containerUsageInter
 		"duration_ms":     interval.duration.Milliseconds(),
 		"pricing_version": interval.quote.PricingVersion,
 	}
-	// Exact interval timestamps are useful OpenMeter event metadata, but would
-	// be unbounded Prometheus label values when that collector is selected.
 	if wm.openMeterMetadata {
 		labels["interval_start"] = interval.start.Format(time.RFC3339Nano)
 		labels["interval_end"] = interval.end.Format(time.RFC3339Nano)
@@ -403,19 +264,33 @@ func (wm *WorkerUsageMetrics) containerMetricLabels(interval containerUsageInter
 	return labels
 }
 
+func (wm *WorkerUsageMetrics) currentTime() time.Time {
+	if wm.now != nil {
+		return wm.now()
+	}
+	return time.Now()
+}
+
+func (wm *WorkerUsageMetrics) usageTicker(interval time.Duration) (<-chan time.Time, func()) {
+	if wm.newTicker != nil {
+		return wm.newTicker(interval)
+	}
+	return usageTicker(interval)
+}
+
+func usageTicker(interval time.Duration) (<-chan time.Time, func()) {
+	ticker := time.NewTicker(interval)
+	return ticker.C, ticker.Stop
+}
+
 func (wm *WorkerUsageMetrics) getContainerCostQuote(request *types.ContainerRequest) clients.ContainerCostQuote {
+	if wm.containerCostClient == nil && wm.quoteProvider == nil {
+		return clients.ContainerCostQuote{}
+	}
 	ctx := wm.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return wm.getContainerCostQuoteWithContext(ctx, request, false)
-}
-
-func (wm *WorkerUsageMetrics) getContainerCostQuoteWithContext(ctx context.Context, request *types.ContainerRequest, suppressCanceled bool) clients.ContainerCostQuote {
-	if wm.containerCostClient == nil && wm.quoteProvider == nil {
-		return clients.ContainerCostQuote{}
-	}
-
 	var quote clients.ContainerCostQuote
 	var err error
 	if wm.quoteProvider != nil {
@@ -423,13 +298,12 @@ func (wm *WorkerUsageMetrics) getContainerCostQuoteWithContext(ctx context.Conte
 	} else {
 		quote, err = wm.containerCostClient.GetContainerCostQuote(ctx, request)
 	}
-	if err != nil && !(suppressCanceled && ctx.Err() != nil) {
+	if err != nil {
 		logger := log.Error()
 		if quote.Valid {
 			logger = log.Warn()
 		}
 		logger.Str("container_id", request.ContainerId).Err(err).Msg("unable to refresh container cost quote")
 	}
-
 	return quote
 }

--- a/pkg/worker/usage_test.go
+++ b/pkg/worker/usage_test.go
@@ -2,8 +2,16 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/beam-cloud/beta9/pkg/clients"
 	"github.com/beam-cloud/beta9/pkg/types"
 )
 
@@ -26,31 +34,397 @@ func TestEmitContainerUsageSkipsPrivatePools(t *testing.T) {
 
 func TestEmitContainerUsageRecordsNonPrivatePools(t *testing.T) {
 	repo := &usageMetricsRecorder{}
+	external := &containerUsageRecorder{}
 	metrics := &WorkerUsageMetrics{
-		workerId:    "worker-1",
-		metricsRepo: repo,
-		poolMode:    types.PoolModeLocal,
+		workerId:      "worker-1",
+		metricsRepo:   repo,
+		poolMode:      types.PoolModeLocal,
+		usageRecorder: external,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	metrics.EmitContainerUsage(ctx, &types.ContainerRequest{ContainerId: "container-1"})
+	metrics.EmitContainerUsage(ctx, &types.ContainerRequest{ContainerId: "container-1", CostPerMs: 99})
 
-	if repo.count != 2 {
-		t.Fatalf("local pool emitted %d usage counters, want duration and cost", repo.count)
+	if repo.count != 1 {
+		t.Fatalf("local pool emitted %d usage counters, want duration only without a quote", repo.count)
+	}
+	if external.count != 1 || external.unpriced != 1 || external.invalidCost {
+		t.Fatalf("external recorder calls/unpriced/invalid = %d/%d/%t, want one authoritative unpriced interval", external.count, external.unpriced, external.invalidCost)
+	}
+}
+
+func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
+	type capturedEvent struct {
+		ID     string                 `json:"id"`
+		Source string                 `json:"source"`
+		Type   string                 `json:"type"`
+		Data   map[string]interface{} `json:"data"`
+	}
+
+	var mu sync.Mutex
+	quoteCalls := make(map[clients.ContainerCostRequest]int)
+	events := make([]capturedEvent, 0)
+	failedFirstCostAttempt := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/quote", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer quote-token" {
+			t.Errorf("quote authorization = %q", r.Header.Get("Authorization"))
+		}
+		var request clients.ContainerCostRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode quote request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		quoteCalls[request]++
+		mu.Unlock()
+
+		if request.Gpu == "T4" {
+			if request.Cpu != 1_000 || request.Memory != 1_024 || request.GpuCount != 1 {
+				t.Errorf("T4 quote dimensions = %+v, want 1000m CPU/1024MiB/one T4", request)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"cost_per_ms":     "0.00002082",
+				"pricing_version": "legacy-gpu",
+				"valid_until":     time.Now().Add(time.Hour).Format(time.RFC3339Nano),
+			})
+			return
+		}
+
+		switch request.Cpu {
+		case 1_000:
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"cost_per_ms":     "0.00000170",
+				"pricing_version": "cpu-only-202607",
+				"valid_until":     time.Now().Add(time.Hour).Format(time.RFC3339Nano),
+			})
+		case 2_000:
+			_, _ = w.Write([]byte(`{"cost_per_ms":"NaN","pricing_version":"broken"}`))
+		default:
+			http.Error(w, "unknown resources", http.StatusBadRequest)
+		}
+	})
+	mux.HandleFunc("/api/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer openmeter-key" {
+			t.Errorf("OpenMeter authorization = %q", r.Header.Get("Authorization"))
+		}
+		var event capturedEvent
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Errorf("decode OpenMeter event: %v", err)
+			http.Error(w, "invalid event", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		events = append(events, event)
+		shouldFail := event.Type == types.UsageMetricsWorkerContainerCost && !failedFirstCostAttempt
+		if shouldFail {
+			failedFirstCostAttempt = true
+		}
+		mu.Unlock()
+		if shouldFail {
+			http.Error(w, "retry", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	config := types.AppConfig{Monitoring: types.MonitoringConfig{
+		MetricsCollector: string(types.MetricsCollectorOpenMeter),
+		OpenMeter: types.OpenMeterConfig{
+			ServerUrl: server.URL,
+			ApiKey:    "openmeter-key",
+		},
+		ContainerCostHookConfig: types.ContainerCostHookConfig{
+			Endpoint: server.URL + "/quote",
+			Token:    "quote-token",
+		},
+	}}
+	external := &containerUsageRecorder{}
+	metrics, err := NewWorkerUsageMetrics(context.Background(), "worker-1", config, "", types.PoolModeLocal, external)
+	if err != nil {
+		t.Fatalf("NewWorkerUsageMetrics: %v", err)
+	}
+
+	start := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	baseRequest := func(cpu int64) *types.ContainerRequest {
+		return &types.ContainerRequest{
+			ContainerId: "container-1",
+			WorkspaceId: "workspace-1",
+			StubId:      "stub-1",
+			AppId:       "app-1",
+			Cpu:         cpu,
+			Memory:      1_024,
+		}
+	}
+
+	// The first logical cost event gets a transient response. The repository
+	// retries the exact CloudEvent, preserving its source and ID.
+	metrics.emitContainerUsageInterval(baseRequest(1_000), start, start.Add(time.Hour))
+	mu.Lock()
+	firstEvents := append([]capturedEvent(nil), events...)
+	mu.Unlock()
+	if len(firstEvents) != 3 {
+		t.Fatalf("first interval HTTP events = %d, want duration plus two cost attempts", len(firstEvents))
+	}
+	if firstEvents[1].Type != types.UsageMetricsWorkerContainerCost || firstEvents[2].Type != types.UsageMetricsWorkerContainerCost {
+		t.Fatalf("retried event types = %q/%q, want cost", firstEvents[1].Type, firstEvents[2].Type)
+	}
+	if firstEvents[1].ID == "" || firstEvents[1].ID != firstEvents[2].ID || firstEvents[1].Source != firstEvents[2].Source {
+		t.Fatalf("retry identity = %q/%q and %q/%q, want same nonempty source+ID", firstEvents[1].Source, firstEvents[1].ID, firstEvents[2].Source, firstEvents[2].ID)
+	}
+	if firstEvents[0].Data["value"] != float64(3_600_000) || math.Abs(firstEvents[1].Data["value"].(float64)-6.12) > 1e-12 {
+		t.Fatalf("duration/cost values = %v/%v, want one hour/6.12 cents", firstEvents[0].Data["value"], firstEvents[1].Data["value"])
+	}
+	if firstEvents[0].Data["interval_start"] != start.Format(time.RFC3339Nano) ||
+		firstEvents[0].Data["interval_end"] != start.Add(time.Hour).Format(time.RFC3339Nano) ||
+		firstEvents[1].Data["pricing_version"] != "cpu-only-202607" {
+		t.Fatalf("interval metadata = %+v", firstEvents[0].Data)
+	}
+
+	// A GPU worker uses the unchanged GPU-attached aggregate quote and sends
+	// the exact T4 resource dimensions on the wire.
+	gpuMetrics, err := NewWorkerUsageMetrics(context.Background(), "worker-gpu", config, "T4", types.PoolModeLocal, external)
+	if err != nil {
+		t.Fatalf("NewWorkerUsageMetrics GPU: %v", err)
+	}
+	gpuRequest := baseRequest(1_000)
+	gpuRequest.GpuCount = 1
+	gpuMetrics.emitContainerUsageInterval(gpuRequest, start, start.Add(time.Hour))
+
+	// An invalid quote emits authoritative duration but no cost. The client
+	// tests exercise deterministic negative-cache expiry and recovery.
+	mu.Lock()
+	before := len(events)
+	mu.Unlock()
+	metrics.emitContainerUsageInterval(baseRequest(2_000), start, start.Add(time.Second))
+	mu.Lock()
+	afterInvalid := append([]capturedEvent(nil), events...)
+	mu.Unlock()
+	if len(afterInvalid) != before+1 || afterInvalid[len(afterInvalid)-1].Type != types.UsageMetricsWorkerContainerDuration {
+		t.Fatalf("invalid quote emitted events %+v, want duration only", afterInvalid[before:])
+	}
+	missingAgain := baseRequest(2_000)
+	missingAgain.ContainerId = "container-2"
+	metrics.emitContainerUsageInterval(missingAgain, start.Add(time.Second), start.Add(2*time.Second))
+	// A canceled container context still performs the final flush through the
+	// real loop rather than waiting for the periodic ticker.
+	finalCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	finalRequest := baseRequest(2_000)
+	finalRequest.ContainerId = "final-container"
+	metrics.EmitContainerUsage(finalCtx, finalRequest)
+
+	mu.Lock()
+	allEvents := append([]capturedEvent(nil), events...)
+	calls := make(map[clients.ContainerCostRequest]int, len(quoteCalls))
+	for request, count := range quoteCalls {
+		calls[request] = count
+	}
+	mu.Unlock()
+
+	var durations, costAttempts int
+	var finalDurationSeen, gpuCostSeen bool
+	for _, event := range allEvents {
+		switch event.Type {
+		case types.UsageMetricsWorkerContainerDuration:
+			durations++
+			if event.Data["container_id"] == "final-container" {
+				finalDurationSeen = true
+			}
+		case types.UsageMetricsWorkerContainerCost:
+			costAttempts++
+			if event.Data["pricing_version"] == "legacy-gpu" &&
+				event.Data["gpu"] == "T4" && event.Data["gpu_count"] == float64(1) &&
+				math.Abs(event.Data["value"].(float64)-74.952) < 1e-12 {
+				gpuCostSeen = true
+			}
+		}
+	}
+	if durations != 5 || costAttempts != 3 {
+		t.Fatalf("duration/cost HTTP attempts = %d/%d, want 5/3", durations, costAttempts)
+	}
+	if !finalDurationSeen || !gpuCostSeen {
+		t.Fatalf("final/GPU flags = %t/%t", finalDurationSeen, gpuCostSeen)
+	}
+	if calls[clients.ContainerCostRequest{Cpu: 1_000, Memory: 1_024}] != 1 ||
+		calls[clients.ContainerCostRequest{Cpu: 1_000, Memory: 1_024, Gpu: "T4", GpuCount: 1}] != 1 ||
+		calls[clients.ContainerCostRequest{Cpu: 2_000, Memory: 1_024}] != 1 {
+		t.Fatalf("quote calls = %+v, want cache, missing retry, refresh, and final flush", calls)
+	}
+	if external.count != 5 || external.unpriced != 3 || external.invalidCost {
+		t.Fatalf("external recorder calls/unpriced/invalid = %d/%d/%t, want five intervals with three quiet unpriced records", external.count, external.unpriced, external.invalidCost)
+	}
+}
+
+func TestEmitContainerUsageFreezesCancellationBoundaryDuringQuoteLatency(t *testing.T) {
+	quoteStarted := make(chan struct{})
+	releaseQuote := make(chan struct{})
+	var startedOnce, releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseQuote) }) }
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		startedOnce.Do(func() { close(quoteStarted) })
+		<-releaseQuote
+		_, _ = w.Write([]byte(`{"cost_per_ms":"0.001","pricing_version":"test"}`))
+	}))
+	t.Cleanup(func() {
+		release()
+		server.Close()
+	})
+
+	start := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	tickAt := start.Add(5 * time.Second)
+	cancelAt := start.Add(7 * time.Second)
+	ticks := make(chan time.Time, 1)
+
+	cancelCaptured := make(chan struct{})
+	var nowCalls atomic.Int32
+	var captureOnce sync.Once
+	repository := &usageMetricsRecorder{notify: make(chan struct{}, 4)}
+	metrics := &WorkerUsageMetrics{
+		ctx:                 context.Background(),
+		workerId:            "worker-1",
+		metricsRepo:         repository,
+		containerCostClient: clients.NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test"}),
+		poolMode:            types.PoolModeLocal,
+		openMeterMetadata:   true,
+		now: func() time.Time {
+			if nowCalls.Add(1) == 1 {
+				return start
+			}
+			captureOnce.Do(func() { close(cancelCaptured) })
+			return cancelAt
+		},
+		newTicker: func(interval time.Duration) (<-chan time.Time, func()) {
+			if interval != types.ContainerDurationEmissionInterval {
+				t.Errorf("ticker interval = %v", interval)
+			}
+			return ticks, func() {}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		metrics.EmitContainerUsage(ctx, &types.ContainerRequest{
+			ContainerId: "container-1",
+			WorkspaceId: "workspace-1",
+			Cpu:         1_000,
+			Memory:      1_024,
+		})
+		close(done)
+	}()
+
+	select {
+	case <-quoteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("quote request did not start")
+	}
+	ticks <- tickAt
+	select {
+	case <-repository.notify:
+	case <-time.After(time.Second):
+		t.Fatal("duration was not emitted while quote request was blocked")
+	}
+	repository.mu.Lock()
+	eventsBeforeQuoteRelease := append([]recordedUsageMetric(nil), repository.events...)
+	repository.mu.Unlock()
+	if len(eventsBeforeQuoteRelease) != 1 || eventsBeforeQuoteRelease[0].name != types.UsageMetricsWorkerContainerDuration || eventsBeforeQuoteRelease[0].value != 5_000 {
+		t.Fatalf("events while quote blocked = %+v, want authoritative duration first", eventsBeforeQuoteRelease)
+	}
+	cancel()
+	select {
+	case <-cancelCaptured:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation boundary was not captured during quote latency")
+	}
+	release()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("usage loop did not finish after quote release")
+	}
+
+	repository.mu.Lock()
+	events := append([]recordedUsageMetric(nil), repository.events...)
+	repository.mu.Unlock()
+	var durations []recordedUsageMetric
+	for _, event := range events {
+		if event.name == types.UsageMetricsWorkerContainerDuration {
+			durations = append(durations, event)
+		}
+	}
+	if len(durations) != 2 {
+		t.Fatalf("duration events = %d, want periodic and final", len(durations))
+	}
+	if durations[0].value != 5_000 || durations[1].value != 2_000 {
+		t.Fatalf("duration values = %v/%v, want 5000/2000ms", durations[0].value, durations[1].value)
+	}
+	if durations[0].labels["interval_end"] != tickAt.Format(time.RFC3339Nano) ||
+		durations[1].labels["interval_end"] != cancelAt.Format(time.RFC3339Nano) {
+		t.Fatalf("interval ends = %v/%v, want tick/cancellation boundaries", durations[0].labels["interval_end"], durations[1].labels["interval_end"])
 	}
 }
 
 type usageMetricsRecorder struct {
-	count int
+	mu     sync.Mutex
+	count  int
+	events []recordedUsageMetric
+	notify chan struct{}
+}
+
+type containerUsageRecorder struct {
+	mu          sync.Mutex
+	count       int
+	unpriced    int
+	invalidCost bool
+}
+
+type recordedUsageMetric struct {
+	name   string
+	labels map[string]interface{}
+	value  float64
+}
+
+func (r *containerUsageRecorder) RecordContainerUsage(_ context.Context, request *types.ContainerRequest, _, _ time.Time, costCents *float64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.count++
+	if costCents == nil {
+		r.unpriced++
+		if request.CostPerMs != 0 {
+			r.invalidCost = true
+		}
+		return nil
+	}
+	if request.CostPerMs < 0 || *costCents < 0 {
+		r.invalidCost = true
+	}
+	return nil
 }
 
 func (r *usageMetricsRecorder) Init(string) error {
 	return nil
 }
 
-func (r *usageMetricsRecorder) IncrementCounter(string, map[string]interface{}, float64) error {
+func (r *usageMetricsRecorder) IncrementCounter(name string, labels map[string]interface{}, value float64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.count++
+	r.events = append(r.events, recordedUsageMetric{name: name, labels: labels, value: value})
+	if r.notify != nil {
+		select {
+		case r.notify <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 

--- a/pkg/worker/usage_test.go
+++ b/pkg/worker/usage_test.go
@@ -59,6 +59,7 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 		ID     string                 `json:"id"`
 		Source string                 `json:"source"`
 		Type   string                 `json:"type"`
+		Time   time.Time              `json:"time"`
 		Data   map[string]interface{} `json:"data"`
 	}
 
@@ -166,7 +167,7 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 
 	// The first logical cost event gets a transient response. The repository
 	// retries the exact CloudEvent, preserving its source and ID.
-	metrics.emitContainerUsageInterval(baseRequest(1_000), start, start.Add(time.Hour))
+	emitResolvedContainerUsageInterval(metrics, baseRequest(1_000), start, start.Add(time.Hour))
 	mu.Lock()
 	firstEvents := append([]capturedEvent(nil), events...)
 	mu.Unlock()
@@ -178,6 +179,9 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 	}
 	if firstEvents[1].ID == "" || firstEvents[1].ID != firstEvents[2].ID || firstEvents[1].Source != firstEvents[2].Source {
 		t.Fatalf("retry identity = %q/%q and %q/%q, want same nonempty source+ID", firstEvents[1].Source, firstEvents[1].ID, firstEvents[2].Source, firstEvents[2].ID)
+	}
+	if !firstEvents[0].Time.Equal(start) || !firstEvents[1].Time.Equal(start) || !firstEvents[2].Time.Equal(start) {
+		t.Fatalf("event times = %v/%v/%v, want interval start %v across retry", firstEvents[0].Time, firstEvents[1].Time, firstEvents[2].Time, start)
 	}
 	if firstEvents[0].Data["value"] != float64(3_600_000) || math.Abs(firstEvents[1].Data["value"].(float64)-6.12) > 1e-12 {
 		t.Fatalf("duration/cost values = %v/%v, want one hour/6.12 cents", firstEvents[0].Data["value"], firstEvents[1].Data["value"])
@@ -196,14 +200,14 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 	}
 	gpuRequest := baseRequest(1_000)
 	gpuRequest.GpuCount = 1
-	gpuMetrics.emitContainerUsageInterval(gpuRequest, start, start.Add(time.Hour))
+	emitResolvedContainerUsageInterval(gpuMetrics, gpuRequest, start, start.Add(time.Hour))
 
 	// An invalid quote emits authoritative duration but no cost. The client
 	// tests exercise deterministic negative-cache expiry and recovery.
 	mu.Lock()
 	before := len(events)
 	mu.Unlock()
-	metrics.emitContainerUsageInterval(baseRequest(2_000), start, start.Add(time.Second))
+	emitResolvedContainerUsageInterval(metrics, baseRequest(2_000), start, start.Add(time.Second))
 	mu.Lock()
 	afterInvalid := append([]capturedEvent(nil), events...)
 	mu.Unlock()
@@ -212,7 +216,7 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 	}
 	missingAgain := baseRequest(2_000)
 	missingAgain.ContainerId = "container-2"
-	metrics.emitContainerUsageInterval(missingAgain, start.Add(time.Second), start.Add(2*time.Second))
+	emitResolvedContainerUsageInterval(metrics, missingAgain, start.Add(time.Second), start.Add(2*time.Second))
 	// A canceled container context still performs the final flush through the
 	// real loop rather than waiting for the periodic ticker.
 	finalCtx, cancel := context.WithCancel(context.Background())
@@ -264,37 +268,25 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 }
 
 func TestEmitContainerUsageFreezesCancellationBoundaryDuringQuoteLatency(t *testing.T) {
-	quoteStarted := make(chan struct{})
-	releaseQuote := make(chan struct{})
-	var startedOnce, releaseOnce sync.Once
-	release := func() { releaseOnce.Do(func() { close(releaseQuote) }) }
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		startedOnce.Do(func() { close(quoteStarted) })
-		<-releaseQuote
-		_, _ = w.Write([]byte(`{"cost_per_ms":"0.001","pricing_version":"test"}`))
-	}))
-	t.Cleanup(func() {
-		release()
-		server.Close()
-	})
-
 	start := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	tickAt := start.Add(5 * time.Second)
 	cancelAt := start.Add(7 * time.Second)
 	ticks := make(chan time.Time, 1)
+	initialQuote := make(chan struct{})
+	nextQuoteStarted := make(chan struct{})
+	releaseNextQuote := make(chan struct{})
 
 	cancelCaptured := make(chan struct{})
 	var nowCalls atomic.Int32
+	var quoteCalls atomic.Int32
 	var captureOnce sync.Once
 	repository := &usageMetricsRecorder{notify: make(chan struct{}, 4)}
 	metrics := &WorkerUsageMetrics{
-		ctx:                 context.Background(),
-		workerId:            "worker-1",
-		metricsRepo:         repository,
-		containerCostClient: clients.NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test"}),
-		poolMode:            types.PoolModeLocal,
-		openMeterMetadata:   true,
+		ctx:               context.Background(),
+		workerId:          "worker-1",
+		metricsRepo:       repository,
+		poolMode:          types.PoolModeLocal,
+		openMeterMetadata: true,
 		now: func() time.Time {
 			if nowCalls.Add(1) == 1 {
 				return start
@@ -307,6 +299,16 @@ func TestEmitContainerUsageFreezesCancellationBoundaryDuringQuoteLatency(t *test
 				t.Errorf("ticker interval = %v", interval)
 			}
 			return ticks, func() {}
+		},
+		quoteProvider: func(context.Context, *types.ContainerRequest) (clients.ContainerCostQuote, error) {
+			switch quoteCalls.Add(1) {
+			case 1:
+				close(initialQuote)
+			case 2:
+				close(nextQuoteStarted)
+				<-releaseNextQuote
+			}
+			return clients.ContainerCostQuote{}, nil
 		},
 	}
 
@@ -323,21 +325,21 @@ func TestEmitContainerUsageFreezesCancellationBoundaryDuringQuoteLatency(t *test
 	}()
 
 	select {
-	case <-quoteStarted:
+	case <-initialQuote:
 	case <-time.After(time.Second):
-		t.Fatal("quote request did not start")
+		t.Fatal("initial quote was not resolved")
 	}
 	ticks <- tickAt
 	select {
-	case <-repository.notify:
+	case <-nextQuoteStarted:
 	case <-time.After(time.Second):
-		t.Fatal("duration was not emitted while quote request was blocked")
+		t.Fatal("post-tick quote did not start")
 	}
 	repository.mu.Lock()
-	eventsBeforeQuoteRelease := append([]recordedUsageMetric(nil), repository.events...)
+	metricsBeforeQuote := append([]recordedUsageMetric(nil), repository.events...)
 	repository.mu.Unlock()
-	if len(eventsBeforeQuoteRelease) != 1 || eventsBeforeQuoteRelease[0].name != types.UsageMetricsWorkerContainerDuration || eventsBeforeQuoteRelease[0].value != 5_000 {
-		t.Fatalf("events while quote blocked = %+v, want authoritative duration first", eventsBeforeQuoteRelease)
+	if len(metricsBeforeQuote) != 1 || metricsBeforeQuote[0].name != types.UsageMetricsWorkerContainerDuration {
+		t.Fatalf("metrics before blocked quote = %+v, want authoritative duration", metricsBeforeQuote)
 	}
 	cancel()
 	select {
@@ -345,11 +347,11 @@ func TestEmitContainerUsageFreezesCancellationBoundaryDuringQuoteLatency(t *test
 	case <-time.After(time.Second):
 		t.Fatal("cancellation boundary was not captured during quote latency")
 	}
-	release()
+	close(releaseNextQuote)
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("usage loop did not finish after quote release")
+		t.Fatal("usage loop did not finish after bounded quote release")
 	}
 
 	repository.mu.Lock()
@@ -371,6 +373,252 @@ func TestEmitContainerUsageFreezesCancellationBoundaryDuringQuoteLatency(t *test
 		durations[1].labels["interval_end"] != cancelAt.Format(time.RFC3339Nano) {
 		t.Fatalf("interval ends = %v/%v, want tick/cancellation boundaries", durations[0].labels["interval_end"], durations[1].labels["interval_end"])
 	}
+}
+
+func TestEmitContainerUsageSplitsAtQuoteValidityBoundary(t *testing.T) {
+	transition := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	start := transition.Add(-time.Second)
+	end := transition.Add(4 * time.Second)
+	ticks := make(chan time.Time, 1)
+	initialQuoteProvided := make(chan struct{})
+
+	repository := &usageMetricsRecorder{notify: make(chan struct{}, 16)}
+	external := &containerUsageRecorder{}
+	var quoteCalls atomic.Int32
+	var initialQuoteOnce sync.Once
+	var nowCalls atomic.Int32
+	metrics := &WorkerUsageMetrics{
+		ctx:               context.Background(),
+		workerId:          "worker-1",
+		metricsRepo:       repository,
+		usageRecorder:     external,
+		poolMode:          types.PoolModeLocal,
+		openMeterMetadata: true,
+		now: func() time.Time {
+			if nowCalls.Add(1) == 1 {
+				return start
+			}
+			return end
+		},
+		newTicker: func(time.Duration) (<-chan time.Time, func()) {
+			return ticks, func() {}
+		},
+		quoteProvider: func(context.Context, *types.ContainerRequest) (clients.ContainerCostQuote, error) {
+			if quoteCalls.Add(1) == 1 {
+				initialQuoteOnce.Do(func() { close(initialQuoteProvided) })
+				return clients.ContainerCostQuote{
+					CostPerMs:      0.001,
+					PricingVersion: "old",
+					EffectiveAt:    start.Add(-time.Hour),
+					ValidUntil:     transition,
+					Valid:          true,
+				}, nil
+			}
+			return clients.ContainerCostQuote{
+				CostPerMs:      0.002,
+				PricingVersion: "new",
+				EffectiveAt:    transition,
+				Valid:          true,
+			}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		metrics.EmitContainerUsage(ctx, &types.ContainerRequest{
+			ContainerId: "container-1",
+			WorkspaceId: "workspace-1",
+			Cpu:         1_000,
+			Memory:      1_024,
+		})
+		close(done)
+	}()
+
+	select {
+	case <-initialQuoteProvided:
+	case <-time.After(time.Second):
+		t.Fatal("old quote was not resolved at interval start")
+	}
+	ticks <- end
+	waitForUsageMetrics(t, repository.notify, 4)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("transition usage loop did not stop")
+	}
+
+	repository.mu.Lock()
+	events := append([]recordedUsageMetric(nil), repository.events...)
+	repository.mu.Unlock()
+	var durationTotal, oldCost, newCost float64
+	for _, event := range events {
+		intervalStart, _ := time.Parse(time.RFC3339Nano, event.labels["interval_start"].(string))
+		intervalEnd, _ := time.Parse(time.RFC3339Nano, event.labels["interval_end"].(string))
+		version, _ := event.labels["pricing_version"].(string)
+		if event.name == types.UsageMetricsWorkerContainerDuration && event.value > 0 {
+			durationTotal += event.value
+		}
+		if event.name != types.UsageMetricsWorkerContainerCost {
+			continue
+		}
+		switch version {
+		case "old":
+			oldCost += event.value
+			if intervalEnd.After(transition) {
+				t.Fatalf("old quote crossed transition: %v to %v", intervalStart, intervalEnd)
+			}
+		case "new":
+			newCost += event.value
+			if intervalStart.Before(transition) {
+				t.Fatalf("new quote applied before transition: %v to %v", intervalStart, intervalEnd)
+			}
+		}
+	}
+	if durationTotal != 5_000 || oldCost != 1 || newCost != 8 {
+		t.Fatalf("duration/old/new = %v/%v/%v, want 5000ms/1/8 cents", durationTotal, oldCost, newCost)
+	}
+	if external.count < 2 || external.invalidCost {
+		t.Fatalf("external transition records = %d, invalid = %t", external.count, external.invalidCost)
+	}
+}
+
+func TestEmitContainerUsageQuoteFailureRemainsDurationOnly(t *testing.T) {
+	start := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Second)
+	ticks := make(chan time.Time, 1)
+	quoteFailed := make(chan struct{})
+	var quoteFailedOnce sync.Once
+	repository := &usageMetricsRecorder{notify: make(chan struct{}, 4)}
+	metrics := &WorkerUsageMetrics{
+		ctx:         context.Background(),
+		workerId:    "worker-1",
+		metricsRepo: repository,
+		poolMode:    types.PoolModeLocal,
+		now:         func() time.Time { return start },
+		newTicker: func(time.Duration) (<-chan time.Time, func()) {
+			return ticks, func() {}
+		},
+		quoteProvider: func(context.Context, *types.ContainerRequest) (clients.ContainerCostQuote, error) {
+			quoteFailedOnce.Do(func() { close(quoteFailed) })
+			return clients.ContainerCostQuote{}, context.DeadlineExceeded
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		metrics.EmitContainerUsage(ctx, &types.ContainerRequest{ContainerId: "container-1"})
+		close(done)
+	}()
+	select {
+	case <-quoteFailed:
+	case <-time.After(time.Second):
+		t.Fatal("quote failure was not returned")
+	}
+	ticks <- end
+	waitForUsageMetrics(t, repository.notify, 1)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("failed-quote usage loop did not stop")
+	}
+
+	repository.mu.Lock()
+	events := append([]recordedUsageMetric(nil), repository.events...)
+	repository.mu.Unlock()
+	for _, event := range events {
+		if event.name == types.UsageMetricsWorkerContainerCost {
+			t.Fatalf("failed quote emitted cost event %+v", event)
+		}
+	}
+}
+
+func TestExpiredStaleQuoteDoesNotPriceAfterTransition(t *testing.T) {
+	transition := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	start := transition.Add(-time.Second)
+	end := transition.Add(4 * time.Second)
+	repository := &usageMetricsRecorder{}
+	external := &containerUsageRecorder{}
+	metrics := &WorkerUsageMetrics{
+		workerId:          "worker-1",
+		metricsRepo:       repository,
+		usageRecorder:     external,
+		poolMode:          types.PoolModeLocal,
+		openMeterMetadata: true,
+	}
+	request := types.ContainerRequest{ContainerId: "container-1", Cpu: 1_000, Memory: 1_024}
+	stale := clients.ContainerCostQuote{
+		CostPerMs:      0.001,
+		PricingVersion: "old",
+		EffectiveAt:    start.Add(-time.Hour),
+		ValidUntil:     transition,
+		Valid:          true,
+	}
+
+	metrics.emitContainerDurationSegments(request, start, end, stale)
+	metrics.emitContainerPriceSegments(request, start, end, stale, stale)
+
+	repository.mu.Lock()
+	events := append([]recordedUsageMetric(nil), repository.events...)
+	repository.mu.Unlock()
+	var duration, cost float64
+	var costEvents int
+	for _, event := range events {
+		if event.name == types.UsageMetricsWorkerContainerDuration {
+			duration += event.value
+		}
+		if event.name == types.UsageMetricsWorkerContainerCost {
+			cost += event.value
+			costEvents++
+		}
+	}
+	if duration != 5_000 || cost != 1 || costEvents != 1 {
+		t.Fatalf("duration/cost/events = %v/%v/%d, want 5000ms/1 cent/one pre-transition cost", duration, cost, costEvents)
+	}
+	if external.count != 2 || external.unpriced != 1 || external.invalidCost {
+		t.Fatalf("external records/unpriced/invalid = %d/%d/%t, want two/one/false", external.count, external.unpriced, external.invalidCost)
+	}
+}
+
+func TestContainerUsageSegmentsPreserveWholeIntervalMilliseconds(t *testing.T) {
+	start := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	middle := start.Add(500 * time.Microsecond)
+	segments := containerUsageSegments(
+		types.ContainerRequest{}, start, start.Add(time.Millisecond), middle,
+	)
+	if len(segments) != 2 {
+		t.Fatalf("segments = %d, want 2", len(segments))
+	}
+	var total int64
+	for _, segment := range segments {
+		total += segment.duration.Milliseconds()
+	}
+	if total != 1 {
+		t.Fatalf("split duration = %dms, want 1ms", total)
+	}
+}
+
+func waitForUsageMetrics(t *testing.T, notifications <-chan struct{}, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-notifications:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for usage metric %d/%d", i+1, count)
+		}
+	}
+}
+
+func emitResolvedContainerUsageInterval(metrics *WorkerUsageMetrics, request *types.ContainerRequest, start, end time.Time) {
+	requestSnapshot := *request
+	requestSnapshot.Gpu = metrics.gpuType
+	requestSnapshot.CostPerMs = 0
+	quote := metrics.getContainerCostQuote(&requestSnapshot)
+	metrics.emitContainerDurationSegments(requestSnapshot, start, end, quote)
+	metrics.emitContainerPriceSegments(requestSnapshot, start, end, quote, quote)
 }
 
 type usageMetricsRecorder struct {

--- a/pkg/worker/usage_test.go
+++ b/pkg/worker/usage_test.go
@@ -484,6 +484,134 @@ func TestEmitContainerUsageSplitsAtQuoteValidityBoundary(t *testing.T) {
 	}
 }
 
+func TestEmitContainerDurationSplitsAtKnownQuoteBoundary(t *testing.T) {
+	boundary := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	start := boundary.Add(-time.Second)
+	end := boundary.Add(4 * time.Second)
+	repository := &usageMetricsRecorder{}
+	metrics := &WorkerUsageMetrics{
+		workerId:          "worker-1",
+		metricsRepo:       repository,
+		openMeterMetadata: true,
+	}
+	quote := clients.ContainerCostQuote{
+		CostPerMs:      0.001,
+		PricingVersion: "old",
+		EffectiveAt:    start.Add(-time.Hour),
+		ValidUntil:     boundary,
+		Valid:          true,
+	}
+
+	metrics.emitContainerDurationSegments(types.ContainerRequest{ContainerId: "container-1"}, start, end, quote)
+
+	if len(repository.events) != 2 {
+		t.Fatalf("duration events = %d, want 2", len(repository.events))
+	}
+	first, second := repository.events[0], repository.events[1]
+	if first.value != 1_000 || second.value != 4_000 {
+		t.Fatalf("duration values = %v/%v, want 1000/4000ms", first.value, second.value)
+	}
+	if first.labels["interval_end"] != boundary.Format(time.RFC3339Nano) ||
+		second.labels["interval_start"] != boundary.Format(time.RFC3339Nano) {
+		t.Fatalf("duration boundary metadata = %v/%v, want %v", first.labels["interval_end"], second.labels["interval_start"], boundary)
+	}
+	if first.labels["pricing_version"] != "old" || second.labels["pricing_version"] != "" {
+		t.Fatalf("duration pricing versions = %q/%q, want old/empty after expiry", first.labels["pricing_version"], second.labels["pricing_version"])
+	}
+}
+
+func TestEmitContainerUsageDoesNotBackdateUndatedRefresh(t *testing.T) {
+	start := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	firstEnd := start.Add(time.Second)
+	secondEnd := firstEnd.Add(time.Second)
+	thirdEnd := secondEnd.Add(time.Second)
+	ticks := make(chan time.Time, 3)
+	repository := &usageMetricsRecorder{notify: make(chan struct{}, 6)}
+	var nowCalls atomic.Int32
+	var quoteCalls atomic.Int32
+	metrics := &WorkerUsageMetrics{
+		workerId:          "worker-1",
+		metricsRepo:       repository,
+		poolMode:          types.PoolModeLocal,
+		openMeterMetadata: true,
+		now: func() time.Time {
+			if nowCalls.Add(1) == 1 {
+				return start
+			}
+			return thirdEnd
+		},
+		newTicker: func(time.Duration) (<-chan time.Time, func()) {
+			return ticks, func() {}
+		},
+		quoteProvider: func(context.Context, *types.ContainerRequest) (clients.ContainerCostQuote, error) {
+			switch quoteCalls.Add(1) {
+			case 1:
+				return clients.ContainerCostQuote{
+					CostPerMs:      0.001,
+					PricingVersion: "old",
+					EffectiveAt:    start.Add(-time.Hour),
+					Valid:          true,
+				}, nil
+			case 2:
+				return clients.ContainerCostQuote{CostPerMs: 0.001, PricingVersion: "old", Valid: true}, nil
+			}
+			return clients.ContainerCostQuote{
+				CostPerMs:      0.002,
+				PricingVersion: "new",
+				Valid:          true,
+			}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		metrics.EmitContainerUsage(ctx, &types.ContainerRequest{ContainerId: "container-1"})
+		close(done)
+	}()
+	ticks <- firstEnd
+	waitForUsageMetrics(t, repository.notify, 2)
+	ticks <- secondEnd
+	waitForUsageMetrics(t, repository.notify, 2)
+	ticks <- thirdEnd
+	waitForUsageMetrics(t, repository.notify, 2)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("usage loop did not stop")
+	}
+
+	repository.mu.Lock()
+	events := append([]recordedUsageMetric(nil), repository.events...)
+	repository.mu.Unlock()
+	if len(events) != 6 {
+		t.Fatalf("usage events = %d, want three duration/cost pairs", len(events))
+	}
+	for i, want := range []struct {
+		name    string
+		version string
+		value   float64
+	}{
+		{types.UsageMetricsWorkerContainerDuration, "old", 1_000},
+		{types.UsageMetricsWorkerContainerCost, "old", 1},
+		{types.UsageMetricsWorkerContainerDuration, "old", 1_000},
+		{types.UsageMetricsWorkerContainerCost, "old", 1},
+		{types.UsageMetricsWorkerContainerDuration, "new", 1_000},
+		{types.UsageMetricsWorkerContainerCost, "new", 2},
+	} {
+		if events[i].name != want.name || events[i].labels["pricing_version"] != want.version || events[i].value != want.value {
+			t.Fatalf("event %d = %s/%v/%v, want %s/%s/%v", i, events[i].name, events[i].labels["pricing_version"], events[i].value, want.name, want.version, want.value)
+		}
+	}
+	if events[2].labels["pricing_effective_at"] != start.Add(-time.Hour).Format(time.RFC3339Nano) {
+		t.Fatalf("unchanged quote effective_at advanced to %v", events[2].labels["pricing_effective_at"])
+	}
+	if events[4].labels["pricing_effective_at"] != secondEnd.Format(time.RFC3339Nano) {
+		t.Fatalf("new quote effective_at = %v, want frozen second interval end %v", events[4].labels["pricing_effective_at"], secondEnd)
+	}
+}
+
 func TestEmitContainerUsageQuoteFailureRemainsDurationOnly(t *testing.T) {
 	start := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
 	end := start.Add(5 * time.Second)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add pricing-versioned container cost quotes and make metering resilient to quote outages. OpenMeter ingest is now timeout-bounded and safely retried with deterministic IDs to avoid duplicate billing.

- **New Features**
  - `pkg/clients`: return `ContainerCostQuote` with `pricing_version`, `effective_at`, `valid_until`; cache per resource key with refresh/negative-cache and bounded backoff; coalesce concurrent refreshes via `golang.org/x/sync/singleflight`; strict response validation (finite nonnegative cost, RFC3339 times, no trailing JSON); enforce HTTP timeouts and response/error size limits; keep `GetContainerCostPerMs` for legacy callers.
  - `pkg/worker/usage.go`: emit duration before cost; split intervals at `effective_at`/`valid_until` and UTC midnight; include `pricing_version`, `interval_start`/`interval_end`, and `pricing_effective_at`/`pricing_valid_until` in OpenMeter metadata; do not backdate undated quote changes (apply prospectively); flush exactly on cancel; send `cost_per_ms` and `cost_for_duration` on cost events; record unpriced usage when no valid quote.
  - `pkg/repository/usage/usage_openmeter.go`: add HTTP timeouts and bounded retries on retryable errors; compute deterministic CloudEvent ID from resource+interval+value for idempotent replays; set event time from `interval_start`.
  - `pkg/clients/marketplace_usage.go`: omit price fields when no quote via custom JSON marshalling (`OmitPrice`).
  - `pkg/repository/backend_postgres.go`: include `disabled_by_cluster_admin` in `ListTokens` results.

- **Migration**
  - Update `ContainerUsageRecorder.RecordContainerUsage` to accept `costCents *float64`; pass nil to send unpriced usage.
  - If constructing `MarketplaceUsageRequest` directly, set `OmitPrice` (or pass nil cost) to omit price fields automatically.

<sup>Written for commit 990272b6e7407c668f1ca994dabb03758515b63b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

