### PR TITLE
Fix pending container stop finalization

### DIFF
--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -51,8 +51,8 @@ func (gws GatewayService) ListContainers(ctx context.Context, in *pb.ListContain
 			StubId:       state.StubId,
 			WorkspaceId:  state.WorkspaceId,
 			Status:       string(state.Status),
-			ScheduledAt:  timestamppb.New(time.Unix(state.ScheduledAt, 0)),
-			StartedAt:    timestamppb.New(time.Unix(state.StartedAt, 0)),
+			ScheduledAt:  containerTimestamp(state.ScheduledAt),
+			StartedAt:    containerTimestamp(state.StartedAt),
 			WorkerId:     containerWorkerMap[state.ContainerId].WorkerId,
 			MachineId:    containerWorkerMap[state.ContainerId].MachineId,
 			DeploymentId: deploymentId,
@@ -63,6 +63,13 @@ func (gws GatewayService) ListContainers(ctx context.Context, in *pb.ListContain
 		Ok:         true,
 		Containers: containers,
 	}, nil
+}
+
+func containerTimestamp(unixSeconds int64) *timestamppb.Timestamp {
+	if unixSeconds <= 0 {
+		return nil
+	}
+	return timestamppb.New(time.Unix(unixSeconds, 0))
 }
 
 type containerDetails struct {

--- a/pkg/gateway/services/container_test.go
+++ b/pkg/gateway/services/container_test.go
@@ -1,0 +1,18 @@
+package gatewayservices
+
+import (
+	"testing"
+	"time"
+)
+
+func TestContainerTimestamp(t *testing.T) {
+	if timestamp := containerTimestamp(0); timestamp != nil {
+		t.Fatalf("expected zero start time to be omitted, got %s", timestamp)
+	}
+
+	const unixSeconds = int64(1_700_000_000)
+	timestamp := containerTimestamp(unixSeconds)
+	if timestamp == nil || !timestamp.AsTime().Equal(time.Unix(unixSeconds, 0)) {
+		t.Fatalf("unexpected timestamp: %v", timestamp)
+	}
+}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -67,6 +67,7 @@ type ContainerRepository interface {
 	DeleteBackendRoutesByContainerID(ctx context.Context, containerID string) error
 	DeleteBackendRoutesByMachine(ctx context.Context, workspaceID, poolName, machineID string) error
 	UpdateContainerStatus(string, types.ContainerStatus, int64) error
+	MarkPendingContainerStoppingIfUnassigned(containerId string, expirySeconds int64) (bool, error)
 	DeleteContainerState(containerId string) error
 	SetContainerRequestStatus(containerId string, status types.ContainerRequestStatus) error
 	SetWorkerAddress(containerId string, addr string) error

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -293,6 +293,30 @@ func (cr *ContainerRedisRepository) UpdateContainerStatus(containerId string, st
 	return nil
 }
 
+var markPendingContainerStoppingIfUnassignedScript = redis.NewScript(`
+if redis.call("HGET", KEYS[1], "status") ~= ARGV[1] then
+	return 0
+end
+local worker_id = redis.call("HGET", KEYS[1], "worker_id")
+if worker_id and worker_id ~= "" then
+	return 0
+end
+redis.call("HSET", KEYS[1], "status", ARGV[2])
+redis.call("EXPIRE", KEYS[1], ARGV[3])
+return 1
+`)
+
+func (cr *ContainerRedisRepository) MarkPendingContainerStoppingIfUnassigned(containerId string, expirySeconds int64) (bool, error) {
+	stateKey := common.RedisKeys.SchedulerContainerState(containerId)
+	marked, err := markPendingContainerStoppingIfUnassignedScript.Run(context.TODO(), cr.rdb, []string{stateKey},
+		string(types.ContainerStatusPending), string(types.ContainerStatusStopping), expirySeconds,
+	).Bool()
+	if err != nil {
+		return false, fmt.Errorf("failed to stop unassigned pending container <%s>: %w", containerId, err)
+	}
+	return marked, nil
+}
+
 func (cr *ContainerRedisRepository) DeleteContainerState(containerId string) error {
 	err := cr.lock.Acquire(context.TODO(), common.RedisKeys.SchedulerContainerLock(containerId), common.RedisLockOptions{TtlS: 10, Retries: 5})
 	if err != nil {

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -337,6 +337,70 @@ func TestUpdateContainerStatusDoesNotMoveStoppingBackToRunning(t *testing.T) {
 	}
 }
 
+func TestMarkPendingContainerStoppingIfUnassigned(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	for _, test := range []struct {
+		name     string
+		state    *types.ContainerState
+		expected bool
+	}{
+		{
+			name: "unassigned pending container",
+			state: &types.ContainerState{
+				ContainerId: "pending-unassigned",
+				Status:      types.ContainerStatusPending,
+			},
+			expected: true,
+		},
+		{
+			name: "assigned pending container",
+			state: &types.ContainerState{
+				ContainerId: "pending-assigned",
+				Status:      types.ContainerStatusPending,
+				WorkerId:    "worker-1",
+			},
+		},
+		{
+			name: "running container",
+			state: &types.ContainerState{
+				ContainerId: "running",
+				Status:      types.ContainerStatusRunning,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := repo.SetContainerState(test.state.ContainerId, test.state); err != nil {
+				t.Fatal(err)
+			}
+
+			marked, err := repo.MarkPendingContainerStoppingIfUnassigned(test.state.ContainerId, types.ContainerStateTtlSWhilePending)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if marked != test.expected {
+				t.Fatalf("expected marked=%t, got %t", test.expected, marked)
+			}
+
+			state, err := repo.GetContainerState(test.state.ContainerId)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedStatus := test.state.Status
+			if test.expected {
+				expectedStatus = types.ContainerStatusStopping
+			}
+			if state.Status != expectedStatus {
+				t.Fatalf("expected status %s, got %s", expectedStatus, state.Status)
+			}
+		})
+	}
+}
+
 func TestBackendRoutesAreIndexedByMachine(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	if err != nil {

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -277,6 +277,12 @@ if status ~= "available" then
 end
 
 for i = 6, #ARGV, 4 do
+	if redis.call("HGET", ARGV[i], "status") ~= "PENDING" then
+		return -3
+	end
+end
+
+for i = 6, #ARGV, 4 do
 	local state = ARGV[i]
 	redis.call("RPUSH", KEYS[2], ARGV[i + 1])
 	redis.call("HSET", state,
@@ -1392,6 +1398,9 @@ func (r *WorkerRedisRepository) ScheduleContainerRequests(worker *types.Worker, 
 		}
 		if committed == -1 {
 			return &types.ErrWorkerNotFound{WorkerId: worker.Id}
+		}
+		if committed == -3 {
+			return errors.New("container request is no longer pending")
 		}
 		return fmt.Errorf("worker <%s> is not available", worker.Id)
 	}

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/tj/assert"
 )
 
+func setPendingContainerRequests(t *testing.T, rdb *common.RedisClient, requests ...*types.ContainerRequest) {
+	t.Helper()
+	for _, request := range requests {
+		assert.NoError(t, rdb.HSet(
+			context.TODO(),
+			common.RedisKeys.SchedulerContainerState(request.ContainerId),
+			"container_id", request.ContainerId,
+			"status", string(types.ContainerStatusPending),
+		).Err())
+	}
+}
+
 func TestNewWorkerRedisRepository(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)
@@ -77,6 +89,7 @@ func TestRemoveWorkerRequeuesPendingWorkerRequests(t *testing.T) {
 		{ContainerId: "container-1", WorkspaceId: "workspace", StubId: "stub", Cpu: 100, Memory: 100, RetryCount: 2},
 		{ContainerId: "container-2", WorkspaceId: "workspace", StubId: "stub", Cpu: 100, Memory: 100, RetryCount: 4},
 	}
+	setPendingContainerRequests(t, rdb, requests...)
 	for _, request := range requests {
 		currentWorker, err := repo.GetWorkerById(worker.Id)
 		assert.Nil(t, err)
@@ -741,6 +754,7 @@ func TestScheduleContainerRequestRestoresCapacityWhenQueuePushFails(t *testing.T
 		Cpu:         100,
 		Memory:      100,
 	}
+	setPendingContainerRequests(t, rdb, request)
 
 	err = repo.ScheduleContainerRequest(worker, request)
 	assert.Error(t, err)
@@ -917,6 +931,43 @@ func TestScheduleContainerRequestRejectsDisabledWorker(t *testing.T) {
 	assert.Equal(t, int64(1000), updatedWorker.FreeMemory)
 }
 
+func TestScheduleContainerRequestRejectsNonPendingState(t *testing.T) {
+	for _, status := range []types.ContainerStatus{types.ContainerStatusStopping, ""} {
+		t.Run(firstNonEmpty(string(status), "deleted"), func(t *testing.T) {
+			rdb, err := NewRedisClientForTest()
+			assert.NoError(t, err)
+			repo := NewWorkerRedisRepositoryForTest(rdb)
+			worker := &types.Worker{
+				Id:         "worker-cancelled-before-commit",
+				Status:     types.WorkerStatusAvailable,
+				FreeCpu:    100,
+				FreeMemory: 125,
+			}
+			request := &types.ContainerRequest{
+				ContainerId: "container-cancelled-before-commit",
+				Cpu:         100,
+				Memory:      100,
+			}
+			assert.NoError(t, repo.AddWorker(worker))
+			if status != "" {
+				assert.NoError(t, rdb.HSet(
+					context.TODO(),
+					common.RedisKeys.SchedulerContainerState(request.ContainerId),
+					"status", string(status),
+				).Err())
+			}
+
+			assert.Error(t, repo.ScheduleContainerRequest(worker, request))
+			updated, err := repo.GetWorkerById(worker.Id)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(100), updated.FreeCpu)
+			assert.Equal(t, int64(125), updated.FreeMemory)
+			assert.Equal(t, int64(0), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+			assert.Equal(t, int64(0), rdb.SCard(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id)).Val())
+		})
+	}
+}
+
 func TestScheduledRequestCommitRejectsWorkerCordonedAfterReservation(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NoError(t, err)
@@ -984,6 +1035,7 @@ func TestScheduleContainerRequestRejectsStaleWorkerReservation(t *testing.T) {
 		Cpu:         100,
 		Memory:      100,
 	}
+	setPendingContainerRequests(t, rdb, firstRequest, secondRequest)
 
 	err = repo.ScheduleContainerRequest(firstWorkerCopy, firstRequest)
 	assert.Nil(t, err)
@@ -1018,12 +1070,14 @@ func TestScheduleContainerRequestDoesNotWaitForMaintenanceLock(t *testing.T) {
 	assert.NoError(t, maintenance.Acquire(context.Background(), common.RedisKeys.SchedulerWorkerLock(worker.Id), common.RedisLockOptions{TtlS: 10}))
 	defer maintenance.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id))
 
-	startedAt := time.Now()
-	assert.NoError(t, repo.ScheduleContainerRequest(worker, &types.ContainerRequest{
+	request := &types.ContainerRequest{
 		ContainerId: "container-live-scheduling",
 		Cpu:         100,
 		Memory:      100,
-	}))
+	}
+	setPendingContainerRequests(t, rdb, request)
+	startedAt := time.Now()
+	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
 	assert.Less(t, time.Since(startedAt), 100*time.Millisecond)
 }
 
@@ -1057,6 +1111,7 @@ func TestScheduleContainerRequestUsesCurrentCapacityForStaleWorkerReservation(t 
 		Cpu:         100,
 		Memory:      100,
 	}
+	setPendingContainerRequests(t, rdb, firstRequest, secondRequest)
 
 	err = repo.ScheduleContainerRequest(firstWorkerCopy, firstRequest)
 	assert.Nil(t, err)
@@ -1105,6 +1160,7 @@ func TestScheduleContainerRequestsReservesAndQueuesBatch(t *testing.T) {
 		{ContainerId: "container-batch-2", Cpu: 100, Memory: 100, Gpu: worker.Gpu},
 		{ContainerId: "container-batch-3", Cpu: 100, Memory: 100, Gpu: worker.Gpu},
 	}
+	setPendingContainerRequests(t, rdb, requests...)
 	assert.NoError(t, repo.ScheduleContainerRequests(worker, requests))
 	select {
 	case message := <-messages:
@@ -1152,6 +1208,7 @@ func TestContainerRequestRemainsRecoverableUntilWorkerAcknowledgesIt(t *testing.
 	}
 	request := &types.ContainerRequest{ContainerId: "container-pending-delivery", Cpu: 100, Memory: 100}
 	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
 	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
 
 	delivered, err := repo.GetNextContainerRequests(worker.Id, 1)
@@ -1181,8 +1238,8 @@ func TestAcknowledgedContainerRequestIsNotReplayedWhenWorkerIsRemoved(t *testing
 	}
 	request := &types.ContainerRequest{ContainerId: "container-acknowledged-delivery", Cpu: 100, Memory: 100}
 	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
 	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
-	assert.NoError(t, rdb.HSet(context.TODO(), common.RedisKeys.SchedulerContainerState(request.ContainerId), "status", string(types.ContainerStatusPending)).Err())
 	delivered, err := repo.GetNextContainerRequests(worker.Id, 1)
 	assert.NoError(t, err)
 
@@ -1211,6 +1268,7 @@ func TestContainerRequestAcknowledgementRejectsCancelledContainer(t *testing.T) 
 			}
 			request := &types.ContainerRequest{ContainerId: "container-cancelled-delivery", Cpu: 100, Memory: 100}
 			assert.NoError(t, repo.AddWorker(worker))
+			setPendingContainerRequests(t, rdb, request)
 			assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
 			delivered, err := repo.GetNextContainerRequests(worker.Id, 1)
 			assert.NoError(t, err)
@@ -1239,8 +1297,8 @@ func TestRecoveredContainerRequestRejectsStaleAcknowledgement(t *testing.T) {
 	worker := &types.Worker{Id: "worker-reconnect", Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
 	request := &types.ContainerRequest{ContainerId: "container-reconnect", Cpu: 100, Memory: 100}
 	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
 	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
-	assert.NoError(t, rdb.HSet(context.TODO(), common.RedisKeys.SchedulerContainerState(request.ContainerId), "status", string(types.ContainerStatusPending)).Err())
 	first, err := repo.GetNextContainerRequests(worker.Id, 1)
 	assert.NoError(t, err)
 
@@ -1261,8 +1319,8 @@ func TestSendFailureDoesNotRequeueAcknowledgedDelivery(t *testing.T) {
 	worker := &types.Worker{Id: "worker-ack-race", Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
 	request := &types.ContainerRequest{ContainerId: "container-ack-race", Cpu: 100, Memory: 100}
 	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
 	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
-	assert.NoError(t, rdb.HSet(context.TODO(), common.RedisKeys.SchedulerContainerState(request.ContainerId), "status", string(types.ContainerStatusPending)).Err())
 	delivered, err := repo.GetNextContainerRequests(worker.Id, 1)
 	assert.NoError(t, err)
 	assert.NoError(t, repo.AddContainerToWorker(worker.Id, request.ContainerId, delivered[0].DeliveryToken))
@@ -1283,6 +1341,7 @@ func TestRequeueContainerRequestsPreservesOrder(t *testing.T) {
 		{ContainerId: "container-requeue-2", Cpu: 100, Memory: 100},
 		{ContainerId: "container-requeue-3", Cpu: 100, Memory: 100},
 	}
+	setPendingContainerRequests(t, rdb, requests...)
 	assert.NoError(t, repo.ScheduleContainerRequests(worker, requests))
 	delivered, err := repo.GetNextContainerRequests(worker.Id, len(requests))
 	assert.NoError(t, err)

--- a/pkg/scheduler/batch.go
+++ b/pkg/scheduler/batch.go
@@ -57,8 +57,12 @@ func (b *schedulingBatch) planRequest(request *types.ContainerRequest) {
 			"planned_count_so_far": fmt.Sprintf("%d", len(b.schedules)),
 		})
 	}()
+	attempt := newSchedulingAttempt(b.scheduler, request, b.workers)
+	if !attempt.runnable() {
+		return
+	}
 	if !b.scheduler.checkpointReady(request) {
-		newSchedulingAttempt(b.scheduler, request, b.workers).requeueForWorkerWaitDelay(checkpointHandoffRetryDelay, "checkpoint_handoff")
+		attempt.requeueForWorkerWaitDelay(checkpointHandoffRetryDelay, "checkpoint_handoff")
 		return
 	}
 
@@ -145,20 +149,19 @@ func (b *schedulingBatch) dispatchSchedules(schedules []plannedSchedule) {
 }
 
 func (b *schedulingBatch) completeSchedule(schedule plannedSchedule, err error) {
+	attempt := newSchedulingAttempt(b.scheduler, schedule.request, b.workers)
 	if err != nil {
 		workerLog(requestLog(log.Error(), schedule.request), schedule.worker).
 			Err(err).
 			Msg("unable to schedule planned request on worker")
 
-		attempt := newSchedulingAttempt(b.scheduler, schedule.request, b.workers)
 		attempt.recordBacklogWait(false, "schedule_failed")
 		metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, "schedule_failed")
-		attempt.retrySoon("schedule_failed")
+		attempt.retryIfRunnable("schedule_failed")
 		return
 	}
 
 	duration := time.Since(schedule.request.Timestamp)
-	attempt := newSchedulingAttempt(b.scheduler, schedule.request, b.workers)
 	attempt.recordBacklogWait(true, "scheduled")
 	metrics.RecordRequestSchedulingDuration(duration, schedule.request)
 	metrics.RecordSchedulerWorkerWait(duration, schedule.request, "scheduled")

--- a/pkg/scheduler/pool_cleaner_test.go
+++ b/pkg/scheduler/pool_cleaner_test.go
@@ -24,7 +24,7 @@ func TestWorkerResourceCleanerRemovesWorkerStateWithoutJobAndRequeuesRequests(t 
 	workerRepo := repo.NewWorkerRedisRepositoryForTest(rdb)
 	worker := cleanerTestWorker("stale-worker", "default", "")
 	assert.Nil(t, workerRepo.AddWorker(worker))
-	assert.Nil(t, workerRepo.ScheduleContainerRequest(worker, cleanerTestRequest("container-1")))
+	scheduleCleanerRequest(t, rdb, workerRepo, worker, cleanerTestRequest("container-1"))
 
 	cleaner := WorkerResourceCleaner{
 		PoolName:   "default",
@@ -77,7 +77,7 @@ func TestWorkerResourceCleanerDeletesCompletedWorkerJob(t *testing.T) {
 	workerRepo := repo.NewWorkerRedisRepositoryForTest(rdb)
 	worker := cleanerTestWorker("completed-worker", "default", "machine-a")
 	assert.Nil(t, workerRepo.AddWorker(worker))
-	assert.Nil(t, workerRepo.ScheduleContainerRequest(worker, cleanerTestRequest("container-1")))
+	scheduleCleanerRequest(t, rdb, workerRepo, worker, cleanerTestRequest("container-1"))
 
 	job := cleanerTestWorkerJob("worker-default-completed-worker", worker.Id, "default", "machine-a")
 	pod := cleanerTestWorkerPod("worker-default-completed-worker-pod", job.Name, worker.Id, "default", "machine-a", corev1.PodSucceeded)
@@ -120,6 +120,16 @@ func cleanerTestRequest(containerId string) *types.ContainerRequest {
 		Cpu:         100,
 		Memory:      100,
 	}
+}
+
+func scheduleCleanerRequest(t *testing.T, rdb *common.RedisClient, workerRepo repo.WorkerRepository, worker *types.Worker, request *types.ContainerRequest) {
+	t.Helper()
+	containerRepo := repo.NewContainerRedisRepositoryForTest(rdb)
+	assert.NoError(t, containerRepo.SetContainerState(request.ContainerId, &types.ContainerState{
+		ContainerId: request.ContainerId,
+		Status:      types.ContainerStatusPending,
+	}))
+	assert.NoError(t, workerRepo.ScheduleContainerRequest(worker, request))
 }
 
 func cleanerTestWorkerJob(name, workerId, poolName, machineId string) *batchv1.Job {

--- a/pkg/scheduler/reserve.go
+++ b/pkg/scheduler/reserve.go
@@ -27,6 +27,9 @@ func newSchedulingAttempt(scheduler *Scheduler, request *types.ContainerRequest,
 }
 
 func (a *schedulingAttempt) run() {
+	if !a.runnable() {
+		return
+	}
 	normalizeGPURequest(a.request)
 
 	// Keep the scheduling order explicit: use ready capacity first, wait on
@@ -74,7 +77,7 @@ func (a *schedulingAttempt) scheduleOnAvailableWorker() bool {
 			Msg("unable to schedule request on existing worker")
 		a.recordBacklogWait(false, "schedule_failed")
 		metrics.RecordSchedulerWorkerWait(time.Since(a.request.Timestamp), a.request, "schedule_failed")
-		a.retrySoon("schedule_failed")
+		a.retryIfRunnable("schedule_failed")
 		return true
 	}
 
@@ -83,6 +86,22 @@ func (a *schedulingAttempt) scheduleOnAvailableWorker() bool {
 	metrics.RecordRequestSchedulingDuration(duration, a.request)
 	metrics.RecordSchedulerWorkerWait(duration, a.request, "scheduled")
 	return true
+}
+
+func (a *schedulingAttempt) runnable() bool {
+	pending, err := a.scheduler.containerRequestPending(a.request.ContainerId)
+	if err == nil {
+		return pending
+	}
+	requestLog(log.Error(), a.request).Err(err).Msg("failed to verify container request state")
+	a.retrySoon("container_state_lookup_failed")
+	return false
+}
+
+func (a *schedulingAttempt) retryIfRunnable(reason string) {
+	if a.runnable() {
+		a.retrySoon(reason)
+	}
 }
 
 func (a *schedulingAttempt) reservePendingWorkerCapacity() bool {

--- a/pkg/scheduler/reserve_test.go
+++ b/pkg/scheduler/reserve_test.go
@@ -182,6 +182,7 @@ func TestWorkerProvisioningBackoffDoesNotBlockExistingPoolCapacity(t *testing.T)
 		PoolSelector: "beta9-cpu",
 		Timestamp:    time.Now(),
 	}
+	setPendingSchedulerRequests(t, scheduler, scheduleRequest)
 	newSchedulingAttempt(scheduler, scheduleRequest, []*types.Worker{worker}).run()
 
 	queued, err := scheduler.workerRepo.GetNextContainerRequest(worker.Id)
@@ -247,6 +248,7 @@ func TestPrivatePoolMissFallsBackToRegularAvailableWorker(t *testing.T) {
 	assert.Empty(t, fallback.PoolSelector)
 	privateController.hasCapacity = false
 
+	setPendingSchedulerRequests(t, scheduler, request)
 	newSchedulingAttempt(scheduler, request, []*types.Worker{privateWorker, regularWorker}).run()
 
 	queued, err := scheduler.workerRepo.GetNextContainerRequest(regularWorker.Id)
@@ -336,6 +338,7 @@ func TestPrivatePoolMissWithoutRegularCapacityKeepsPrivateSelector(t *testing.T)
 		Timestamp:    time.Now(),
 		Workspace:    testWorkspaceWithStorage(),
 	}
+	setPendingSchedulerRequests(t, scheduler, request)
 	newSchedulingAttempt(scheduler, request, nil).run()
 
 	select {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -492,15 +492,23 @@ func (s *Scheduler) Stop(stopArgs *types.StopContainerArgs) error {
 	}
 	s.eventRepo.PushContainerEvent(event)
 
-	if state != nil && strings.HasPrefix(stopArgs.ContainerId, types.BuildContainerPrefix) && types.ContainerStatus(state.Status) == types.ContainerStatusPending {
+	stoppedBeforeAssignment, err := s.containerRepo.MarkPendingContainerStoppingIfUnassigned(
+		stopArgs.ContainerId,
+		types.ContainerStateTtlSWhilePending,
+	)
+	if err != nil {
+		return err
+	}
+	if stoppedBeforeAssignment {
 		if err := s.containerRepo.DeleteContainerState(stopArgs.ContainerId); err != nil {
 			return err
 		}
-	} else {
-		err := s.containerRepo.UpdateContainerStatus(stopArgs.ContainerId, types.ContainerStatusStopping, types.ContainerStateTtlSWhilePending)
-		if err != nil {
-			return err
-		}
+		return nil
+	}
+
+	err = s.containerRepo.UpdateContainerStatus(stopArgs.ContainerId, types.ContainerStatusStopping, types.ContainerStateTtlSWhilePending)
+	if err != nil {
+		return err
 	}
 
 	eventArgs, err := stopArgs.ToMap()
@@ -519,6 +527,18 @@ func (s *Scheduler) Stop(stopArgs *types.StopContainerArgs) error {
 	}
 
 	return nil
+}
+
+func (s *Scheduler) containerRequestPending(containerID string) (bool, error) {
+	state, err := s.containerRepo.GetContainerState(containerID)
+	if err != nil {
+		notFound := &types.ErrContainerStateNotFound{}
+		if notFound.From(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return state != nil && state.Status == types.ContainerStatusPending, nil
 }
 
 func (s *Scheduler) getControllers(request *types.ContainerRequest) ([]WorkerPoolController, error) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -98,6 +98,22 @@ func NewSchedulerForTest() (*Scheduler, error) {
 	}, nil
 }
 
+func setPendingSchedulerRequests(t *testing.T, scheduler *Scheduler, requests ...*types.ContainerRequest) {
+	t.Helper()
+
+	for _, request := range requests {
+		if request.ContainerId == "" {
+			request.ContainerId = uuid.NewString()
+		}
+		assert.NoError(t, scheduler.containerRepo.SetContainerState(request.ContainerId, &types.ContainerState{
+			ContainerId: request.ContainerId,
+			Status:      types.ContainerStatusPending,
+			WorkspaceId: request.WorkspaceId,
+			ScheduledAt: time.Now().Unix(),
+		}))
+	}
+}
+
 func TestPrivateWorkerRequestUsesPoolMode(t *testing.T) {
 	manager := NewWorkerPoolManager(false)
 	privateState := &compute.PoolState{Selector: "private-pool"}
@@ -923,11 +939,12 @@ func TestRunContainer(t *testing.T) {
 	}
 }
 
-func TestStopDeletesPendingBuildContainerState(t *testing.T) {
+func TestStopDeletesUnassignedPendingContainerState(t *testing.T) {
 	wb, err := NewSchedulerForTest()
 	assert.Nil(t, err)
 
-	containerId := types.BuildContainerPrefix + "pending"
+	containerId := "pending-container"
+	request := &types.ContainerRequest{ContainerId: containerId, Timestamp: time.Now()}
 	err = wb.containerRepo.SetContainerState(containerId, &types.ContainerState{
 		ContainerId: containerId,
 		Status:      types.ContainerStatusPending,
@@ -935,6 +952,7 @@ func TestStopDeletesPendingBuildContainerState(t *testing.T) {
 		ScheduledAt: time.Now().Unix(),
 	})
 	assert.Nil(t, err)
+	assert.NoError(t, wb.requestBacklog.Push(request))
 
 	err = wb.Stop(&types.StopContainerArgs{
 		ContainerId: containerId,
@@ -944,7 +962,36 @@ func TestStopDeletesPendingBuildContainerState(t *testing.T) {
 
 	_, err = wb.containerRepo.GetContainerState(containerId)
 	notFound := &types.ErrContainerStateNotFound{}
-	assert.True(t, notFound.From(err), "expected deleted pending build state, got %v", err)
+	assert.True(t, notFound.From(err), "expected deleted pending state, got %v", err)
+
+	popped, err := wb.requestBacklog.Pop()
+	assert.NoError(t, err)
+	wb.processRequestBatch([]*types.ContainerRequest{popped}, nil)
+	assert.Equal(t, int64(0), wb.requestBacklog.Len())
+}
+
+func TestStopPreservesAssignedPendingContainerForWorkerCancellation(t *testing.T) {
+	wb, err := NewSchedulerForTest()
+	assert.NoError(t, err)
+
+	containerID := "assigned-pending-container"
+	assert.NoError(t, wb.containerRepo.SetContainerState(containerID, &types.ContainerState{
+		ContainerId: containerID,
+		Status:      types.ContainerStatusPending,
+		WorkspaceId: "workspace-1",
+		WorkerId:    "worker-1",
+		ScheduledAt: time.Now().Unix(),
+	}))
+
+	assert.NoError(t, wb.Stop(&types.StopContainerArgs{
+		ContainerId: containerID,
+		Reason:      types.StopContainerReasonUser,
+	}))
+
+	state, err := wb.containerRepo.GetContainerState(containerID)
+	assert.NoError(t, err)
+	assert.Equal(t, types.ContainerStatusStopping, state.Status)
+	assert.Equal(t, "worker-1", state.WorkerId)
 }
 
 func TestRunCleansContainerStateWhenBacklogPushFails(t *testing.T) {
@@ -1234,6 +1281,7 @@ func TestProcessRequestUsesInFlightProvisioningForCurrentBatch(t *testing.T) {
 		PoolSelector: "beta9-cpu",
 		Timestamp:    time.Now(),
 	}
+	setPendingSchedulerRequests(t, wb, firstRequest, secondRequest)
 
 	wb.processRequest(firstRequest, nil)
 	select {
@@ -1314,6 +1362,7 @@ func TestProcessRequestTracksPendingWorkerCapacityAcrossBatches(t *testing.T) {
 		PoolSelector: "beta9-a10g",
 		Timestamp:    time.Now(),
 	}
+	setPendingSchedulerRequests(t, wb, firstRequest, secondRequest)
 
 	firstBatchWorkers, err := wb.workerRepo.GetAllWorkers()
 	assert.Nil(t, err)
@@ -1372,6 +1421,7 @@ func TestProcessRequestUpdatesBatchWorkerCapacity(t *testing.T) {
 		Memory:      1,
 		Timestamp:   time.Now(),
 	}
+	setPendingSchedulerRequests(t, wb, firstRequest)
 
 	wb.processRequest(firstRequest, workers)
 
@@ -1422,6 +1472,7 @@ func TestProcessRequestBatchDoesNotOverScheduleWorkerSnapshot(t *testing.T) {
 			Timestamp:   time.Now(),
 		},
 	}
+	setPendingSchedulerRequests(t, wb, requests...)
 
 	wb.processRequestBatch(requests, workers)
 
@@ -1489,6 +1540,7 @@ func TestProcessRequestBatchSpreadsAcrossEqualWorkers(t *testing.T) {
 			Timestamp:   time.Now(),
 		},
 	}
+	setPendingSchedulerRequests(t, wb, requests...)
 
 	wb.processRequestBatch(requests, workers)
 
@@ -1550,6 +1602,7 @@ func TestProcessRequestBatchSchedulesTinySandboxBurstByRequestedCapacity(t *test
 			},
 		}
 	}
+	setPendingSchedulerRequests(t, wb, requests...)
 
 	workerSnapshot, err := wb.workerRepo.GetAllWorkers()
 	assert.Nil(t, err)
@@ -1616,6 +1669,7 @@ func TestProcessRequestBatchKeepsCPUAndGPUCapacitySeparate(t *testing.T) {
 		GpuRequest:  []string{"A10G"},
 		Timestamp:   time.Now(),
 	}
+	setPendingSchedulerRequests(t, wb, gpuRequest, cpuRequest)
 
 	wb.processRequestBatch([]*types.ContainerRequest{gpuRequest, cpuRequest}, workers)
 
@@ -1682,6 +1736,7 @@ func TestProcessRequestKeepsCPUAndGPUWorkersSeparate(t *testing.T) {
 		GpuCount:    1,
 		Timestamp:   time.Now(),
 	}
+	setPendingSchedulerRequests(t, wb, cpuRequest, gpuRequest)
 
 	wb.processRequest(cpuRequest, workers)
 	wb.processRequest(gpuRequest, workers)
@@ -1740,6 +1795,7 @@ func TestProcessRequestDefaultsGPUCountBeforeScheduling(t *testing.T) {
 		GpuRequest:  []string{"A10G"},
 		Timestamp:   time.Now(),
 	}
+	setPendingSchedulerRequests(t, wb, request)
 
 	wb.processRequest(request, workers)
 
@@ -1795,6 +1851,7 @@ func TestProcessRequestStaleReplicaGPUReservationRequeues(t *testing.T) {
 		GpuRequest:  []string{"A10G"},
 		Timestamp:   time.Now(),
 	}
+	setPendingSchedulerRequests(t, firstScheduler, firstRequest, secondRequest)
 
 	firstScheduler.processRequest(firstRequest, firstReplicaWorkers)
 	secondScheduler.processRequest(secondRequest, secondReplicaWorkers)
@@ -1877,6 +1934,7 @@ func TestProcessRequestConcurrentStaleReplicaGPUReservationRequeues(t *testing.T
 		GpuRequest:  []string{"A10G"},
 		Timestamp:   time.Now(),
 	}
+	setPendingSchedulerRequests(t, firstScheduler, firstRequest, secondRequest)
 
 	start := make(chan struct{})
 	var wg sync.WaitGroup
@@ -2422,6 +2480,7 @@ func TestSelectGPUWorker(t *testing.T) {
 	assert.Equal(t, newWorker.Id, worker.Id)
 
 	// Actually schedule the request
+	setPendingSchedulerRequests(t, wb, firstRequest)
 	err = wb.scheduleRequest(worker, firstRequest)
 	assert.Nil(t, err)
 
@@ -2506,6 +2565,7 @@ func TestSelectCPUWorker(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Select a worker for the request
+	setPendingSchedulerRequests(t, wb, firstRequest, secondRequest, thirdRequest)
 	worker, err := wb.selectWorker(firstRequest)
 	assert.Nil(t, err)
 	assert.Equal(t, newWorker.Gpu, worker.Gpu)
@@ -2716,6 +2776,7 @@ func TestSelectWorkersWithBackupGPU(t *testing.T) {
 					assert.True(t, stringInSlice(worker.Gpu, reqGpus))
 				}
 
+				setPendingSchedulerRequests(t, wb, req)
 				err = wb.scheduleRequest(worker, req)
 				assert.Nil(t, err)
 			}
@@ -2823,6 +2884,7 @@ func TestRequiresPoolSelectorWorker(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, newWorkerWithRequiresPoolSelector.Id, worker.Id)
 
+	setPendingSchedulerRequests(t, wb, firstRequest)
 	err = wb.scheduleRequest(worker, firstRequest)
 	assert.Nil(t, err)
 
@@ -2956,6 +3018,7 @@ func TestServerlessPoolFallsBackWhenHighPriorityPoolIsFull(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, gladiatorWorker.Id, worker.Id)
 
+	setPendingSchedulerRequests(t, wb, request)
 	err = wb.scheduleRequest(worker, request)
 	assert.Nil(t, err)
 
@@ -3035,6 +3098,7 @@ func TestSelectBuildWorker(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, newWorker.Gpu, worker.Gpu)
 
+	setPendingSchedulerRequests(t, wb, request)
 	err = wb.scheduleRequest(worker, request)
 	assert.Nil(t, err)
 

--- a/sdk/src/beta9/cli/container.py
+++ b/sdk/src/beta9/cli/container.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List
+from typing import List, Optional
 
 import click
 from betterproto import Casing
@@ -44,6 +44,17 @@ AVAILABLE_LIST_COLUMNS = {
 }
 
 
+def _format_uptime(
+    started_at: Optional[datetime.datetime], now: datetime.datetime
+) -> str:
+    if started_at is None:
+        return "N/A"
+    epoch = datetime.datetime.fromtimestamp(0, tz=started_at.tzinfo)
+    if started_at <= epoch:
+        return "N/A"
+    return terminal.humanize_duration(now - started_at)
+
+
 @management.command(
     name="list",
     help="""
@@ -78,9 +89,7 @@ def list_containers(ctx: click.Context, service: ServiceClient, format: str, col
         containers = []
         for c in res.containers:
             container_dict = c.to_dict(casing=Casing.SNAKE)
-            container_dict["uptime"] = (
-                terminal.humanize_duration(now - c.started_at) if c.started_at else "N/A"
-            )
+            container_dict["uptime"] = _format_uptime(c.started_at, now)
             containers.append(container_dict)
         terminal.print_json(containers)
         return
@@ -108,11 +117,7 @@ def list_containers(ctx: click.Context, service: ServiceClient, format: str, col
         row = []
         for col in ordered_columns:
             if col == "uptime":
-                value = (
-                    terminal.humanize_duration(now - container.started_at)
-                    if container.started_at
-                    else "N/A"
-                )
+                value = _format_uptime(container.started_at, now)
             else:
                 value = getattr(container, col)
                 if isinstance(value, datetime.datetime):

--- a/sdk/tests/test_cli.py
+++ b/sdk/tests/test_cli.py
@@ -1,9 +1,11 @@
+import datetime
 from types import SimpleNamespace
 
 import click
 import pytest
 
 from beta9.cli import database as database_cli
+from beta9.cli import container as container_cli
 from beta9.cli.main import load_cli
 
 
@@ -19,6 +21,15 @@ def test_disk_management_commands_registered():
     assert "format" in {param.name for param in disk.commands["list"].params}
     assert "format" in {param.name for param in disk.commands["snapshots"].params}
     assert "yes" in {param.name for param in disk.commands["delete"].params}
+
+
+def test_container_uptime_ignores_unset_timestamp():
+    now = datetime.datetime(2026, 7, 18, tzinfo=datetime.timezone.utc)
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
+
+    assert container_cli._format_uptime(None, now) == "N/A"
+    assert container_cli._format_uptime(epoch, now) == "N/A"
+    assert container_cli._format_uptime(now - datetime.timedelta(seconds=5), now) == "5 seconds"
 
 
 def test_database_commands_are_nested_under_db():


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race where stopping a pending container could still be scheduled. Unassigned pending containers are now atomically finalized, and non-pending requests are no longer scheduled or retried.

- **Bug Fixes**
  - Scheduler Stop: atomically mark unassigned pending containers as stopping, then delete their state; keep assigned pending containers and set to stopping for worker cancellation.
  - Repository: added `MarkPendingContainerStoppingIfUnassigned` Redis script to transition pending→stopping only when no `worker_id`, with TTL.
  - Worker scheduling: validate container state is `PENDING` at commit time; reject and restore capacity if not.
  - Scheduler: only schedule/retry if the request is still pending to avoid replaying canceled/deleted requests.
  - Gateway/CLI: omit zero timestamps in API; show "N/A" uptime when `started_at` is missing or epoch.

<sup>Written for commit c9155f528485d304de073fb9b388cdab2f213174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

