### PR TITLE
fix token persistence

### DIFF
--- a/pkg/gateway/services/compute/agent.go
+++ b/pkg/gateway/services/compute/agent.go
@@ -182,8 +182,11 @@ func (s *Service) commitPrivateAgentJoin(ctx context.Context, token *model.JoinT
 		if pool == nil {
 			return errors.New("pool no longer exists")
 		}
-		if pool.CreatedAt.IsZero() || token.PoolCreatedAt.IsZero() || !pool.CreatedAt.Equal(token.PoolCreatedAt) {
-			return errors.New("join token is invalid or expired")
+		// Reject tokens minted for a previous incarnation of the pool. Only
+		// compare when both timestamps exist: legacy tokens carry a zero value
+		// and rejecting them bricked already-provisioned machines on deploy.
+		if !token.PoolCreatedAt.IsZero() && !pool.CreatedAt.IsZero() && !pool.CreatedAt.Equal(token.PoolCreatedAt) {
+			return errors.New("join token was issued for a previous instance of this pool")
 		}
 		agent.Mode = firstNonEmpty(token.Mode, pool.Mode)
 		agent.MarketplaceListingID = firstNonEmpty(token.MarketplaceListingID, pool.MarketplaceListingID)

--- a/pkg/gateway/services/compute/compute_test.go
+++ b/pkg/gateway/services/compute/compute_test.go
@@ -166,8 +166,46 @@ func TestPrivatePoolJoinTokenCannotJoinRecreatedPool(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if joined.Ok || joined.ErrMsg != "join token is invalid or expired" {
+	if joined.Ok || joined.ErrMsg != "join token was issued for a previous instance of this pool" {
 		t.Fatalf("JoinAgent() response = %+v", joined)
+	}
+}
+
+// Legacy tokens predate PoolCreatedAt; rejecting their zero value stranded
+// machines provisioned right before a deploy.
+func TestPrivatePoolJoinTokenWithoutPoolCreatedAtStillJoins(t *testing.T) {
+	createdAt := time.Now().UTC()
+	repo := &fakeComputeRepo{pools: map[string][]*model.PoolState{
+		"workspace-1": {{
+			WorkspaceID: "workspace-1",
+			Name:        "pool-1",
+			Mode:        string(types.PoolModePrivate),
+			Config:      &pb.PoolConfig{Name: "pool-1", Mode: string(types.PoolModePrivate)},
+			CreatedAt:   createdAt,
+		}},
+	}}
+	repo.joinTokens = map[string]*model.JoinTokenState{
+		hashComputeToken("legacy-token"): {
+			TokenHash:   hashComputeToken("legacy-token"),
+			WorkspaceID: "workspace-1",
+			PoolName:    "pool-1",
+			// No PoolCreatedAt: minted by a build that predates the field.
+		},
+	}
+	service := &Service{computeRepo: repo}
+
+	joined, err := service.JoinAgent(context.Background(), &pb.JoinAgentRequest{
+		JoinToken:          "legacy-token",
+		MachineFingerprint: "fingerprint-1",
+		CpuCount:           4,
+		MemoryMb:           8192,
+		Schedulable:        true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !joined.Ok {
+		t.Fatalf("JoinAgent() rejected a legacy token: %+v", joined)
 	}
 }
 

--- a/pkg/gateway/services/compute/launch.go
+++ b/pkg/gateway/services/compute/launch.go
@@ -164,7 +164,9 @@ func (s *Service) launchPoolCapacityLocked(ctx context.Context, workspaceID, act
 			}
 			machineID := model.ManagedMachineID(workspaceID, pool.Name, machineSeed)
 			nodeName := model.ManagedNodeName(workspaceID, pool.Name, machineID)
-			bootstrapCommand, registrationToken, _, err := s.createPrivatePoolJoinCommandForWorkspace(ctx, workspaceID, pool.Name, poolCreatedAt, "", machineID)
+
+			// Persistent: provider boot times routinely exceed any fixed TTL.
+			bootstrapCommand, registrationToken, err := s.createPersistentPrivatePoolJoinCommandForWorkspace(ctx, workspaceID, pool.Name, poolCreatedAt, machineID)
 			if err != nil {
 				return cleanupLaunchFailure("bootstrap_failed", err), nil
 			}
@@ -414,6 +416,8 @@ func launchPoolError(code, msg string, decision billingDecision) *pb.LaunchPoolC
 func (s *Service) compensatePoolLaunchFailure(ctx context.Context, workspaceID, poolName string, previous *model.PoolState, vendors map[string]model.Vendor, reservations []model.Reservation, cause error) error {
 	failures := []string{}
 	for _, reservation := range reservations {
+		// Rolled-back reservations must not leave live registration tokens.
+		s.revokeReservationJoinToken(ctx, &reservation)
 		vendor := vendors[reservation.Provider]
 		if vendor == nil {
 			failures = append(failures, fmt.Sprintf("vendor %q is not configured", reservation.Provider))

--- a/pkg/gateway/services/compute/reconcile.go
+++ b/pkg/gateway/services/compute/reconcile.go
@@ -764,6 +764,8 @@ func (s *Service) terminateReservation(ctx context.Context, workspaceID string, 
 	if reservation.Status == model.ReservationDeleted || reservation.Status == model.ReservationFailed {
 		return false
 	}
+	// Registration tokens are persistent; kill them whenever a reservation closes.
+	s.revokeReservationJoinToken(ctx, reservation)
 	vendor := vendors[reservation.Provider]
 	if vendor == nil {
 		reservation.Status = model.ReservationTerminating

--- a/pkg/gateway/services/compute/tokens.go
+++ b/pkg/gateway/services/compute/tokens.go
@@ -98,10 +98,24 @@ func (s *Service) createPrivatePoolJoinCommandForWorkspace(ctx context.Context, 
 	if err != nil {
 		return "", "", time.Time{}, err
 	}
+	return s.joinCommandForToken(token), token, expiresAt, nil
+}
+
+// Non-expiring machine-scoped join command for provider launches: boot time is
+// unbounded, so safety comes from machine/fingerprint scoping and revocation
+// on reservation close rather than a TTL.
+func (s *Service) createPersistentPrivatePoolJoinCommandForWorkspace(ctx context.Context, workspaceID, poolName string, poolCreatedAt time.Time, machineID string) (string, string, error) {
+	token, _, err := s.createPersistentPrivatePoolJoinToken(ctx, workspaceID, poolName, poolCreatedAt, machineID)
+	if err != nil {
+		return "", "", err
+	}
+	return s.joinCommandForToken(token), token, nil
+}
+
+func (s *Service) joinCommandForToken(token string) string {
 	gatewayURL := strings.TrimRight(s.appConfig.GatewayService.HTTP.GetExternalURL(), "/")
 	devMode := isLocalGatewayURL(gatewayURL)
-	command := agentInstallCommand(gatewayURL, token, devMode, agentWorkerImage(s.appConfig))
-	return command, token, expiresAt, nil
+	return agentInstallCommand(gatewayURL, token, devMode, agentWorkerImage(s.appConfig))
 }
 
 func agentInstallCommand(gatewayURL, token string, devMode bool, workerImage string) string {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make private pool join tokens persistent and machine-scoped to handle long provider boot times. Revoke tokens on reservation close or rollback, and keep legacy tokens (without `PoolCreatedAt`) working.

- Bug Fixes
  - Use non-expiring, machine-scoped tokens in `launchPoolCapacityLocked`; replaces TTL-based token path.
  - Revoke reservation tokens in `terminateReservation` and during launch rollback.
  - Accept legacy tokens with zero `PoolCreatedAt`; compare timestamps only when both exist.
  - Clarify error: "join token was issued for a previous instance of this pool."
  - Add tests for legacy token acceptance and the new error.

- Refactors
  - Add `createPersistentPrivatePoolJoinCommandForWorkspace()` and `joinCommandForToken()`.
  - Update call sites to use the persistent join command.

<sup>Written for commit 4b0dca51e15bc2d1ad2b05b95a3c0f885b9de3de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

