### PR TITLE
fix: recover direct sandbox connections during bursts

### DIFF
--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -83,7 +84,7 @@ func (s *GenericPodService) sandboxExecWithConnectRetry(ctx context.Context, in 
 			return nil, err
 		}
 
-		client, _, cacheKey, err := s.getClientWithCacheKey(ctx, in.ContainerId, token, workspaceID)
+		client, _, err := s.getClient(ctx, in.ContainerId, token, workspaceID)
 		retryable := false
 		if err != nil {
 			logSandboxConnectFailure(err, in.ContainerId)
@@ -96,9 +97,6 @@ func (s *GenericPodService) sandboxExecWithConnectRetry(ctx context.Context, in 
 			}
 			lastErr = err
 			retryable = isTransientSandboxConnectFailure(err)
-			if retryable {
-				s.evictClient(cacheKey, client)
-			}
 		}
 
 		if !retryable || time.Now().Add(sandboxExecConnectRetryDelay).After(deadline) {
@@ -145,7 +143,7 @@ func (s *GenericPodService) SandboxStatus(ctx context.Context, in *pb.PodSandbox
 		return resp, nil
 	}
 
-	client, _, cacheKey, err := s.getClientWithCacheKey(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
+	client, _, err := s.getClient(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
 	if err != nil {
 		return &pb.PodSandboxStatusResponse{
 			Ok:       false,
@@ -154,15 +152,6 @@ func (s *GenericPodService) SandboxStatus(ctx context.Context, in *pb.PodSandbox
 	}
 
 	resp, err := client.SandboxStatusContext(ctx, in.ContainerId, in.Pid)
-	if err != nil && isTransientSandboxConnectFailure(err) {
-		s.evictClient(cacheKey, client)
-		client, _, retryErr := s.getClient(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
-		if retryErr != nil {
-			err = retryErr
-		} else {
-			resp, err = client.SandboxStatusContext(ctx, in.ContainerId, in.Pid)
-		}
-	}
 	if err != nil {
 		return &pb.PodSandboxStatusResponse{
 			Ok:       false,
@@ -205,21 +194,12 @@ func (s *GenericPodService) sandboxContainerStatus(ctx context.Context, containe
 }
 
 func (s *GenericPodService) sandboxRuntimeStatus(ctx context.Context, containerId string, authInfo *auth.AuthInfo) (*pb.PodSandboxStatusResponse, error) {
-	client, _, cacheKey, err := s.getClientWithCacheKey(ctx, containerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
+	client, _, err := s.getClient(ctx, containerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
 	if err != nil {
 		return sandboxStatus(types.SandboxStatusPending), nil
 	}
 
 	resp, err := client.SandboxStatusContext(ctx, containerId, 0)
-	if err != nil && isTransientSandboxConnectFailure(err) {
-		s.evictClient(cacheKey, client)
-		client, _, retryErr := s.getClient(ctx, containerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
-		if retryErr != nil {
-			err = retryErr
-		} else {
-			resp, err = client.SandboxStatusContext(ctx, containerId, 0)
-		}
-	}
 	if err != nil {
 		return sandboxStatus(types.SandboxStatusPending), nil
 	}
@@ -770,31 +750,29 @@ func (s *GenericPodService) SandboxFindInFiles(ctx context.Context, in *pb.PodSa
 func (s *GenericPodService) SandboxConnect(ctx context.Context, in *pb.PodSandboxConnectRequest) (*pb.PodSandboxConnectResponse, error) {
 	authInfo, _ := auth.AuthInfoFromContext(ctx)
 
-	client, container, cacheKey, err := s.getClientWithCacheKey(ctx, in.ContainerId, authInfo.Token.Key, authInfo.Workspace.ExternalId)
-	if err == nil {
-		phaseStart := time.Now()
-		readyCtx, cancel := context.WithTimeout(ctx, sandboxConnectReadyTimeout)
-		err = waitForSandboxReady(readyCtx, func(probeCtx context.Context) (*pb.ContainerSandboxStatusResponse, error) {
-			resp, probeErr := client.SandboxStatusContext(probeCtx, in.ContainerId, 0)
-			if !isTransientSandboxConnectFailure(probeErr) {
-				return resp, probeErr
-			}
-
-			s.evictClient(cacheKey, client)
-			refreshedClient, _, refreshedCacheKey, refreshErr := s.getClientWithCacheKey(
+	var client *common.ContainerClient
+	var container *types.ContainerState
+	phaseStart := time.Now()
+	readyCtx, cancel := context.WithTimeout(ctx, sandboxConnectReadyTimeout)
+	err := waitForSandboxReady(readyCtx, func(probeCtx context.Context) (*pb.ContainerSandboxStatusResponse, error) {
+		if client == nil {
+			acquiredClient, acquiredContainer, acquireErr := s.getClient(
 				probeCtx,
 				in.ContainerId,
 				authInfo.Token.Key,
 				authInfo.Workspace.ExternalId,
 			)
-			if refreshErr != nil {
-				return nil, refreshErr
+			if acquireErr != nil {
+				return nil, acquireErr
 			}
-			client = refreshedClient
-			cacheKey = refreshedCacheKey
-			return client.SandboxStatusContext(probeCtx, in.ContainerId, 0)
-		})
-		cancel()
+			client = acquiredClient
+			container = acquiredContainer
+		}
+		return client.SandboxStatusContext(probeCtx, in.ContainerId, 0)
+	})
+	cancel()
+
+	if container != nil {
 		failureClass := ""
 		if err != nil {
 			failureClass = "process_manager_unavailable"
@@ -851,26 +829,21 @@ func waitForSandboxReady(ctx context.Context, probe func(context.Context) (*pb.C
 }
 
 func (s *GenericPodService) getClient(ctx context.Context, containerId, token string, workspaceId string) (*common.ContainerClient, *types.ContainerState, error) {
-	client, container, _, err := s.getClientWithCacheKey(ctx, containerId, token, workspaceId)
-	return client, container, err
-}
-
-func (s *GenericPodService) getClientWithCacheKey(ctx context.Context, containerId, token string, workspaceId string) (*common.ContainerClient, *types.ContainerState, string, error) {
 	phaseStart := time.Now()
 	container, err := s.containerRepo.GetContainerState(containerId)
 	if err != nil {
 		metrics.RecordSandboxConnectPhase("container_state_lookup", workspaceId, "", "", "state_lookup_failed", false, time.Since(phaseStart))
-		return nil, nil, "", err
+		return nil, nil, err
 	}
 
 	if container == nil {
 		metrics.RecordSandboxConnectPhase("container_state_lookup", workspaceId, "", "", "container_not_found", false, time.Since(phaseStart))
-		return nil, nil, "", errors.New("container not found")
+		return nil, nil, errors.New("container not found")
 	}
 
 	if container.WorkspaceId != workspaceId {
 		metrics.RecordSandboxConnectPhase("container_state_lookup", workspaceId, container.StubId, string(container.Status), "invalid_workspace", false, time.Since(phaseStart))
-		return nil, nil, "", errors.New("invalid workspace")
+		return nil, nil, errors.New("invalid workspace")
 	}
 	metrics.RecordSandboxConnectPhase("container_state_lookup", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
 
@@ -880,24 +853,27 @@ func (s *GenericPodService) getClientWithCacheKey(ctx context.Context, container
 	cancel()
 	if err != nil {
 		metrics.RecordSandboxConnectPhase("worker_address_lookup", workspaceId, container.StubId, string(container.Status), "worker_address_unavailable", false, time.Since(phaseStart))
-		return nil, nil, "", err
+		return nil, nil, err
 	}
 	metrics.RecordSandboxConnectPhase("worker_address_lookup", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
 
 	cacheKey := sandboxClientCacheKey(hostname, token)
 	client, cached, err := s.loadOrCreateSandboxClient(ctx, cacheKey, func() (*common.ContainerClient, error) {
-		phaseStart := time.Now()
 		dialCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sandboxConnectWorkerDialTimeout)
 		defer cancel()
-		conn, dialErr := network.ConnectToBackend(dialCtx, hostname, sandboxConnectWorkerDialTimeout, s.tailscale, s.config.Tailscale, s.containerRepo)
-		if dialErr != nil {
-			metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), "worker_dial_failed", false, time.Since(phaseStart))
-			return nil, dialErr
+		dialer := func(connectCtx context.Context, _ string) (net.Conn, error) {
+			phaseStart := time.Now()
+			conn, dialErr := network.ConnectToBackend(connectCtx, hostname, sandboxConnectWorkerDialTimeout, s.tailscale, s.config.Tailscale, s.containerRepo)
+			failureClass := ""
+			if dialErr != nil {
+				failureClass = "worker_dial_failed"
+			}
+			metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), failureClass, dialErr == nil, time.Since(phaseStart))
+			return conn, dialErr
 		}
-		metrics.RecordSandboxConnectPhase("worker_dial", workspaceId, container.StubId, string(container.Status), "", true, time.Since(phaseStart))
 
 		phaseStart = time.Now()
-		created, createErr := common.NewContainerClient(hostname, token, conn)
+		created, createErr := common.NewContainerClientWithDialer(dialCtx, hostname, token, dialer)
 		if createErr != nil {
 			metrics.RecordSandboxConnectPhase("client_create", workspaceId, container.StubId, string(container.Status), "client_create_failed", false, time.Since(phaseStart))
 			return nil, createErr
@@ -906,12 +882,12 @@ func (s *GenericPodService) getClientWithCacheKey(ctx context.Context, container
 		return created, nil
 	})
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, err
 	}
 	if cached {
 		metrics.RecordSandboxConnectPhase("client_cache", workspaceId, container.StubId, string(container.Status), "", true, 0)
 	}
-	return client, container, cacheKey, nil
+	return client, container, nil
 }
 
 type sandboxClientLoadResult struct {
@@ -962,13 +938,6 @@ func (s *GenericPodService) loadOrCreateSandboxClient(
 
 func sandboxClientCacheKey(workerAddress, token string) string {
 	return workerAddress + ":" + token
-}
-
-func (s *GenericPodService) evictClient(cacheKey string, client *common.ContainerClient) {
-	if client == nil || !s.clientCache.CompareAndDelete(cacheKey, client) {
-		return
-	}
-	_ = client.Close()
 }
 
 func sandboxConnectErrorMessage(_ error) string {

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,8 +12,10 @@ import (
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -127,20 +130,6 @@ func TestSandboxClientCacheKeyKeepsDifferentWorkerAddressesDistinct(t *testing.T
 	keyB := sandboxClientCacheKey("route://worker-b", "token")
 	if keyA == keyB {
 		t.Fatalf("worker route cache keys unexpectedly matched: %q", keyA)
-	}
-}
-
-func TestEvictClientDoesNotDeleteNewerReplacement(t *testing.T) {
-	service := &GenericPodService{}
-	stale := &common.ContainerClient{}
-	replacement := &common.ContainerClient{}
-	service.clientCache.Store("worker:token", replacement)
-
-	service.evictClient("worker:token", stale)
-
-	got, ok := service.clientCache.Load("worker:token")
-	if !ok || got != replacement {
-		t.Fatal("evicting a stale client deleted its newer replacement")
 	}
 }
 
@@ -290,5 +279,294 @@ func TestSandboxKillRejectsMissingAuthContext(t *testing.T) {
 	}
 	if status.Code(err) != codes.Unauthenticated {
 		t.Fatalf("SandboxKill error code = %s, want %s", status.Code(err), codes.Unauthenticated)
+	}
+}
+
+const sandboxReconnectTarget = 500 * time.Millisecond
+
+type sandboxReconnectTestRepository struct {
+	repository.ContainerRepository
+	container       *types.ContainerState
+	address         string
+	addressFailures atomic.Int32
+}
+
+func (r *sandboxReconnectTestRepository) GetContainerState(string) (*types.ContainerState, error) {
+	return r.container, nil
+}
+
+func (r *sandboxReconnectTestRepository) GetWorkerAddress(context.Context, string) (string, error) {
+	for remaining := r.addressFailures.Load(); remaining > 0; remaining = r.addressFailures.Load() {
+		if r.addressFailures.CompareAndSwap(remaining, remaining-1) {
+			return "", errors.New("failed to schedule container")
+		}
+	}
+	return r.address, nil
+}
+
+type trackedSandboxListener struct {
+	net.Listener
+	accepted chan net.Conn
+	count    atomic.Int32
+}
+
+func newTrackedSandboxListener(listener net.Listener) *trackedSandboxListener {
+	return &trackedSandboxListener{
+		Listener: listener,
+		accepted: make(chan net.Conn, 4),
+	}
+}
+
+func (l *trackedSandboxListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.count.Add(1)
+	select {
+	case l.accepted <- conn:
+	default:
+	}
+	return conn, nil
+}
+
+func (l *trackedSandboxListener) nextConnection(t *testing.T) net.Conn {
+	t.Helper()
+	select {
+	case conn := <-l.accepted:
+		return conn
+	case <-time.After(time.Second):
+		t.Fatal("worker connection was not accepted")
+		return nil
+	}
+}
+
+type sandboxReconnectStatusServer struct {
+	pb.UnimplementedContainerServiceServer
+
+	mu                   sync.Mutex
+	unavailableResponses int
+}
+
+func (s *sandboxReconnectStatusServer) failNextStatusCalls(count int) {
+	s.mu.Lock()
+	s.unavailableResponses = count
+	s.mu.Unlock()
+}
+
+func (s *sandboxReconnectStatusServer) ContainerSandboxStatus(
+	context.Context,
+	*pb.ContainerSandboxStatusRequest,
+) (*pb.ContainerSandboxStatusResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.unavailableResponses > 0 {
+		s.unavailableResponses--
+		return nil, status.Error(codes.Unavailable, "temporary application response")
+	}
+	return &pb.ContainerSandboxStatusResponse{
+		Ok:     true,
+		Status: string(types.SandboxStatusRunning),
+	}, nil
+}
+
+type sandboxReconnectTestHarness struct {
+	service     *GenericPodService
+	repository  *sandboxReconnectTestRepository
+	listener    *trackedSandboxListener
+	server      *sandboxReconnectStatusServer
+	context     context.Context
+	containerID string
+	stubID      string
+	cacheKey    string
+}
+
+func newSandboxReconnectTestHarness(t *testing.T) *sandboxReconnectTestHarness {
+	t.Helper()
+
+	rawListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	listener := newTrackedSandboxListener(rawListener)
+	statusServer := &sandboxReconnectStatusServer{}
+	workerServer := grpc.NewServer()
+	pb.RegisterContainerServiceServer(workerServer, statusServer)
+	go func() {
+		_ = workerServer.Serve(listener)
+	}()
+	t.Cleanup(workerServer.Stop)
+
+	const (
+		containerID = "sandbox-reconnect"
+		stubID      = "stub-reconnect"
+		workspaceID = "workspace-reconnect"
+		token       = "token-reconnect"
+	)
+	workerAddress := listener.Addr().String()
+	repo := &sandboxReconnectTestRepository{
+		container: &types.ContainerState{
+			ContainerId: containerID,
+			StubId:      stubID,
+			WorkspaceId: workspaceID,
+			Status:      types.ContainerStatusRunning,
+		},
+		address: workerAddress,
+	}
+	service := &GenericPodService{containerRepo: repo}
+	t.Cleanup(func() {
+		service.clientCache.Range(func(_, value any) bool {
+			if client, ok := value.(*common.ContainerClient); ok {
+				_ = client.Close()
+			}
+			return true
+		})
+	})
+
+	return &sandboxReconnectTestHarness{
+		service:    service,
+		repository: repo,
+		listener:   listener,
+		server:     statusServer,
+		context: auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+			Workspace: &types.Workspace{ExternalId: workspaceID},
+			Token:     &types.Token{Key: token},
+		}),
+		containerID: containerID,
+		stubID:      stubID,
+		cacheKey:    sandboxClientCacheKey(workerAddress, token),
+	}
+}
+
+func (h *sandboxReconnectTestHarness) connect(t *testing.T, ctx context.Context) {
+	t.Helper()
+	resp, err := h.service.SandboxConnect(ctx, &pb.PodSandboxConnectRequest{
+		ContainerId: h.containerID,
+	})
+	if err != nil {
+		t.Fatalf("SandboxConnect: %v", err)
+	}
+	if !resp.Ok {
+		t.Fatalf("SandboxConnect failed: %s", resp.ErrorMsg)
+	}
+	if resp.StubId != h.stubID {
+		t.Fatalf("stub id = %q, want %q", resp.StubId, h.stubID)
+	}
+}
+
+func (h *sandboxReconnectTestHarness) cachedClient(t *testing.T) *common.ContainerClient {
+	t.Helper()
+	value, ok := h.service.clientCache.Load(h.cacheKey)
+	if !ok {
+		t.Fatal("sandbox client was not cached")
+	}
+	client, ok := value.(*common.ContainerClient)
+	if !ok {
+		t.Fatalf("cached sandbox client has type %T", value)
+	}
+	return client
+}
+
+func TestSandboxConnectBurstRedialsDroppedTransportUnderTarget(t *testing.T) {
+	const burstSize = 100
+
+	harness := newSandboxReconnectTestHarness(t)
+	primeCtx, primeCancel := context.WithTimeout(harness.context, time.Second)
+	defer primeCancel()
+	harness.connect(t, primeCtx)
+	firstConnection := harness.listener.nextConnection(t)
+	cachedClient := harness.cachedClient(t)
+
+	start := make(chan struct{})
+	results := make(chan error, burstSize)
+	var waitGroup sync.WaitGroup
+	for index := 0; index < burstSize; index++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			callCtx, cancel := context.WithTimeout(harness.context, time.Second)
+			defer cancel()
+			resp, err := harness.service.SandboxConnect(callCtx, &pb.PodSandboxConnectRequest{
+				ContainerId: harness.containerID,
+			})
+			if err != nil {
+				results <- err
+				return
+			}
+			if !resp.Ok {
+				results <- status.Error(codes.Internal, resp.ErrorMsg)
+				return
+			}
+			results <- nil
+		}()
+	}
+
+	recoveryStarted := time.Now()
+	if err := firstConnection.Close(); err != nil {
+		t.Fatalf("close worker transport: %v", err)
+	}
+	close(start)
+	waitGroup.Wait()
+	recoveryDuration := time.Since(recoveryStarted)
+	close(results)
+
+	for err := range results {
+		if err != nil {
+			t.Fatalf("SandboxConnect burst failed after transport drop: %v", err)
+		}
+	}
+	if recoveryDuration >= sandboxReconnectTarget {
+		t.Fatalf("transport recovery took %s, target is under %s", recoveryDuration, sandboxReconnectTarget)
+	}
+	if got := harness.listener.count.Load(); got != 2 {
+		t.Fatalf("worker connections = %d, want initial connection plus one reconnect", got)
+	}
+	if reconnectedClient := harness.cachedClient(t); reconnectedClient != cachedClient {
+		t.Fatal("transport recovery replaced the cached ContainerClient")
+	}
+}
+
+func TestSandboxConnectApplicationUnavailableKeepsSharedClient(t *testing.T) {
+	harness := newSandboxReconnectTestHarness(t)
+	primeCtx, primeCancel := context.WithTimeout(harness.context, time.Second)
+	defer primeCancel()
+	harness.connect(t, primeCtx)
+	_ = harness.listener.nextConnection(t)
+	cachedClient := harness.cachedClient(t)
+	harness.server.failNextStatusCalls(1)
+
+	retryCtx, retryCancel := context.WithTimeout(harness.context, time.Second)
+	defer retryCancel()
+	started := time.Now()
+	harness.connect(t, retryCtx)
+	retryDuration := time.Since(started)
+
+	if retryDuration >= sandboxReconnectTarget {
+		t.Fatalf("application retry took %s, target is under %s", retryDuration, sandboxReconnectTarget)
+	}
+	if got := harness.listener.count.Load(); got != 1 {
+		t.Fatalf("worker connections = %d, application Unavailable must not redial", got)
+	}
+	if retriedClient := harness.cachedClient(t); retriedClient != cachedClient {
+		t.Fatal("application Unavailable replaced the cached ContainerClient")
+	}
+}
+
+func TestSandboxConnectRetriesInitialAddressLookupUnderTarget(t *testing.T) {
+	harness := newSandboxReconnectTestHarness(t)
+	harness.repository.addressFailures.Store(1)
+
+	connectCtx, cancel := context.WithTimeout(harness.context, time.Second)
+	defer cancel()
+	started := time.Now()
+	harness.connect(t, connectCtx)
+	connectDuration := time.Since(started)
+
+	if connectDuration >= sandboxReconnectTarget {
+		t.Fatalf("address lookup recovery took %s, target is under %s", connectDuration, sandboxReconnectTarget)
+	}
+	if got := harness.listener.count.Load(); got != 1 {
+		t.Fatalf("worker connections = %d, want one connection after address publication", got)
 	}
 }

--- a/pkg/common/container_client.go
+++ b/pkg/common/container_client.go
@@ -12,6 +12,7 @@ import (
 
 	pb "github.com/beam-cloud/beta9/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -21,77 +22,111 @@ const (
 	containerClientSandboxStatusTimeout = 5 * time.Second
 	containerClientSandboxOutputTimeout = 5 * time.Second
 	containerClientExistingConnTimeout  = 1 * time.Second
+	containerClientReconnectBaseDelay   = 20 * time.Millisecond
+	containerClientReconnectMaxDelay    = 100 * time.Millisecond
+	containerClientReconnectMinTimeout  = 2 * time.Second
 )
+
+type ContainerClientDialer func(context.Context, string) (net.Conn, error)
 
 type ContainerClient struct {
 	ServiceUrl   string
 	ServiceToken string
 	conn         *grpc.ClientConn
 	client       pb.ContainerServiceClient
-	existingConn net.Conn
 }
 
 func NewContainerClient(serviceUrl, serviceToken string, existingConn net.Conn) (*ContainerClient, error) {
+	dialCtx := context.Background()
+	cancel := func() {}
+	dialOptions := []grpc.DialOption{}
+	if existingConn != nil {
+		dialCtx, cancel = context.WithTimeout(dialCtx, containerClientExistingConnTimeout)
+		dialOptions = append(
+			dialOptions,
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+				return existingConn, nil
+			}),
+			grpc.WithBlock(),
+		)
+	}
+	defer cancel()
+
+	client, err := newContainerClient(dialCtx, serviceUrl, serviceToken, dialOptions...)
+	if err != nil && existingConn != nil {
+		_ = existingConn.Close()
+	}
+	return client, err
+}
+
+// NewContainerClientWithDialer creates a client whose cached gRPC channel can
+// open a fresh backend connection whenever its transport needs to reconnect.
+func NewContainerClientWithDialer(
+	ctx context.Context,
+	serviceUrl string,
+	serviceToken string,
+	dialer ContainerClientDialer,
+) (*ContainerClient, error) {
+	if dialer == nil {
+		return nil, errors.New("container client dialer is required")
+	}
+	return newContainerClient(
+		ctx,
+		serviceUrl,
+		serviceToken,
+		grpc.WithContextDialer(dialer),
+		grpc.WithBlock(),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				BaseDelay:  containerClientReconnectBaseDelay,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   containerClientReconnectMaxDelay,
+			},
+			MinConnectTimeout: containerClientReconnectMinTimeout,
+		}),
+	)
+}
+
+func newContainerClient(
+	ctx context.Context,
+	serviceUrl string,
+	serviceToken string,
+	additionalDialOptions ...grpc.DialOption,
+) (*ContainerClient, error) {
 	client := &ContainerClient{
 		ServiceUrl:   serviceUrl,
 		ServiceToken: serviceToken,
-		existingConn: existingConn,
 	}
 
-	err := client.connect()
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
-}
-
-func (c *ContainerClient) connect() error {
 	grpcOption := grpc.WithTransportCredentials(insecure.NewCredentials())
 
-	isTLS := strings.HasSuffix(c.ServiceUrl, "443")
+	isTLS := strings.HasSuffix(serviceUrl, "443")
 	if isTLS {
 		h2creds := credentials.NewTLS(&tls.Config{NextProtos: []string{"h2"}})
 		grpcOption = grpc.WithTransportCredentials(h2creds)
 	}
 
-	var dialOpts = []grpc.DialOption{grpcOption}
-
-	// Use existingConn if provided
-	if c.existingConn != nil {
-		dialOpts = append(dialOpts, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-			return c.existingConn, nil
-		}))
-	}
+	dialOptions := []grpc.DialOption{grpcOption}
 
 	maxMessageSize := 1 << 30 // 1Gi
-	if c.ServiceToken != "" {
-		dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(GRPCClientAuthInterceptor(c.ServiceToken)),
+	if serviceToken != "" {
+		dialOptions = append(dialOptions, grpc.WithUnaryInterceptor(GRPCClientAuthInterceptor(serviceToken)),
 			grpc.WithDefaultCallOptions(
 				grpc.MaxCallRecvMsgSize(maxMessageSize),
 				grpc.MaxCallSendMsgSize(maxMessageSize),
 			))
 	}
+	dialOptions = append(dialOptions, additionalDialOptions...)
 
-	dialCtx := context.Background()
-	cancel := func() {}
-	if c.existingConn != nil {
-		dialOpts = append(dialOpts, grpc.WithBlock())
-		dialCtx, cancel = context.WithTimeout(dialCtx, containerClientExistingConnTimeout)
-	}
-	defer cancel()
-
-	conn, err := grpc.DialContext(dialCtx, c.ServiceUrl, dialOpts...)
+	conn, err := grpc.DialContext(ctx, serviceUrl, dialOptions...)
 	if err != nil {
-		if c.existingConn != nil {
-			_ = c.existingConn.Close()
-		}
-		return err
+		return nil, err
 	}
 
-	c.conn = conn
-	c.client = pb.NewContainerServiceClient(conn)
-	return nil
+	client.conn = conn
+	client.client = pb.NewContainerServiceClient(conn)
+	return client, nil
 }
 
 func (c *ContainerClient) Close() error {
@@ -157,7 +192,11 @@ func (c *ContainerClient) SandboxStatusContext(ctx context.Context, containerId 
 	ctx, cancel := context.WithTimeout(ctx, containerClientSandboxStatusTimeout)
 	defer cancel()
 
-	resp, err := c.client.ContainerSandboxStatus(ctx, &pb.ContainerSandboxStatusRequest{ContainerId: containerId, Pid: pid})
+	resp, err := c.client.ContainerSandboxStatus(
+		ctx,
+		&pb.ContainerSandboxStatusRequest{ContainerId: containerId, Pid: pid},
+		grpc.WaitForReady(true),
+	)
 	if err != nil {
 		return resp, err
 	}


### PR DESCRIPTION
## What changed

- Retry initial direct-worker client acquisition inside the existing 25-second sandbox readiness window.
- Replace a cached `ContainerClient` after a genuine transient readiness RPC failure.
- Preserve healthy shared clients when an individual caller is canceled.
- Keep compare-and-delete eviction and per-worker singleflight dialing under burst concurrency.
- Add direct legacy-worker regression coverage for 100 concurrent callers, a deliberately poisoned cached connection, request cancellation, and a shared initial dial failure.

## Root cause

The failed production run used legacy provider workers with direct worker addresses, not the agent route path. All 100 process managers became ready, but 56 requests exhausted the gateway's 25-second readiness timeout without executing a command. A `ContainerClient` wraps a one-shot backend connection; after that transport becomes unusable, the old `SandboxConnect` path kept probing the same cached client for the full timeout. Request-local cancellation could also evict and close a healthy client shared by sibling requests.

## Impact

Sandbox connect now redials a direct worker when its cached transport becomes unusable, while avoiding cancellation-driven connection churn. A shared initial dial failure is retried rather than fanned out as an immediate burst-wide failure.

## Validation

- `go test ./pkg/abstractions/pod -count=1`
- Focused 100-way regression tests, 10 consecutive runs
- Focused tests under `go test -race`
- Latest upstream ComputeSDK benchmarks at `cc891554` with `@computesdk/beam@0.3.0` and `@beamcloud/beam-js@1.0.13`
- Okteto staging, CI-equivalent sequence at 0.1 CPU due staging quota:
  - Sequential: 100/100, median 0.21s, p99 0.27s
  - Staggered: 100/100, median 0.23s, p99 0.30s
  - Burst: 100/100, median 1.27s, p99 1.53s
- Okteto staging, standard 1 CPU: 24/24, median 1.74s, p99 2.15s
- Gateway remained Ready with zero restarts and no matching connect/transport/panic errors; benchmark cleanup left zero active containers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers direct-worker sandbox connections under burst load by using a reconnecting gRPC channel with fast backoff and `WaitForReady`, healing dropped transports in under 500ms while keeping the cached `ContainerClient`. Adds focused tests for burst recovery, application Unavailable handling (no redial), and initial address lookup retries.

- **Bug Fixes**
  - Reconnecting client: introduced `NewContainerClientWithDialer` using a custom dialer and `grpc.ConnectParams` backoff; status probes call `grpc.WaitForReady(true)` to ride out transport drops without replacing the cached client.
  - `SandboxConnect`: acquires a client once during the readiness wait; removed cache-key eviction and redial paths; keeps per-worker singleflight dialing.
  - Status paths: removed evict+retry logic in `SandboxStatus` and runtime status; tests cover 100-way bursts (<500ms recovery), Unavailable responses (no redial), and one-shot address publication failures.

<sup>Written for commit 0a1fd4db38af01f000d2111c0152ce4363e2c45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

