### PR TITLE
Fix #1544: Restore Bitnami Helm dependency images

### DIFF
--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -146,6 +146,23 @@ redis:
   nameOverride: redis
   fullnameOverride: redis
   architecture: standalone
+  # Bitnami removed the immutable tags used by this pinned chart version from
+  # its primary repository. Keep the tested versions available without a
+  # post-render rewrite or an implicit Redis major-version upgrade.
+  image:
+    repository: bitnamilegacy/redis
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  sysctl:
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     enabled: false
   master:
@@ -160,6 +177,9 @@ postgresql:
   enabled: true
   nameOverride: postgresql
   fullnameOverride: postgresql
+  # Match the immutable PostgreSQL and helper tags selected by chart 13.4.3.
+  image:
+    repository: bitnamilegacy/postgresql
   global:
     postgresql:
       auth:
@@ -172,6 +192,11 @@ postgresql:
       shared_buffers='400MB'
   volumePermissions:
     enabled: true
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
   persistence:
     enabled: true
     size: 1Gi
@@ -182,6 +207,21 @@ juicefs-redis:
   nameOverride: juicefs-redis
   fullnameOverride: juicefs-redis
   architecture: standalone
+  # Use the same resolvable immutable images as the gateway Redis deployment.
+  image:
+    repository: bitnamilegacy/redis
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  sysctl:
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     enabled: false
   master:


### PR DESCRIPTION
## Description

This PR closes #1544 by pointing the pinned Bitnami Redis and PostgreSQL subcharts at the immutable images Bitnami moved from `docker.io/bitnami` to `docker.io/bitnamilegacy`.

The chart currently resolves versioned Redis, PostgreSQL, and helper-image tags that no longer exist in Bitnami's primary Docker Hub repositories. A default installation therefore fails while pulling its dependencies unless users rewrite every rendered image with a Helm post-renderer.

This keeps the dependency versions already selected and tested by the chart, restores pullable images without an installation-time rewrite, and avoids silently upgrading Redis or PostgreSQL across major versions.

## Changes

- Point the gateway Redis deployment at the matching legacy Redis image.
- Point the JuiceFS Redis deployment at the same matching legacy image.
- Point PostgreSQL and its volume-permissions helper at their matching legacy images.
- Cover the optional Redis Sentinel, metrics, volume-permissions, and sysctl images.
- Cover the optional PostgreSQL metrics image.
- Preserve all existing Helm dependency and application versions.

## Verification

- `helm dependency build` passes.
- `helm lint` passes.
- The default chart renders successfully.
- Metrics, volume-permissions, and sysctl configurations render successfully.
- Redis Sentinel configurations render successfully.
- No tested configuration renders a `docker.io/bitnami/*` dependency image.
- All seven rendered `docker.io/bitnamilegacy/*` tags resolve through the Docker registry.
- Helm chart packaging passes.
- The complete Go package test suite passes.
- The Python SDK suite passes with 201 tests passed and 2 integration tests skipped.
- The branch is conflict-free with current `main`.

Closes #1544


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores pullable Bitnami Helm dependency images by switching Redis and PostgreSQL subcharts to immutable tags under `docker.io/bitnamilegacy`, fixing default install failures without upgrading across major versions. Closes #1544.

- **Bug Fixes**
  - Redirect Redis (gateway and `juicefs-redis`) to `bitnamilegacy/redis` and supporting images (`redis-sentinel`, `redis-exporter`, `os-shell`, `sysctl`).
  - Redirect PostgreSQL and helpers to `bitnamilegacy/postgresql`, `os-shell`, and `postgres-exporter`.
  - Preserve all existing chart and dependency versions; only the image repository path changes.

<sup>Written for commit f381f33bc51e56930fa8e274b1d41f43b88c354f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

