### PR TITLE
fix: keep worker routes ready during bursts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/uv.lock') }}
 
       - name: Install dependencies
-        run: |
-          uv sync
-          uv pip install ruff pytest pytest-cov
-        if: steps.cached-dependencies.outputs.cache-hit != 'true'
+        run: uv sync --locked --group dev
 
       - name: Code formatting
         run: uv run ruff format .

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
 )
 
 type PodServiceOpts struct {
@@ -76,6 +77,7 @@ type GenericPodService struct {
 	controller      *abstractions.InstanceController
 	podInstances    *common.SafeMap[*podInstance]
 	clientCache     sync.Map
+	clientDialGroup singleflight.Group
 	tcpServer       *PodTCPServer
 	drainCtx        context.Context
 }

--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -97,7 +97,7 @@ func (s *GenericPodService) sandboxExecWithConnectRetry(ctx context.Context, in 
 			lastErr = err
 			retryable = isTransientSandboxConnectFailure(err)
 			if retryable {
-				s.evictClient(cacheKey)
+				s.evictClient(cacheKey, client)
 			}
 		}
 
@@ -155,7 +155,7 @@ func (s *GenericPodService) SandboxStatus(ctx context.Context, in *pb.PodSandbox
 
 	resp, err := client.SandboxStatusContext(ctx, in.ContainerId, in.Pid)
 	if err != nil && isTransientSandboxConnectFailure(err) {
-		s.evictClient(cacheKey)
+		s.evictClient(cacheKey, client)
 		client, _, retryErr := s.getClient(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
 		if retryErr != nil {
 			err = retryErr
@@ -212,7 +212,7 @@ func (s *GenericPodService) sandboxRuntimeStatus(ctx context.Context, containerI
 
 	resp, err := client.SandboxStatusContext(ctx, containerId, 0)
 	if err != nil && isTransientSandboxConnectFailure(err) {
-		s.evictClient(cacheKey)
+		s.evictClient(cacheKey, client)
 		client, _, retryErr := s.getClient(ctx, containerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
 		if retryErr != nil {
 			err = retryErr
@@ -770,11 +770,28 @@ func (s *GenericPodService) SandboxFindInFiles(ctx context.Context, in *pb.PodSa
 func (s *GenericPodService) SandboxConnect(ctx context.Context, in *pb.PodSandboxConnectRequest) (*pb.PodSandboxConnectResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	client, container, _, err := s.getClientWithCacheKey(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
+	client, container, cacheKey, err := s.getClientWithCacheKey(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
 	if err == nil {
 		phaseStart := time.Now()
 		readyCtx, cancel := context.WithTimeout(ctx, sandboxConnectReadyTimeout)
 		err = waitForSandboxReady(readyCtx, func(probeCtx context.Context) (*pb.ContainerSandboxStatusResponse, error) {
+			resp, probeErr := client.SandboxStatusContext(probeCtx, in.ContainerId, 0)
+			if !isTransientSandboxConnectFailure(probeErr) {
+				return resp, probeErr
+			}
+
+			s.evictClient(cacheKey, client)
+			refreshedClient, _, refreshedCacheKey, refreshErr := s.getClientWithCacheKey(
+				probeCtx,
+				in.ContainerId,
+				authInfo.Token.Key,
+				authInfo.Workspace.ExternalId,
+			)
+			if refreshErr != nil {
+				return nil, refreshErr
+			}
+			client = refreshedClient
+			cacheKey = refreshedCacheKey
 			return client.SandboxStatusContext(probeCtx, in.ContainerId, 0)
 		})
 		cancel()
@@ -868,48 +885,90 @@ func (s *GenericPodService) getClientWithCacheKey(ctx context.Context, container
 	metrics.RecordSandboxConnectPhase("worker_address_lookup", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
 
 	cacheKey := sandboxClientCacheKey(hostname, token)
+	client, cached, err := s.loadOrCreateSandboxClient(ctx, cacheKey, func() (*common.ContainerClient, error) {
+		phaseStart := time.Now()
+		dialCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sandboxConnectWorkerDialTimeout)
+		defer cancel()
+		conn, dialErr := network.ConnectToBackend(dialCtx, hostname, sandboxConnectWorkerDialTimeout, s.tailscale, s.config.Tailscale, s.containerRepo)
+		if dialErr != nil {
+			metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), "worker_dial_failed", false, time.Since(phaseStart))
+			return nil, dialErr
+		}
+		metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
+
+		phaseStart = time.Now()
+		created, createErr := common.NewContainerClient(hostname, token, conn)
+		if createErr != nil {
+			metrics.RecordSandboxConnectPhase("client_create", workspaceId, container.StubId, string(container.Status), "client_create_failed", false, time.Since(phaseStart))
+			return nil, createErr
+		}
+		metrics.RecordSandboxConnectPhase("client_create", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
+		return created, nil
+	})
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if cached {
+		metrics.RecordSandboxConnectPhase("client_cache", workspaceId, container.StubId, string(container.Status), "", true, 0)
+	}
+	return client, container, cacheKey, nil
+}
+
+type sandboxClientLoadResult struct {
+	client *common.ContainerClient
+	cached bool
+}
+
+func (s *GenericPodService) loadOrCreateSandboxClient(
+	ctx context.Context,
+	cacheKey string,
+	create func() (*common.ContainerClient, error),
+) (*common.ContainerClient, bool, error) {
 	if cached, ok := s.clientCache.Load(cacheKey); ok {
 		if client, ok := cached.(*common.ContainerClient); ok {
-			metrics.RecordSandboxConnectPhase("client_cache", workspaceId, container.StubId, string(container.Status), "", true, 0)
-			return client, container, cacheKey, nil
+			return client, true, nil
 		}
 	}
 
-	phaseStart = time.Now()
-	dialCtx, cancel := context.WithTimeout(ctx, sandboxConnectWorkerDialTimeout)
-	conn, err := network.ConnectToBackend(dialCtx, hostname, sandboxConnectWorkerDialTimeout, s.tailscale, s.config.Tailscale, s.containerRepo)
-	cancel()
-	if err != nil {
-		metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), "worker_dial_failed", false, time.Since(phaseStart))
-		return nil, nil, "", err
-	}
-	metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
+	result := s.clientDialGroup.DoChan(cacheKey, func() (any, error) {
+		if cached, ok := s.clientCache.Load(cacheKey); ok {
+			if client, ok := cached.(*common.ContainerClient); ok {
+				return sandboxClientLoadResult{client: client, cached: true}, nil
+			}
+		}
 
-	phaseStart = time.Now()
-	client, err := common.NewContainerClient(hostname, token, conn)
-	if err != nil {
-		metrics.RecordSandboxConnectPhase("client_create", workspaceId, container.StubId, string(container.Status), "client_create_failed", false, time.Since(phaseStart))
-		return nil, nil, "", err
-	}
-	metrics.RecordSandboxConnectPhase("client_create", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
+		client, err := create()
+		if err != nil {
+			return nil, err
+		}
+		s.clientCache.Store(cacheKey, client)
+		return sandboxClientLoadResult{client: client}, nil
+	})
 
-	s.clientCache.Store(cacheKey, client)
-	return client, container, cacheKey, nil
+	select {
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	case loaded := <-result:
+		if loaded.Err != nil {
+			return nil, false, loaded.Err
+		}
+		value, ok := loaded.Val.(sandboxClientLoadResult)
+		if !ok || value.client == nil {
+			return nil, false, errors.New("sandbox client dial returned no client")
+		}
+		return value.client, value.cached || loaded.Shared, nil
+	}
 }
 
 func sandboxClientCacheKey(workerAddress, token string) string {
 	return workerAddress + ":" + token
 }
 
-func (s *GenericPodService) evictClient(cacheKey string) {
-	cached, ok := s.clientCache.LoadAndDelete(cacheKey)
-	if !ok {
+func (s *GenericPodService) evictClient(cacheKey string, client *common.ContainerClient) {
+	if client == nil || !s.clientCache.CompareAndDelete(cacheKey, client) {
 		return
 	}
-
-	if client, ok := cached.(*common.ContainerClient); ok {
-		_ = client.Close()
-	}
+	_ = client.Close()
 }
 
 func sandboxConnectErrorMessage(_ error) string {

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -3,10 +3,14 @@ package pod
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"google.golang.org/grpc/codes"
@@ -123,6 +127,78 @@ func TestSandboxClientCacheKeyKeepsDifferentWorkerAddressesDistinct(t *testing.T
 	keyB := sandboxClientCacheKey("route://worker-b", "token")
 	if keyA == keyB {
 		t.Fatalf("worker route cache keys unexpectedly matched: %q", keyA)
+	}
+}
+
+func TestEvictClientDoesNotDeleteNewerReplacement(t *testing.T) {
+	service := &GenericPodService{}
+	stale := &common.ContainerClient{}
+	replacement := &common.ContainerClient{}
+	service.clientCache.Store("worker:token", replacement)
+
+	service.evictClient("worker:token", stale)
+
+	got, ok := service.clientCache.Load("worker:token")
+	if !ok || got != replacement {
+		t.Fatal("evicting a stale client deleted its newer replacement")
+	}
+}
+
+func TestSandboxClientDialIsSingleFlightPerWorkerDuringBurst(t *testing.T) {
+	const (
+		workerCount         = 4
+		containersPerWorker = 25
+	)
+
+	service := &GenericPodService{}
+	start := make(chan struct{})
+	releaseCreates := make(chan struct{})
+	createStarted := make(chan struct{}, workerCount)
+	var createCount atomic.Int32
+	var wg sync.WaitGroup
+	errs := make(chan error, workerCount*containersPerWorker)
+
+	for worker := 0; worker < workerCount; worker++ {
+		cacheKey := fmt.Sprintf("route://machine-a:worker-%d::worker:0:token", worker)
+		for container := 0; container < containersPerWorker; container++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				client, _, err := service.loadOrCreateSandboxClient(context.Background(), cacheKey, func() (*common.ContainerClient, error) {
+					createCount.Add(1)
+					createStarted <- struct{}{}
+					<-releaseCreates
+					return &common.ContainerClient{}, nil
+				})
+				if err != nil {
+					errs <- err
+					return
+				}
+				if client == nil {
+					errs <- errors.New("nil sandbox client")
+				}
+			}()
+		}
+	}
+
+	close(start)
+	for worker := 0; worker < workerCount; worker++ {
+		select {
+		case <-createStarted:
+		case <-time.After(time.Second):
+			t.Fatal("worker client dial did not start")
+		}
+	}
+	close(releaseCreates)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatal(err)
+	}
+	if got := createCount.Load(); got != workerCount {
+		t.Fatalf("client creates = %d, want one per worker (%d)", got, workerCount)
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -143,6 +143,39 @@ func TestRouteProxyPollsOpeningRouteWithoutBackoff(t *testing.T) {
 	}
 }
 
+func TestRouteProxyRechecksOpeningRouteThatRacesReadyUpdate(t *testing.T) {
+	backend := startEchoListener(t, "127.0.0.1:0")
+	target := backend.Addr().String()
+	client := &blockingRouteStatusClient{
+		updates:      make(chan *pb.UpdateAgentRouteStatusRequest, 2),
+		releaseFirst: make(chan struct{}),
+	}
+	proxy := newRouteProxy(client, "agent-token", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	proxy.setRoute("route-one", target)
+	proxy.ensureRouteReady(ctx, "route-one", target)
+
+	select {
+	case <-client.updates:
+	case <-time.After(time.Second):
+		t.Fatal("first route readiness update did not start")
+	}
+
+	// This models an opening snapshot arriving while the previous ready update
+	// is still in flight. The second check must not be lost when the first exits.
+	proxy.ensureRouteReady(ctx, "route-one", target)
+	close(client.releaseFirst)
+
+	select {
+	case <-client.updates:
+	case <-time.After(time.Second):
+		t.Fatal("opening route was not rechecked after the active ready update")
+	}
+}
+
 func TestDialLocalTargetFallsBackToLoopback(t *testing.T) {
 	backend := startEchoListener(t, "127.0.0.1:0")
 	_, port, err := net.SplitHostPort(backend.Addr().String())
@@ -167,6 +200,36 @@ func (c *routeStatusClient) UpdateAgentRouteStatus(ctx context.Context, in *pb.U
 	case c.updates <- in:
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	}
+	return &pb.UpdateAgentRouteStatusResponse{Ok: true}, nil
+}
+
+type blockingRouteStatusClient struct {
+	pb.GatewayServiceClient
+	mu           sync.Mutex
+	calls        int
+	updates      chan *pb.UpdateAgentRouteStatusRequest
+	releaseFirst chan struct{}
+}
+
+func (c *blockingRouteStatusClient) UpdateAgentRouteStatus(ctx context.Context, in *pb.UpdateAgentRouteStatusRequest, _ ...grpc.CallOption) (*pb.UpdateAgentRouteStatusResponse, error) {
+	c.mu.Lock()
+	c.calls++
+	call := c.calls
+	c.mu.Unlock()
+
+	select {
+	case c.updates <- in:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	if call == 1 {
+		select {
+		case <-c.releaseFirst:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 	return &pb.UpdateAgentRouteStatusResponse{Ok: true}, nil
 }

--- a/pkg/agent/route_proxy.go
+++ b/pkg/agent/route_proxy.go
@@ -36,17 +36,18 @@ func newRouteProxy(client pb.GatewayServiceClient, agentToken string, listener n
 		stderr = io.Discard
 	}
 	return &routeProxy{
-		agentToken:      agentToken,
-		client:          client,
-		listener:        listener,
-		proxyTarget:     proxyTarget,
-		workers:         workers,
-		stdout:          stdout,
-		stderr:          stderr,
-		routes:          map[string]string{},
-		readinessChecks: map[string]string{},
-		failureCounts:   map[string]int{},
-		statusSlots:     make(chan struct{}, routeStatusConcurrency),
+		agentToken:       agentToken,
+		client:           client,
+		listener:         listener,
+		proxyTarget:      proxyTarget,
+		workers:          workers,
+		stdout:           stdout,
+		stderr:           stderr,
+		routes:           map[string]string{},
+		readinessChecks:  map[string]string{},
+		readinessPending: map[string]string{},
+		failureCounts:    map[string]int{},
+		statusSlots:      make(chan struct{}, routeStatusConcurrency),
 	}
 }
 
@@ -63,6 +64,10 @@ type routeProxy struct {
 
 	// routeID -> local target currently being probed for readiness.
 	readinessChecks map[string]string
+
+	// routeID -> local target that must be probed again after the active check.
+	// A repeated opening snapshot can race the active check's ready update.
+	readinessPending map[string]string
 
 	// routeID -> consecutive local dial failures.
 	failureCounts map[string]int
@@ -163,8 +168,12 @@ func (p *routeProxy) setRoute(routeID, localTarget string) {
 	if p.readinessChecks == nil {
 		p.readinessChecks = map[string]string{}
 	}
+	if p.readinessPending == nil {
+		p.readinessPending = map[string]string{}
+	}
 	if previous := p.routes[routeID]; previous != "" && previous != localTarget {
 		delete(p.readinessChecks, routeID)
+		delete(p.readinessPending, routeID)
 	}
 	p.routes[routeID] = localTarget
 	p.mu.Unlock()
@@ -174,6 +183,7 @@ func (p *routeProxy) deleteRoute(routeID string) {
 	p.mu.Lock()
 	delete(p.routes, routeID)
 	delete(p.readinessChecks, routeID)
+	delete(p.readinessPending, routeID)
 	delete(p.failureCounts, routeID)
 	p.mu.Unlock()
 }
@@ -185,6 +195,7 @@ func (p *routeProxy) deleteRoutesNotIn(seen map[string]struct{}) {
 		if _, ok := seen[routeID]; !ok {
 			delete(p.routes, routeID)
 			delete(p.readinessChecks, routeID)
+			delete(p.readinessPending, routeID)
 			delete(p.failureCounts, routeID)
 		}
 	}
@@ -204,9 +215,11 @@ func (p *routeProxy) ensureRouteReady(ctx context.Context, routeID, localTarget 
 		return
 	}
 	if p.readinessChecks[routeID] == localTarget {
+		p.readinessPending[routeID] = localTarget
 		p.mu.Unlock()
 		return
 	}
+	delete(p.readinessPending, routeID)
 	p.readinessChecks[routeID] = localTarget
 	p.mu.Unlock()
 
@@ -214,7 +227,7 @@ func (p *routeProxy) ensureRouteReady(ctx context.Context, routeID, localTarget 
 }
 
 func (p *routeProxy) waitForRouteReady(ctx context.Context, routeID, localTarget string) {
-	defer p.clearReadinessCheck(routeID, localTarget)
+	defer p.finishReadinessCheck(ctx, routeID, localTarget)
 
 	statusRetry := 100 * time.Millisecond
 	for {
@@ -274,6 +287,29 @@ func (p *routeProxy) clearReadinessCheck(routeID, localTarget string) {
 	defer p.mu.Unlock()
 	if p.readinessChecks[routeID] == localTarget {
 		delete(p.readinessChecks, routeID)
+	}
+	if p.readinessPending[routeID] == localTarget {
+		delete(p.readinessPending, routeID)
+	}
+}
+
+func (p *routeProxy) finishReadinessCheck(ctx context.Context, routeID, localTarget string) {
+	p.mu.Lock()
+	if p.readinessChecks[routeID] != localTarget {
+		p.mu.Unlock()
+		return
+	}
+	delete(p.readinessChecks, routeID)
+
+	recheck := p.routes[routeID] == localTarget && p.readinessPending[routeID] == localTarget
+	delete(p.readinessPending, routeID)
+	if recheck {
+		p.readinessChecks[routeID] = localTarget
+	}
+	p.mu.Unlock()
+
+	if recheck {
+		go p.waitForRouteReady(ctx, routeID, localTarget)
 	}
 }
 

--- a/pkg/gateway/services/compute/agent.go
+++ b/pkg/gateway/services/compute/agent.go
@@ -395,6 +395,17 @@ func (s *Service) StreamAgent(in *pb.StreamAgentRequest, stream pb.GatewayServic
 		return stream.Send(&pb.StreamAgentResponse{Ok: true, Routes: routes, Slots: slots})
 	}
 
+	// Subscribe before the initial snapshot so a route registration cannot be
+	// lost between reading Redis and starting the event listener. Events that
+	// race the snapshot stay buffered and trigger a second reconciliation.
+	events := make(chan common.KeyEvent, 32)
+	if s.keyEventManager != nil {
+		revisionKey := agentSnapshotRevisionKey(agentState)
+		if err := s.keyEventManager.ListenForPublishedPattern(ctx, revisionKey, events); err != nil {
+			return err
+		}
+	}
+
 	for {
 		if err := sendSnapshot(); err != nil {
 			if !isAgentSnapshotTransient(err) {
@@ -410,14 +421,6 @@ func (s *Service) StreamAgent(in *pb.StreamAgentRequest, stream pb.GatewayServic
 			}
 		}
 		break
-	}
-
-	events := make(chan common.KeyEvent, 32)
-	if s.keyEventManager != nil {
-		revisionKey := agentSnapshotRevisionKey(agentState)
-		if err := s.keyEventManager.ListenForPublishedPattern(ctx, revisionKey, events); err != nil {
-			return err
-		}
 	}
 
 	ticker := time.NewTicker(agentStreamRefresh)

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -45,6 +45,38 @@ const (
 
 var errConcurrencyCounterRepairing = errors.New("concurrency counter repair in progress")
 
+// Opening worker routes are republished for every container startup. Once the
+// agent has made an identical shared route ready, those registrations must not
+// demote it or erase its proxy target. WorkspaceID is deliberately not part of
+// the target identity because marketplace workers can serve buyer workspaces.
+var setOpeningWorkerBackendRouteScript = redis.NewScript(`
+local incoming = cjson.decode(ARGV[1])
+local current = redis.call("GET", KEYS[1])
+
+if current ~= false then
+	local decoded, existing = pcall(cjson.decode, current)
+	if decoded and
+		existing.state == ARGV[2] and
+		existing.proxy_target and
+		existing.proxy_target ~= "" and
+		existing.route_id == incoming.route_id and
+		existing.pool_name == incoming.pool_name and
+		existing.machine_id == incoming.machine_id and
+		existing.worker_id == incoming.worker_id and
+		existing.container_id == incoming.container_id and
+		existing.kind == incoming.kind and
+		existing.port == incoming.port and
+		existing.protocol == incoming.protocol and
+		existing.transport == incoming.transport and
+		existing.local_target == incoming.local_target then
+		return 0
+	end
+end
+
+redis.call("SET", KEYS[1], ARGV[1])
+return 1
+`)
+
 // Workspace concurrency accounting must stay O(1) during bursts. The old
 // implementation scanned every active container while holding a workspace lock
 // for each request. Instead, the first quota-bearing request rebuilds an
@@ -447,7 +479,20 @@ func (cr *ContainerRedisRepository) SetBackendRoutes(ctx context.Context, routes
 	_, err := cr.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		for _, item := range encoded {
 			route := item.route
-			pipe.Set(ctx, common.RedisKeys.SchedulerBackendRoute(route.RouteID), item.data, 0)
+			routeKey := common.RedisKeys.SchedulerBackendRoute(route.RouteID)
+			if route.Kind == types.BackendRouteKindWorker &&
+				route.ContainerID == "" &&
+				route.State == types.BackendRouteStateOpening {
+				setOpeningWorkerBackendRouteScript.Eval(
+					ctx,
+					pipe,
+					[]string{routeKey},
+					item.data,
+					types.BackendRouteStateReady,
+				)
+			} else {
+				pipe.Set(ctx, routeKey, item.data, 0)
+			}
 			if route.ContainerID != "" {
 				pipe.SAdd(ctx, common.RedisKeys.SchedulerBackendRouteIndex(route.ContainerID), route.RouteID)
 			}

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -527,6 +527,182 @@ func TestBackendRoutesAreIndexedByMachine(t *testing.T) {
 	}
 }
 
+func TestReadyWorkerRouteSurvivesOneHundredConcurrentRegistrations(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	ctx := context.Background()
+	ready := testReadyWorkerRoute("machine-one", "worker-one")
+	if err := repo.SetBackendRoute(ctx, ready); err != nil {
+		t.Fatal(err)
+	}
+
+	opening := ready
+	opening.WorkspaceID = "buyer-workspace"
+	opening.ProxyTarget = ""
+	opening.State = types.BackendRouteStateOpening
+	opening.UpdatedAt = 0
+
+	const starts = 100
+	start := make(chan struct{})
+	errs := make(chan error, starts)
+	var wg sync.WaitGroup
+	for range starts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- repo.SetBackendRoute(ctx, opening)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent route registration failed: %v", err)
+		}
+	}
+
+	got, err := repo.GetBackendRoute(ctx, ready.RouteID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != types.BackendRouteStateReady {
+		t.Fatalf("route state = %q, want ready", got.State)
+	}
+	if got.ProxyTarget != ready.ProxyTarget {
+		t.Fatalf("proxy target = %q, want %q", got.ProxyTarget, ready.ProxyTarget)
+	}
+	if got.UpdatedAt != ready.UpdatedAt {
+		t.Fatalf("updated at = %d, want %d", got.UpdatedAt, ready.UpdatedAt)
+	}
+}
+
+func TestReadyWorkerRoutesRemainIndependentDuringSameHostBurst(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	ctx := context.Background()
+	const (
+		workers         = 4
+		startsPerWorker = 25
+	)
+	routes := make([]types.BackendRoute, 0, workers)
+	for workerIndex := range workers {
+		route := testReadyWorkerRoute("shared-machine", fmt.Sprintf("worker-%d", workerIndex))
+		if err := repo.SetBackendRoute(ctx, route); err != nil {
+			t.Fatal(err)
+		}
+		routes = append(routes, route)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, workers*startsPerWorker)
+	var wg sync.WaitGroup
+	for _, ready := range routes {
+		opening := ready
+		opening.ProxyTarget = ""
+		opening.State = types.BackendRouteStateOpening
+		opening.UpdatedAt = 0
+		for range startsPerWorker {
+			wg.Add(1)
+			go func(route types.BackendRoute) {
+				defer wg.Done()
+				<-start
+				errs <- repo.SetBackendRoute(ctx, route)
+			}(opening)
+		}
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent route registration failed: %v", err)
+		}
+	}
+	for _, ready := range routes {
+		got, err := repo.GetBackendRoute(ctx, ready.RouteID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.State != types.BackendRouteStateReady || got.ProxyTarget != ready.ProxyTarget {
+			t.Fatalf("route %s = state %q target %q, want ready target %q", got.RouteID, got.State, got.ProxyTarget, ready.ProxyTarget)
+		}
+	}
+}
+
+func TestChangedWorkerRouteReopens(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(*types.BackendRoute)
+	}{
+		{
+			name: "local target",
+			change: func(route *types.BackendRoute) {
+				route.LocalTarget = "127.0.0.1:32001"
+			},
+		},
+		{
+			name: "transport",
+			change: func(route *types.BackendRoute) {
+				route.Transport = types.BackendRouteTransportLocalDirect
+			},
+		},
+		{
+			name: "pool",
+			change: func(route *types.BackendRoute) {
+				route.PoolName = "pool-two"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rdb, err := NewRedisClientForTest()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			repo := NewContainerRedisRepositoryForTest(rdb)
+			ctx := context.Background()
+			ready := testReadyWorkerRoute("machine-one", "worker-one")
+			if err := repo.SetBackendRoute(ctx, ready); err != nil {
+				t.Fatal(err)
+			}
+
+			opening := ready
+			opening.ProxyTarget = ""
+			opening.State = types.BackendRouteStateOpening
+			opening.UpdatedAt = 0
+			test.change(&opening)
+			if err := repo.SetBackendRoute(ctx, opening); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := repo.GetBackendRoute(ctx, ready.RouteID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.State != types.BackendRouteStateOpening {
+				t.Fatalf("route state = %q, want opening", got.State)
+			}
+			if got.ProxyTarget != "" {
+				t.Fatalf("proxy target = %q, want empty", got.ProxyTarget)
+			}
+		})
+	}
+}
+
 func TestBackendRoutesAreIndexedByMachineID(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	if err != nil {
@@ -684,6 +860,23 @@ func TestDeleteBackendRoutesByContainerIDKeepsSiblingContainerRoutesOnSameMachin
 	}
 	if _, err := repo.GetBackendRoute(ctx, routeB.RouteID); err != nil {
 		t.Fatalf("sibling route was removed: %v", err)
+	}
+}
+
+func testReadyWorkerRoute(machineID, workerID string) types.BackendRoute {
+	return types.BackendRoute{
+		RouteID:     types.BackendRouteID(machineID, workerID, "", types.BackendRouteKindWorker, 0),
+		WorkspaceID: "workspace-one",
+		PoolName:    "pool-one",
+		MachineID:   machineID,
+		WorkerID:    workerID,
+		Kind:        types.BackendRouteKindWorker,
+		Protocol:    types.BackendRouteProtocolTCP,
+		Transport:   types.BackendRouteTransportTSNet,
+		LocalTarget: "127.0.0.1:32000",
+		ProxyTarget: machineID + ".tailnet:29443",
+		State:       types.BackendRouteStateReady,
+		UpdatedAt:   123,
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents ready worker routes from being overwritten by opening registrations during bursts and makes route/sandbox connections resilient under load. This keeps routes ready and avoids cold starts when many containers start at once.

- **Bug Fixes**
  - Repository: Guarded `SetBackendRoute` with a Redis script to ignore opening worker registrations when an identical ready route with a `proxy_target` exists; routes reopen only if identity/params change.
  - Agent: Rechecks route readiness if an opening snapshot races an in-flight ready update; subscribes to route events before the initial snapshot to avoid missed registrations.
  - Pod: Deduplicates sandbox client dials per worker using `golang.org/x/sync/singleflight`; on transient connect errors, evicts only the matching cached client and redials; refreshes client during ready probes when needed.
  - Tests: Added burst and race coverage for Redis route registration, route proxy readiness rechecks, single-flight client dialing, and safe client eviction.

- **Dependencies**
  - CI: Install Python dev tools from the lockfile via `uv sync --locked --group dev`.

<sup>Written for commit d046ca056374828ebede7b456c04180f0f3263a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

