### PR TITLE
bump sdk

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.258"
+version = "0.1.261"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/cli/machine.py
+++ b/sdk/src/beta9/cli/machine.py
@@ -61,27 +61,61 @@ def _cheapest_offers_by_gpu(offers: Sequence[PoolOffer]) -> Dict[str, PoolOffer]
     return cheapest
 
 
+def _section_header(text: str) -> str:
+    return f"[bold {terminal.BRAND_COLOR}]=> {text}[/bold {terminal.BRAND_COLOR}]"
+
+
 def _machine_list_renderables(
     res: ListMachinesResponse,
     offers: Optional[Sequence[PoolOffer]],
 ) -> List[Any]:
     renderables: List[Any] = [
+        _section_header("GPU inventory"),
         gpu_inventory_table(
             res.gpus,
             res.supported_gpus,
             _cheapest_offers_by_gpu(offers or []),
             offers_available=offers is not None,
         ),
+        "",
+        _section_header("Your machines"),
     ]
-    renderables.append("")
     if res.machines:
-        renderables.append(machine_table(res.machines, title="Your machines"))
+        renderables.append(machine_table(res.machines))
     else:
-        renderables.append(
-            f"[bold {terminal.BRAND_COLOR}]Your machines[/bold {terminal.BRAND_COLOR}]\n"
-            "[dim]  none yet — try 'beta9 machine reserve --gpu <type>'[/dim]"
-        )
+        renderables.append("[dim]  none yet — try 'beta9 machine reserve --gpu <type>'[/dim]")
     return renderables
