### PR TITLE
bump sdk again

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
 ]
 name = "beta9"
-version = "0.1.261"
+version = "0.1.262"
 description = ""
 
 [project.scripts]

--- a/sdk/src/beta9/abstractions/base/runner.py
+++ b/sdk/src/beta9/abstractions/base/runner.py
@@ -319,7 +319,12 @@ class RunnerAbstraction(BaseAbstraction):
         if not res.ok:
             return terminal.error("Failed to get invocation URL", exit=False)
 
-        if self.ports or "<PORT>" in res.url or self.tcp:
+        if "<PORT>" in res.url and not self.ports:
+            # The URL is port-templated but no ports were declared: nothing
+            # is actually exposed, so there is no endpoint to print.
+            return res
+
+        if self.ports or self.tcp:
             terminal.header("Exposed endpoints\n")
 
             if self.tcp:

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "beta9"
-version = "0.1.260"
+version = "0.1.261"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped `beta9` SDK to v0.1.262 and fixed invocation snippet output to avoid listing endpoints when none are exposed.

- **Bug Fixes**
  - If the URL is port-templated ("<PORT>") and no ports are declared, return the URL without printing "Exposed endpoints"; only show endpoints when `ports` or `tcp` are set.

<sup>Written for commit e3b09dd12874c0f8cb51aada0ac88ac30946505b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

