### PR TITLE
Allow CRIU restores across ERMS differences

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -260,6 +260,7 @@ ARG CRIU_COMMIT=b47c692bb3a73ae45ee1c4ab215a8f6869d40efd
 COPY docker/patches/criu/criu-network-remap.patch /tmp/criu-network-remap.patch
 COPY docker/patches/criu/criu-skip-non-cuda-resume.patch /tmp/criu-skip-non-cuda-resume.patch
 COPY docker/patches/criu/criu-skip-fresh-zero-pages.patch /tmp/criu-skip-fresh-zero-pages.patch
+COPY docker/patches/criu/criu-ignore-erms-compat.patch /tmp/criu-ignore-erms-compat.patch
 
 RUN <<EOT
 set -eux
@@ -291,6 +292,8 @@ if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "aarch64" ]; then
     git apply --unidiff-zero /tmp/criu-skip-non-cuda-resume.patch
     git apply --check /tmp/criu-skip-fresh-zero-pages.patch
     git apply /tmp/criu-skip-fresh-zero-pages.patch
+    git apply --check /tmp/criu-ignore-erms-compat.patch
+    git apply /tmp/criu-ignore-erms-compat.patch
 
     if [ "$(uname -m)" = "x86_64" ]; then
         make install-lib install-criu install-compel install-cuda_plugin PREFIX=/usr SKIP_PIP_INSTALL=1

--- a/docker/patches/criu/criu-ignore-erms-compat.patch
+++ b/docker/patches/criu/criu-ignore-erms-compat.patch
@@ -1,0 +1,23 @@
+diff --git a/criu/arch/x86/cpu.c b/criu/arch/x86/cpu.c
+--- a/criu/arch/x86/cpu.c
++++ b/criu/arch/x86/cpu.c
+@@ -106,6 +106,11 @@
+ 
+ #define __ins_bit(__l, __v) (1u << ((__v)-32u * (__l)))
+ 
++/*
++ * ERMS changes the performance of REP MOVSB/STOSB, not their availability,
++ * so it must not make an otherwise compatible restore host fail validation.
++ */
++
+ // clang-format off
+ static uint32_t x86_ins_capability_mask[NCAPINTS] = {
+ 	[CPUID_1_EDX] =
+@@ -164,7 +169,6 @@ static uint32_t x86_ins_capability_mask[NCAPINTS] = {
+ 	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_HLE) |
+ 	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_AVX2) |
+ 	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_BMI2) |
+-	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_ERMS) |
+ 	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_RTM) |
+ 	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_MPX) |
+ 	__ins_bit(CPUID_7_0_EBX, X86_FEATURE_AVX512F) |


### PR DESCRIPTION
## Summary

- Exclude ERMS from CRIU's x86 instruction compatibility mask.
- Keep all existing ISA, XSAVE, FPU, and CPU image compatibility checks enabled.
- Apply the patch when building the pinned CRIU version in the worker image.

## Root cause

Two RTX4090 workers use the same AMD EPYC 7B13 CPU family, model, stepping, and microcode, but their firmware exposes different raw CPUID capabilities. The checkpoint host exposes ERMS while the restore host does not. CRIU treats ERMS as required instruction availability and rejects the restore, even though ERMS only changes the optimized behavior of `REP MOVSB/STOSB`; those instructions remain valid without it.

## Validation

- Reproduced the production failure by dumping CPU metadata on the original checkpoint host and checking it on the original restore host with stock CRIU 4.2 from worker 0.1.694.
- Built patched CRIU from the exact pinned commit and confirmed it accepts the real cross-host CPU metadata.
- Added AVX-512F to a copy of the metadata and confirmed patched CRIU still rejects the unavailable ISA feature.
- Confirmed all four worker CRIU patches apply cleanly in Dockerfile order.
- Did not modify or restart any production worker or workload container.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow CRIU restores across hosts that differ only in ERMS support, preventing false restore failures. All other CPU/ISA compatibility checks remain enforced.

- **Bug Fixes**
  - Exclude ERMS from CRIU’s x86 instruction compatibility mask.
  - Apply `criu-ignore-erms-compat.patch` during the pinned CRIU build in `docker/Dockerfile.worker`.

<sup>Written for commit 0568806721c423223da0f5ea84225b872779eeb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

