### PR TITLE
logging performance fixes

### DIFF
--- a/pkg/api/v1/events_test.go
+++ b/pkg/api/v1/events_test.go
@@ -7,11 +7,51 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/labstack/echo/v4"
 )
+
+type taskLogBoundsBackend struct {
+	repository.BackendRepository
+	task *types.TaskWithRelated
+}
+
+func (r *taskLogBoundsBackend) GetTaskWithRelated(context.Context, string) (*types.TaskWithRelated, error) {
+	return r.task, nil
+}
+
+func TestAuthorizeCompletedTaskSetsHistoryBounds(t *testing.T) {
+	createdAt := time.Date(2026, 7, 22, 16, 32, 0, 0, time.UTC)
+	endedAt := time.Date(2026, 7, 22, 16, 33, 0, 0, time.UTC)
+	task := &types.TaskWithRelated{
+		Task:      types.Task{ExternalId: "task-1", Status: types.TaskStatusComplete, WorkspaceId: 1, CreatedAt: types.Time{Time: createdAt}, EndedAt: types.NullTime{Time: endedAt, Valid: true}},
+		Workspace: types.Workspace{Id: 1, ExternalId: "workspace-1"},
+		Stub:      types.Stub{ExternalId: "stub-1"},
+		App:       types.App{ExternalId: "app-1"},
+	}
+	group := &LogGroup{backendRepo: &taskLogBoundsBackend{task: task}}
+	e := echo.New()
+	ctx := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), httptest.NewRecorder())
+	authInfo := &auth.AuthInfo{Workspace: &types.Workspace{Id: 1, ExternalId: "workspace-1"}}
+	query := types.LogQuery{ObjectID: "task-1", ObjectType: types.GatewayObjectTypeTask, WorkspaceID: "workspace-1"}
+
+	if err := group.authorizeLogQuery(ctx, authInfo, &query); err != nil {
+		t.Fatal(err)
+	}
+	if query.HistoryEnd == nil || !query.HistoryEnd.Equal(endedAt.Add(time.Minute)) {
+		t.Fatalf("history end = %v, want %v", query.HistoryEnd, endedAt.Add(time.Minute))
+	}
+	if query.HistoryStart == nil || !query.HistoryStart.Equal(createdAt.Add(-time.Minute)) {
+		t.Fatalf("history start = %v, want %v", query.HistoryStart, createdAt.Add(-time.Minute))
+	}
+	if query.EndTime != nil {
+		t.Fatalf("authorization must not cap live streams: end_time = %v", query.EndTime)
+	}
+}
 
 func TestSummarizeContainerEventsBatchReturnsCoverageAndBottleneck(t *testing.T) {
 	items := []ContainerEventSummary{

--- a/pkg/api/v1/logs.go
+++ b/pkg/api/v1/logs.go
@@ -275,6 +275,14 @@ func (g *LogGroup) authorizeLogQuery(ctx echo.Context, authInfo *auth.AuthInfo, 
 		query.AppID = task.App.ExternalId
 		query.TaskID = task.ExternalId
 		query.ContainerID = task.ContainerId
+		if !task.CreatedAt.Time.IsZero() {
+			start := task.CreatedAt.Time.UTC().Add(-time.Minute)
+			query.HistoryStart = &start
+		}
+		if task.Status.IsCompleted() && task.EndedAt.Valid {
+			end := task.EndedAt.Time.UTC().Add(time.Minute)
+			query.HistoryEnd = &end
+		}
 	case types.GatewayObjectTypeStub:
 		stub, err := g.backendRepo.GetStubByExternalId(ctx.Request().Context(), query.ObjectID, types.QueryFilter{Field: "workspace_id", Value: query.WorkspaceID})
 		if err != nil {

--- a/pkg/api/v1/stub.go
+++ b/pkg/api/v1/stub.go
@@ -846,6 +846,12 @@ func (g *StubGroup) ListSandboxes(ctx echo.Context) error {
 	if err != nil {
 		return HTTPInternalServerError("Failed to list sandboxes")
 	}
+	if len(page.Data) == 0 {
+		return ctx.JSON(http.StatusOK, SandboxListResponse{
+			Data: []SandboxRow{},
+			Next: page.Next,
+		})
+	}
 
 	containersByStub := g.activeContainersByStub(workspaceID)
 	summaries, err := g.sandboxStatsContainerSummariesResult(
@@ -895,6 +901,23 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 		return HTTPInternalServerError("Failed to list sandboxes")
 	}
 
+	statusCounts := map[string]int{
+		SandboxStatusRunning:  0,
+		SandboxStatusPending:  0,
+		SandboxStatusStopping: 0,
+		SandboxStatusStopped:  0,
+		SandboxStatusFailed:   0,
+	}
+	if len(stubs) == 0 {
+		return ctx.JSON(http.StatusOK, SandboxStatsResponse{
+			Concurrent:     0,
+			TotalCreated:   0,
+			RatePerSecond:  0,
+			StatusCounts:   statusCounts,
+			CreatedBuckets: buildSandboxSummaryCreatedBuckets(nil, ctx.QueryParam("chart_range")),
+		})
+	}
+
 	containersByStub := g.activeContainersByStub(workspaceID)
 
 	appID := ctx.QueryParam("app_id")
@@ -903,14 +926,6 @@ func (g *StubGroup) GetSandboxStats(ctx echo.Context) error {
 		return sandboxHistoryUnavailable(ctx, err)
 	}
 	sandboxRows := g.buildSandboxStatsRowsWithSummaries(ctx.Request().Context(), workspaceID, stubs, containersByStub, summaries)
-
-	statusCounts := map[string]int{
-		SandboxStatusRunning:  0,
-		SandboxStatusPending:  0,
-		SandboxStatusStopping: 0,
-		SandboxStatusStopped:  0,
-		SandboxStatusFailed:   0,
-	}
 
 	concurrent := 0
 	var earliest, latest time.Time

--- a/pkg/api/v1/stub_test.go
+++ b/pkg/api/v1/stub_test.go
@@ -41,14 +41,36 @@ type sandboxRowsEventRepo struct {
 
 type sandboxHistoryBackendRepo struct {
 	repository.BackendRepository
+	stubs []types.StubWithRelated
 }
 
-func (sandboxHistoryBackendRepo) ListStubs(context.Context, types.StubFilter) ([]types.StubWithRelated, error) {
-	return nil, nil
+func (r sandboxHistoryBackendRepo) ListStubs(context.Context, types.StubFilter) ([]types.StubWithRelated, error) {
+	return r.stubs, nil
 }
 
-func (sandboxHistoryBackendRepo) ListStubsPaginated(context.Context, types.StubFilter) (repocommon.CursorPaginationInfo[types.StubWithRelated], error) {
-	return repocommon.CursorPaginationInfo[types.StubWithRelated]{}, nil
+func (r sandboxHistoryBackendRepo) ListStubsPaginated(context.Context, types.StubFilter) (repocommon.CursorPaginationInfo[types.StubWithRelated], error) {
+	return repocommon.CursorPaginationInfo[types.StubWithRelated]{Data: r.stubs}, nil
+}
+
+type unexpectedSandboxRealtimeRepo struct {
+	repository.EventRepository
+	repository.ContainerRepository
+	calls int
+}
+
+func (r *unexpectedSandboxRealtimeRepo) GetEventHistory(context.Context, types.EventQuery) (*types.EventHistoryResponse, error) {
+	r.calls++
+	return nil, errors.New("unexpected sandbox event history query")
+}
+
+func (r *unexpectedSandboxRealtimeRepo) GetContainerEvents(context.Context, string, types.EventQuery) (*types.ContainerEventsResponse, error) {
+	r.calls++
+	return nil, errors.New("unexpected sandbox container event query")
+}
+
+func (r *unexpectedSandboxRealtimeRepo) GetActiveContainersByWorkspaceId(string) ([]types.ContainerState, error) {
+	r.calls++
+	return nil, errors.New("unexpected active container query")
 }
 
 func (r *sandboxRowsEventRepo) GetEventHistory(_ context.Context, query types.EventQuery) (*types.EventHistoryResponse, error) {
@@ -161,7 +183,7 @@ func TestSandboxHistoryCapacityReturnsRetryableError(t *testing.T) {
 	for name, handler := range handlers {
 		t.Run(name, func(t *testing.T) {
 			group := &StubGroup{
-				backendRepo: sandboxHistoryBackendRepo{},
+				backendRepo: sandboxHistoryBackendRepo{stubs: []types.StubWithRelated{{Stub: types.Stub{ExternalId: "sandbox-stub"}}}},
 				eventRepo:   &sandboxRowsEventRepo{history: &types.EventHistoryResponse{}},
 			}
 			e := echo.New()
@@ -180,6 +202,55 @@ func TestSandboxHistoryCapacityReturnsRetryableError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEmptySandboxHandlersSkipRealtimeRepositories(t *testing.T) {
+	run := func(t *testing.T, url string, handler func(*StubGroup, echo.Context) error) *httptest.ResponseRecorder {
+		t.Helper()
+		realtimeRepo := &unexpectedSandboxRealtimeRepo{}
+		group := &StubGroup{
+			backendRepo:   sandboxHistoryBackendRepo{},
+			eventRepo:     realtimeRepo,
+			containerRepo: realtimeRepo,
+		}
+		recorder := httptest.NewRecorder()
+		ctx := echo.New().NewContext(httptest.NewRequest(http.MethodGet, url, nil), recorder)
+		ctx.SetParamNames("workspaceId")
+		ctx.SetParamValues("workspace")
+		if err := handler(group, ctx); err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+		if recorder.Code != http.StatusOK || realtimeRepo.calls != 0 {
+			t.Fatalf("status = %d, realtime calls = %d; want 200 and 0", recorder.Code, realtimeRepo.calls)
+		}
+		return recorder
+	}
+
+	t.Run("list", func(t *testing.T) {
+		recorder := run(t, "/?app_id=app-1", func(group *StubGroup, ctx echo.Context) error { return group.ListSandboxes(ctx) })
+		if got := recorder.Body.String(); got != "{\"data\":[],\"next\":\"\"}\n" {
+			t.Fatalf("response = %q, want an empty data array", got)
+		}
+	})
+
+	t.Run("stats", func(t *testing.T) {
+		recorder := run(t, "/?app_id=app-1&chart_range=last_day", func(group *StubGroup, ctx echo.Context) error { return group.GetSandboxStats(ctx) })
+		var response SandboxStatsResponse
+		if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if response.Concurrent != 0 || response.TotalCreated != 0 || response.RatePerSecond != 0 {
+			t.Fatalf("non-zero empty stats response: %#v", response)
+		}
+		if len(response.StatusCounts) != 5 || len(response.CreatedBuckets) != 60 {
+			t.Fatalf("empty stats shape = %d statuses, %d buckets; want 5 and 60", len(response.StatusCounts), len(response.CreatedBuckets))
+		}
+		for _, bucket := range response.CreatedBuckets {
+			if bucket.Timestamp.IsZero() || bucket.Count != 0 {
+				t.Fatalf("invalid empty bucket: %#v", bucket)
+			}
+		}
+	})
 }
 
 func TestBuildSandboxRowsDoesNotReloadPreloadedEmptyHistory(t *testing.T) {

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -761,16 +761,19 @@ func (r *PostgresBackendRepository) ListTasks(ctx context.Context) ([]types.Task
 	return tasks, nil
 }
 
-func (c *PostgresBackendRepository) listTaskWithRelatedQueryBuilder(filters types.TaskFilter) squirrel.SelectBuilder {
-	qb := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).Select(
-		"t.*, w.external_id AS \"workspace.external_id\", w.name AS \"workspace.name\", " +
-			"w.created_at AS \"workspace.created_at\", w.updated_at AS \"workspace.updated_at\", " +
-			"s.external_id AS \"stub.external_id\", s.name AS \"stub.name\", s.config AS \"stub.config\", s.type AS \"stub.type\", d.external_id AS \"deployment.external_id\", d.name AS \"deployment.name\", d.version AS \"deployment.version\"",
-	).From("task t").
-		Join("workspace w ON t.workspace_id = w.id").
-		Join("stub s ON t.stub_id = s.id").
-		LeftJoin("deployment d ON s.id = d.stub_id").
-		OrderBy("t.id DESC")
+const taskWithRelatedColumns = "t.*, w.external_id AS \"workspace.external_id\", w.name AS \"workspace.name\", " +
+	"w.created_at AS \"workspace.created_at\", w.updated_at AS \"workspace.updated_at\", " +
+	"s.external_id AS \"stub.external_id\", s.name AS \"stub.name\", s.config AS \"stub.config\", s.type AS \"stub.type\", d.external_id AS \"deployment.external_id\", d.name AS \"deployment.name\", d.version AS \"deployment.version\""
+
+func (c *PostgresBackendRepository) listTaskWithRelatedQueryBuilder(filters types.TaskFilter, pageOnly bool) squirrel.SelectBuilder {
+	columns := taskWithRelatedColumns
+	if pageOnly {
+		columns = "t.id, t.created_at"
+	}
+	qb := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).Select(columns).From("task t").Join("stub s ON t.stub_id = s.id")
+	if !pageOnly {
+		qb = qb.Join("workspace w ON t.workspace_id = w.id").LeftJoin("deployment d ON s.id = d.stub_id").OrderBy("t.id DESC")
+	}
 
 	// Apply filters
 	if filters.All {
@@ -850,6 +853,11 @@ func (c *PostgresBackendRepository) listTaskWithRelatedQueryBuilder(filters type
 
 	if filters.AppId != "" {
 		qb = qb.Join("app a ON s.app_id = a.id")
+		if filters.WorkspaceID > 0 {
+			qb = qb.Where(squirrel.Eq{"a.workspace_id": filters.WorkspaceID})
+		} else if filters.ExternalWorkspaceID > 0 {
+			qb = qb.Where(squirrel.Eq{"a.workspace_id": filters.ExternalWorkspaceID})
+		}
 		qb = qb.Where(squirrel.Eq{"a.external_id": filters.AppId})
 		qb = qb.Where("a.deleted_at IS NULL")
 	}
@@ -934,7 +942,7 @@ func (c *PostgresBackendRepository) AggregateTasksByTimeWindow(ctx context.Conte
 		qb = qb.Where(squirrel.Eq{"t.workspace_id": filters.WorkspaceID})
 	}
 
-	if len(filters.StubIds) > 0 || filters.AppId != "" {
+	if len(filters.StubIds) > 0 {
 		qb = qb.Join("stub s ON t.stub_id = s.id")
 	}
 
@@ -943,8 +951,16 @@ func (c *PostgresBackendRepository) AggregateTasksByTimeWindow(ctx context.Conte
 	}
 
 	if filters.AppId != "" {
-		qb = qb.Join("app a ON s.app_id = a.id")
-		qb = qb.Where(squirrel.Eq{"a.external_id": filters.AppId})
+		appWorkspaceId := filters.WorkspaceID
+		if appWorkspaceId == 0 {
+			appWorkspaceId = filters.ExternalWorkspaceID
+		}
+		appStubIds := squirrel.Select("app_stub.id").From("stub app_stub").
+			Join("app app_scope ON app_stub.app_id = app_scope.id").
+			Where(squirrel.Eq{"app_scope.workspace_id": appWorkspaceId}).
+			Where(squirrel.Eq{"app_scope.external_id": filters.AppId}).
+			Where("app_scope.deleted_at IS NULL")
+		qb = qb.Where(squirrel.Expr("t.stub_id IN (?)", appStubIds))
 	}
 
 	if filters.CreatedAtStart != "" {
@@ -982,7 +998,7 @@ func (c *PostgresBackendRepository) ListTasksWithRelated(ctx context.Context, fi
 		return tasks.Data, nil
 	}
 
-	qb := c.listTaskWithRelatedQueryBuilder(filters)
+	qb := c.listTaskWithRelatedQueryBuilder(filters, false)
 
 	sql, args, err := qb.ToSql()
 	if err != nil {
@@ -1003,7 +1019,18 @@ func (c *PostgresBackendRepository) ListTasksWithRelatedPaginated(ctx context.Co
 		return c.listAllTasksWithRelatedPaginated(ctx, filters)
 	}
 
-	qb := c.listTaskWithRelatedQueryBuilder(filters)
+	pageOnly := filters.AppId != ""
+	qb := c.listTaskWithRelatedQueryBuilder(filters, pageOnly)
+	queryWrapper := func(page squirrel.SelectBuilder, pageSize int) squirrel.SelectBuilder {
+		if !pageOnly {
+			return page
+		}
+		return squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).Select(taskWithRelatedColumns).
+			FromSelect(page, "page").Join("task t ON t.id = page.id").
+			Join("workspace w ON t.workspace_id = w.id").Join("stub s ON t.stub_id = s.id").
+			LeftJoin("LATERAL (SELECT d.external_id, d.name, d.version FROM deployment d WHERE d.stub_id = s.id AND d.deleted_at IS NULL ORDER BY d.created_at DESC, d.id DESC LIMIT 1) d ON true").
+			OrderBy("page.created_at DESC", "page.id DESC").Limit(uint64(pageSize + 1))
+	}
 
 	page, err := common.Paginate(
 		common.SquirrelCursorPaginator[types.TaskWithRelated]{
@@ -1013,6 +1040,7 @@ func (c *PostgresBackendRepository) ListTasksWithRelatedPaginated(ctx context.Co
 			SortColumn:      "created_at",
 			SortQueryPrefix: "t",
 			PageSize:        int(filters.Limit),
+			QueryWrapper:    queryWrapper,
 		},
 		filters.Cursor,
 	)
@@ -1102,9 +1130,9 @@ func (r *PostgresBackendRepository) GetOrCreateStub(ctx context.Context, name, s
 		queryGet := `
     SELECT id, external_id, name, type, config, config_version, object_id, workspace_id, created_at, updated_at, app_id
     FROM stub
-    WHERE name = $1 AND type = $2 AND object_id = $3 AND config::jsonb = $4::jsonb AND workspace_id = $5;
+    WHERE name = $1 AND type = $2 AND object_id = $3 AND config::jsonb = $4::jsonb AND workspace_id = $5 AND app_id = $6;
     `
-		err = r.client.GetContext(ctx, &stub, queryGet, name, stubType, objectId, string(configJSON), workspaceId)
+		err = r.client.GetContext(ctx, &stub, queryGet, name, stubType, objectId, string(configJSON), workspaceId, appId)
 		if err == nil {
 			queryTouch := `
     UPDATE stub

--- a/pkg/repository/backend_postgres_test.go
+++ b/pkg/repository/backend_postgres_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	repositoryCommon "github.com/beam-cloud/beta9/pkg/repository/common"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
@@ -51,6 +52,27 @@ func TestListTaskWithRelated(t *testing.T) {
 	require.Equal(t, 10, len(res.Data))
 	require.Equal(t, secondPageId, res.Data[0].Id)
 	require.NotNil(t, res.Next)
+}
+
+func TestListTasksWithRelatedPaginatedAppliesCursorBeforeHydration(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	cursorTime := time.Date(2026, time.July, 22, 16, 42, 45, 0, time.UTC)
+	cursor := repositoryCommon.EncodeCursor(repositoryCommon.DatetimeCursor{Value: cursorTime.Format(repositoryCommon.CursorTimestampFormat), Id: 77})
+
+	mock.ExpectQuery(`FROM \(SELECT t\.id, t\.created_at FROM task t JOIN stub s ON t\.stub_id = s\.id JOIN app a ON s\.app_id = a\.id WHERE t\.workspace_id = \$1 AND a\.workspace_id = \$2 AND a\.external_id = \$3 AND a\.deleted_at IS NULL AND \(t\.created_at < \$4 OR \(t\.created_at = \$5 AND t\.id < \$6\)\) ORDER BY t\.created_at DESC, t\.id DESC LIMIT 3\) AS page JOIN task t ON t\.id = page\.id JOIN workspace w ON t\.workspace_id = w\.id JOIN stub s ON t\.stub_id = s\.id LEFT JOIN LATERAL \(SELECT d\.external_id, d\.name, d\.version FROM deployment d WHERE d\.stub_id = s\.id AND d\.deleted_at IS NULL ORDER BY d\.created_at DESC, d\.id DESC LIMIT 1\) d ON true ORDER BY page\.created_at DESC, page\.id DESC LIMIT 3`).
+		WithArgs(uint(11), uint(11), "app-external", cursorTime, cursorTime, uint(77)).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	result, err := repo.ListTasksWithRelatedPaginated(context.Background(), types.TaskFilter{
+		WorkspaceID: 11,
+		AppId:       "app-external",
+		Cursor:      cursor,
+		BaseFilter:  types.BaseFilter{Limit: 2},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result.Data)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetAdminWorkspaceMapsExternalID(t *testing.T) {
@@ -274,7 +296,7 @@ func TestUpdateDeploymentDoesNotMatchDeletedRowsByNumericID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGetOrCreateStubTouchesExistingWorkspaceScopedStub(t *testing.T) {
+func TestGetOrCreateStubTouchesExistingAppScopedStub(t *testing.T) {
 	repo, mock := NewBackendPostgresRepositoryForTest()
 	postgresRepo := repo.(*PostgresBackendRepository)
 
@@ -294,8 +316,8 @@ func TestGetOrCreateStubTouchesExistingWorkspaceScopedStub(t *testing.T) {
 		"app_id",
 	}
 
-	mock.ExpectQuery("FROM stub").
-		WithArgs("stub-name", string(types.StubTypeFunction), uint(7), sqlmock.AnyArg(), uint(11)).
+	mock.ExpectQuery(`app_id = \$6`).
+		WithArgs("stub-name", string(types.StubTypeFunction), uint(7), sqlmock.AnyArg(), uint(11), uint(13)).
 		WillReturnRows(sqlmock.NewRows(stubRows).AddRow(
 			uint(5),
 			"stub-external",
@@ -343,6 +365,25 @@ func TestGetOrCreateStubTouchesExistingWorkspaceScopedStub(t *testing.T) {
 	require.Equal(t, uint(5), stub.Id)
 	require.Equal(t, uint(11), stub.WorkspaceId)
 	require.True(t, stub.UpdatedAt.Time.Equal(updatedAt))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAggregateTasksByTimeWindowScopesAppStubSubquery(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	postgresRepo := repo.(*PostgresBackendRepository)
+
+	mock.ExpectQuery(`FROM task t JOIN stub s ON t\.stub_id = s\.id WHERE t\.workspace_id = \$1 AND s\.external_id IN \(\$2\) AND t\.stub_id IN \(SELECT app_stub\.id FROM stub app_stub JOIN app app_scope ON app_stub\.app_id = app_scope\.id WHERE app_scope\.workspace_id = \$3 AND app_scope\.external_id = \$4 AND app_scope\.deleted_at IS NULL\)`).
+		WithArgs(uint(11), "stub-external", uint(11), "app-external").
+		WillReturnRows(sqlmock.NewRows([]string{"time", "count", "status_counts"}))
+
+	result, err := postgresRepo.AggregateTasksByTimeWindow(context.Background(), types.TaskFilter{
+		WorkspaceID: 11,
+		StubIds:     []string{"stub-external"},
+		AppId:       "app-external",
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/repository/common/paginator.go
+++ b/pkg/repository/common/paginator.go
@@ -61,6 +61,7 @@ type SquirrelCursorPaginator[DBType any] struct {
 	SortColumn      string
 	SortQueryPrefix string
 	PageSize        int
+	QueryWrapper    func(squirrel.SelectBuilder, int) squirrel.SelectBuilder
 }
 
 func getOperator(sortOrder string) string {
@@ -121,6 +122,9 @@ func Paginate[DBType any](settings SquirrelCursorPaginator[DBType], cursorString
 		operator := getOperator(settings.SortOrder)
 		whereExp := fmt.Sprintf("(%s %s ? OR (%s = ? AND %s %s ?))", sortColumnName, operator, sortColumnName, sortIdColumnName, operator)
 		settings.SelectBuilder = settings.SelectBuilder.Where(squirrel.Expr(whereExp, timeValue, timeValue, cursor.Id))
+	}
+	if settings.QueryWrapper != nil {
+		settings.SelectBuilder = settings.QueryWrapper(settings.SelectBuilder, settings.PageSize)
 	}
 
 	sql, args, err := settings.SelectBuilder.ToSql()

--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -62,6 +62,14 @@ func reserveS2MetricsRead(remaining *atomic.Int64) uint64 {
 }
 
 func (r *S2EventRepository) GetLogs(ctx context.Context, query types.LogQuery) (*types.LogsResponse, error) {
+	if query.HistoryStart != nil && (query.StartTime == nil || query.StartTime.Before(*query.HistoryStart)) {
+		start := query.HistoryStart.UTC()
+		query.StartTime = &start
+	}
+	if query.HistoryEnd != nil && (query.EndTime == nil || query.EndTime.After(*query.HistoryEnd)) {
+		end := query.HistoryEnd.UTC()
+		query.EndTime = &end
+	}
 	limit := query.Limit
 	if limit == 0 {
 		limit = defaultS2LogReadLimit
@@ -91,18 +99,26 @@ func (r *S2EventRepository) GetLogs(ctx context.Context, query types.LogQuery) (
 		response.Logs = append(response.Logs, logs...)
 	}
 
-	// Tasks that predate the multiplexed stub task stream only have log
-	// records in the legacy per-task log stream.
+	// Fall back from the app aggregate to multiplexed, then legacy task logs.
 	if response.TotalExpected == 0 && query.TaskID != "" && query.WorkspaceID != "" {
-		legacyStream := r.legacyTaskLogStreamName(query.WorkspaceID, query.TaskID)
-		if !responseReadStream(response.Streams, legacyStream) {
-			total, logs, err := r.readLogStreamPage(ctx, legacyStream, query, limit)
+		fallbacks := []s2.StreamName{r.legacyTaskLogStreamName(query.WorkspaceID, query.TaskID)}
+		if query.ObjectType == types.GatewayObjectTypeTask && query.AppID != "" && query.StubID != "" {
+			fallbacks = append([]s2.StreamName{r.stubTaskStreamName(query.WorkspaceID, query.StubID)}, fallbacks...)
+		}
+		for _, streamName := range fallbacks {
+			if responseReadStream(response.Streams, streamName) {
+				continue
+			}
+			total, logs, err := r.readLogStreamPage(ctx, streamName, query, limit)
 			if err != nil {
 				return nil, err
 			}
 			response.TotalExpected += total
-			response.Streams = append(response.Streams, string(legacyStream))
+			response.Streams = append(response.Streams, string(streamName))
 			response.Logs = append(response.Logs, logs...)
+			if response.TotalExpected > 0 {
+				break
+			}
 		}
 	}
 
@@ -595,6 +611,12 @@ func (r *S2EventRepository) resolveLogStreams(query types.LogQuery) ([]s2.Stream
 	}
 
 	switch {
+	case query.ObjectType == types.GatewayObjectTypeContainer:
+		query.ObjectType, query.TaskID = "", ""
+		query.MachineID, query.WorkerID = "", ""
+		return r.resolveLogStreams(query)
+	case query.ObjectType == types.GatewayObjectTypeTask && query.AppID != "" && query.WorkspaceID != "":
+		return addKnown(r.appNamespaceLogStreamName(query.WorkspaceID, query.AppID))
 	case query.MachineID != "":
 		return addKnownMany(r.machineLogStreams(query)...)
 	case query.TaskID != "" && query.WorkspaceID != "" && query.StubID != "":
@@ -647,6 +669,22 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 		return total, []types.LogRecord{}, nil
 	}
 
+	scannedFromTail := uint64(0)
+	if query.EndTime != nil {
+		endTimestamp := uint64(query.EndTime.UTC().UnixMilli())
+		count, clamp := uint64(1), true
+		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{Timestamp: &endTimestamp, Count: &count, Clamp: &clamp})
+		if err != nil {
+			if isS2ReadEmpty(err) {
+				return 0, nil, nil
+			}
+			return 0, nil, fmt.Errorf("position s2 log stream %q at end time: %w", streamName, err)
+		}
+		if len(batch.Records) > 0 {
+			scannedFromTail = logTailOffsetBeforeSeq(tail.Tail.SeqNum, batch.Records[0].SeqNum)
+		}
+	}
+
 	targetMatches := int((query.Page + 1) * limit)
 	skipMatches := int(query.Page * limit)
 	chunkSize := limit
@@ -659,7 +697,6 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 
 	matchesNewestFirst := make([]types.LogRecord, 0, targetMatches)
 	recordsScanned := uint64(0)
-	scannedFromTail := uint64(0)
 	exhausted := false
 	for scannedFromTail < tail.Tail.SeqNum && recordsScanned < s2ReadScanLimit {
 		tailOffset, count := nextTailReadWindow(scannedFromTail, tail.Tail.SeqNum, chunkSize)
@@ -694,6 +731,9 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 			}
 		}
 		exhausted = uint64(len(batch.Records)) < count || scannedFromTail == tail.Tail.SeqNum
+		if query.StartTime != nil && batch.Records[0].Timestamp < uint64(query.StartTime.UTC().UnixMilli()) {
+			exhausted = true
+		}
 		if len(matchesNewestFirst) >= targetMatches || exhausted {
 			break
 		}
@@ -715,6 +755,13 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 		filteredTotal = targetMatches + 1
 	}
 	return filteredTotal, logs, nil
+}
+
+func logTailOffsetBeforeSeq(tailSeqNum, endSeqNum uint64) uint64 {
+	if endSeqNum >= tailSeqNum {
+		return 0
+	}
+	return tailSeqNum - endSeqNum
 }
 
 // nextTailReadWindow returns the next tail offset and record count for scanning

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -557,6 +557,37 @@ func TestResolveLogStreamsUsesMultiplexedStubTaskStream(t *testing.T) {
 	}
 }
 
+func TestResolveLogStreamsHonorsExplicitTaskAndContainerScopes(t *testing.T) {
+	repo := &S2EventRepository{streamPrefix: "events"}
+	tests := []struct {
+		name  string
+		query types.LogQuery
+		want  s2.StreamName
+	}{
+		{
+			name:  "task prefers complete app aggregate",
+			query: types.LogQuery{ObjectType: types.GatewayObjectTypeTask, WorkspaceID: "workspace-123", StubID: "stub-456", AppID: "app-789", TaskID: "task-123", ContainerID: "container-abc"},
+			want:  "events/logs/workspaces/workspace-123/apps/app-789",
+		},
+		{
+			name:  "container keeps container stream with task filter",
+			query: types.LogQuery{ObjectType: types.GatewayObjectTypeContainer, WorkspaceID: "workspace-123", StubID: "stub-456", TaskID: "task-123", ContainerID: "container-abc"},
+			want:  "events/logs/workspaces/workspace-123/stubs/stub-456/containers/container-abc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streams, err := repo.resolveLogStreams(tt.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(streams) != 1 || streams[0] != tt.want {
+				t.Fatalf("streams = %q, want [%q]", streams, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveLogStreamsFallsBackToLegacyTaskStreamWithoutStub(t *testing.T) {
 	repo := &S2EventRepository{streamPrefix: "events"}
 
@@ -688,6 +719,12 @@ func TestNextTailReadWindow(t *testing.T) {
 	}
 	if offset, count := nextTailReadWindow(0, 250, 0); offset != 250 || count != 250 {
 		t.Fatalf("unexpected zero chunk window: got offset=%d count=%d want offset=250 count=250", offset, count)
+	}
+	// A historical end position skips records appended later instead of
+	// spending the 50k scan budget walking backward from the live tail.
+	start := logTailOffsetBeforeSeq(185443, 125443)
+	if offset, count := nextTailReadWindow(start, 185443, 100); start != 60000 || offset != 60100 || count != 100 {
+		t.Fatalf("unexpected positioned window: start=%d offset=%d count=%d", start, offset, count)
 	}
 }
 

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -927,6 +927,9 @@ type LogQuery struct {
 	TailOffset  *int64     `json:"tail_offset,omitempty"`
 	WaitSeconds *int32     `json:"wait,omitempty"`
 	Clamp       *bool      `json:"clamp,omitempty"`
+
+	HistoryStart *time.Time `json:"-"`
+	HistoryEnd   *time.Time `json:"-"`
 }
 
 const (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved log read performance by bounding task history windows, smarter stream selection, and tail positioning, plus faster empty sandbox responses and cursor-first pagination for app-filtered task lists.

- **Performance**
  - Set `HistoryStart`/`HistoryEnd` for task log queries based on task lifecycle; clamp S2 reads to these bounds.
  - Prefer app aggregate logs for tasks; fall back to stub-multiplexed, then legacy per-task streams.
  - Position reads at `EndTime` to avoid scanning from the live tail; stop when crossing `StartTime`.
  - Apply cursor pagination before hydration for app-scoped task lists; hydrate after paging with minimal columns.
  - Scope app filters to the workspace in SQL and use a stub subquery for task aggregation.
  - Short-circuit sandbox list/stats when no stubs exist to skip realtime repositories and return empty shapes quickly.

- **Bug Fixes**
  - Ensure `GetOrCreateStub` matches existing stubs by `app_id` to prevent touching the wrong stub.
  - Correct workspace scoping for app filters in task queries and aggregates.
  - Return consistent empty responses for sandbox list and stats.

<sup>Written for commit d80fcd18d25fcb5607cbcb2f4cbe0f0ef420bce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

