### PR TITLE
Use direct I/O for gVisor checkpoint restore

### DIFF
--- a/pkg/runtime/runsc.go
+++ b/pkg/runtime/runsc.go
@@ -434,7 +434,7 @@ func (r *Runsc) Restore(ctx context.Context, containerID string, opts *RestoreOp
 	if nvproxyEnabled {
 		args = append(args, "--nvproxy=true")
 	}
-	args = append(args, "restore", "--background")
+	args = append(args, "restore", "--background", "--direct")
 	if opts.ImagePath != "" {
 		args = append(args, "--image-path", opts.ImagePath)
 	}

--- a/pkg/runtime/runsc_test.go
+++ b/pkg/runtime/runsc_test.go
@@ -114,7 +114,7 @@ esac
 	require.Contains(t, string(logData), "restore-ready\n")
 	require.Contains(t, string(logData), "wait-done\n")
 	require.NotContains(t, string(logData), "restore-done\n")
-	require.Contains(t, string(logData), "restore --background")
+	require.Contains(t, string(logData), "restore --background --direct")
 }
 
 func TestRunscPrepareMarksOnlyGPUBundles(t *testing.T) {


### PR DESCRIPTION
## Summary
- pass gVisor `--direct` during checkpoint restore
- keep restore reads out of the host page cache
- cover the restore argument in the runtime unit test

## Validation
- `go test ./pkg/runtime -count=1`
- five cold, stopped-container Qwen2.5-1.5B restores returned HTTP 200 with exact completion output
- gVisor restore: 6.13s, 6.69s, 6.67s, 6.99s, 6.24s (p50 6.67s)
- public request-to-completion: 7.31s, 7.87s, 7.81s, 8.16s, 7.39s (p50 7.81s)
- no-direct cold reference: 7.96s gVisor restore, 9.44s public request
- host page cache remained stable across repeated restores

## Scope
This is a generic runtime optimization. It does not alter vLLM configuration, model state, KV cache sizing, or application behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use direct I/O for gVisor checkpoint restore by adding --direct to restore. This avoids polluting the host page cache and reduces cold restore latency; updated the runtime unit test to assert "restore --background --direct".

- **Performance**
  - gVisor restore p50: 6.67s vs 7.96s (no-direct).
  - Request-to-completion p50: 7.81s vs 9.44s.
  - Host page cache stayed stable across repeated restores.

<sup>Written for commit 04126e03d8023578ef19b7c25975c10a2a713208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

