### PR TITLE
Handle closed Redis subscription channels

### DIFF
--- a/pkg/common/key_events.go
+++ b/pkg/common/key_events.go
@@ -104,18 +104,26 @@ func (kem *KeyEventManager) listenForSubscriptionPattern(
 	go func() {
 		defer close()
 
-	retry:
 		for {
 			select {
-			case m := <-messages:
-				keyEventChan <- kem.messageToKeyEvent(patternPrefix, m.Channel, string(m.Payload))
+			case m, ok := <-messages:
+				if !ok || m == nil {
+					return
+				}
+				select {
+				case keyEventChan <- kem.messageToKeyEvent(patternPrefix, m.Channel, string(m.Payload)):
+				case <-ctx.Done():
+					return
+				}
 
 			case <-ctx.Done():
 				return
 
-			case err := <-errs:
-				log.Error().Err(err).Msg("error with key manager subscription")
-				break retry
+			case err, ok := <-errs:
+				if ok && err != nil {
+					log.Error().Err(err).Msg("error with key manager subscription")
+				}
+				return
 			}
 		}
 	}()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gracefully handle closed Redis pub/sub channels in KeyEventManager to prevent panics and goroutine leaks. The listener now exits on channel closure or context cancel, avoids blocked sends, and only logs real errors.

<sup>Written for commit 679866795ce12d31830907693ba2206589fcef43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

