### PR TITLE
Scope realtime pricing quotes by workspace

### DIFF
--- a/pkg/clients/container_cost.go
+++ b/pkg/clients/container_cost.go
@@ -43,11 +43,12 @@ type ContainerCostQuote struct {
 }
 
 type ContainerCostRequest struct {
-	Cpu      int64  `json:"cpu"`
-	Memory   int64  `json:"memory"`
-	Gpu      string `json:"gpu"`
-	GpuCount uint32 `json:"gpu_count"`
-	Sandbox  bool   `json:"sandbox"`
+	WorkspaceId string `json:"workspace_id,omitempty"`
+	Cpu         int64  `json:"cpu"`
+	Memory      int64  `json:"memory"`
+	Gpu         string `json:"gpu"`
+	GpuCount    uint32 `json:"gpu_count"`
+	Sandbox     bool   `json:"sandbox"`
 }
 
 type containerCostCacheEntry struct {
@@ -85,7 +86,7 @@ func NewContainerCostClient(config types.ContainerCostHookConfig) *ContainerCost
 	}
 }
 
-// GetContainerCostQuote caches by resources for five minutes (or valid_until).
+// GetContainerCostQuote caches by workspace and resources for five minutes (or valid_until).
 // A failed refresh returns the last good quote and retries on a later lookup.
 func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request *types.ContainerRequest) (ContainerCostQuote, error) {
 	if c == nil {
@@ -99,7 +100,8 @@ func (c *ContainerCostClient) GetContainerCostQuote(ctx context.Context, request
 	}
 
 	key := ContainerCostRequest{
-		Cpu: request.Cpu, Memory: request.Memory,
+		WorkspaceId: request.WorkspaceId,
+		Cpu:         request.Cpu, Memory: request.Memory,
 		Gpu: strings.TrimSpace(request.Gpu), GpuCount: request.GpuCount,
 		Sandbox: request.Stub.Type.Kind() == types.StubTypeSandbox,
 	}

--- a/pkg/clients/container_cost_test.go
+++ b/pkg/clients/container_cost_test.go
@@ -133,7 +133,7 @@ func TestContainerCostClientCachesByResourcesAndFallsBackToLastGoodQuote(t *test
 	}
 }
 
-func TestContainerCostClientSeparatesSandboxQuotes(t *testing.T) {
+func TestContainerCostClientSeparatesWorkspaceAndSandboxQuotes(t *testing.T) {
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -142,6 +142,9 @@ func TestContainerCostClientSeparatesSandboxQuotes(t *testing.T) {
 			t.Fatal(err)
 		}
 		cost := "0.1"
+		if request.WorkspaceId == "workspace-b" {
+			cost = "0.2"
+		}
 		if request.Sandbox {
 			cost = "0.3"
 		}
@@ -150,22 +153,25 @@ func TestContainerCostClientSeparatesSandboxQuotes(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
-	standard := &types.ContainerRequest{Cpu: 1_000, Memory: 1_024}
+	standard := &types.ContainerRequest{WorkspaceId: "workspace-a", Cpu: 1_000, Memory: 1_024}
+	otherWorkspace := &types.ContainerRequest{WorkspaceId: "workspace-b", Cpu: 1_000, Memory: 1_024}
 	sandbox := &types.ContainerRequest{
-		Cpu:    1_000,
-		Memory: 1_024,
-		Stub:   types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeSandbox)}},
+		WorkspaceId: "workspace-a",
+		Cpu:         1_000,
+		Memory:      1_024,
+		Stub:        types.StubWithRelated{Stub: types.Stub{Type: types.StubType(types.StubTypeSandbox)}},
 	}
 	standardQuote, standardErr := client.GetContainerCostQuote(context.Background(), standard)
+	otherQuote, otherErr := client.GetContainerCostQuote(context.Background(), otherWorkspace)
 	sandboxQuote, sandboxErr := client.GetContainerCostQuote(context.Background(), sandbox)
-	if standardErr != nil || sandboxErr != nil {
-		t.Fatalf("standard/sandbox quote errors = %v/%v", standardErr, sandboxErr)
+	if standardErr != nil || otherErr != nil || sandboxErr != nil {
+		t.Fatalf("standard/workspace/sandbox quote errors = %v/%v/%v", standardErr, otherErr, sandboxErr)
 	}
-	if standardQuote.CostPerMs != 0.1 || sandboxQuote.CostPerMs != 0.3 {
-		t.Fatalf("standard/sandbox quotes = %v/%v", standardQuote.CostPerMs, sandboxQuote.CostPerMs)
+	if standardQuote.CostPerMs != 0.1 || otherQuote.CostPerMs != 0.2 || sandboxQuote.CostPerMs != 0.3 {
+		t.Fatalf("standard/workspace/sandbox quotes = %v/%v/%v", standardQuote.CostPerMs, otherQuote.CostPerMs, sandboxQuote.CostPerMs)
 	}
-	if calls.Load() != 2 {
-		t.Fatalf("quote calls = %d, want separate standard and sandbox quotes", calls.Load())
+	if calls.Load() != 3 {
+		t.Fatalf("quote calls = %d, want separate workspace and sandbox quotes", calls.Load())
 	}
 }
 

--- a/pkg/worker/usage_test.go
+++ b/pkg/worker/usage_test.go
@@ -79,6 +79,9 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
+		if request.WorkspaceId != "workspace-1" {
+			t.Errorf("quote workspace = %q, want workspace-1", request.WorkspaceId)
+		}
 
 		mu.Lock()
 		quoteCalls[request]++
@@ -257,9 +260,9 @@ func TestWorkerUsageOpenMeterHTTPIntegration(t *testing.T) {
 	if !finalDurationSeen || !gpuCostSeen {
 		t.Fatalf("final/GPU flags = %t/%t", finalDurationSeen, gpuCostSeen)
 	}
-	if calls[clients.ContainerCostRequest{Cpu: 1_000, Memory: 1_024}] != 1 ||
-		calls[clients.ContainerCostRequest{Cpu: 1_000, Memory: 1_024, Gpu: "T4", GpuCount: 1}] != 1 ||
-		calls[clients.ContainerCostRequest{Cpu: 2_000, Memory: 1_024}] != 1 {
+	if calls[clients.ContainerCostRequest{WorkspaceId: "workspace-1", Cpu: 1_000, Memory: 1_024}] != 1 ||
+		calls[clients.ContainerCostRequest{WorkspaceId: "workspace-1", Cpu: 1_000, Memory: 1_024, Gpu: "T4", GpuCount: 1}] != 1 ||
+		calls[clients.ContainerCostRequest{WorkspaceId: "workspace-1", Cpu: 2_000, Memory: 1_024}] != 1 {
 		t.Fatalf("quote calls = %+v, want cache, missing retry, refresh, and final flush", calls)
 	}
 	if external.count != 5 || external.unpriced != 3 || external.invalidCost {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scope realtime pricing quotes by workspace to prevent cross-workspace cache reuse and ensure correct prices. Cache keys now include `workspace_id` alongside resources; sandbox quotes remain separate.

- **New Features**
  - Added `WorkspaceId` to `ContainerCostRequest` payload and to the in-memory cache key used by `GetContainerCostQuote`.
  - Updated tests to verify per-workspace and sandbox separation; worker usage test now asserts `workspace_id` is passed through.

<sup>Written for commit ec720110f0ade52a8b976e6f747ecf761621d09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

