### PR TITLE
Fix agent worker recovery and S2 pagination

### DIFF
--- a/pkg/gateway/services/repository/worker_repo.go
+++ b/pkg/gateway/services/repository/worker_repo.go
@@ -55,6 +55,9 @@ func (s *WorkerRepositoryService) GetNextContainerRequest(req *pb.GetNextContain
 	if err := s.workerRepo.RecoverPendingContainerRequests(req.WorkerId); err != nil {
 		return err
 	}
+	if err := s.workerRepo.ToggleWorkerAvailable(req.WorkerId); err != nil {
+		return err
+	}
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/pkg/repository/events_s2.go
+++ b/pkg/repository/events_s2.go
@@ -822,9 +822,6 @@ func (r *S2EventRepository) readEventHistoryStream(ctx context.Context, streamNa
 		seq := last.SeqNum + 1
 		nextSeqNum = &seq
 		startTimestamp = nil
-		if len(batch.Records) < int(count) {
-			return nil
-		}
 	}
 	return nil
 }

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -473,10 +473,10 @@ func (r *WorkerRedisRepository) restoreWorkerRequests(ctx context.Context, worke
 }
 
 func (r *WorkerRedisRepository) UpdateWorkerStatus(workerId string, status types.WorkerStatus) error {
-	return r.updateWorkerStatus(workerId, status, false)
+	return r.updateWorkerStatus(workerId, status, "", false)
 }
 
-func (r *WorkerRedisRepository) updateWorkerStatus(workerId string, status types.WorkerStatus, reconcileCapacity bool) error {
+func (r *WorkerRedisRepository) updateWorkerStatus(workerId string, status, expected types.WorkerStatus, reconcileCapacity bool) error {
 	err := r.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerWorkerLock(workerId), schedulerWorkerLockOptions)
 	if err != nil {
 		return err
@@ -487,6 +487,9 @@ func (r *WorkerRedisRepository) updateWorkerStatus(workerId string, status types
 	worker, err := r.getWorkerFromKey(stateKey)
 	if err != nil {
 		return err
+	}
+	if expected != "" && worker.Status != expected {
+		return nil
 	}
 
 	if reconcileCapacity && status == types.WorkerStatusAvailable {
@@ -714,7 +717,7 @@ func (r *WorkerRedisRepository) SetWorkerKeepAlive(workerId string, keepAlive ty
 }
 
 func (r *WorkerRedisRepository) ToggleWorkerAvailable(workerId string) error {
-	return r.updateWorkerStatus(workerId, types.WorkerStatusAvailable, true)
+	return r.updateWorkerStatus(workerId, types.WorkerStatusAvailable, types.WorkerStatusPending, true)
 }
 
 func (r *WorkerRedisRepository) workerIndexKeys(worker *types.Worker) []string {

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -172,6 +172,21 @@ func TestToggleWorkerAvailable(t *testing.T) {
 	assert.Equal(t, types.WorkerStatusAvailable, worker.Status)
 }
 
+func TestToggleWorkerAvailablePreservesDisabledWorker(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.Nil(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{Id: "disabled-worker", Status: types.WorkerStatusDisabled}
+	assert.Nil(t, repo.AddWorker(worker))
+	assert.Nil(t, repo.ToggleWorkerAvailable(worker.Id))
+
+	worker, err = repo.GetWorkerById(worker.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, types.WorkerStatusDisabled, worker.Status)
+}
+
 func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes agent worker recovery and S2 pagination. Workers are only made available after recovery, without re-enabling disabled workers. S2 event history now paginates correctly.

- **Bug Fixes**
  - After recovering pending container requests, the service now calls `ToggleWorkerAvailable` to move the worker back to Available and reconcile capacity.
  - `ToggleWorkerAvailable` only transitions Pending -> Available and ignores other states (e.g., Disabled). Added a test to confirm disabled workers stay disabled.
  - S2 event history: removed a premature return when batch size < count, ensuring the stream is fully read.

<sup>Written for commit d1f4cb8c2ba1aec835a20a30f87dd2568874bafb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

