### PR TITLE
Harden GeeseFS cache-through reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -331,7 +331,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.mod
+++ b/go.mod
@@ -331,7 +331,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260717025658-eebe20552a45
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,6 @@ github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd h1:qdvWIpwFIHK4
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881 h1:KZr/hTVMERLHFndxFTnQFxdyeqBDMHfVEARTog9uT34=
 github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
-github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f h1:GmawU+eW9eSjrxmb6wC47yeNqFNZNgFjYuIypAqp3ug=
-github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs v0.0.0-20260717025658-eebe20552a45 h1:r5Mt4WdG2yzeNAH3n0BBCFYxx4adrnNLNK0hvFi/lhc=
 github.com/beam-cloud/geesefs v0.0.0-20260717025658-eebe20552a45/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881 h1:KZr/hTVMERLH
 github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f h1:GmawU+eW9eSjrxmb6wC47yeNqFNZNgFjYuIypAqp3ug=
 github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260717025658-eebe20552a45 h1:r5Mt4WdG2yzeNAH3n0BBCFYxx4adrnNLNK0hvFi/lhc=
+github.com/beam-cloud/geesefs v0.0.0-20260717025658-eebe20552a45/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd h1:qdvWIpwFIHK4
 github.com/beam-cloud/geesefs v0.0.0-20260604132438-6acb73b2cebd/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881 h1:KZr/hTVMERLHFndxFTnQFxdyeqBDMHfVEARTog9uT34=
 github.com/beam-cloud/geesefs v0.0.0-20260716095427-ddd6815a3881/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f h1:GmawU+eW9eSjrxmb6wC47yeNqFNZNgFjYuIypAqp3ug=
+github.com/beam-cloud/geesefs v0.0.0-20260717011335-ddef37c9ca0f/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -300,6 +300,36 @@ func (c *Client) localServersSnapshot() []*Server {
 	return servers
 }
 