+
+
+def _fetch_offers_quiet(service: ServiceClient) -> List[PoolOffer]:
+    """Fetch offers without any decorative output, for JSON consumers."""
+    from ..clients.gateway import ListPoolOffersRequest, PoolConfig
+
+    res = service.gateway.list_pool_offers(ListPoolOffersRequest(pool=PoolConfig()))
+    return list(res.offers) if res.ok else []
+
+
+def _inventory_json(
+    res: ListMachinesResponse, offers: Optional[Sequence[PoolOffer]]
+) -> List[Dict[str, Any]]:
+    cheapest = _cheapest_offers_by_gpu(offers or [])
+    inventory = []
+    for gpu_type in sorted(set(res.gpus) | set(res.supported_gpus) | set(cheapest)):
+        if res.gpus.get(gpu_type):
+            serverless = "ready"
+        elif res.supported_gpus.get(gpu_type):
+            serverless = "available"
+        else:
+            serverless = "none"
+        offer = cheapest.get(gpu_type)
+        inventory.append(
+            {
+                "gpu": gpu_type,
+                "serverless": serverless,
+                "on_demand": offer.to_dict(casing=Casing.SNAKE) if offer else None,  # type: ignore
+            }
+        )
+    return inventory
 
 
 @management.command(
@@ -142,10 +176,13 @@ def list_machines(
         terminal.error(res.err_msg)
 
     if format == "json":
+        offers = _fetch_offers_quiet(service) if show_offers else []
         machines = [d.to_dict(casing=Casing.SNAKE) for d in res.machines]  # type:ignore
-        res.gpus = {gpu: res.gpus[gpu] for gpu in sorted(res.gpus)}
         terminal.print_json(
-            {"machines": machines, "gpus": res.gpus, "supported_gpus": res.supported_gpus}
+            {
+                "inventory": _inventory_json(res, offers),
+                "machines": machines,
+            }
         )
         return
 

--- a/sdk/src/beta9/cli/machine_format.py
+++ b/sdk/src/beta9/cli/machine_format.py
@@ -50,16 +50,14 @@ def gpu_inventory_table(
 
     caption = None
     if hidden > 0:
-        caption = f"{hidden} more GPU types · no capacity"
+        # Leading pad keeps the caption aligned with the table's cell content.
+        caption = f"  {hidden} more GPU types · no capacity"
 
     table = Table(
         Column("GPU", no_wrap=True),
         Column("Serverless", no_wrap=True),
         Column("On-demand", justify="right", no_wrap=True),
         box=box.SIMPLE,
-        title="GPU inventory",
-        title_justify="left",
-        title_style=f"bold {terminal.BRAND_COLOR}",
         caption=caption,
         caption_justify="left",
         caption_style="dim",
@@ -73,7 +71,7 @@ def gpu_inventory_table(
     return table
 
 
-def machine_table(machines: Sequence[Machine], title: str = "") -> Table:
+def machine_table(machines: Sequence[Machine]) -> Table:
     table = Table(
         Column("ID", no_wrap=True),
         Column("Pool"),
@@ -83,9 +81,6 @@ def machine_table(machines: Sequence[Machine], title: str = "") -> Table:
         Column("Last seen"),
         Column("Agent"),
         box=box.SIMPLE,
-        title=title or None,
-        title_justify="left",
-        title_style=f"bold {terminal.BRAND_COLOR}",
     )
     for machine in machines:
         table.add_row(
@@ -117,6 +112,13 @@ def format_memory(memory_mb: int) -> str:
     return f"{memory_mb}MiB"
 
 
+def format_memory_pair(free_mb: int, total_mb: int) -> str:
+    """Compact free/total memory in the total's unit: 34.7/64.0GiB."""
+    if total_mb >= 1024:
+        return f"{free_mb / 1024:.1f}/{total_mb / 1024:.1f}GiB"
+    return f"{free_mb}/{total_mb}MiB"
+
+
 def format_gpu(gpu: str, gpu_count: int = 0) -> str:
     if not gpu:
         return "-"
@@ -133,7 +135,7 @@ def machine_capacity(machine: Machine) -> str:
         parts.append(format_memory(machine.memory))
     if machine.gpu:
         parts.append(format_gpu(machine.gpu, machine.gpu_count))
-    return "\n".join(parts) or "-"
+    return " · ".join(parts) or "-"
 
 
 def machine_load(machine: Machine) -> str:
@@ -147,7 +149,7 @@ def machine_load(machine: Machine) -> str:
         workers = "worker" if metrics.worker_count == 1 else "workers"
         containers = "container" if metrics.container_count == 1 else "containers"
         parts.append(f"{metrics.worker_count} {workers} · {metrics.container_count} {containers}")
-    return "\n".join(parts) or "-"
+    return " · ".join(parts) or "-"
 
 
 def machine_status(status: str) -> str:

--- a/sdk/src/beta9/cli/worker.py
+++ b/sdk/src/beta9/cli/worker.py
@@ -10,7 +10,7 @@ from ..cli import extraclick
 from ..clients.gateway import ListWorkersRequest, ListWorkersResponse
 from ..clients.types import Worker
 from .extraclick import ClickCommonGroup, ClickManagementGroup
-from .machine_format import format_memory
+from .machine_format import format_memory_pair
 from .worker_management import apply_worker_action, worker_ids_from_args
 
 
@@ -54,14 +54,18 @@ def _worker_matches_state(worker: Worker, state: str) -> bool:
     return worker.status == state
 
 
-def _worker_resources(worker: Worker) -> str:
-    parts = [
-        f"{worker.free_cpu / 1000:g}/{worker.total_cpu / 1000:g} CPU",
-        f"{format_memory(worker.free_memory)}/{format_memory(worker.total_memory)}",
-    ]
-    if worker.gpu or worker.total_gpu_count:
-        parts.append(f"{worker.free_gpu_count}/{worker.total_gpu_count} {worker.gpu or 'GPU'}")
-    return "\n".join(parts)
+def _worker_cpu(worker: Worker) -> str:
+    return f"{worker.free_cpu / 1000:g}/{worker.total_cpu / 1000:g}"
+
+
+def _worker_memory(worker: Worker) -> str:
+    return format_memory_pair(worker.free_memory, worker.total_memory)
+
+
+def _worker_gpu(worker: Worker) -> str:
+    if not worker.gpu and not worker.total_gpu_count:
+        return "-"
+    return f"{worker.free_gpu_count}/{worker.total_gpu_count} {worker.gpu or 'GPU'}"
 
 
 def _worker_version(worker: Worker) -> str:
@@ -133,12 +137,14 @@ def list_workers(
 
     table = Table(
         Column("ID", no_wrap=True),
-        Column("Pool"),
-        Column("State"),
-        Column("Machine"),
-        Column("Free / total", no_wrap=True),
-        Column("Ctrs", justify="right"),
-        Column("Version"),
+        Column("Pool", no_wrap=True),
+        Column("State", no_wrap=True),
+        Column("Machine", no_wrap=True),
+        Column("CPU", justify="right", no_wrap=True),
+        Column("Memory", justify="right", no_wrap=True),
+        Column("GPU", no_wrap=True),
+        Column("Containers", justify="right"),
+        Column("Version", no_wrap=True),
         box=box.SIMPLE,
     )
     for worker in workers:
@@ -147,12 +153,15 @@ def list_workers(
             worker.pool_name or "-",
             _worker_state(worker),
             worker.machine_id or "-",
-            _worker_resources(worker),
+            _worker_cpu(worker),
+            _worker_memory(worker),
+            _worker_gpu(worker),
             str(len(worker.active_containers)),
             _worker_version(worker),
         )
     table.add_section()
-    table.add_row(f"[bold]{len(workers)} items")
+    count, suffix = terminal.pluralize(workers, "s")
+    table.add_row(f"[bold]{count} worker{suffix}")
     terminal.print(table)
 
 

--- a/sdk/tests/test_machine_cli.py
+++ b/sdk/tests/test_machine_cli.py
@@ -82,7 +82,7 @@ def test_gpu_inventory_collapses_empty_gpu_types():
     assert "H100" not in text
     # Hidden GPU types are summarized in the caption, not table rows (long
     # row text would stretch the GPU column).
-    assert table.caption == "2 more GPU types · no capacity"
+    assert table.caption.strip() == "2 more GPU types · no capacity"
 
 
 def test_release_candidates_skips_empty_pools():
@@ -118,6 +118,35 @@ def test_release_options_show_gpu_machines_and_expiry():
 
 def test_release_expiry_handles_missing_expiration():
     assert _release_expiry(PrivatePool(name="p")) == "manual release"
+
+
+def test_inventory_json_shape():
+    from beta9.cli.machine import _inventory_json
+
+    res = ListMachinesResponse(
+        ok=True,
+        gpus={"T4": True},
+        supported_gpus={"T4": True, "A10G": True, "H100": False},
+    )
+    offers = [PoolOffer(id="o1", provider="vast", gpu="A6000", hourly_cost_micros=550_000)]
+
+    inventory = _inventory_json(res, offers)
+    by_gpu = {entry["gpu"]: entry for entry in inventory}
+
+    assert by_gpu["T4"]["serverless"] == "ready"
+    assert by_gpu["A10G"]["serverless"] == "available"
+    assert by_gpu["H100"]["serverless"] == "none"
+    assert by_gpu["A6000"]["serverless"] == "none"
+    assert by_gpu["A6000"]["on_demand"]["id"] == "o1"
+    assert by_gpu["T4"]["on_demand"] is None
+
+
+def test_format_memory_pair_uses_single_unit():
+    from beta9.cli.machine_format import format_memory_pair
+
+    assert format_memory_pair(35533, 65536) == "34.7/64.0GiB"
+    assert format_memory_pair(0, 81920) == "0.0/80.0GiB"
+    assert format_memory_pair(256, 512) == "256/512MiB"
 
 
 def test_cheapest_offers_by_gpu_picks_lowest_price():

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "beta9"
-version = "0.1.258"
+version = "0.1.260"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve machine and worker CLI output and JSON shape, and bump the `beta9` SDK version. The machine list now returns a structured inventory for JSON consumers and clearer tables for humans.

- New Features
  - Machine list: adds section headers and a compact layout for capacity/load.
  - JSON output: returns inventory entries with serverless state and cheapest on-demand offer per GPU.
  - Worker list: splits resources into CPU, Memory, and GPU columns; adds a concise footer count.

- Migration
  - CLI JSON change: machine list now returns { inventory, machines } instead of gpus/supported_gpus. Update any parsers to read inventory entries (gpu, serverless, on_demand).

<sup>Written for commit 9d111e3367dc73eaf0fecba3fa7c91c2a64e6b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

