### PR TITLE
Wake idle workers on request streams

### DIFF
--- a/pkg/gateway/services/repository/worker_repo.go
+++ b/pkg/gateway/services/repository/worker_repo.go
@@ -28,8 +28,9 @@ type WorkerRepositoryService struct {
 }
 
 const (
-	containerRequestPollingInterval time.Duration = 100 * time.Millisecond
-	containerRequestBatchSize                     = 128
+	containerRequestPollingInterval   = 100 * time.Millisecond
+	containerRequestHeartbeatInterval = 30 * time.Second
+	containerRequestBatchSize         = 128
 )
 
 func NewWorkerRepositoryService(ctx context.Context, workerRepo repository.WorkerRepository, containerRepo repository.ContainerRepository, backendRepo repository.BackendRepository, computeRepo repository.ComputeRepository, eventRepo repository.EventRepository, rdb *common.RedisClient, appConfig types.AppConfig, cacheCoordinatorToken string) *WorkerRepositoryService {
@@ -58,6 +59,7 @@ func (s *WorkerRepositoryService) GetNextContainerRequest(req *pb.GetNextContain
 	if err := s.workerRepo.ToggleWorkerAvailable(req.WorkerId); err != nil {
 		return err
 	}
+	heartbeatAt := time.Now().Add(containerRequestHeartbeatInterval)
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -88,6 +90,12 @@ func (s *WorkerRepositoryService) GetNextContainerRequest(req *pb.GetNextContain
 
 			if len(requests) > 0 {
 				continue
+			}
+			if time.Now().After(heartbeatAt) {
+				if err := stream.Send(&pb.GetNextContainerRequestResponse{Ok: true}); err != nil {
+					return err
+				}
+				heartbeatAt = time.Now().Add(containerRequestHeartbeatInterval)
 			}
 
 			time.Sleep(containerRequestPollingInterval)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send periodic heartbeats on idle `GetNextContainerRequest` streams to keep workers awake and reduce latency when new container requests arrive. This keeps long-lived streams alive and helps workers pick up jobs faster.

- **Performance**
  - Added a 30s heartbeat (`containerRequestHeartbeatInterval`) that sends `Ok: true` when no requests are available.
  - Maintains the 100ms polling loop; workers stay responsive without extra load.

<sup>Written for commit e3061f3552842855b291ac295ed49378682019b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

