### PR TITLE
Fix S2 log history past stream tail

### DIFF
--- a/pkg/repository/events_s2_realtime.go
+++ b/pkg/repository/events_s2_realtime.go
@@ -674,14 +674,12 @@ func (r *S2EventRepository) readLogStreamPage(ctx context.Context, streamName s2
 		endTimestamp := uint64(query.EndTime.UTC().UnixMilli())
 		count, clamp := uint64(1), true
 		batch, err := r.basin.Stream(streamName).Read(ctx, &s2.ReadOptions{Timestamp: &endTimestamp, Count: &count, Clamp: &clamp})
-		if err != nil {
-			if isS2ReadEmpty(err) {
-				return 0, nil, nil
-			}
-			return 0, nil, fmt.Errorf("position s2 log stream %q at end time: %w", streamName, err)
+		if isS2StreamNotFound(err) {
+			return 0, nil, nil
 		}
-		if len(batch.Records) > 0 {
-			scannedFromTail = logTailOffsetBeforeSeq(tail.Tail.SeqNum, batch.Records[0].SeqNum)
+		scannedFromTail, err = logEndPositionTailOffset(tail.Tail.SeqNum, batch, err)
+		if err != nil {
+			return 0, nil, fmt.Errorf("position s2 log stream %q at end time: %w", streamName, err)
 		}
 	}
 
@@ -762,6 +760,18 @@ func logTailOffsetBeforeSeq(tailSeqNum, endSeqNum uint64) uint64 {
 		return 0
 	}
 	return tailSeqNum - endSeqNum
+}
+
+func logEndPositionTailOffset(tailSeqNum uint64, batch *s2.ReadBatch, err error) (uint64, error) {
+	// S2 returns 416 when the requested timestamp is newer than the stream
+	// tail. Scanning from the live tail is already the correct end position.
+	if isS2RangeNotSatisfiable(err) {
+		return 0, nil
+	}
+	if err != nil || batch == nil || len(batch.Records) == 0 {
+		return 0, err
+	}
+	return logTailOffsetBeforeSeq(tailSeqNum, batch.Records[0].SeqNum), nil
 }
 
 // nextTailReadWindow returns the next tail offset and record count for scanning

--- a/pkg/repository/events_s2_test.go
+++ b/pkg/repository/events_s2_test.go
@@ -1684,6 +1684,23 @@ func TestS2ReadEmptyRecognizesStreamNotFoundByCodeAndMessage(t *testing.T) {
 	}
 }
 
+func TestS2EndPositionPastTailFallsBackToLiveTail(t *testing.T) {
+	err := &s2.RangeNotSatisfiableError{S2Error: &s2.S2Error{
+		Status: httpStatusRangeNotSatisfiable,
+		Origin: "server",
+	}}
+	offset, positionErr := logEndPositionTailOffset(100, nil, err)
+	if positionErr != nil || offset != 0 {
+		t.Fatalf("expected live-tail fallback, got offset=%d err=%v", offset, positionErr)
+	}
+
+	batch := &s2.ReadBatch{Records: []s2.SequencedRecord{{SeqNum: 40}}}
+	offset, positionErr = logEndPositionTailOffset(100, batch, nil)
+	if positionErr != nil || offset != 60 {
+		t.Fatalf("expected historical offset 60, got offset=%d err=%v", offset, positionErr)
+	}
+}
+
 func TestAugmentContainerEventResponseBuildsLifecycleSummary(t *testing.T) {
 	now := time.Now().UTC()
 	response := &types.ContainerEventsResponse{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes S2 log history reads when the requested end time is past the stream tail by falling back to the live tail instead of erroring. Also returns empty for missing streams.

- **Bug Fixes**
  - Treat `416 RangeNotSatisfiable` from `s2` as “past tail” and use live tail (offset 0).
  - Add `logEndPositionTailOffset` to compute tail offsets and handle nil/empty batches.
  - Replace `isS2ReadEmpty` with `isS2StreamNotFound` for correct empty-stream handling.
  - Add tests for past-tail fallback and historical offset calculation.

<sup>Written for commit 18c74eb8b9ae5996082bbc48e535f310feb4633b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

