### PR TITLE
Add native ARM64 gateway and runner images

### DIFF
--- a/.github/workflows/dispatch-gateway-build.yml
+++ b/.github/workflows/dispatch-gateway-build.yml
@@ -21,7 +21,53 @@ permissions:
   contents: read
 
 jobs:
-  build_and_release_worker:
+  build_and_release_gateway:
+    environment: Release
+    name: build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_GITHUB }}
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+        with:
+          registry-type: public
+          mask-password: 'true'
+
+      - name: Build and push container image to Amazon ECR
+        uses: docker/build-push-action@v5
+        with:
+          file: ./docker/Dockerfile.gateway
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway:${{ inputs.tag }}-${{ matrix.arch }}
+          target: release
+          platforms: ${{ matrix.platform }}
+
+  publish_gateway_manifest:
+    needs: build_and_release_gateway
     environment: Release
     runs-on: ubuntu-latest
 
@@ -58,12 +104,12 @@ jobs:
           registry-type: public
           mask-password: 'true'
 
-      - name: Build and push container image to Amazon ECR
-        uses: docker/build-push-action@v5
-        with:
-          file: ./docker/Dockerfile.gateway
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway:${{ inputs.tag }}
-          target: release
-          platforms: linux/amd64
+      - name: Publish multi-platform image manifest
+        env:
+          IMAGE: ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${TAG_NAME}" \
+            "${IMAGE}:${TAG_NAME}-amd64" \
+            "${IMAGE}:${TAG_NAME}-arm64"

--- a/.github/workflows/dispatcher-runner-build.yml
+++ b/.github/workflows/dispatcher-runner-build.yml
@@ -13,19 +13,28 @@ permissions:
   contents: read
 
 jobs:
-  build_and_release_worker:
+  build_and_release_runner:
     environment: Release
