### PR TITLE
Fix pod proxy shutdown retirement race

### DIFF
--- a/pkg/abstractions/pod/instance.go
+++ b/pkg/abstractions/pod/instance.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -17,6 +18,26 @@ type podInstance struct {
 	*abstractions.AutoscaledInstance
 	buffer                    *PodProxyBuffer
 	durableDiskPlacementRepos abstractions.DurableDiskPlacementRepos
+}
+
+func (i *podInstance) ConsumeContainerEvent(event types.ContainerEvent) {
+	i.AutoscaledInstance.ConsumeContainerEvent(event)
+	if i.buffer == nil || i.ContainerRepo == nil || event.ContainerId == "" {
+		return
+	}
+	if event.Change < 0 {
+		i.buffer.retireAvailableContainer(event.ContainerId)
+		return
+	}
+
+	state, err := i.ContainerRepo.GetContainerState(event.ContainerId)
+	if err != nil {
+		i.buffer.signalDiscovery()
+		return
+	}
+	if state.Status == types.ContainerStatusStopping {
+		i.buffer.retireAvailableContainer(event.ContainerId)
+	}
 }
 
 func (i *podInstance) ensureReadyForRequest() error {
@@ -44,7 +65,14 @@ func (i *podInstance) ensureReadyForRequest() error {
 		return nil
 	}
 
-	return i.HandleScalingEvent(desiredContainers)
+	err = i.HandleScalingEvent(desiredContainers)
+	if common.IsRedisLockNotObtained(err) {
+		if i.Autoscaler != nil {
+			i.Autoscaler.Trigger()
+		}
+		return nil
+	}
+	return err
 }
 
 func (i *podInstance) startContainers(containersToRun int) error {
@@ -176,22 +204,53 @@ func (i *podInstance) stopContainers(containersToStop int) error {
 		return err
 	}
 
-	for c := 0; c < containersToStop && len(containerIds) > 0; c++ {
+	stopped := 0
+	for stopped < containersToStop && len(containerIds) > 0 {
 		idx := rnd.Intn(len(containerIds))
 		containerId := containerIds[idx]
+		containerIds = append(containerIds[:idx], containerIds[idx+1:]...)
+
+		if !i.retireContainerForStop(containerId) {
+			continue
+		}
 
 		err := i.Scheduler.Stop(&types.StopContainerArgs{ContainerId: containerId, Force: true, Reason: types.StopContainerReasonScheduler})
 		if err != nil {
+			if i.buffer != nil {
+				i.buffer.cancelContainerRetirement(containerId)
+			}
 			log.Error().Str("instance_name", i.Name).Err(err).Msg("unable to stop container")
 			return err
 		}
-
-		// Remove the containerId from the containerIds slice to avoid
-		// sending multiple stop requests to the same container
-		containerIds = append(containerIds[:idx], containerIds[idx+1:]...)
+		stopped++
 	}
 
 	return nil
+}
+
+func (i *podInstance) retireContainerForStop(containerId string) bool {
+	if i.buffer == nil {
+		return true
+	}
+
+	// Retire the proxy route before stopping the backend so a new request is
+	// queued for a replacement instead of reusing an idle connection.
+	i.buffer.retireAvailableContainer(containerId)
+	if !i.IsActive {
+		return true
+	}
+	if i.buffer.containerConnectionCount(containerId) > 0 {
+		i.buffer.cancelContainerRetirement(containerId)
+		return false
+	}
+
+	connections, err := i.buffer.sharedContainerConnectionCount(containerId)
+	if err != nil || connections > 0 {
+		i.buffer.cancelContainerRetirement(containerId)
+		return false
+	}
+
+	return true
 }
 
 func (i *podInstance) stoppableContainers() ([]string, error) {

--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -114,6 +114,7 @@ type PodProxyBuffer struct {
 	tsConfig                types.TailscaleConfig
 	availableContainers     []container
 	availableContainersLock sync.RWMutex
+	retiringContainers      map[string]struct{}
 	totalConnections        atomic.Int64
 	containerConnections    sync.Map
 	pendingKeepWarmLocks    sync.Map
@@ -853,6 +854,39 @@ func (pb *PodProxyBuffer) removeAvailableContainer(containerID string) {
 	}
 }
 
+func (pb *PodProxyBuffer) retireAvailableContainer(containerID string) {
+	if containerID == "" {
+		return
+	}
+
+	pb.availableContainersLock.Lock()
+	if pb.retiringContainers == nil {
+		pb.retiringContainers = make(map[string]struct{})
+	}
+	pb.retiringContainers[containerID] = struct{}{}
+	available := make([]container, 0, len(pb.availableContainers))
+	for _, candidate := range pb.availableContainers {
+		if candidate.id != containerID {
+			available = append(available, candidate)
+		}
+	}
+	pb.availableContainers = available
+	pb.availableContainersLock.Unlock()
+
+	pb.pruneBackendTransports(available)
+}
+
+func (pb *PodProxyBuffer) cancelContainerRetirement(containerID string) {
+	if containerID == "" {
+		return
+	}
+
+	pb.availableContainersLock.Lock()
+	delete(pb.retiringContainers, containerID)
+	pb.availableContainersLock.Unlock()
+	pb.signalDiscovery()
+}
+
 func (pb *PodProxyBuffer) recordQueuedRequestWait(conn *connection, protocol string) {
 	if conn.enqueuedAt.IsZero() {
 		return
@@ -1037,10 +1071,12 @@ func (pb *PodProxyBuffer) discoverContainers() {
 		containerStates, err := pb.containerRepo.GetActiveContainersByStubId(pb.stubId)
 		if err == nil {
 
+			activeContainerIDs := make(map[string]struct{}, len(containerStates))
 			var wg sync.WaitGroup
 			availableContainersChan := make(chan container, len(containerStates))
 
 			for _, containerState := range containerStates {
+				activeContainerIDs[containerState.ContainerId] = struct{}{}
 				wg.Add(1)
 
 				go func(cs types.ContainerState) {
@@ -1087,11 +1123,7 @@ func (pb *PodProxyBuffer) discoverContainers() {
 				return availableContainers[i].connections < availableContainers[j].connections
 			})
 
-			pb.availableContainersLock.Lock()
-			pb.availableContainers = availableContainers
-			pb.availableContainersLock.Unlock()
-			pb.pruneBackendTransports(availableContainers)
-			pb.signalWork()
+			pb.updateDiscoveredContainers(availableContainers, activeContainerIDs)
 		}
 
 		interval := containerDiscoveryInterval
@@ -1114,6 +1146,27 @@ func (pb *PodProxyBuffer) discoverContainers() {
 		case <-timer.C:
 		}
 	}
+}
+
+func (pb *PodProxyBuffer) updateDiscoveredContainers(discovered []container, activeContainerIDs map[string]struct{}) {
+	pb.availableContainersLock.Lock()
+	for containerID := range pb.retiringContainers {
+		if _, active := activeContainerIDs[containerID]; !active {
+			delete(pb.retiringContainers, containerID)
+		}
+	}
+
+	available := discovered[:0]
+	for _, candidate := range discovered {
+		if _, retiring := pb.retiringContainers[candidate.id]; !retiring {
+			available = append(available, candidate)
+		}
+	}
+	pb.availableContainers = available
+	pb.availableContainersLock.Unlock()
+
+	pb.pruneBackendTransports(available)
+	pb.signalWork()
 }
 
 func (pb *PodProxyBuffer) readyAddressMap(addressMap map[int32]string) map[int32]string {

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -1275,6 +1275,224 @@ func TestStoppableContainersSkipsPendingKeepWarmLock(t *testing.T) {
 	}
 }
 
+func TestRetireContainerForStopRemovesProxyBackend(t *testing.T) {
+	containerID := "pod-stub-container-1"
+	address := types.BackendRouteAddress("route-1")
+	pb := &PodProxyBuffer{
+		availableContainers: []container{{
+			id:              containerID,
+			addressMap:      map[int32]string{8000: address},
+			readyAddressMap: map[int32]string{8000: address},
+		}},
+		discoverReady: make(chan struct{}, 1),
+	}
+	transportKey := backendTransportKey{targetHost: address, dialTimeout: time.Second}
+	pb.backendTransports.Store(transportKey, &http.Transport{})
+
+	instance := &podInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{IsActive: true},
+		buffer:             pb,
+	}
+	if !instance.retireContainerForStop(containerID) {
+		t.Fatal("idle container was not prepared for stop")
+	}
+	if got := pb.availableContainerSnapshot(); len(got) != 0 {
+		t.Fatalf("available containers = %v, want none", got)
+	}
+	if _, ok := pb.backendTransports.Load(transportKey); ok {
+		t.Fatal("idle backend transport was not pruned")
+	}
+}
+
+func TestEnsureReadyForRequestAllowsConcurrentScaling(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	lockKey := "pod:stub:instance"
+	holder := common.NewRedisLock(rdb)
+	if err := holder.Acquire(context.Background(), lockKey, common.RedisLockOptions{TtlS: 10}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = holder.Release(lockKey) })
+
+	instance := &podInstance{AutoscaledInstance: &abstractions.AutoscaledInstance{
+		Ctx:             context.Background(),
+		IsActive:        true,
+		Lock:            common.NewRedisLock(rdb),
+		InstanceLockKey: lockKey,
+		ContainerRepo:   repository.NewContainerRedisRepositoryForTest(rdb),
+		Stub: &types.StubWithRelated{Stub: types.Stub{
+			ExternalId: "stub",
+			Type:       types.StubType(types.StubTypePod),
+		}},
+		StubConfig: &types.StubConfigV1{},
+	}}
+
+	if err := instance.ensureReadyForRequest(); err != nil {
+		t.Fatalf("concurrent scaling returned an error: %v", err)
+	}
+}
+
+func TestContainerEventRetiresStoppingProxyBackend(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	repo := repository.NewContainerRedisRepositoryForTest(rdb)
+	containerID := "pod-stub-container-1"
+	if err := repo.SetContainerState(containerID, &types.ContainerState{
+		ContainerId: containerID,
+		StubId:      "stub",
+		WorkspaceId: "workspace",
+		Status:      types.ContainerStatusRunning,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pb := &PodProxyBuffer{
+		availableContainers: []container{{id: containerID}},
+		discoverReady:       make(chan struct{}, 1),
+	}
+	instance := &podInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{
+			Ctx:                context.Background(),
+			ContainerEventChan: make(chan types.ContainerEvent, 1),
+			ContainerRepo:      repo,
+		},
+		buffer: pb,
+	}
+
+	if err := repo.UpdateContainerStatus(containerID, types.ContainerStatusStopping, int64(types.ContainerStateTtlSWhilePending)); err != nil {
+		t.Fatal(err)
+	}
+	instance.ConsumeContainerEvent(types.ContainerEvent{ContainerId: containerID, Change: 1})
+	if got := pb.availableContainerSnapshot(); len(got) != 0 {
+		t.Fatalf("available containers = %v, want stopping container retired", got)
+	}
+}
+
+func TestRunningContainerEventDoesNotCancelRetirement(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	repo := repository.NewContainerRedisRepositoryForTest(rdb)
+	containerID := "pod-stub-container-1"
+	if err := repo.SetContainerState(containerID, &types.ContainerState{
+		ContainerId: containerID,
+		StubId:      "stub",
+		WorkspaceId: "workspace",
+		Status:      types.ContainerStatusRunning,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pb := &PodProxyBuffer{
+		availableContainers: []container{{id: containerID}},
+		discoverReady:       make(chan struct{}, 1),
+	}
+	pb.retireAvailableContainer(containerID)
+	instance := &podInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{
+			Ctx:                context.Background(),
+			ContainerEventChan: make(chan types.ContainerEvent, 1),
+			ContainerRepo:      repo,
+		},
+		buffer: pb,
+	}
+
+	instance.ConsumeContainerEvent(types.ContainerEvent{ContainerId: containerID, Change: 1})
+	pb.updateDiscoveredContainers([]container{{id: containerID}}, map[string]struct{}{containerID: {}})
+	if got := pb.availableContainerSnapshot(); len(got) != 0 {
+		t.Fatalf("available containers = %v, want retiring container excluded after running heartbeat", got)
+	}
+}
+
+func TestDiscoveryDoesNotReaddRetiringContainer(t *testing.T) {
+	containerID := "pod-stub-container-1"
+	discovered := []container{{id: containerID}}
+	active := map[string]struct{}{containerID: {}}
+	pb := &PodProxyBuffer{
+		availableContainers: discovered,
+	}
+
+	pb.retireAvailableContainer(containerID)
+	pb.updateDiscoveredContainers(discovered, active)
+	if got := pb.availableContainerSnapshot(); len(got) != 0 {
+		t.Fatalf("available containers = %v, want retiring container excluded", got)
+	}
+
+	pb.cancelContainerRetirement(containerID)
+	pb.updateDiscoveredContainers(discovered, active)
+	if got := pb.availableContainerSnapshot(); len(got) != 1 || got[0].id != containerID {
+		t.Fatalf("available containers = %v, want canceled retirement restored", got)
+	}
+}
+
+func TestRetireContainerForStopRejectsNewLocalConnection(t *testing.T) {
+	containerID := "pod-stub-container-1"
+	pb := &PodProxyBuffer{
+		availableContainers: []container{{id: containerID}},
+		discoverReady:       make(chan struct{}, 1),
+	}
+	counter, _ := pb.containerConnectionCounter(containerID)
+	counter.Store(1)
+
+	instance := &podInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{IsActive: true},
+		buffer:             pb,
+	}
+	if instance.retireContainerForStop(containerID) {
+		t.Fatal("busy local container was prepared for stop")
+	}
+	select {
+	case <-pb.discoverReady:
+	default:
+		t.Fatal("container discovery was not requested after stop was rejected")
+	}
+}
+
+func TestRetireContainerForStopRejectsNewSharedConnection(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	workspace := &types.Workspace{Name: "workspace"}
+	containerID := "pod-stub-container-1"
+	remote := &PodProxyBuffer{
+		rdb:       rdb,
+		workspace: workspace,
+		stubId:    "stub",
+		proxyId:   "remote-proxy",
+	}
+	remote.publishContainerConnectionSnapshot(containerID, 1)
+
+	pb := &PodProxyBuffer{
+		rdb:                 rdb,
+		workspace:           workspace,
+		stubId:              "stub",
+		proxyId:             "local-proxy",
+		availableContainers: []container{{id: containerID}},
+		discoverReady:       make(chan struct{}, 1),
+	}
+	instance := &podInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{IsActive: true},
+		buffer:             pb,
+	}
+	if instance.retireContainerForStop(containerID) {
+		t.Fatal("container with a connection on another proxy was prepared for stop")
+	}
+}
+
+func TestRetireContainerForStopAllowsExplicitStopWithConnection(t *testing.T) {
+	containerID := "pod-stub-container-1"
+	pb := &PodProxyBuffer{
+		availableContainers: []container{{id: containerID}},
+	}
+	counter, _ := pb.containerConnectionCounter(containerID)
+	counter.Store(1)
+	instance := &podInstance{
+		AutoscaledInstance: &abstractions.AutoscaledInstance{IsActive: false},
+		buffer:             pb,
+	}
+
+	if !instance.retireContainerForStop(containerID) {
+		t.Fatal("explicit stop was blocked by an active connection")
+	}
+	if got := pb.availableContainerSnapshot(); len(got) != 0 {
+		t.Fatalf("available containers = %v, want explicitly stopped container retired", got)
+	}
+}
+
 func TestProxyConnectionIndexRefreshIsThrottled(t *testing.T) {
 	pb := &PodProxyBuffer{}
 	now := time.Unix(0, 100)


### PR DESCRIPTION
## Summary

- retire pod backends from proxy discovery before scheduler shutdown
- propagate STOPPING state across gateway replicas and prune idle transports
- queue concurrent cold-start requests when another gateway holds the scaling lock
- preserve explicit force-stop semantics while rechecking connections for automatic scale-down

## Root cause

The autoscaler could select an idle pod for shutdown while its route and HTTP keepalive transport were still published. A request arriving at the shutdown boundary could reuse that transport and receive an immediate 502 instead of waiting for a checkpoint restore. Discovery could also republish the still-RUNNING container before Scheduler.Stop committed STOPPING.

## Validation

- go test ./pkg/abstractions/common ./pkg/abstractions/pod -count=1
- go test -race ./pkg/abstractions/pod -count=1
- staging: repeated untouched Qwen checkpoint restores with exact chat completions, including shutdown-boundary and concurrent request waves; no 500/502 responses
- restored staging to two stock gateway 0.1.722 replicas after Okteto testing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shutdown race in the pod proxy that caused 502s at scale-down. The proxy now retires backends before stopping containers, propagates STOPPING across replicas, and queues cold-starts when another gateway holds the scaling lock.

- **Bug Fixes**
  - Retire containers from discovery and remove idle transports before `Scheduler.Stop` to prevent keepalive reuse.
  - Track retiring container IDs in `PodProxyBuffer` and filter them during discovery; allow canceling retirement if needed.
  - Propagate STOPPING via container events; prune transports on state change; check both local and shared connection counts.
  - Reject automatic stop when connections exist; keep explicit force-stop behavior.
  - On scaling lock contention, trigger autoscaler and allow requests to queue instead of erroring.

<sup>Written for commit 8cbac8610f69c06454ea0a9ed0048fbae984a694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

