### PR TITLE
Enable Xet for checkpoint model downloads

### DIFF
--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -818,18 +818,17 @@ func checkpointModelCacheVolumeName(in *pb.GetOrCreateStubRequest) string {
 }
 
 func checkpointCacheEnv(modelCachePath string) []string {
-	// Persist model files across checkpoint boots, but keep compiler/JIT artifacts on
-	// local disk so Triton/TorchInductor can compile before the checkpoint is created.
+	// Persist model files across checkpoint boots, but keep compiler/JIT artifacts and
+	// Xet's transfer cache on local disk so they do not inflate the workspace volume.
 	return []string{
 		fmt.Sprintf("HF_HOME=%s", modelCachePath),
 		fmt.Sprintf("HF_HUB_CACHE=%s/hub", modelCachePath),
+		fmt.Sprintf("HF_XET_CACHE=%s/hf-xet", checkpointCompileCacheRoot),
 		fmt.Sprintf("TRANSFORMERS_CACHE=%s", modelCachePath),
 		fmt.Sprintf("TRITON_CACHE_DIR=%s/triton", checkpointCompileCacheRoot),
 		fmt.Sprintf("TORCHINDUCTOR_CACHE_DIR=%s/torchinductor", checkpointCompileCacheRoot),
 		fmt.Sprintf("VLLM_CACHE_ROOT=%s/vllm", checkpointCompileCacheRoot),
 		fmt.Sprintf("CUDA_CACHE_PATH=%s/cuda", checkpointCompileCacheRoot),
-		"HF_HUB_DISABLE_XET=1",
-		"HF_HUB_ENABLE_HF_TRANSFER=0",
 	}
 }
 

--- a/pkg/gateway/services/stub_test.go
+++ b/pkg/gateway/services/stub_test.go
@@ -224,16 +224,23 @@ func TestHandleCheckpointEnabledSplitsModelAndCompilerCaches(t *testing.T) {
 	require.ElementsMatch(t, []string{
 		"HF_HOME=/checkpoint-model-cache-qwen",
 		"HF_HUB_CACHE=/checkpoint-model-cache-qwen/hub",
+		"HF_XET_CACHE=/tmp/beam-checkpoint-compile-cache/hf-xet",
 		"TRANSFORMERS_CACHE=/checkpoint-model-cache-qwen",
 		"TRITON_CACHE_DIR=/tmp/beam-checkpoint-compile-cache/triton",
 		"TORCHINDUCTOR_CACHE_DIR=/tmp/beam-checkpoint-compile-cache/torchinductor",
 		"VLLM_CACHE_ROOT=/tmp/beam-checkpoint-compile-cache/vllm",
 		"CUDA_CACHE_PATH=/tmp/beam-checkpoint-compile-cache/cuda",
-		"HF_HUB_DISABLE_XET=1",
-		"HF_HUB_ENABLE_HF_TRANSFER=0",
 		"USER_ENV=1",
 	}, in.Env)
 	require.Len(t, in.Volumes, 1)
 	require.Equal(t, "volume-123", in.Volumes[0].Id)
 	require.Equal(t, "/checkpoint-model-cache-qwen", in.Volumes[0].MountPath)
+}
+
+func TestCheckpointCacheEnvLeavesHubTransportSelectionToRuntime(t *testing.T) {
+	env := checkpointCacheEnv("/model-cache")
+
+	require.NotContains(t, env, "HF_HUB_DISABLE_XET=1")
+	require.NotContains(t, env, "HF_HUB_ENABLE_HF_TRANSFER=0")
+	require.Contains(t, env, "HF_XET_CACHE=/tmp/beam-checkpoint-compile-cache/hf-xet")
 }


### PR DESCRIPTION
## Summary
- stop forcing Hugging Face Hub onto the deprecated serial HTTP transfer path for checkpoint-enabled workloads
- keep Xet transfer scratch data on local ephemeral storage while model files remain in workspace storage
- cover transport environment behavior in gateway tests

## Staging validation
- exact Qwen2.5-1.5B-Instruct cold deploy on RTX5090
- model transfer: 2.88 GiB in 22.3s
- untouched checkpoint archive: 7.97 GiB
- scale-to-zero restore and exact chat completion: HTTP 200 in 8.64s
- gVisor runtime restore: 6.74s

## Tests
- `go test ./pkg/gateway/services -count=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Xet for checkpoint model downloads to improve transfer performance and keep workspace volumes small. Move Xet transfer cache to ephemeral storage and let the runtime choose the Hub transport.

- **New Features**
  - Enable Xet for checkpoint-enabled model transfers; remove `HF_HUB_DISABLE_XET` and `HF_HUB_ENABLE_HF_TRANSFER` overrides.
  - Add `HF_XET_CACHE` in the ephemeral compile cache; keep model files in the workspace volume.
  - Extend gateway tests to cover env layout and transport selection.

<sup>Written for commit 35f34d464899993df400f30fd162f03028f09466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