+type clientLocalStore struct {
+	store  *Store
+	source string
+}
+
+func (c *Client) preferredLocalStores() []clientLocalStore {
+	localServers := c.localServersSnapshot()
+	stores := make([]clientLocalStore, 0, len(localServers)+1)
+	seenPaths := make(map[string]struct{}, len(localServers)+1)
+	appendStore := func(store *Store, source string) {
+		if store == nil {
+			return
+		}
+		cacheDir := filepath.Clean(store.serverConfig.DiskCacheDir)
+		if cacheDir != "." {
+			if _, ok := seenPaths[cacheDir]; ok {
+				return
+			}
+			seenPaths[cacheDir] = struct{}{}
+		}
+		stores = append(stores, clientLocalStore{store: store, source: source})
+	}
+
+	for _, server := range localServers {
+		appendStore(server.cas, "local_server")
+	}
+	appendStore(c.localDiskStore, "local_disk")
+	return stores
+}
+
 func (c *Client) initLocalDiskStore(cfg Config, locality string) {
 	if cfg.Server.DiskCacheDir == "" || cfg.Server.PageSizeBytes <= 0 {
 		return
@@ -1370,6 +1400,12 @@ func (c *Client) ClientLocalPageFileViewsWithTrace(hash string, offset int64, le
 	if offset < 0 || length <= 0 {
 		return nil, trace, nil
 	}
+	if c.clientConfig.PreferLocalCacheHost {
+		if views, host, source, ok := c.clientLocalPageFileViewsFromPreferredStores(hash, offset, length); ok {
+			trace.addAttempt(-1, host, source, "hit", int64(len(views)), time.Since(started), nil)
+			return views, trace, nil
+		}
+	}
 
 	host, err := c.getSelectedHostForRequest(ClientRequestTypeRetrieval, hash, opts.RoutingKey)
 	if err != nil {
@@ -1392,6 +1428,21 @@ func (c *Client) ClientLocalPageFileViewsWithTrace(hash string, offset int64, le
 	trace.addAttempt(0, host, "client_local_page_file", "miss", 0, time.Since(started), ErrContentNotFound)
 	atomic.AddInt64(&cachePathStats.clientLocalPageFileMisses, 1)
 	return nil, trace, ErrContentNotFound
+}
+
+func (c *Client) clientLocalPageFileViewsFromPreferredStores(hash string, offset int64, length int64) ([]ClientLocalPageFileView, *Host, string, bool) {
+	for _, candidate := range c.preferredLocalStores() {
+		if !candidate.store.Exists(hash) {
+			continue
+		}
+		if views, ok := clientLocalPageFileViewsFromStore(candidate.store, hash, offset, length); ok {
+			cacheReadClientLocalPageFileTotal.Inc()
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileHits, 1)
+			atomic.AddInt64(&cachePathStats.clientLocalPageFileBytes, length)
+			return views, candidate.store.currentHost, candidate.source + "_page_file", true
+		}
+	}
+	return nil, nil, "", false
 }
 
 func (c *Client) clientLocalPageFileViewsFromHost(host *Host, hash string, offset int64, length int64) ([]ClientLocalPageFileView, string, bool) {
@@ -1485,6 +1536,11 @@ func (c *Client) ReadContentIntoWithTrace(ctx context.Context, hash string, offs
 	}()
 	atomic.AddInt64(&cachePathStats.clientReadIntoRequests, 1)
 	atomic.AddInt64(&cachePathStats.clientReadIntoBytes, length)
+	if c.clientConfig.PreferLocalCacheHost {
+		if n, ok := c.readContentIntoFromPreferredLocalStores(hash, offset, dst, &trace); ok {
+			return n, trace, nil
+		}
+	}
 
 	if n, err := c.tryReadContentIntoKnownHosts(ctx, hash, offset, dst, opts, &trace); err == nil {
 		return n, trace, nil
@@ -1494,6 +1550,25 @@ func (c *Client) ReadContentIntoWithTrace(ctx context.Context, hash string, offs
 
 	read, err = c.readContentIntoAfterHostRefresh(ctx, hash, offset, dst, opts, &trace)
 	return read, trace, err
+}
+
+func (c *Client) readContentIntoFromPreferredLocalStores(hash string, offset int64, dst []byte, trace *OperationTrace) (int64, bool) {
+	length := int64(len(dst))
+	for _, candidate := range c.preferredLocalStores() {
+		if !candidate.store.Exists(hash) {
+			continue
+		}
+		started := time.Now()
+		n, err := candidate.store.ReadAt(hash, offset, dst)
+		trace.addAttempt(-1, candidate.store.currentHost, candidate.source, operationTraceReadResult(err, n, length), n, time.Since(started), err)
+		if err == nil && n == length {
+			cacheReadLocalTotal.Inc()
+			atomic.AddInt64(&cachePathStats.clientLocalHits, 1)
+			return n, true
+		}
+		atomic.AddInt64(&cachePathStats.clientLocalMisses, 1)
+	}
+	return 0, false
 }
 
 func shouldRefreshReadContentIntoHosts(err error) bool {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -967,6 +967,74 @@ func TestContentReadsKeepSelectedHostRoutingWhenLocalPreferenceDisabled(t *testi
 	require.Empty(t, views)
 }
 
+func TestContentReadsFallBackWhenMaterializedLocalContentIsIncomplete(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        5,
+			ObjectTtlS:           300,
+		},
+		Client: ClientConfig{NTopHosts: 1, PreferLocalCacheHost: true},
+		Global: GlobalConfig{
+			GRPCMessageSizeBytes: 1024 * 1024,
+			GRPCDialTimeoutS:     1,
+		},
+	}
+
+	remoteServer, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	remoteAddr, err := remoteServer.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, remoteServer.Close()) }()
+
+	content := []byte("complete-content-from-remote")
+	hash, _, err := remoteServer.cas.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	localStore := newTestStore(t, cfg.Server.PageSizeBytes)
+	localHash, _, err := localStore.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+	require.Equal(t, hash, localHash)
+	require.NoError(t, os.Remove(localStore.pagePath(hash, 0)))
+
+	localStore.currentHost = &Host{HostId: "local-host", NodeID: "node-a"}
+	remoteHost := remoteServer.Host()
+	require.NotNil(t, remoteHost)
+	remoteHost.Addr = remoteAddr
+	remoteHost.PrivateAddr = remoteAddr
+
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          cfg.Client,
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	client.AttachLocalServer(&Server{cas: localStore})
+	require.NoError(t, client.addHost(remoteHost))
+	defer client.Cleanup()
+
+	dst := make([]byte, len(content))
+	n, trace, err := client.ReadContentIntoWithTrace(ctx, hash, 0, dst, ClientOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+	require.GreaterOrEqual(t, len(trace.Attempts), 2)
+	require.Equal(t, "local_server", trace.Attempts[0].Source)
+	require.Equal(t, "miss", trace.Attempts[0].Result)
+	require.Equal(t, "remote-host", trace.Attempts[1].HostID)
+}
+
 func TestContentReadHotPathDoesNotUseCacheFSMetadata(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("local-cache-content")

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -889,6 +889,84 @@ func TestReadContentIntoUsesSelectedLocalServer(t *testing.T) {
 	require.Equal(t, content, dst)
 }
 
+func TestContentReadsPreferMaterializedLocalContentOverSelectedRemoteHost(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("materialized-local-content")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	localHost := &Host{HostId: "local-host", NodeID: "node-a"}
+	remoteHost := &Host{HostId: "remote-host", NodeID: "node-b", Addr: "remote.invalid:443"}
+	store.currentHost = localHost
+	client := &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1, PreferLocalCacheHost: true},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	client.AttachLocalServer(&Server{cas: store})
+
+	dst := make([]byte, len(content))
+	n, readTrace, err := client.ReadContentIntoWithTrace(context.Background(), hash, 0, dst, ClientOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+	require.Len(t, readTrace.Attempts, 1)
+	require.Equal(t, "local_server", readTrace.Attempts[0].Source)
+	require.Equal(t, "local-host", readTrace.Attempts[0].HostID)
+	require.Equal(t, -1, readTrace.Attempts[0].HostIndex)
+
+	views, pageTrace, err := client.ClientLocalPageFileViewsWithTrace(hash, 0, int64(len(content)), ClientOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, views)
+	require.Len(t, pageTrace.Attempts, 1)
+	require.Equal(t, "local_server_page_file", pageTrace.Attempts[0].Source)
+	require.Equal(t, "local-host", pageTrace.Attempts[0].HostID)
+	require.Equal(t, -1, pageTrace.Attempts[0].HostIndex)
+
+	require.NoError(t, os.Remove(store.completeMarkerPath(hash)))
+	_, err = client.ReadContentInto(context.Background(), hash, 0, make([]byte, len(content)), ClientOptions{})
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+	views, err = client.ClientLocalPageFileViews(hash, 0, int64(len(content)), ClientOptions{})
+	require.ErrorIs(t, err, ErrContentNotFound)
+	require.Empty(t, views)
+}
+
+func TestContentReadsKeepSelectedHostRoutingWhenLocalPreferenceDisabled(t *testing.T) {
+	store := newTestStore(t, 5)
+	content := []byte("materialized-local-content")
+	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
+	require.NoError(t, err)
+
+	localHost := &Host{HostId: "local-host", NodeID: "node-a"}
+	remoteHost := &Host{HostId: "remote-host", NodeID: "node-b"}
+	store.currentHost = localHost
+	client := &Client{
+		ctx:                   context.Background(),
+		clientConfig:          ClientConfig{NTopHosts: 1},
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{remoteHost}},
+		maxGetContentAttempts: 1,
+	}
+	client.AttachLocalServer(&Server{cas: store})
+
+	_, err = client.ReadContentInto(context.Background(), hash, 0, make([]byte, len(content)), ClientOptions{})
+	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+
+	views, err := client.ClientLocalPageFileViews(hash, 0, int64(len(content)), ClientOptions{})
+	require.ErrorIs(t, err, ErrContentNotFound)
+	require.Empty(t, views)
+}
+
 func TestContentReadHotPathDoesNotUseCacheFSMetadata(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("local-cache-content")


### PR DESCRIPTION
## What changed

- pin the GeeseFS staged-generation and bounded-listing fixes from beam-cloud/geesefs#19
- prefer fully materialized content from a physical local cache store before rendezvous-selected remote hosts
- preserve existing replica/origin fallback when local content is incomplete, evicted, or unavailable
- add trace attribution and focused fallback coverage

## Why

Required-content reconciliation deliberately materializes recent image and checkpoint content on each relevant worker. Reads still followed rendezvous ownership even when a verified local copy existed, which could reintroduce network reads. Local presence is now an advisory fast path guarded by the atomic completion marker; routing and scheduler eligibility are unchanged.

## Staging results

- 3.09 GB cached model read: 1.34s, about 2.2 GB/s
- packet capture: no object-store traffic during the model read
- nested Hugging Face glob: 0.72s, down from roughly 34s
- generic checkpoint restore: 1.19s worker-side, 1.58s externally
- Qwen checkpoint restore and `/v1/models`: 12.89s worker-side, 13.24s externally
- valid post-restore chat completion: 0.45s
- build/index path retained: 34 layers / 17.54 GiB indexed in 0.3s with 32 cached layers

## Validation

- `go test ./pkg/cache -count=1`
- `go test -race ./pkg/cache -count=1`
- `go test ./pkg/storage -count=1`
- `go test ./pkg/worker -run '^$' -count=1`
- Beta9 CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer fully materialized local cache content for GeeseFS reads to cut network I/O, while preserving fallback to replicas/origin when local data is incomplete or missing. Pins `github.com/yandex-cloud/geesefs` to the `github.com/beam-cloud/geesefs` fork with staged-generation safety and bounded-listing fixes.

- **New Features**
  - Add a local-fast-path for `ReadContentInto` and page-file views that checks local servers and `localDiskStore` first when `PreferLocalCacheHost` is enabled.
  - Use the atomic completion marker to ensure only fully materialized content is served locally; otherwise, fall back to the rendezvous-selected host.
  - Add trace attribution for local hits; routing and scheduler eligibility remain unchanged.

- **Dependencies**
  - Replace `github.com/yandex-cloud/geesefs` with `github.com/beam-cloud/geesefs` to pick up staged-generation and bounded-listing fixes.

<sup>Written for commit 15e52e0a3f0e1b3730160c092bc71c94991db1c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