-    runs-on: ubuntu-latest
+    name: build (${{ matrix.image }}, ${{ matrix.architecture.platform }})
+    runs-on: ${{ matrix.architecture.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['py38', 'py39', 'py310', 'py311', 'py312']
+        image: ['py38', 'py39', 'py310', 'py311', 'py312']
+        architecture:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
@@ -38,16 +47,47 @@ jobs:
           mask-password: 'true'
           registry-type: public
 
-      - name: Build and push Docker image for ${{ matrix.python-version }}
-        uses: docker/build-push-action@v4
+      - name: Build and push Docker image for ${{ matrix.image }}
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile.runner
           push: true
-          tags:  ${{ secrets.ECR_REGISTRY }}/beta9-runner:${{ matrix.python-version }}-${{ inputs.tag }}
-          target: ${{ matrix.python-version }}
+          tags: ${{ secrets.ECR_REGISTRY }}/beta9-runner:${{ matrix.image }}-${{ inputs.tag }}-${{ matrix.architecture.arch }}
+          target: ${{ matrix.image }}
+          platforms: ${{ matrix.architecture.platform }}
           load: false
-          registry: ${{ steps.login-ecr.outputs.registry }}
-          repository: ${{ steps.login-ecr.outputs.registry }}/beta9-runner
-          add_git_labels: true
-          tag_with_ref: true
+
+  publish_runner_manifests:
+    needs: build_and_release_runner
+    environment: Release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ['py38', 'py39', 'py310', 'py311', 'py312']
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        with:
+          mask-password: 'true'
+          registry-type: public
+
+      - name: Publish multi-platform image manifest
+        env:
+          IMAGE: ${{ secrets.ECR_REGISTRY }}/beta9-runner
+          IMAGE_TAG: ${{ matrix.image }}-${{ inputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${IMAGE_TAG}" \
+            "${IMAGE}:${IMAGE_TAG}-amd64" \
+            "${IMAGE}:${IMAGE_TAG}-arm64"

--- a/.github/workflows/release-gateway.yml
+++ b/.github/workflows/release-gateway.yml
@@ -18,6 +18,62 @@ jobs:
   build_and_release_gateway:
     if: startsWith(github.ref, 'refs/tags/gateway-') || inputs.app_version != ''
     environment: Release
+    name: build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set version
+        id: set-version
+        run: |
+          if [[ ! -z "${{ inputs.app_version }}" ]]; then
+            echo "app_version=${{ inputs.app_version }}" >> $GITHUB_OUTPUT
+          else
+            echo "app_version=${GITHUB_REF_NAME#gateway-}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_GITHUB }}
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+        with:
+          registry-type: public
+          mask-password: 'true'
+
+      - name: Build and push gateway container image to Amazon ECR
+        uses: docker/build-push-action@v5
+        with:
+          file: ./docker/Dockerfile.gateway
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway:${{ steps.set-version.outputs.app_version }}-${{ matrix.arch }}
+          target: release
+          platforms: ${{ matrix.platform }}
+
+  publish_gateway_manifest_and_chart:
+    if: startsWith(github.ref, 'refs/tags/gateway-') || inputs.app_version != ''
+    needs: build_and_release_gateway
+    environment: Release
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +91,7 @@ jobs:
       - name: Set version
         id: set-version
         run: |
-          if [[ ! -z "${{ inputs.app_version }}" ]]; then
+          if [[ -n "${{ inputs.app_version }}" ]]; then
             echo "app_version=${{ inputs.app_version }}" >> $GITHUB_OUTPUT
           else
             echo "app_version=${GITHUB_REF_NAME#gateway-}" >> $GITHUB_OUTPUT
@@ -62,16 +118,20 @@ jobs:
           registry-type: public
           mask-password: 'true'
 
-      - name: Build and push gateway container image to Amazon ECR
-        uses: docker/build-push-action@v5
-        with:
-          file: ./docker/Dockerfile.gateway
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway:${{ steps.set-version.outputs.app_version }}
-            ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway:latest
-          target: release
-          platforms: linux/amd64
+      - name: Publish multi-platform image manifests
+        env:
+          IMAGE: ${{ steps.login-ecr.outputs.registry }}/n4e0e1y0/beta9-gateway
+          TAG_NAME: ${{ steps.set-version.outputs.app_version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${TAG_NAME}" \
+            "${IMAGE}:${TAG_NAME}-amd64" \
+            "${IMAGE}:${TAG_NAME}-arm64"
+
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${TAG_NAME}-amd64" \
+            "${IMAGE}:${TAG_NAME}-arm64"
 
       - name: Package and push Helm chart to Amazon ECR
         env:

--- a/.github/workflows/release-runner.yml
+++ b/.github/workflows/release-runner.yml
@@ -8,39 +8,56 @@ jobs:
   build_and_release_runner:
     if: startsWith(github.ref, 'refs/tags/runner-')
     environment: Release
-    runs-on: ubuntu-latest
+    name: build (${{ matrix.image.tag }}, ${{ matrix.architecture.platform }})
+    runs-on: ${{ matrix.architecture.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          # Python versions
+        image:
           - version: '3.8'
             target: 'py38'
+            tag: 'py38'
           - version: '3.9'
             target: 'py39'
+            tag: 'py39'
           - version: '3.10'
             target: 'py310'
+            tag: 'py310'
           - version: '3.11'
             target: 'py311'
+            tag: 'py311'
           - version: '3.12'
             target: 'py312'
-          # Micromamba versions
+            tag: 'py312'
           - version: '3.8'
             target: 'micromamba'
+            tag: 'micromamba3.8'
           - version: '3.9'
             target: 'micromamba'
+            tag: 'micromamba3.9'
           - version: '3.10'
             target: 'micromamba'
+            tag: 'micromamba3.10'
           - version: '3.11'
             target: 'micromamba'
+            tag: 'micromamba3.11'
           - version: '3.12'
             target: 'micromamba'
+            tag: 'micromamba3.12'
+        architecture:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
@@ -57,18 +74,67 @@ jobs:
         run: echo "RUNNER_TAG=${GITHUB_REF#refs/tags/runner-}" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile.runner
           push: true
-          tags: ${{ secrets.ECR_REGISTRY }}/beta9-runner:${{ matrix.target == 'micromamba' && format('micromamba{0}', matrix.version) || matrix.target }}-${{ env.RUNNER_TAG }},${{ secrets.ECR_REGISTRY }}/beta9-runner:${{ matrix.target == 'micromamba' && format('micromamba{0}', matrix.version) || matrix.target }}-latest
-          target: ${{ matrix.target }}
+          tags: ${{ secrets.ECR_REGISTRY }}/beta9-runner:${{ matrix.image.tag }}-${{ env.RUNNER_TAG }}-${{ matrix.architecture.arch }}
+          target: ${{ matrix.image.target }}
           build-args: |
-            ${{ matrix.target == 'micromamba' && format('PYTHON_VERSION={0}', matrix.version) || '' }}
-          platforms: linux/amd64
+            ${{ matrix.image.target == 'micromamba' && format('PYTHON_VERSION={0}', matrix.image.version) || '' }}
+          platforms: ${{ matrix.architecture.platform }}
           load: false
-          registry: ${{ steps.login-ecr.outputs.registry }}
-          repository: ${{ steps.login-ecr.outputs.registry }}/beta9-runner
-          add_git_labels: true
-          tag_with_ref: true
+
+  publish_runner_manifests:
+    if: startsWith(github.ref, 'refs/tags/runner-')
+    needs: build_and_release_runner
+    environment: Release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - tag: 'py38'
+          - tag: 'py39'
+          - tag: 'py310'
+          - tag: 'py311'
+          - tag: 'py312'
+          - tag: 'micromamba3.8'
+          - tag: 'micromamba3.9'
+          - tag: 'micromamba3.10'
+          - tag: 'micromamba3.11'
+          - tag: 'micromamba3.12'
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        with:
+          mask-password: 'true'
+          registry-type: public
+
+      - name: Extract tag name
+        run: echo "RUNNER_TAG=${GITHUB_REF#refs/tags/runner-}" >> $GITHUB_ENV
+
+      - name: Publish multi-platform image manifests
+        env:
+          IMAGE: ${{ secrets.ECR_REGISTRY }}/beta9-runner
+          IMAGE_TAG: ${{ matrix.image.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${IMAGE_TAG}-${RUNNER_TAG}" \
+            "${IMAGE}:${IMAGE_TAG}-${RUNNER_TAG}-amd64" \
+            "${IMAGE}:${IMAGE_TAG}-${RUNNER_TAG}-arm64"
+
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${IMAGE_TAG}-latest" \
+            "${IMAGE}:${IMAGE_TAG}-${RUNNER_TAG}-amd64" \
+            "${IMAGE}:${IMAGE_TAG}-${RUNNER_TAG}-arm64"

--- a/docker/Dockerfile.gateway
+++ b/docker/Dockerfile.gateway
@@ -2,10 +2,27 @@
 
 FROM golang:1.23-bullseye AS base
 
+ARG TARGETARCH
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends fuse3
 
-RUN curl -L https://beam-runner-python-deps.s3.amazonaws.com/juicefs -o /usr/local/bin/juicefs && chmod +x /usr/local/bin/juicefs
+RUN <<EOT
+set -eux
+case "$TARGETARCH" in
+    amd64)
+        curl -fsSL https://beam-runner-python-deps.s3.amazonaws.com/juicefs -o /usr/local/bin/juicefs
+        chmod +x /usr/local/bin/juicefs
+        ;;
+    arm64)
+        curl -fsSL https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-arm64.tar.gz -o /tmp/juicefs.tar.gz
+        tar -xzf /tmp/juicefs.tar.gz -C /tmp juicefs
+        install /tmp/juicefs /usr/local/bin/juicefs
+        rm -f /tmp/juicefs.tar.gz /tmp/juicefs
+        ;;
+    *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;;
+esac
+EOT
 RUN curl -fsSL https://tailscale.com/install.sh | sh
 
 RUN apt-get install -y libfuse2 libfuse-dev bash-completion && \


### PR DESCRIPTION
## Description

This PR completes #1760 by publishing native ARM64 gateway and runner images alongside AMD64 and assembling stable multi-platform manifests. Worker images and CLI release binaries already supported ARM64; this closes the remaining official-image gaps and removes the gateway's AMD64-only JuiceFS installation path.

## Changes

- Build gateway release and dispatch images natively on AMD64 and ARM64.
- Publish versioned, latest, and custom-tag gateway manifests only after both architectures succeed.
- Add an ARM64-safe JuiceFS installation path while preserving the existing Beam-pinned AMD64 build.
- Build every Python and Micromamba runner variant natively on AMD64 and ARM64.
- Publish versioned, latest, and custom-tag runner multi-platform manifests.
- Keep Helm chart and BYOC publication behind successful dual-architecture gateway builds.
- Correct stale workflow job names and remove invalid legacy build-push inputs in the modified release paths.

Kubernetes can now resolve the correct gateway, worker, and runner image architecture from the unsuffixed multi-platform tags, including mixed-architecture clusters, without requiring architecture-specific Helm values.

## Verification

- Actionlint passes all four modified workflows.
- Workflow topology assertions confirm both architecture matrices, build dependencies, and manifest coverage for all runner variants.
- Gateway, worker, and agent cross-compile for `linux/amd64` and `linux/arm64`.
- The complete ARM64 gateway production image builds and runs JuiceFS 1.3.1 and mount-s3 1.5.0.
- The AMD64 gateway base image builds successfully and preserves the existing Beam-pinned JuiceFS path.
- All ten ARM64 runner variants build and execute with their expected Python versions.
- `go test ./pkg/...` passes.
- SDK suite passes with 201 tests and 2 intentional skips.
- `git diff --check` passes.

Closes #1760


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native ARM64 builds for the gateway and all runner images, and publishes multi-platform manifests so Kubernetes pulls the correct architecture automatically. Also adds an ARM64-safe `juicefs` install and gates Helm/BYOC publish on dual-arch success. Closes #1760.

- New Features
  - Build gateway and all Python/Micromamba runners natively for `linux/amd64` and `linux/arm64`.
  - Publish versioned, latest, and custom multi-platform manifests after both architectures succeed.
  - Add ARM64-safe `juicefs` install in `docker/Dockerfile.gateway`; keep the AMD64 Beam-pinned path.
  - Clean up workflows: corrected job names and removed invalid legacy inputs.

- Migration
  - No arch-specific Helm values needed; use unsuffixed tags and Kubernetes selects the right image.
  - Mixed-architecture clusters work without changes.

<sup>Written for commit 335ad4e48ea7d76137d12604df3123040620a9db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

