### PR TITLE
Reduce sandbox worker address lookup latency

### DIFF
--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -40,7 +40,7 @@ const (
 	concurrencyCounterRepairInterval   = 5 * time.Second
 	concurrencyReservationInFlightTTL  = 2 * time.Minute
 	workerAddressWaitTimeout           = 5 * time.Minute
-	workerAddressPollInterval          = 250 * time.Millisecond
+	workerAddressPollInterval          = 25 * time.Millisecond
 )
 
 var errConcurrencyCounterRepairing = errors.New("concurrency counter repair in progress")


### PR DESCRIPTION
## What changed

Reduce the Redis worker-address polling interval from 250 ms to 25 ms while retaining the existing five-minute readiness timeout.

## Why

Sandbox connect requests were consistently spending about 250 ms in `worker_address_lookup` even though workers published their address much earlier. The coarse poll interval dominated steady-state cold-start latency.

## Impact

In the latest upstream ComputeSDK 100-iteration sequential benchmark, this change plus the coordinated client inline-exec path reduced Beam's reported TTI from:

- median: 332.9 ms → 169.5 ms
- p99: 442.4 ms → 214.9 ms
- score: 96.25 → 98.20

The production-order staggered run completed 100/100 with a reported p99 of 228.8 ms.

## Validation

- `go test ./pkg/repository`
- `git diff --check`
- Latest ComputeSDK benchmark upstream, Node 24, scheduled production ordering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the Redis worker-address poll interval from 250 ms to 25 ms to cut sandbox connect latency while keeping the 5-minute readiness timeout. This removes the ~250 ms wait in `worker_address_lookup` and speeds up cold starts.

- **Performance**
  - TTI median: 332.9 ms → 169.5 ms
  - TTI p99: 442.4 ms → 214.9 ms
  - Score: 96.25 → 98.20
  - Production-order run: 100/100; p99 228.8 ms

<sup>Written for commit b84c6532d4a7f6d92f911622ec3947bb73c30bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

