### PR TITLE
update sandbox pricing

### DIFF
--- a/pkg/clients/container_cost.go
+++ b/pkg/clients/container_cost.go
@@ -47,6 +47,7 @@ type ContainerCostRequest struct {
 	Memory   int64  `json:"memory"`
 	Gpu      string `json:"gpu"`
 	GpuCount uint32 `json:"gpu_count"`
+	Sandbox  bool   `json:"sandbox"`
 }
 
 type containerCostCacheEntry struct {
@@ -100,6 +101,7 @@ func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request
 	key := ContainerCostRequest{
 		Cpu: request.Cpu, Memory: request.Memory,
 		Gpu: strings.TrimSpace(request.Gpu), GpuCount: request.GpuCount,
+		Sandbox: request.Stub.Type.Kind() == types.StubTypeSandbox,
 	}
 	if quote, ok := c.cached(key); ok {
 		return quote, nil

--- a/pkg/clients/container_cost_test.go
+++ b/pkg/clients/container_cost_test.go
@@ -50,7 +50,7 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 		now := clock.Now()
 		_ = json.NewEncoder(w).Encode(ContainerCostResponse{
 			CostPerMs:      "0.0000017",
-			PricingVersion: "cpu-only-202607",
+			PricingVersion: "rates-test",
 			EffectiveAt:    now.Add(-time.Hour).Format(time.RFC3339Nano),
 			ValidUntil:     now.Add(time.Minute).Format(time.RFC3339Nano),
 		})
@@ -65,7 +65,7 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	if err != nil {
 		t.Fatalf("initial quote: %v", err)
 	}
-	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "cpu-only-202607" || !quote.EffectiveAt.Equal(clock.Now().Add(-time.Hour)) {
+	if !quote.Valid || quote.CostPerMs != 0.0000017 || quote.PricingVersion != "rates-test" || !quote.EffectiveAt.Equal(clock.Now().Add(-time.Hour)) {
 		t.Fatalf("initial quote = %+v", quote)
 	}
 
@@ -130,6 +130,42 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	}
 	if surfacedErrors != 2 {
 		t.Fatalf("surfaced refresh errors = %d, want one per failed HTTP refresh", surfacedErrors)
+	}
+}
+
+func TestContainerCostClientSeparatesSandboxQuotes(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var request ContainerCostRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		cost := "0.1"
+		if request.Sandbox {
+			cost = "0.3"
+		}
+		_, _ = fmt.Fprintf(w, `{"cost_per_ms":%q}`, cost)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	standard := &types.ContainerRequest{Cpu: 1_000, Memory: 1_024}
+	sandbox := &types.ContainerRequest{
+		Cpu:    1_000,
+		Memory: 1_024,
+		Stub:   types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeSandbox)}},
+	}
+	standardQuote, standardErr := client.GetContainerCostQuote(context.Background(), standard)
+	sandboxQuote, sandboxErr := client.GetContainerCostQuote(context.Background(), sandbox)
+	if standardErr != nil || sandboxErr != nil {
+		t.Fatalf("standard/sandbox quote errors = %v/%v", standardErr, sandboxErr)
+	}
+	if standardQuote.CostPerMs != 0.1 || sandboxQuote.CostPerMs != 0.3 {
+		t.Fatalf("standard/sandbox quotes = %v/%v", standardQuote.CostPerMs, sandboxQuote.CostPerMs)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("quote calls = %d, want separate standard and sandbox quotes", calls.Load())
 	}
 }
 

--- a/pkg/worker/usage_test.go
+++ b/pkg/worker/usage_test.go
@@ -100,7 +100,7 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 		case 1_000:
 			_ = json.NewEncoder(w).Encode(map[string]string{
 				"cost_per_ms":     "0.00000170",
-				"pricing_version": "cpu-only-202607",
+				"pricing_version": "rates-test",
 				"valid_until":     time.Now().Add(time.Hour).Format(time.RFC3339Nano),
 			})
 		case 2_000:
@@ -188,7 +188,7 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 	}
 	if firstEvents[0].Data["interval_start"] != start.Format(time.RFC3339Nano) ||
 		firstEvents[0].Data["interval_end"] != start.Add(time.Hour).Format(time.RFC3339Nano) ||
-		firstEvents[1].Data["pricing_version"] != "cpu-only-202607" {
+		firstEvents[1].Data["pricing_version"] != "rates-test" {
 		t.Fatalf("interval metadata = %+v", firstEvents[0].Data)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Separate sandbox pricing from standard container pricing so quotes and caching don’t mix between them.

- **New Features**
  - Add `Sandbox` field to the container cost request and set it from the stub type.
  - Include `Sandbox` in the cache key to keep sandbox and standard quotes separate.
  - Add a test that confirms sandbox and standard quotes are requested separately.
  - Update test fixtures to use pricing version `rates-test`.

<sup>Written for commit d0d2eab91e93f11d1baa928de93824932dc232df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

