### PR TITLE
fix gateway readiness reconciliation stall

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -66,7 +66,6 @@ type Gateway struct {
 	httpServer           *http.Server
 	grpcServer           *grpc.Server
 	healthServer         *health.Server
-	computeReady         <-chan struct{}
 	RedisClient          *common.RedisClient
 	TaskDispatcher       *task.Dispatcher
 	TaskRepo             repository.TaskRepository
@@ -206,7 +205,6 @@ func NewGateway() (*Gateway, error) {
 		RedisClient:      redisClient,
 		Tailscale:        tailscale,
 	})
-	gateway.computeReady = gateway.ComputeService.Ready()
 	gateway.ComputeService.Start(ctx)
 
 	return gateway, nil
@@ -662,18 +660,7 @@ func (g *Gateway) Start() error {
 }
 
 func (g *Gateway) isReady() bool {
-	if g.draining.Load() {
-		return false
-	}
-	if g.computeReady == nil {
-		return true
-	}
-	select {
-	case <-g.computeReady:
-		return true
-	default:
-		return false
-	}
+	return !g.draining.Load()
 }
 
 func (g *Gateway) registerHealthService() {
@@ -683,25 +670,10 @@ func (g *Gateway) registerHealthService() {
 
 func (g *Gateway) newHealthServer() *health.Server {
 	hs := health.NewServer()
-	// Keep the unnamed service serving for clients using the legacy health
-	// check. Kubernetes uses the named services below so reconciliation can
-	// gate readiness without coupling it to liveness.
 	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	hs.SetServingStatus(gatewayLivenessService, healthpb.HealthCheckResponse_SERVING)
-	hs.SetServingStatus(gatewayReadinessService, healthpb.HealthCheckResponse_NOT_SERVING)
+	hs.SetServingStatus(gatewayReadinessService, healthpb.HealthCheckResponse_SERVING)
 	g.healthServer = hs
-
-	if g.computeReady == nil {
-		g.markReady()
-	} else if g.ctx != nil {
-		go func() {
-			select {
-			case <-g.computeReady:
-				g.markReady()
-			case <-g.ctx.Done():
-			}
-		}()
-	}
 
 	if g.ctx != nil {
 		go func() {
@@ -710,18 +682,6 @@ func (g *Gateway) newHealthServer() *health.Server {
 		}()
 	}
 	return hs
-}
-
-func (g *Gateway) markReady() {
-	if g.healthServer == nil || g.draining.Load() {
-		return
-	}
-	g.healthServer.SetServingStatus(gatewayReadinessService, healthpb.HealthCheckResponse_SERVING)
-	// Draining can begin between the check and status update. Reasserting the
-	// terminal readiness state closes that race without coupling liveness to it.
-	if g.draining.Load() {
-		g.healthServer.SetServingStatus(gatewayReadinessService, healthpb.HealthCheckResponse_NOT_SERVING)
-	}
 }
 
 func (g *Gateway) drainMiddleware(next echo.HandlerFunc) echo.HandlerFunc {

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -96,30 +96,17 @@ func gatewayHealthStatus(t *testing.T, g *Gateway, service string) healthpb.Heal
 func TestGatewayHealthSeparatesLivenessFromReadiness(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ready := make(chan struct{})
-	g := &Gateway{ctx: ctx, computeReady: ready}
+	g := &Gateway{ctx: ctx}
 	g.newHealthServer()
 
 	if got := gatewayHealthStatus(t, g, gatewayLivenessService); got != healthpb.HealthCheckResponse_SERVING {
 		t.Fatalf("liveness = %v, want serving", got)
 	}
-	if got := gatewayHealthStatus(t, g, gatewayReadinessService); got != healthpb.HealthCheckResponse_NOT_SERVING {
-		t.Fatalf("readiness before reconciliation = %v, want not serving", got)
-	}
-	if g.isReady() {
-		t.Fatal("HTTP readiness reported ready before reconciliation")
-	}
-
-	close(ready)
-	deadline := time.Now().Add(time.Second)
-	for gatewayHealthStatus(t, g, gatewayReadinessService) != healthpb.HealthCheckResponse_SERVING {
-		if time.Now().After(deadline) {
-			t.Fatal("readiness did not become serving after reconciliation")
-		}
-		time.Sleep(time.Millisecond)
+	if got := gatewayHealthStatus(t, g, gatewayReadinessService); got != healthpb.HealthCheckResponse_SERVING {
+		t.Fatalf("readiness = %v, want serving", got)
 	}
 	if !g.isReady() {
-		t.Fatal("HTTP readiness did not become ready after reconciliation")
+		t.Fatal("HTTP readiness did not become ready")
 	}
 
 	g.startDraining()

--- a/pkg/gateway/services/compute/managed_pool_test.go
+++ b/pkg/gateway/services/compute/managed_pool_test.go
@@ -64,14 +64,21 @@ type fakeManagedPoolWorkerPoolRepo struct {
 }
 
 type fakeManagedPoolRepo struct {
-	repo *fakeComputeRepo
+	repo  *fakeComputeRepo
+	saved chan struct{}
 }
 
 func (*fakeManagedPoolRepo) WithManagedPoolStateLock(ctx context.Context, _, _ string, fn func(context.Context) error) error {
 	return fn(ctx)
 }
 func (r *fakeManagedPoolRepo) SaveManagedPoolState(ctx context.Context, workspaceID string, state *model.PoolState) error {
-	return r.repo.SavePoolState(ctx, workspaceID, state)
+	if err := r.repo.SavePoolState(ctx, workspaceID, state); err != nil {
+		return err
+	}
+	if r.saved != nil {
+		r.saved <- struct{}{}
+	}
+	return nil
 }
 func (r *fakeManagedPoolRepo) GetManagedPoolState(ctx context.Context, workspaceID, name string) (*model.PoolState, error) {
 	return r.repo.GetPoolState(ctx, workspaceID, name)
@@ -110,7 +117,6 @@ func managedPoolTestService(config types.AppConfig, repo *fakeComputeRepo) *Serv
 		computeRepo:          repo,
 		managedPoolRepo:      &fakeManagedPoolRepo{repo: managedStates},
 		workerRepo:           workers,
-		managedPoolReady:     make(chan struct{}),
 		managedPoolInstances: map[string]string{},
 	}
 }
@@ -128,7 +134,6 @@ func TestServiceStartDoesNotWaitForManagedPoolReconciliation(t *testing.T) {
 		scheduler:            scheduler.NewSchedulerForCapacityChecks(&fakeWorkerRepo{}, &fakeComputeRepo{}, scheduler.NewWorkerPoolManager(false)),
 		computeRepo:          &fakeComputeRepo{},
 		managedPoolRepo:      &fakeManagedPoolRepo{repo: &fakeComputeRepo{}},
-		managedPoolReady:     make(chan struct{}),
 		managedPoolInstances: map[string]string{},
 	}
 
@@ -299,7 +304,6 @@ func TestManagedPoolsConvergeAcrossGatewayReplicas(t *testing.T) {
 			managedPoolRepo:      repository.NewManagedPoolRedisRepository(rdb),
 			workerRepo:           workers,
 			redisClient:          rdb,
-			managedPoolReady:     make(chan struct{}),
 			managedPoolInstances: map[string]string{},
 		}, manager
 	}
@@ -310,13 +314,6 @@ func TestManagedPoolsConvergeAcrossGatewayReplicas(t *testing.T) {
 	defer cancel()
 	go replicaA.runManagedPoolReconciler(ctx)
 	go replicaB.runManagedPoolReconciler(ctx)
-	for _, replica := range []*Service{replicaA, replicaB} {
-		select {
-		case <-replica.Ready():
-		case <-time.After(time.Second):
-			t.Fatal("replica did not complete initial managed pool reconciliation")
-		}
-	}
 	waitForManagedPoolReplicas(t, []*scheduler.WorkerPoolManager{managerA, managerB}, "config-pool", true, 5)
 	stateA, err := replicaA.managedPoolRepo.GetManagedPoolState(context.Background(), "admin-workspace", "config-pool")
 	if err != nil {
@@ -464,9 +461,11 @@ func TestManagedPoolReconciliationRetriesStartupFailure(t *testing.T) {
 		t.Fatal("initial reconciliation unexpectedly succeeded")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	saved := make(chan struct{}, 1)
+	service.managedPoolRepo.(*fakeManagedPoolRepo).saved = saved
 	go service.runManagedPoolReconciler(ctx)
 	select {
-	case <-service.Ready():
+	case <-saved:
 	case <-time.After(time.Second):
 		cancel()
 		t.Fatal("managed pool reconciliation did not recover")

--- a/pkg/gateway/services/compute/service.go
+++ b/pkg/gateway/services/compute/service.go
@@ -39,8 +39,6 @@ type Service struct {
 	tailscale            *network.Tailscale
 	routePrewarm         routePrewarmer
 	reconcileOnce        sync.Once
-	managedPoolReady     chan struct{}
-	managedPoolReadyOnce sync.Once
 	managedPoolSyncMu    sync.Mutex
 	managedPoolInstances map[string]string
 }
@@ -79,7 +77,6 @@ func New(opts Options) *Service {
 		rentalUsage:          clients.NewMarketplaceUsageClient(opts.Config.ManagedCompute.Billing),
 		tailscale:            opts.Tailscale,
 		routePrewarm:         routePrewarmer{lastAttempt: map[string]time.Time{}},
-		managedPoolReady:     make(chan struct{}),
 		managedPoolInstances: map[string]string{},
 	}
 	service.telemetryCredentials = newTelemetryCredentialIssuer(opts.Config.Database.S2)
@@ -100,23 +97,6 @@ func (s *Service) Start(ctx context.Context) {
 		}
 		go s.runManagedPoolReconciler(ctx)
 	})
-}
-
-// Ready closes after this replica has loaded every managed pool into its local scheduler.
-func (s *Service) Ready() <-chan struct{} {
-	if s == nil || s.managedPoolReady == nil {
-		ready := make(chan struct{})
-		close(ready)
-		return ready
-	}
-	return s.managedPoolReady
-}
-
-func (s *Service) markManagedPoolsReady() {
-	if s == nil || s.managedPoolReady == nil {
-		return
-	}
-	s.managedPoolReadyOnce.Do(func() { close(s.managedPoolReady) })
 }
 
 func (s *Service) runManagedPoolReconciler(ctx context.Context) {
@@ -152,7 +132,6 @@ func (s *Service) runManagedPoolReconciler(ctx context.Context) {
 				resetManagedPoolTimer(timer, managedPoolReconcileRetryInterval)
 				continue
 			}
-			s.markManagedPoolsReady()
 			log.Debug().Dur("duration", time.Since(started)).Msg("managed pools reconciled")
 			resetManagedPoolTimer(timer, managedPoolReconcileInterval)
 		}

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -196,8 +196,8 @@ func (r *PostgresBackendRepository) CreateWorkspace(ctx context.Context) (types.
 	signingKey := "sk_" + base64.StdEncoding.EncodeToString(signingKeyBytes)
 
 	query := `
-	INSERT INTO workspace (name, external_id, signing_key)
-	VALUES ($1, $2, $3)
+	INSERT INTO workspace (name, external_id, signing_key, is_cluster_admin)
+	VALUES ($1, $2, $3, NOT EXISTS (SELECT 1 FROM workspace))
 	RETURNING id, name, external_id, signing_key, created_at, updated_at;
 	`
 
@@ -287,11 +287,8 @@ func (r *PostgresBackendRepository) GetAdminWorkspace(ctx context.Context) (*typ
 
 		var adminWorkspace types.Workspace
 		query := `SELECT w.id, w.external_id, w.name, w.created_at, w.concurrency_limit_id, w.volume_cache_enabled, w.multi_gpu_enabled
-	FROM token t
-	INNER JOIN workspace w ON t.workspace_id = w.id
-	WHERE t.token_type = 'admin'
-	ORDER BY t.id
-	LIMIT 1;`
+	FROM workspace w
+	WHERE w.is_cluster_admin;`
 		err := r.client.GetContext(ctx, &adminWorkspace, query)
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			err = ctxErr

--- a/pkg/repository/backend_postgres_migrations/045_mark_cluster_admin_workspace.go
+++ b/pkg/repository/backend_postgres_migrations/045_mark_cluster_admin_workspace.go
@@ -1,0 +1,50 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(upMarkClusterAdminWorkspace, downMarkClusterAdminWorkspace)
+}
+
+func upMarkClusterAdminWorkspace(ctx context.Context, db *sql.DB) error {
+	// Existing installations have no canonical marker. Preserve their current
+	// admin workspace once; all subsequent lookups use the explicit marker.
+	statements := []string{
+		`ALTER TABLE workspace ADD COLUMN IF NOT EXISTS is_cluster_admin BOOLEAN NOT NULL DEFAULT FALSE;`,
+		`UPDATE workspace
+		 SET is_cluster_admin = TRUE
+		 WHERE id = (
+			 SELECT workspace_id
+			 FROM token
+			 WHERE token_type = 'admin'
+			 ORDER BY id
+			 LIMIT 1
+		 )
+		 AND NOT EXISTS (SELECT 1 FROM workspace WHERE is_cluster_admin);`,
+		`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_workspace_cluster_admin ON workspace (is_cluster_admin) WHERE is_cluster_admin;`,
+	}
+	for _, statement := range statements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downMarkClusterAdminWorkspace(ctx context.Context, db *sql.DB) error {
+	statements := []string{
+		`DROP INDEX CONCURRENTLY IF EXISTS idx_workspace_cluster_admin;`,
+		`ALTER TABLE workspace DROP COLUMN IF EXISTS is_cluster_admin;`,
+	}
+	for _, statement := range statements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/repository/backend_postgres_test.go
+++ b/pkg/repository/backend_postgres_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const adminWorkspaceQueryPattern = `SELECT w\.id, w\.external_id.*WHERE w\.is_cluster_admin`
+
 func TestListTaskWithRelated(t *testing.T) {
 	// Remove this skip if you are testing on local data
 	t.Skip()
@@ -54,7 +56,7 @@ func TestListTaskWithRelated(t *testing.T) {
 func TestGetAdminWorkspaceMapsExternalID(t *testing.T) {
 	repo, mock := NewBackendPostgresRepositoryForTest()
 	createdAt := time.Now().UTC()
-	mock.ExpectQuery(`SELECT w\.id, w\.external_id`).WillReturnRows(sqlmock.NewRows([]string{
+	mock.ExpectQuery(adminWorkspaceQueryPattern).WillReturnRows(sqlmock.NewRows([]string{
 		"id", "external_id", "name", "created_at", "concurrency_limit_id", "volume_cache_enabled", "multi_gpu_enabled",
 	}).AddRow(uint(7), "admin-workspace", "Admin", createdAt, nil, true, true))
 
@@ -80,7 +82,7 @@ func TestGetAdminWorkspaceCanceledCallerDoesNotWaitForLoad(t *testing.T) {
 	repository, mock := NewBackendPostgresRepositoryForTest()
 	repo := repository.(*PostgresBackendRepository)
 	createdAt := time.Now().UTC()
-	mock.ExpectQuery(`SELECT w\.id, w\.external_id`).
+	mock.ExpectQuery(adminWorkspaceQueryPattern).
 		WillDelayFor(200 * time.Millisecond).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "external_id", "name", "created_at", "concurrency_limit_id", "volume_cache_enabled", "multi_gpu_enabled",
@@ -106,7 +108,7 @@ func TestGetAdminWorkspaceSharesFailedLoadWithWaiters(t *testing.T) {
 	repository, mock := NewBackendPostgresRepositoryForTest()
 	repo := repository.(*PostgresBackendRepository)
 	loadErr := errors.New("database unavailable")
-	mock.ExpectQuery(`SELECT w\.id, w\.external_id`).
+	mock.ExpectQuery(adminWorkspaceQueryPattern).
 		WillDelayFor(200 * time.Millisecond).
 		WillReturnError(loadErr)
 
@@ -131,7 +133,7 @@ func TestGetAdminWorkspaceSharesFailedLoadWithWaiters(t *testing.T) {
 	}
 
 	createdAt := time.Now().UTC()
-	mock.ExpectQuery(`SELECT w\.id, w\.external_id`).WillReturnRows(sqlmock.NewRows([]string{
+	mock.ExpectQuery(adminWorkspaceQueryPattern).WillReturnRows(sqlmock.NewRows([]string{
 		"id", "external_id", "name", "created_at", "concurrency_limit_id", "volume_cache_enabled", "multi_gpu_enabled",
 	}).AddRow(uint(7), "admin-workspace", "Admin", createdAt, nil, true, true))
 	workspace, err := repo.GetAdminWorkspace(context.Background())
@@ -147,7 +149,7 @@ func TestGetAdminWorkspaceRetriesCanceledSharedLoad(t *testing.T) {
 	repo.adminWorkspaceLoading = loading
 
 	createdAt := time.Now().UTC()
-	mock.ExpectQuery(`SELECT w\.id, w\.external_id`).WillReturnRows(sqlmock.NewRows([]string{
+	mock.ExpectQuery(adminWorkspaceQueryPattern).WillReturnRows(sqlmock.NewRows([]string{
 		"id", "external_id", "name", "created_at", "concurrency_limit_id", "volume_cache_enabled", "multi_gpu_enabled",
 	}).AddRow(uint(7), "admin-workspace", "Admin", createdAt, nil, true, true))
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a stall where gateway readiness never became serving by removing the dependency on compute reconciliation. Also adds an explicit `is_cluster_admin` workspace flag and migration for reliable admin workspace lookup.

- **Bug Fixes**
  - `pkg/gateway`: readiness now depends only on drain state; `gatewayReadinessService` starts as SERVING; removed `computeReady` wiring and related tests.
  - `pkg/gateway/services/compute`: removed managed pool “ready” channel; reconciliation continues without gating gateway readiness.

- **Migration**
  - Adds `workspace.is_cluster_admin` with a partial unique index; migration marks the current admin workspace using the first `admin` token if none is set.
  - `CreateWorkspace` marks the first workspace as cluster admin; `GetAdminWorkspace` now queries by this flag.
  - Run database migrations before deploy.

<sup>Written for commit 9f2172f2e80d0449918c021252dabe65ab37e3b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

