### PR TITLE
Fix pod failure retry cutoff

### DIFF
--- a/pkg/abstractions/common/instance.go
+++ b/pkg/abstractions/common/instance.go
@@ -295,6 +295,9 @@ func (i *AutoscaledInstance) HandleScalingEvent(desiredContainers int) error {
 
 	if i.FailedContainerThreshold > 0 && len(state.FailedContainers) >= i.FailedContainerThreshold {
 		desiredContainers = 0
+		if err := i.ContainerRepo.SetContainerFailureCooldown(state.FailedContainers); err != nil {
+			log.Warn().Err(err).Str("stub_id", i.Stub.ExternalId).Msg("failed to set container failure cooldown")
+		}
 	}
 
 	if !i.IsActive {

--- a/pkg/abstractions/pod/instance.go
+++ b/pkg/abstractions/pod/instance.go
@@ -258,17 +258,27 @@ func (i *podInstance) stoppableContainers() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	stopAll := !i.IsActive
+	if !stopAll && i.FailedContainerThreshold > 0 {
+		failedContainers, err := i.ContainerRepo.GetFailedContainersByStubId(i.Stub.ExternalId)
+		if err != nil {
+			return nil, err
+		}
+		stopAll = len(failedContainers) >= i.FailedContainerThreshold
+	}
 
-	// Create a slice to hold the keys
 	keys := make([]string, 0, len(containers))
 	for _, container := range containers {
-		if container.Status == types.ContainerStatusStopping || container.Status == types.ContainerStatusPending {
+		if container.Status == types.ContainerStatusStopping {
 			continue
 		}
 
-		// When deployment is stopped, all containers should be stopped even if they have keep warm
-		if !i.IsActive {
+		// Circuit breaking must cancel pending replacements and ignore keep-warm.
+		if stopAll {
 			keys = append(keys, container.ContainerId)
+			continue
+		}
+		if container.Status == types.ContainerStatusPending {
 			continue
 		}
 

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -1275,6 +1275,60 @@ func TestStoppableContainersSkipsPendingKeepWarmLock(t *testing.T) {
 	}
 }
 
+func TestStoppableContainersIncludesPendingAfterFailureThreshold(t *testing.T) {
+	rdb := newPodProxyTestRedis(t)
+	repo := repository.NewContainerRedisRepositoryForTest(rdb)
+	const stubID = "stub"
+	index := common.RedisKeys.SchedulerContainerIndex(stubID)
+
+	addFailure := func(containerID string) {
+		state := common.RedisKeys.SchedulerContainerState(containerID)
+		if err := rdb.SAdd(context.Background(), index, state).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.SetContainerExitCode(containerID, int(types.ContainerExitCodeUnknownError)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const pendingID = "pod-stub-pending"
+	if err := repo.SetContainerState(pendingID, &types.ContainerState{
+		ContainerId: pendingID,
+		StubId:      stubID,
+		WorkspaceId: "workspace",
+		Status:      types.ContainerStatusPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	instance := &podInstance{AutoscaledInstance: &abstractions.AutoscaledInstance{
+		Rdb:                      rdb,
+		IsActive:                 true,
+		FailedContainerThreshold: types.FailedDeploymentContainerThreshold,
+		ContainerRepo:            repo,
+		Workspace:                &types.Workspace{Name: "workspace"},
+		Stub:                     &types.StubWithRelated{Stub: types.Stub{ExternalId: stubID}},
+	}}
+
+	addFailure("failed-1")
+	addFailure("failed-2")
+	stoppable, err := instance.stoppableContainers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stoppable) != 0 {
+		t.Fatalf("stoppable containers below threshold = %v, want none", stoppable)
+	}
+
+	addFailure("failed-3")
+	stoppable, err = instance.stoppableContainers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stoppable) != 1 || stoppable[0] != pendingID {
+		t.Fatalf("stoppable containers = %v, want [%s]", stoppable, pendingID)
+	}
+}
+
 func TestRetireContainerForStopRemovesProxyBackend(t *testing.T) {
 	containerID := "pod-stub-container-1"
 	address := types.BackendRouteAddress("route-1")

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -56,6 +56,7 @@ type ContainerRepository interface {
 	GetContainerState(string) (*types.ContainerState, error)
 	SetContainerState(string, *types.ContainerState) error
 	SetContainerExitCode(string, int) error
+	SetContainerFailureCooldown([]string) error
 	GetContainerExitCode(string) (int, error)
 	SetContainerAddress(containerId string, addr string) error
 	GetContainerAddress(containerId string) (string, error)

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -209,9 +209,34 @@ func (cr *ContainerRedisRepository) SetContainerState(containerId string, state 
 
 func (cr *ContainerRedisRepository) SetContainerExitCode(containerId string, exitCode int) error {
 	exitCodeKey := common.RedisKeys.SchedulerContainerExitCode(containerId)
-	err := cr.rdb.SetEx(context.TODO(), exitCodeKey, exitCode, time.Duration(types.ContainerExitCodeTtlS)*time.Second).Err()
+	ttl := types.ContainerExitCodeTTL
+	if types.ContainerExitCode(exitCode).IsFailed() {
+		ttl = types.ContainerFailureHistoryTTL
+	}
+	err := cr.rdb.SetEx(context.TODO(), exitCodeKey, exitCode, ttl).Err()
 	if err != nil {
 		return fmt.Errorf("failed to set exit code <%v> for container <%v>: %w", exitCodeKey, containerId, err)
+	}
+
+	return nil
+}
+
+func (cr *ContainerRedisRepository) SetContainerFailureCooldown(containerIds []string) error {
+	const clampTTL = `
+if redis.call("PTTL", KEYS[1]) > tonumber(ARGV[1]) then
+	return redis.call("PEXPIRE", KEYS[1], ARGV[1])
+end
+return 0`
+
+	ctx := context.TODO()
+	pipe := cr.rdb.Pipeline()
+	for _, containerId := range containerIds {
+		key := common.RedisKeys.SchedulerContainerExitCode(containerId)
+		pipe.Eval(ctx, clampTTL, []string{key}, types.ContainerFailureCooldown.Milliseconds())
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("failed to set container failure cooldown: %w", err)
 	}
 
 	return nil

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -117,6 +117,47 @@ func TestSetContainerStateCommitsIndexesWithState(t *testing.T) {
 	}
 }
 
+func TestContainerFailureRetentionAndCooldown(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	for containerID, exitCode := range map[string]int{
+		"container-success": int(types.ContainerExitCodeSuccess),
+		"container-failure": int(types.ContainerExitCodeUnknownError),
+	} {
+		if err := repo.SetContainerExitCode(containerID, exitCode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	assertTTL := func(containerID string, want time.Duration) {
+		t.Helper()
+		got, err := rdb.TTL(context.Background(), common.RedisKeys.SchedulerContainerExitCode(containerID)).Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("%s exit code TTL = %s, want %s", containerID, got, want)
+		}
+	}
+
+	assertTTL("container-success", types.ContainerExitCodeTTL)
+	assertTTL("container-failure", types.ContainerFailureHistoryTTL)
+
+	if err := repo.SetContainerFailureCooldown([]string{"container-failure"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTTL("container-failure", types.ContainerFailureCooldown)
+
+	if err := repo.SetContainerFailureCooldown([]string{"container-failure"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTTL("container-failure", types.ContainerFailureCooldown)
+}
+
 func TestSetContainerStateWithConcurrencyLimitUsesAtomicReservationAfterInit(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	if err != nil {

--- a/pkg/types/scheduler.go
+++ b/pkg/types/scheduler.go
@@ -715,7 +715,11 @@ func cloneMounts(mounts []Mount) []Mount {
 	return out
 }
 
-const ContainerExitCodeTtlS int = 300
+const (
+	ContainerExitCodeTTL       = 5 * time.Minute
+	ContainerFailureHistoryTTL = time.Hour
+	ContainerFailureCooldown   = time.Minute
+)
 
 const (
 	ContainerDurationEmissionInterval      time.Duration = 5 * time.Second


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the pod failure retry cutoff by enforcing shutdown at the failure threshold and adding a 1-minute cooldown so retries resume predictably. Failed exits now persist longer for accurate counting, then are shortened when the limit is hit.

- **Bug Fixes**
  - stoppableContainers: force-stop when deployment is inactive or failures >= threshold; overrides pending status and keep-warm locks.
  - Failure tracking and cooldown: exit codes keep 5m TTL on success and 1h on failure; when the threshold is hit we scale desired containers to 0 and clamp failed-exit TTLs to 1m via SetContainerFailureCooldown. Added tests for retention, cooldown, and pending-cancel behavior.

<sup>Written for commit 9ab385e9cf7bb2c2df72b5a113f7121117c28b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

