### PR TITLE
fix: eliminate gateway Redis scan spikes

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -33,6 +33,8 @@ func main() {
 		log.Fatal().Err(err).Msg("error creating gateway service")
 	}
 
-	gw.Start()
+	if err := gw.Start(); err != nil {
+		log.Fatal().Err(err).Msg("gateway stopped unexpectedly")
+	}
 	log.Info().Msg("Gateway stopped")
 }

--- a/hack/cachefs_redis_migrate/main.go
+++ b/hack/cachefs_redis_migrate/main.go
@@ -1,0 +1,346 @@
+// cachefs_redis_migrate converts CacheFS metadata hashes to the compact v2
+// encoding. It is a dry run unless --apply or --rollback is supplied.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultBatchSize = 250
+	scanCount        = 1000
+)
+
+var replaceMetadata = redis.NewScript(`
+if redis.call("TYPE", KEYS[1]).ok ~= "hash" then
+	return 0
+end
+if (redis.call("HGET", KEYS[1], "gen") or "0") ~= ARGV[1] then
+	return -1
+end
+redis.call("HSET", KEYS[2], ARGV[4], ARGV[2])
+redis.call("ZADD", KEYS[3], ARGV[3], ARGV[4])
+redis.call("DEL", KEYS[1])
+return 1
+`)
+
+var restoreMetadata = redis.NewScript(`
+local current = redis.call("HGET", KEYS[1], ARGV[1])
+if not current then
+	return 0
+end
+if current ~= ARGV[2] then
+	return -1
+end
+redis.call("HSET", KEYS[3], unpack(ARGV, 3))
+redis.call("HDEL", KEYS[1], ARGV[1])
+redis.call("ZREM", KEYS[2], ARGV[1])
+return 1
+`)
+
+type report struct {
+	Apply            bool  `json:"apply"`
+	Rollback         bool  `json:"rollback"`
+	Scanned          int64 `json:"scanned"`
+	Legacy           int64 `json:"legacy_hashes"`
+	Compact          int64 `json:"compact_values"`
+	Children         int64 `json:"children_sets"`
+	Invalid          int64 `json:"invalid"`
+	Converted        int64 `json:"converted"`
+	Restored         int64 `json:"restored"`
+	Changed          int64 `json:"changed_during_migration"`
+	RemainingCompact int64 `json:"remaining_compact_values"`
+	LegacyBytes      int64 `json:"legacy_bytes"`
+	CompactBytes     int64 `json:"compact_payload_bytes"`
+	EstimatedSaved   int64 `json:"estimated_bytes_saved"`
+}
+
+type metadataRecord struct {
+	key     string
+	id      string
+	gen     string
+	encoded []byte
+	score   int64
+}
+
+func main() {
+	apply := flag.Bool("apply", false, "enable v2 and replace legacy hashes")
+	rollback := flag.Bool("rollback", false, "disable v2 and restore legacy hashes")
+	batchSize := flag.Int("batch-size", defaultBatchSize, "keys processed per pipeline")
+	pause := flag.Duration("pause", 10*time.Millisecond, "pause between batches")
+	flag.Parse()
+
+	if *apply && *rollback {
+		fmt.Fprintln(os.Stderr, "--apply and --rollback are mutually exclusive")
+		os.Exit(2)
+	}
+	if *batchSize < 1 || *batchSize > 5000 || *pause < 0 {
+		fmt.Fprintln(os.Stderr, "invalid batch size or pause")
+		os.Exit(2)
+	}
+
+	manager, err := common.NewConfigManager[types.AppConfig]()
+	if err != nil {
+		exit("load config", err)
+	}
+	rdb, err := common.NewRedisClient(manager.GetConfig().Database.Redis, common.WithClientName("cachefs-migrate"))
+	if err != nil {
+		exit("connect redis", err)
+	}
+	defer rdb.Close()
+
+	ctx := context.Background()
+	compact, err := compactNodeCount(ctx, rdb)
+	if err != nil {
+		exit("count compact metadata", err)
+	}
+	result := &report{Apply: *apply, Rollback: *rollback, Compact: compact}
+	if *rollback {
+		if err := restoreMetadata.Load(ctx, rdb).Err(); err != nil {
+			exit("load rollback script", err)
+		}
+		if err := rdb.Del(ctx, cache.MetadataKeys.MetadataFsFormat()).Err(); err != nil {
+			exit("disable compact format", err)
+		}
+		for shard := range cache.FSMetadataShardCount {
+			if err := rollbackShard(ctx, rdb, shard, *batchSize, *pause, result); err != nil {
+				exit("rollback shard", err)
+			}
+		}
+		result.RemainingCompact, err = compactNodeCount(ctx, rdb)
+		if err != nil {
+			exit("count remaining compact metadata", err)
+		}
+		writeReport(result)
+		if result.RemainingCompact != 0 {
+			os.Exit(1)
+		}
+		return
+	}
+
+	if *apply {
+		if err := replaceMetadata.Load(ctx, rdb).Err(); err != nil {
+			exit("load migration script", err)
+		}
+		if err := rdb.Set(ctx, cache.MetadataKeys.MetadataFsFormat(), cache.FSMetadataFormatCompact, 0).Err(); err != nil {
+			exit("enable compact format", err)
+		}
+	}
+
+	var cursor uint64
+	for {
+		keys, next, err := rdb.UniversalClient.Scan(ctx, cursor, cache.MetadataKeys.MetadataFsNode("*"), scanCount).Result()
+		if err != nil {
+			exit("scan cachefs metadata", err)
+		}
+		for start := 0; start < len(keys); start += *batchSize {
+			end := min(start+*batchSize, len(keys))
+			if err := migrateBatch(ctx, rdb, keys[start:end], *apply, result); err != nil {
+				exit("migrate batch", err)
+			}
+			time.Sleep(*pause)
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	result.EstimatedSaved = result.LegacyBytes - result.CompactBytes
+	writeReport(result)
+}
+
+func writeReport(result *report) {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(result); err != nil {
+		exit("encode report", err)
+	}
+}
+
+func migrateBatch(ctx context.Context, rdb *common.RedisClient, keys []string, apply bool, result *report) error {
+	typesByKey := make(map[string]*redis.StatusCmd, len(keys))
+	pipe := rdb.Pipeline()
+	for _, key := range keys {
+		typesByKey[key] = pipe.Type(ctx, key)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return err
+	}
+
+	hashes := make([]string, 0, len(keys))
+	for _, key := range keys {
+		result.Scanned++
+		switch typesByKey[key].Val() {
+		case "hash":
+			hashes = append(hashes, key)
+		case "set":
+			if strings.HasSuffix(key, ":children") {
+				result.Children++
+			}
+		}
+	}
+
+	metadataByKey := make(map[string]*redis.MapStringStringCmd, len(hashes))
+	memoryByKey := make(map[string]*redis.IntCmd, len(hashes))
+	pipe = rdb.Pipeline()
+	for _, key := range hashes {
+		metadataByKey[key] = pipe.HGetAll(ctx, key)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return err
+	}
+	pipe = rdb.Pipeline()
+	for _, key := range hashes {
+		memoryByKey[key] = pipe.MemoryUsage(ctx, key)
+	}
+	// MEMORY USAGE is only an estimate; ACLs or older Redis versions must not
+	// prevent conversion.
+	_, _ = pipe.Exec(ctx)
+
+	records := make([]metadataRecord, 0, len(hashes))
+	for _, key := range hashes {
+		metadata := &cache.FSMetadata{}
+		if err := cache.ToStruct(metadataByKey[key].Val(), metadata); err != nil {
+			result.Invalid++
+			continue
+		}
+		encoded, err := cache.MarshalFSMetadata(metadata)
+		if err != nil {
+			result.Invalid++
+			continue
+		}
+		memory := memoryByKey[key].Val()
+		score := int64(max(metadata.Mtime, metadata.Ctime))
+		if score <= 0 || score > time.Now().Unix() {
+			score = time.Now().Unix()
+		}
+		result.Legacy++
+		result.LegacyBytes += memory
+		result.CompactBytes += int64(len(encoded))
+		records = append(records, metadataRecord{
+			key:     key,
+			id:      strings.TrimPrefix(key, cache.MetadataKeys.MetadataFsNode("")),
+			gen:     fmt.Sprint(metadata.Gen),
+			encoded: encoded,
+			score:   score,
+		})
+	}
+
+	if !apply || len(records) == 0 {
+		return nil
+	}
+
+	commands := make([]*redis.Cmd, 0, len(records))
+	pipe = rdb.Pipeline()
+	for _, record := range records {
+		commands = append(commands, replaceMetadata.EvalSha(
+			ctx,
+			pipe,
+			[]string{
+				record.key,
+				cache.MetadataKeys.MetadataFsNodeData(record.id),
+				cache.MetadataKeys.MetadataFsNodeIndex(record.id),
+			},
+			record.gen,
+			record.encoded,
+			record.score,
+			record.id,
+		))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return err
+	}
+	for _, command := range commands {
+		switch command.Val() {
+		case int64(1):
+			result.Converted++
+		case int64(-1):
+			result.Changed++
+		}
+	}
+	return nil
+}
+
+func rollbackShard(ctx context.Context, rdb *common.RedisClient, shard, batchSize int, pause time.Duration, result *report) error {
+	dataKey := cache.MetadataKeys.MetadataFsNodeDataShard(shard)
+	indexKey := cache.MetadataKeys.MetadataFsNodeIndexShard(shard)
+	var values []string
+	var cursor uint64
+	for {
+		batch, next, err := rdb.HScan(ctx, dataKey, cursor, "*", scanCount).Result()
+		if err != nil {
+			return err
+		}
+		values = append(values, batch...)
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+
+	for start := 0; start < len(values); start += 2 * batchSize {
+		end := min(start+2*batchSize, len(values))
+		pipe := rdb.Pipeline()
+		commands := make([]*redis.Cmd, 0, (end-start)/2)
+		for i := start; i+1 < end; i += 2 {
+			id, encoded := values[i], []byte(values[i+1])
+			metadata, err := cache.UnmarshalFSMetadata(encoded)
+			if err != nil || metadata.ID != id {
+				result.Invalid++
+				continue
+			}
+			args := []interface{}{id, encoded}
+			args = append(args, cache.ToSlice(metadata)...)
+			commands = append(commands, restoreMetadata.EvalSha(ctx, pipe, []string{
+				dataKey,
+				indexKey,
+				cache.MetadataKeys.MetadataFsNode(id),
+			}, args...))
+		}
+		if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+			return err
+		}
+		for _, command := range commands {
+			switch command.Val() {
+			case int64(1):
+				result.Restored++
+			case int64(-1):
+				result.Changed++
+			}
+		}
+		time.Sleep(pause)
+	}
+	return nil
+}
+
+func compactNodeCount(ctx context.Context, rdb *common.RedisClient) (int64, error) {
+	commands := make([]*redis.IntCmd, cache.FSMetadataShardCount)
+	pipe := rdb.Pipeline()
+	for shard := range cache.FSMetadataShardCount {
+		commands[shard] = pipe.HLen(ctx, cache.MetadataKeys.MetadataFsNodeDataShard(shard))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return 0, err
+	}
+	var count int64
+	for _, command := range commands {
+		count += command.Val()
+	}
+	return count, nil
+}
+
+func exit(action string, err error) {
+	fmt.Fprintf(os.Stderr, "%s: %v\n", action, err)
+	os.Exit(1)
+}

--- a/hack/cachefs_redis_migrate/main.go
+++ b/hack/cachefs_redis_migrate/main.go
@@ -1,5 +1,5 @@
 // cachefs_redis_migrate converts CacheFS metadata hashes to the compact v2
-// encoding. It is a dry run unless --apply or --rollback is supplied.
+// encoding. It is a dry run unless --apply is supplied.
 package main
 
 import (
@@ -35,35 +35,18 @@ redis.call("DEL", KEYS[1])
 return 1
 `)
 
-var restoreMetadata = redis.NewScript(`
-local current = redis.call("HGET", KEYS[1], ARGV[1])
-if not current then
-	return 0
-end
-if current ~= ARGV[2] then
-	return -1
-end
-redis.call("HSET", KEYS[3], unpack(ARGV, 3))
-redis.call("HDEL", KEYS[1], ARGV[1])
-redis.call("ZREM", KEYS[2], ARGV[1])
-return 1
-`)
-
 type report struct {
-	Apply            bool  `json:"apply"`
-	Rollback         bool  `json:"rollback"`
-	Scanned          int64 `json:"scanned"`
-	Legacy           int64 `json:"legacy_hashes"`
-	Compact          int64 `json:"compact_values"`
-	Children         int64 `json:"children_sets"`
-	Invalid          int64 `json:"invalid"`
-	Converted        int64 `json:"converted"`
-	Restored         int64 `json:"restored"`
-	Changed          int64 `json:"changed_during_migration"`
-	RemainingCompact int64 `json:"remaining_compact_values"`
-	LegacyBytes      int64 `json:"legacy_bytes"`
-	CompactBytes     int64 `json:"compact_payload_bytes"`
-	EstimatedSaved   int64 `json:"estimated_bytes_saved"`
+	Apply          bool  `json:"apply"`
+	Scanned        int64 `json:"scanned"`
+	Legacy         int64 `json:"legacy_hashes"`
+	Compact        int64 `json:"compact_values"`
+	Children       int64 `json:"children_sets"`
+	Invalid        int64 `json:"invalid"`
+	Converted      int64 `json:"converted"`
+	Changed        int64 `json:"changed_during_migration"`
+	LegacyBytes    int64 `json:"legacy_bytes"`
+	CompactBytes   int64 `json:"compact_payload_bytes"`
+	EstimatedSaved int64 `json:"estimated_bytes_saved"`
 }
 
 type metadataRecord struct {
@@ -76,15 +59,10 @@ type metadataRecord struct {
 
 func main() {
 	apply := flag.Bool("apply", false, "enable v2 and replace legacy hashes")
-	rollback := flag.Bool("rollback", false, "disable v2 and restore legacy hashes")
 	batchSize := flag.Int("batch-size", defaultBatchSize, "keys processed per pipeline")
 	pause := flag.Duration("pause", 10*time.Millisecond, "pause between batches")
 	flag.Parse()
 
-	if *apply && *rollback {
-		fmt.Fprintln(os.Stderr, "--apply and --rollback are mutually exclusive")
-		os.Exit(2)
-	}
 	if *batchSize < 1 || *batchSize > 5000 || *pause < 0 {
 		fmt.Fprintln(os.Stderr, "invalid batch size or pause")
 		os.Exit(2)
@@ -105,30 +83,7 @@ func main() {
 	if err != nil {
 		exit("count compact metadata", err)
 	}
-	result := &report{Apply: *apply, Rollback: *rollback, Compact: compact}
-	if *rollback {
-		if err := restoreMetadata.Load(ctx, rdb).Err(); err != nil {
-			exit("load rollback script", err)
-		}
-		if err := rdb.Del(ctx, cache.MetadataKeys.MetadataFsFormat()).Err(); err != nil {
-			exit("disable compact format", err)
-		}
-		for shard := range cache.FSMetadataShardCount {
-			if err := rollbackShard(ctx, rdb, shard, *batchSize, *pause, result); err != nil {
-				exit("rollback shard", err)
-			}
-		}
-		result.RemainingCompact, err = compactNodeCount(ctx, rdb)
-		if err != nil {
-			exit("count remaining compact metadata", err)
-		}
-		writeReport(result)
-		if result.RemainingCompact != 0 {
-			os.Exit(1)
-		}
-		return
-	}
-
+	result := &report{Apply: *apply, Compact: compact}
 	if *apply {
 		if err := replaceMetadata.Load(ctx, rdb).Err(); err != nil {
 			exit("load migration script", err)
@@ -268,58 +223,6 @@ func migrateBatch(ctx context.Context, rdb *common.RedisClient, keys []string, a
 		case int64(-1):
 			result.Changed++
 		}
-	}
-	return nil
-}
-
-func rollbackShard(ctx context.Context, rdb *common.RedisClient, shard, batchSize int, pause time.Duration, result *report) error {
-	dataKey := cache.MetadataKeys.MetadataFsNodeDataShard(shard)
-	indexKey := cache.MetadataKeys.MetadataFsNodeIndexShard(shard)
-	var values []string
-	var cursor uint64
-	for {
-		batch, next, err := rdb.HScan(ctx, dataKey, cursor, "*", scanCount).Result()
-		if err != nil {
-			return err
-		}
-		values = append(values, batch...)
-		cursor = next
-		if cursor == 0 {
-			break
-		}
-	}
-
-	for start := 0; start < len(values); start += 2 * batchSize {
-		end := min(start+2*batchSize, len(values))
-		pipe := rdb.Pipeline()
-		commands := make([]*redis.Cmd, 0, (end-start)/2)
-		for i := start; i+1 < end; i += 2 {
-			id, encoded := values[i], []byte(values[i+1])
-			metadata, err := cache.UnmarshalFSMetadata(encoded)
-			if err != nil || metadata.ID != id {
-				result.Invalid++
-				continue
-			}
-			args := []interface{}{id, encoded}
-			args = append(args, cache.ToSlice(metadata)...)
-			commands = append(commands, restoreMetadata.EvalSha(ctx, pipe, []string{
-				dataKey,
-				indexKey,
-				cache.MetadataKeys.MetadataFsNode(id),
-			}, args...))
-		}
-		if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
-			return err
-		}
-		for _, command := range commands {
-			switch command.Val() {
-			case int64(1):
-				result.Restored++
-			case int64(-1):
-				result.Changed++
-			}
-		}
-		time.Sleep(pause)
 	}
 	return nil
 }

--- a/hack/cachefs_redis_migrate/main_test.go
+++ b/hack/cachefs_redis_migrate/main_test.go
@@ -41,20 +41,4 @@ func TestMigrateBatch(t *testing.T) {
 	if rdb.ZScore(context.Background(), cache.MetadataKeys.MetadataFsNodeIndex(want.ID), want.ID).Err() != nil {
 		t.Fatal("node was not indexed")
 	}
-
-	if err := restoreMetadata.Load(context.Background(), rdb).Err(); err != nil {
-		t.Fatal(err)
-	}
-	rollback := &report{}
-	if err := rollbackShard(context.Background(), rdb, cache.FSMetadataShard(want.ID), 10, 0, rollback); err != nil {
-		t.Fatal(err)
-	}
-	legacy := &cache.FSMetadata{}
-	if err := cache.ToStruct(rdb.HGetAll(context.Background(), key).Val(), legacy); err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(legacy, want) || rollback.Restored != 1 ||
-		rdb.HExists(context.Background(), cache.MetadataKeys.MetadataFsNodeData(want.ID), want.ID).Val() {
-		t.Fatalf("rollback got %#v, restored %d", legacy, rollback.Restored)
-	}
 }

--- a/hack/cachefs_redis_migrate/main_test.go
+++ b/hack/cachefs_redis_migrate/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestMigrateBatch(t *testing.T) {
+	server := miniredis.RunT(t)
+	rdb, err := common.NewRedisClient(types.RedisConfig{Addrs: []string{server.Addr()}, Mode: types.RedisModeSingle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &cache.FSMetadata{ID: "node", PID: "parent", Name: "file", Gen: 3}
+	key := cache.MetadataKeys.MetadataFsNode(want.ID)
+	if err := rdb.HSet(context.Background(), key, cache.ToSlice(want)).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	result := &report{}
+	if err := replaceMetadata.Load(context.Background(), rdb).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrateBatch(context.Background(), rdb, []string{key}, true, result); err != nil {
+		t.Fatal(err)
+	}
+	data, err := rdb.HGet(context.Background(), cache.MetadataKeys.MetadataFsNodeData(want.ID), want.ID).Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := cache.UnmarshalFSMetadata(data)
+	if err != nil || !reflect.DeepEqual(got, want) || result.Converted != 1 || rdb.Exists(context.Background(), key).Val() != 0 {
+		t.Fatalf("got %#v, converted %d, err %v", got, result.Converted, err)
+	}
+	if rdb.ZScore(context.Background(), cache.MetadataKeys.MetadataFsNodeIndex(want.ID), want.ID).Err() != nil {
+		t.Fatal("node was not indexed")
+	}
+
+	if err := restoreMetadata.Load(context.Background(), rdb).Err(); err != nil {
+		t.Fatal(err)
+	}
+	rollback := &report{}
+	if err := rollbackShard(context.Background(), rdb, cache.FSMetadataShard(want.ID), 10, 0, rollback); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &cache.FSMetadata{}
+	if err := cache.ToStruct(rdb.HGetAll(context.Background(), key).Val(), legacy); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(legacy, want) || rollback.Restored != 1 ||
+		rdb.HExists(context.Background(), cache.MetadataKeys.MetadataFsNodeData(want.ID), want.ID).Val() {
+		t.Fatalf("rollback got %#v, restored %d", legacy, rollback.Restored)
+	}
+}

--- a/hack/redis_cleanup/main.go
+++ b/hack/redis_cleanup/main.go
@@ -1,0 +1,340 @@
+// redis_cleanup removes expired task state and old CacheFS leaves through
+// explicit indexes. It is a dry run unless --apply is supplied.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/redis/go-redis/v9"
+)
+
+const cleanupBatchSize = 250
+
+var removeTask = redis.NewScript(`
+if redis.call("EXISTS", KEYS[2]) == 1 then
+	return -1
+end
+if redis.call("EXISTS", KEYS[1]) == 1 and redis.call("PTTL", KEYS[1]) ~= -1 then
+	return -1
+end
+redis.call("UNLINK", KEYS[1], KEYS[2])
+redis.call("SREM", KEYS[3], KEYS[1])
+redis.call("SREM", KEYS[4], ARGV[1])
+redis.call("SREM", KEYS[5], ARGV[1])
+return 1
+`)
+
+var removeCacheFSLeaf = redis.NewScript(`
+local score = redis.call("ZSCORE", KEYS[1], ARGV[1])
+if not score or tonumber(score) > tonumber(ARGV[2]) then
+	return -1
+end
+if not redis.call("HGET", KEYS[2], ARGV[1]) then
+	redis.call("ZREM", KEYS[1], ARGV[1])
+	return 2
+end
+if redis.call("SCARD", KEYS[3]) ~= 0 then
+	return -1
+end
+if redis.call("SISMEMBER", KEYS[4], ARGV[1]) == 1 then
+	return -1
+end
+redis.call("HDEL", KEYS[2], ARGV[1])
+redis.call("UNLINK", KEYS[3])
+redis.call("SREM", KEYS[4], ARGV[1])
+redis.call("ZREM", KEYS[1], ARGV[1])
+return 1
+`)
+
+type cleanupReport struct {
+	Apply                  bool  `json:"apply"`
+	TaskIndexed            int64 `json:"task_indexed"`
+	TaskExpired            int64 `json:"task_expired"`
+	TaskMissing            int64 `json:"task_missing"`
+	TaskProtected          int64 `json:"task_protected"`
+	TaskRemoved            int64 `json:"task_removed"`
+	TaskBytes              int64 `json:"task_bytes"`
+	CacheFSIndexed         int64 `json:"cachefs_indexed"`
+	CacheFSMissing         int64 `json:"cachefs_missing"`
+	CacheFSOrphanLeaves    int64 `json:"cachefs_orphan_leaves"`
+	CacheFSProtected       int64 `json:"cachefs_protected"`
+	CacheFSRemoved         int64 `json:"cachefs_removed"`
+	CacheFSIndexesRemoved  int64 `json:"cachefs_indexes_removed"`
+	CacheFSBytes           int64 `json:"cachefs_bytes"`
+	CacheFSOlderThanSecond int64 `json:"cachefs_older_than_seconds"`
+}
+
+func main() {
+	apply := flag.Bool("apply", false, "apply guarded cleanup")
+	cacheAge := flag.Duration("cachefs-older-than", 30*24*time.Hour, "minimum age for compact CacheFS leaves")
+	pause := flag.Duration("pause", 10*time.Millisecond, "pause between batches")
+	flag.Parse()
+	if *cacheAge <= 0 || *pause < 0 {
+		fmt.Fprintln(os.Stderr, "invalid cache age or pause")
+		os.Exit(2)
+	}
+
+	manager, err := common.NewConfigManager[types.AppConfig]()
+	if err != nil {
+		cleanupExit("load config", err)
+	}
+	rdb, err := common.NewRedisClient(manager.GetConfig().Database.Redis, common.WithClientName("beta9-redis-cleanup"))
+	if err != nil {
+		cleanupExit("connect redis", err)
+	}
+	defer rdb.Close()
+
+	ctx := context.Background()
+	result := &cleanupReport{
+		Apply:                  *apply,
+		CacheFSOlderThanSecond: int64(cacheAge.Seconds()),
+	}
+	if *apply {
+		if err := removeTask.Load(ctx, rdb).Err(); err != nil {
+			cleanupExit("load task cleanup script", err)
+		}
+		if err := removeCacheFSLeaf.Load(ctx, rdb).Err(); err != nil {
+			cleanupExit("load cachefs cleanup script", err)
+		}
+	}
+	if err := cleanupTasks(ctx, rdb, *apply, *pause, result); err != nil {
+		cleanupExit("cleanup tasks", err)
+	}
+	if err := cleanupCacheFS(ctx, rdb, *apply, *cacheAge, *pause, result); err != nil {
+		cleanupExit("cleanup cachefs", err)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(result); err != nil {
+		cleanupExit("encode report", err)
+	}
+}
+
+func cleanupTasks(ctx context.Context, rdb *common.RedisClient, apply bool, pause time.Duration, result *cleanupReport) error {
+	keys, err := rdb.SMembers(ctx, common.RedisKeys.TaskIndex()).Result()
+	if err != nil {
+		return err
+	}
+	result.TaskIndexed = int64(len(keys))
+	for start := 0; start < len(keys); start += cleanupBatchSize {
+		end := min(start+cleanupBatchSize, len(keys))
+		batch := keys[start:end]
+		values := make(map[string]*redis.StringCmd, len(batch))
+		claims := make(map[string]*redis.IntCmd, len(batch))
+		memory := make(map[string]*redis.IntCmd, len(batch))
+		pipe := rdb.Pipeline()
+		for _, key := range batch {
+			values[key] = pipe.Get(ctx, key)
+			claims[key] = pipe.Exists(ctx, key+":claim")
+			memory[key] = pipe.MemoryUsage(ctx, key)
+		}
+		_, _ = pipe.Exec(ctx)
+
+		type candidate struct {
+			key, workspace, stub, task string
+		}
+		candidates := make([]candidate, 0, len(batch))
+		for _, key := range batch {
+			if claims[key].Val() != 0 {
+				result.TaskProtected++
+				continue
+			}
+			value, valueErr := values[key].Bytes()
+			missing := valueErr == redis.Nil
+			expired := false
+			if valueErr == nil {
+				var state struct {
+					Policy struct {
+						Expires time.Time `json:"expires"`
+					} `json:"policy"`
+				}
+				expired = json.Unmarshal(value, &state) == nil &&
+					!state.Policy.Expires.IsZero() &&
+					time.Now().After(state.Policy.Expires)
+			}
+			if !missing && !expired {
+				result.TaskProtected++
+				continue
+			}
+			parts := strings.Split(key, ":")
+			if len(parts) != 4 {
+				result.TaskProtected++
+				continue
+			}
+			if missing {
+				result.TaskMissing++
+			} else {
+				result.TaskExpired++
+				result.TaskBytes += memory[key].Val()
+			}
+			candidates = append(candidates, candidate{key, parts[1], parts[2], parts[3]})
+		}
+		if apply && len(candidates) > 0 {
+			pipe = rdb.Pipeline()
+			commands := make([]*redis.Cmd, 0, len(candidates))
+			for _, item := range candidates {
+				commands = append(commands, removeTask.EvalSha(ctx, pipe, []string{
+					item.key,
+					item.key + ":claim",
+					common.RedisKeys.TaskIndex(),
+					common.RedisKeys.TaskIndexByStub(item.workspace, item.stub),
+					common.RedisKeys.TaskClaimIndex(item.workspace, item.stub),
+				}, item.task))
+			}
+			_, _ = pipe.Exec(ctx)
+			for _, command := range commands {
+				if command.Val() == int64(1) {
+					result.TaskRemoved++
+				} else {
+					result.TaskProtected++
+				}
+			}
+		}
+		time.Sleep(pause)
+	}
+	return nil
+}
+
+func cleanupCacheFS(ctx context.Context, rdb *common.RedisClient, apply bool, age, pause time.Duration, result *cleanupReport) error {
+	cutoff := time.Now().Add(-age).Unix()
+	for shard := range cache.FSMetadataShardCount {
+		index := cache.MetadataKeys.MetadataFsNodeIndexShard(shard)
+		data := cache.MetadataKeys.MetadataFsNodeDataShard(shard)
+		var cursor uint64
+		for {
+			values, next, err := rdb.ZScan(ctx, index, cursor, "*", cleanupBatchSize).Result()
+			if err != nil {
+				return err
+			}
+			ids := make([]string, 0, len(values)/2)
+			for i := 0; i+1 < len(values); i += 2 {
+				score, err := strconv.ParseFloat(values[i+1], 64)
+				if err == nil && int64(score) <= cutoff {
+					ids = append(ids, values[i])
+				}
+			}
+			result.CacheFSIndexed += int64(len(values) / 2)
+			if err := cleanupCacheFSBatch(ctx, rdb, ids, data, index, cutoff, apply, result); err != nil {
+				return err
+			}
+			time.Sleep(pause)
+			cursor = next
+			if cursor == 0 {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func cleanupCacheFSBatch(ctx context.Context, rdb *common.RedisClient, ids []string, dataKey, index string, cutoff int64, apply bool, result *cleanupReport) error {
+	metadata := make(map[string]*redis.StringCmd, len(ids))
+	children := make(map[string]*redis.IntCmd, len(ids))
+	pipe := rdb.Pipeline()
+	for _, id := range ids {
+		metadata[id] = pipe.HGet(ctx, dataKey, id)
+		children[id] = pipe.SCard(ctx, cache.MetadataKeys.MetadataFsNodeChildren(id))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return err
+	}
+
+	type candidate struct {
+		id, parent string
+		missing    bool
+	}
+	candidates := make([]candidate, 0, len(ids))
+	for _, id := range ids {
+		data, err := metadata[id].Bytes()
+		if err == redis.Nil {
+			result.CacheFSMissing++
+			candidates = append(candidates, candidate{id: id, missing: true})
+			continue
+		}
+		if err != nil || children[id].Val() != 0 {
+			result.CacheFSProtected++
+			continue
+		}
+		node, err := cache.UnmarshalFSMetadata(data)
+		if err != nil || node.PID == "" {
+			result.CacheFSProtected++
+			continue
+		}
+		candidates = append(candidates, candidate{id: id, parent: node.PID})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	references := make(map[string]*redis.BoolCmd, len(candidates))
+	pipe = rdb.Pipeline()
+	for _, item := range candidates {
+		if item.missing {
+			continue
+		}
+		references[item.id] = pipe.SIsMember(ctx, cache.MetadataKeys.MetadataFsNodeChildren(item.parent), item.id)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return err
+	}
+
+	orphans := candidates[:0]
+	for _, item := range candidates {
+		if item.missing {
+			orphans = append(orphans, item)
+			continue
+		}
+		if references[item.id].Val() {
+			result.CacheFSProtected++
+			continue
+		}
+		result.CacheFSOrphanLeaves++
+		data, _ := metadata[item.id].Bytes()
+		result.CacheFSBytes += int64(len(item.id) + len(data))
+		orphans = append(orphans, item)
+	}
+	if !apply || len(orphans) == 0 {
+		return nil
+	}
+
+	pipe = rdb.Pipeline()
+	commands := make([]*redis.Cmd, 0, len(orphans))
+	for _, item := range orphans {
+		commands = append(commands, removeCacheFSLeaf.EvalSha(ctx, pipe, []string{
+			index,
+			dataKey,
+			cache.MetadataKeys.MetadataFsNodeChildren(item.id),
+			cache.MetadataKeys.MetadataFsNodeChildren(item.parent),
+		}, item.id, cutoff))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return err
+	}
+	for _, command := range commands {
+		switch command.Val() {
+		case int64(1):
+			result.CacheFSRemoved++
+		case int64(2):
+			result.CacheFSIndexesRemoved++
+		default:
+			result.CacheFSProtected++
+		}
+	}
+	return nil
+}
+
+func cleanupExit(action string, err error) {
+	fmt.Fprintf(os.Stderr, "%s: %v\n", action, err)
+	os.Exit(1)
+}

--- a/hack/redis_cleanup/main_test.go
+++ b/hack/redis_cleanup/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestCleanupCacheFSLeaf(t *testing.T) {
+	server := miniredis.RunT(t)
+	rdb, err := common.NewRedisClient(types.RedisConfig{Addrs: []string{server.Addr()}, Mode: types.RedisModeSingle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := removeCacheFSLeaf.Load(ctx, rdb).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	node := &cache.FSMetadata{ID: "leaf", PID: "parent"}
+	data, err := cache.MarshalFSMetadata(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataKey := cache.MetadataKeys.MetadataFsNodeData(node.ID)
+	index := cache.MetadataKeys.MetadataFsNodeIndex(node.ID)
+	parent := cache.MetadataKeys.MetadataFsNodeChildren(node.PID)
+	if err := rdb.HSet(ctx, dataKey, node.ID, data).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rdb.ZAdd(ctx, index, redis.Z{Member: node.ID, Score: 1}).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rdb.SAdd(ctx, parent, node.ID).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	result := &cleanupReport{}
+	if err := cleanupCacheFSBatch(ctx, rdb, []string{node.ID}, dataKey, index, time.Now().Unix(), true, result); err != nil {
+		t.Fatal(err)
+	}
+	if !rdb.HExists(ctx, dataKey, node.ID).Val() {
+		t.Fatal("referenced leaf was removed")
+	}
+
+	if err := rdb.SRem(ctx, parent, node.ID).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupCacheFSBatch(ctx, rdb, []string{node.ID}, dataKey, index, time.Now().Unix(), true, result); err != nil {
+		t.Fatal(err)
+	}
+	if rdb.HExists(ctx, dataKey, node.ID).Val() || result.CacheFSRemoved != 1 {
+		t.Fatal("orphan leaf was not removed")
+	}
+}

--- a/pkg/abstractions/common/container_events.go
+++ b/pkg/abstractions/common/container_events.go
@@ -36,7 +36,7 @@ func NewContainerEventManager(ctx context.Context, containerPrefixes []string, k
 
 func (em *ContainerEventManager) Listen() {
 	for _, prefix := range em.containerPrefixes {
-		go em.keyEventManager.ListenForPattern(em.ctx, common.RedisKeys.SchedulerContainerState(prefix), em.keyEventChans[prefix])
+		go em.keyEventManager.ListenForContainerPattern(em.ctx, prefix, em.keyEventChans[prefix])
 		go em.handleContainerEventsForPrefix(em.ctx, prefix)
 	}
 }

--- a/pkg/abstractions/common/container_leases.go
+++ b/pkg/abstractions/common/container_leases.go
@@ -1,0 +1,85 @@
+package abstractions
+
+import (
+	"context"
+
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+type ContainerStopper interface {
+	Stop(*types.StopContainerArgs) error
+}
+
+type ContainerLeaseManager struct {
+	redisClient     *common.RedisClient
+	stopper         ContainerStopper
+	containerPrefix string
+	leaseKey        func(string) string
+}
+
+func NewContainerLeaseManager(
+	redisClient *common.RedisClient,
+	stopper ContainerStopper,
+	containerPrefix string,
+	leaseKey func(string) string,
+) *ContainerLeaseManager {
+	return &ContainerLeaseManager{
+		redisClient:     redisClient,
+		stopper:         stopper,
+		containerPrefix: containerPrefix,
+		leaseKey:        leaseKey,
+	}
+}
+
+func (m *ContainerLeaseManager) Run(ctx context.Context) error {
+	containers := make(chan common.KeyEvent)
+	expirations := make(chan common.KeyEvent)
+	events := common.NewKeyEventManager(m.redisClient)
+	if err := events.ListenForPatternEvents(ctx, m.leaseKey(""), expirations); err != nil {
+		return err
+	}
+	listening := make(chan error, 1)
+	go func() {
+		listening <- events.ListenForContainerPattern(ctx, m.containerPrefix, containers)
+	}()
+
+	for {
+		select {
+		case event := <-containers:
+			if event.Operation == common.KeyOperationSet {
+				m.stopIfExpired(ctx, m.containerPrefix+event.Key)
+			}
+		case event := <-expirations:
+			if event.Operation == common.KeyOperationExpired {
+				m.stopIfExpired(ctx, event.Key)
+			}
+		case err := <-listening:
+			if err != nil {
+				return err
+			}
+			listening = nil
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (m *ContainerLeaseManager) stopIfExpired(ctx context.Context, containerId string) {
+	exists, err := m.redisClient.Exists(ctx, m.leaseKey(containerId)).Result()
+	if err != nil {
+		log.Error().Err(err).Str("container_id", containerId).Msg("failed to check container lease")
+		return
+	}
+	if exists != 0 {
+		return
+	}
+	if err = m.stopper.Stop(&types.StopContainerArgs{
+		ContainerId: containerId,
+		Force:       true,
+		Reason:      types.StopContainerReasonTtl,
+	}); err != nil {
+		log.Error().Err(err).Str("container_id", containerId).Msg("failed to stop expired container")
+	}
+}

--- a/pkg/abstractions/common/container_leases_test.go
+++ b/pkg/abstractions/common/container_leases_test.go
@@ -1,0 +1,58 @@
+package abstractions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/redis/go-redis/v9"
+)
+
+type recordingContainerStopper chan *types.StopContainerArgs
+
+func (s recordingContainerStopper) Stop(args *types.StopContainerArgs) error {
+	s <- args
+	return nil
+}
+
+func TestContainerLeaseManagerReplaysContainerIDs(t *testing.T) {
+	server := miniredis.RunT(t)
+	rdb, err := common.NewRedisClient(types.RedisConfig{
+		Addrs: []string{server.Addr()},
+		Mode:  types.RedisModeSingle,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stateKey := common.RedisKeys.SchedulerContainerState("build-indexed")
+	if err := rdb.ZAdd(ctx, common.RedisKeys.SchedulerContainerStateIndex(), redis.Z{
+		Score:  float64(time.Now().Add(time.Minute).Unix()),
+		Member: stateKey,
+	}).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	stopped := make(recordingContainerStopper, 1)
+	manager := NewContainerLeaseManager(
+		rdb,
+		stopped,
+		types.BuildContainerPrefix,
+		common.RedisKeys.ImageBuildContainerTTL,
+	)
+	go manager.Run(ctx)
+
+	select {
+	case args := <-stopped:
+		if args.ContainerId != "build-indexed" || !args.Force || args.Reason != types.StopContainerReasonTtl {
+			t.Fatalf("unexpected stop: %#v", args)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("indexed container was not stopped")
+	}
+}

--- a/pkg/abstractions/endpoint/buffer.go
+++ b/pkg/abstractions/endpoint/buffer.go
@@ -120,7 +120,7 @@ func NewRequestBuffer(
 	go rb.processRequests()
 
 	// Listen for heartbeat key events
-	go rb.keyEventManager.ListenForPattern(rb.ctx, Keys.endpointRequestHeartbeat(rb.workspace.Name, rb.stubId, "*", "*"), rb.keyEventChan)
+	go rb.keyEventManager.ListenForPatternEvents(rb.ctx, Keys.endpointRequestHeartbeat(rb.workspace.Name, rb.stubId, "*", "*"), rb.keyEventChan)
 	go rb.handleHeartbeatEvents()
 
 	return rb

--- a/pkg/abstractions/endpoint/endpoint.go
+++ b/pkg/abstractions/endpoint/endpoint.go
@@ -81,10 +81,7 @@ func NewHTTPEndpointService(
 	ctx context.Context,
 	opts EndpointServiceOpts,
 ) (EndpointService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(opts.RedisClient)
 
 	es := &HttpEndpointService{
 		ctx:               ctx,

--- a/pkg/abstractions/experimental/bot/bot.go
+++ b/pkg/abstractions/experimental/bot/bot.go
@@ -93,7 +93,7 @@ func NewPetriBotService(ctx context.Context, opts BotServiceOpts) (BotService, e
 	}
 
 	// Listen for container events with a bot container prefix
-	go keyEventManager.ListenForPattern(ctx, common.RedisKeys.SchedulerContainerState(botContainerPrefix), pbs.keyEventChan)
+	go keyEventManager.ListenForContainerPattern(ctx, botContainerPrefix, pbs.keyEventChan)
 	go pbs.handleBotContainerEvents(ctx)
 
 	// Register task dispatcher

--- a/pkg/abstractions/experimental/bot/bot.go
+++ b/pkg/abstractions/experimental/bot/bot.go
@@ -68,10 +68,7 @@ type PetriBotService struct {
 }
 
 func NewPetriBotService(ctx context.Context, opts BotServiceOpts) (BotService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(opts.RedisClient)
 
 	pbs := &PetriBotService{
 		ctx:             ctx,

--- a/pkg/abstractions/function/function.go
+++ b/pkg/abstractions/function/function.go
@@ -77,10 +77,7 @@ type FunctionServiceOpts struct {
 func NewContainerFunctionService(ctx context.Context,
 	opts FunctionServiceOpts,
 ) (FunctionService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(opts.RedisClient)
 
 	fs := &ContainerFunctionService{
 		ctx:              ctx,

--- a/pkg/abstractions/image/builder.go
+++ b/pkg/abstractions/image/builder.go
@@ -474,8 +474,13 @@ func (b *Builder) refreshBuildContainerTTL(ctx context.Context, containerId stri
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := b.containerRepo.SetBuildContainerTTL(containerId, time.Duration(imageContainerTtlS)*time.Second); err != nil {
-				log.Error().Str("container_id", containerId).Err(err).Msg("failed to set build container ttl")
+			refreshed, err := b.containerRepo.RefreshBuildContainerTTL(containerId, time.Duration(imageContainerTtlS)*time.Second)
+			if err != nil {
+				log.Error().Str("container_id", containerId).Err(err).Msg("failed to refresh build container ttl")
+				continue
+			}
+			if !refreshed {
+				return
 			}
 		}
 	}

--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 
+	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/network"
@@ -29,9 +29,6 @@ type ContainerImageService struct {
 	builder          *Builder
 	config           types.AppConfig
 	backendRepo      repository.BackendRepository
-	containerRepo    repository.ContainerRepository
-	keyEventChan     chan common.KeyEvent
-	keyEventManager  *common.KeyEventManager
 	baseImageDigests baseImageDigestCache
 }
 
@@ -61,24 +58,24 @@ func NewContainerImageService(
 		return nil, err
 	}
 
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
-
 	is := ContainerImageService{
 		builder:          builder,
 		config:           opts.Config,
 		backendRepo:      opts.BackendRepo,
-		containerRepo:    opts.ContainerRepo,
-		keyEventChan:     make(chan common.KeyEvent),
-		keyEventManager:  keyEventManager,
 		baseImageDigests: newBaseImageDigestCache(),
 	}
 
-	go is.monitorImageContainers(ctx)
-	go is.keyEventManager.ListenForPatternEvents(ctx, common.RedisKeys.ImageBuildContainerTTL(""), is.keyEventChan)
-	go is.keyEventManager.ListenForContainerPattern(ctx, types.BuildContainerPrefix, is.keyEventChan)
+	leases := abstractions.NewContainerLeaseManager(
+		opts.RedisClient,
+		opts.Scheduler,
+		types.BuildContainerPrefix,
+		common.RedisKeys.ImageBuildContainerTTL,
+	)
+	go func() {
+		if err := leases.Run(ctx); err != nil {
+			log.Error().Err(err).Msg("image container lease manager stopped")
+		}
+	}()
 
 	return &is, nil
 }
@@ -248,39 +245,6 @@ func (is *ContainerImageService) retrieveBuildSecrets(ctx context.Context, secre
 		}
 	}
 	return buildSecrets, nil
-}
-
-func (is *ContainerImageService) monitorImageContainers(ctx context.Context) {
-	for {
-		select {
-		case event := <-is.keyEventChan:
-			switch event.Operation {
-			case common.KeyOperationSet:
-				if strings.Contains(event.Key, common.RedisKeys.SchedulerContainerState("")) {
-					containerId := strings.TrimPrefix(is.keyEventManager.TrimKeyspacePrefix(event.Key), common.RedisKeys.SchedulerContainerState(""))
-
-					if !is.containerRepo.HasBuildContainerTTL(containerId) {
-						is.builder.scheduler.Stop(&types.StopContainerArgs{
-							ContainerId: containerId,
-							Force:       true,
-							Reason:      types.StopContainerReasonTtl,
-						})
-					}
-				}
-			case common.KeyOperationExpired:
-				if strings.Contains(event.Key, common.RedisKeys.ImageBuildContainerTTL("")) {
-					containerId := strings.TrimPrefix(is.keyEventManager.TrimKeyspacePrefix(event.Key), common.RedisKeys.ImageBuildContainerTTL(""))
-					is.builder.scheduler.Stop(&types.StopContainerArgs{
-						ContainerId: containerId,
-						Force:       true,
-						Reason:      types.StopContainerReasonTtl,
-					})
-				}
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
 }
 
 func convertBuildSteps(buildSteps []*pb.BuildStep) []BuildStep {

--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -77,8 +77,8 @@ func NewContainerImageService(
 	}
 
 	go is.monitorImageContainers(ctx)
-	go is.keyEventManager.ListenForPattern(ctx, common.RedisKeys.ImageBuildContainerTTL("*"), is.keyEventChan)
-	go is.keyEventManager.ListenForPattern(ctx, common.RedisKeys.SchedulerContainerState(types.BuildContainerPrefix+"*"), is.keyEventChan)
+	go is.keyEventManager.ListenForPatternEvents(ctx, common.RedisKeys.ImageBuildContainerTTL(""), is.keyEventChan)
+	go is.keyEventManager.ListenForContainerPattern(ctx, types.BuildContainerPrefix, is.keyEventChan)
 
 	return &is, nil
 }

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -88,10 +88,7 @@ func NewPodService(
 	ctx context.Context,
 	opts PodServiceOpts,
 ) (PodService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(opts.RedisClient)
 
 	ps := &GenericPodService{
 		ctx:             ctx,

--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -293,7 +293,12 @@ func (pb *PodProxyBuffer) waitForConnection(conn *connection, requestDone <-chan
 		case <-conn.done:
 			return nil
 		case <-requestDone:
-			return nil
+			if conn.cancelQueued() {
+				return nil
+			}
+			// An active proxy goroutine owns the response writer. Wait for it
+			// to observe request cancellation before net/http finalizes headers.
+			requestDone = nil
 		}
 	}
 }
@@ -492,6 +497,18 @@ func (c *connection) finish() {
 
 func (c *connection) claim() bool {
 	return c != nil && c.state.CompareAndSwap(connectionQueued, connectionActive)
+}
+
+func (c *connection) cancelQueued() bool {
+	if c == nil || !c.state.CompareAndSwap(connectionQueued, connectionFinished) {
+		return false
+	}
+	c.finishOnce.Do(func() {
+		if c.done != nil {
+			close(c.done)
+		}
+	})
+	return true
 }
 
 func (pb *PodProxyBuffer) availableContainerSnapshot() []container {

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -37,6 +37,33 @@ func TestPodBackendURLPreservesDirectAddress(t *testing.T) {
 	}
 }
 
+func TestWaitForConnectionWaitsForActiveWriterAfterCancellation(t *testing.T) {
+	pb := &PodProxyBuffer{ctx: context.Background()}
+	conn := &connection{done: make(chan struct{})}
+	if !conn.claim() {
+		t.Fatal("failed to claim connection")
+	}
+	requestDone := make(chan struct{})
+	close(requestDone)
+	returned := make(chan struct{})
+	go func() {
+		_ = pb.waitForConnection(conn, requestDone)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		t.Fatal("returned while the response writer was still active")
+	case <-time.After(20 * time.Millisecond):
+	}
+	conn.finish()
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("did not return after the response writer finished")
+	}
+}
+
 func TestProcessBufferWakesWhenBackendBecomesAvailable(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/pkg/abstractions/pod/task.go
+++ b/pkg/abstractions/pod/task.go
@@ -313,7 +313,7 @@ func (ps *GenericPodService) deletePodRunTaskMapping(ctx context.Context, contai
 // container state key finalizes the task from the recorded exit code.
 func (ps *GenericPodService) watchPodRunTaskContainers() {
 	eventChan := make(chan common.KeyEvent, podRunTaskEventBufferSize)
-	err := ps.keyEventManager.ListenForPattern(ps.ctx, common.RedisKeys.SchedulerContainerState(podContainerPrefix), eventChan)
+	err := ps.keyEventManager.ListenForContainerPattern(ps.ctx, podContainerPrefix, eventChan)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to listen for pod run container events")
 		return

--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -70,21 +70,18 @@ func hasShellPermission(authInfo *auth.AuthInfo) bool {
 
 type SSHShellService struct {
 	pb.UnimplementedShellServiceServer
-	ctx                context.Context
-	config             types.AppConfig
-	rdb                *common.RedisClient
-	keyEventManager    *common.KeyEventManager
-	scheduler          *scheduler.Scheduler
-	backendRepo        repository.BackendRepository
-	computeRepo        repository.ComputeRepository
-	workspaceRepo      repository.WorkspaceRepository
-	containerRepo      repository.ContainerRepository
-	workerRepo         repository.WorkerRepository
-	workerPoolRepo     repository.WorkerPoolRepository
-	eventRepo          repository.EventRepository
-	tailscale          *network.Tailscale
-	ttlEventChan       chan common.KeyEvent
-	containerEventChan chan common.KeyEvent
+	ctx            context.Context
+	config         types.AppConfig
+	rdb            *common.RedisClient
+	scheduler      *scheduler.Scheduler
+	backendRepo    repository.BackendRepository
+	computeRepo    repository.ComputeRepository
+	workspaceRepo  repository.WorkspaceRepository
+	containerRepo  repository.ContainerRepository
+	workerRepo     repository.WorkerRepository
+	workerPoolRepo repository.WorkerPoolRepository
+	eventRepo      repository.EventRepository
+	tailscale      *network.Tailscale
 }
 
 type ShellServiceOpts struct {
@@ -106,52 +103,35 @@ func NewSSHShellService(
 	ctx context.Context,
 	opts ShellServiceOpts,
 ) (ShellService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
-
 	ss := &SSHShellService{
-		ctx:                ctx,
-		config:             opts.Config,
-		rdb:                opts.RedisClient,
-		keyEventManager:    keyEventManager,
-		scheduler:          opts.Scheduler,
-		backendRepo:        opts.BackendRepo,
-		computeRepo:        opts.ComputeRepo,
-		workspaceRepo:      opts.WorkspaceRepo,
-		containerRepo:      opts.ContainerRepo,
-		workerRepo:         opts.WorkerRepo,
-		workerPoolRepo:     opts.WorkerPoolRepo,
-		tailscale:          opts.Tailscale,
-		eventRepo:          opts.EventRepo,
-		ttlEventChan:       make(chan common.KeyEvent),
-		containerEventChan: make(chan common.KeyEvent),
+		ctx:            ctx,
+		config:         opts.Config,
+		rdb:            opts.RedisClient,
+		scheduler:      opts.Scheduler,
+		backendRepo:    opts.BackendRepo,
+		computeRepo:    opts.ComputeRepo,
+		workspaceRepo:  opts.WorkspaceRepo,
+		containerRepo:  opts.ContainerRepo,
+		workerRepo:     opts.WorkerRepo,
+		workerPoolRepo: opts.WorkerPoolRepo,
+		tailscale:      opts.Tailscale,
+		eventRepo:      opts.EventRepo,
 	}
 
 	authMiddleware := auth.AuthMiddleware(opts.BackendRepo, opts.WorkspaceRepo)
 	registerShellRoutes(opts.RouteGroup.Group(shellRoutePrefix, authMiddleware), ss)
 
-	// Listen for shell container ttl events
+	leases := abstractions.NewContainerLeaseManager(
+		opts.RedisClient,
+		opts.Scheduler,
+		shellContainerPrefix,
+		Keys.shellContainerTTL,
+	)
 	go func() {
-		if err := ss.keyEventManager.ListenForPatternEvents(
-			ss.ctx,
-			Keys.shellContainerTTL(""),
-			ss.ttlEventChan,
-		); err != nil {
-			log.Error().Err(err).Msg("shell TTL event listener stopped")
+		if err := leases.Run(ctx); err != nil {
+			log.Error().Err(err).Msg("shell container lease manager stopped")
 		}
 	}()
-	go func() {
-		if err := ss.keyEventManager.ListenForContainerPattern(
-			ss.ctx,
-			shellContainerPrefix,
-			ss.containerEventChan,
-		); err != nil {
-			log.Error().Err(err).Msg("shell container event listener stopped")
-		}
-	}()
-	go ss.handleTTLEvents()
 
 	return ss, nil
 }
@@ -162,48 +142,6 @@ func (ss *SSHShellService) durableDiskPlacementRepos() abstractions.DurableDiskP
 		ComputeRepo:    ss.computeRepo,
 		WorkerRepo:     ss.workerRepo,
 		WorkerPoolRepo: ss.workerPoolRepo,
-	}
-}
-
-func (ss *SSHShellService) handleTTLEvents() {
-	for {
-		select {
-		case event := <-ss.ttlEventChan:
-			if event.Operation == common.KeyOperationExpired {
-				ss.stopShellWithoutLease(event.Key)
-			}
-		case event := <-ss.containerEventChan:
-			if event.Operation == common.KeyOperationSet {
-				// Reconcile shell containers left behind while no gateway was
-				// subscribed to their TTL events.
-				ss.stopShellWithoutLease(shellContainerPrefix + event.Key)
-			}
-		case <-ss.ctx.Done():
-			return
-		}
-	}
-}
-
-func (ss *SSHShellService) stopShellWithoutLease(containerId string) {
-	if !IsStandaloneContainer(containerId) {
-		return
-	}
-
-	exists, err := ss.rdb.Exists(ss.ctx, Keys.shellContainerTTL(containerId)).Result()
-	if err != nil {
-		log.Error().Err(err).Str("container_id", containerId).Msg("failed to inspect shell TTL")
-		return
-	}
-	// Ignore a stale expiry notification if a valid lease is present.
-	if exists != 0 {
-		return
-	}
-	if err := ss.scheduler.Stop(&types.StopContainerArgs{
-		ContainerId: containerId,
-		Force:       true,
-		Reason:      types.StopContainerReasonTtl,
-	}); err != nil {
-		log.Error().Err(err).Str("container_id", containerId).Msg("failed to stop expired shell")
 	}
 }
 

--- a/pkg/abstractions/shell/shell.go
+++ b/pkg/abstractions/shell/shell.go
@@ -44,7 +44,6 @@ const (
 	pendingShellTTL               time.Duration = 5 * time.Minute
 	containerWaitPollIntervalS    time.Duration = 1 * time.Second
 	containerKeepAliveIntervalS   time.Duration = 5 * time.Second
-	shellReconcileInterval        time.Duration = 30 * time.Second
 	sshProbeTimeoutDurationS      time.Duration = 500 * time.Millisecond
 	sshBannerTimeoutDurationS     time.Duration = 500 * time.Millisecond
 	sshStartupTimeoutDurationS    time.Duration = 10 * time.Second
@@ -135,7 +134,7 @@ func NewSSHShellService(
 
 	// Listen for shell container ttl events
 	go func() {
-		if err := ss.keyEventManager.ListenForPattern(
+		if err := ss.keyEventManager.ListenForPatternEvents(
 			ss.ctx,
 			Keys.shellContainerTTL(""),
 			ss.ttlEventChan,
@@ -144,9 +143,9 @@ func NewSSHShellService(
 		}
 	}()
 	go func() {
-		if err := ss.keyEventManager.ListenForPattern(
+		if err := ss.keyEventManager.ListenForContainerPattern(
 			ss.ctx,
-			common.RedisKeys.SchedulerContainerState(shellContainerPrefix),
+			shellContainerPrefix,
 			ss.containerEventChan,
 		); err != nil {
 			log.Error().Err(err).Msg("shell container event listener stopped")
@@ -167,9 +166,6 @@ func (ss *SSHShellService) durableDiskPlacementRepos() abstractions.DurableDiskP
 }
 
 func (ss *SSHShellService) handleTTLEvents() {
-	reconcileTicker := time.NewTicker(shellReconcileInterval)
-	defer reconcileTicker.Stop()
-
 	for {
 		select {
 		case event := <-ss.ttlEventChan:
@@ -182,24 +178,9 @@ func (ss *SSHShellService) handleTTLEvents() {
 				// subscribed to their TTL events.
 				ss.stopShellWithoutLease(shellContainerPrefix + event.Key)
 			}
-		case <-reconcileTicker.C:
-			ss.reconcileShellLeases()
 		case <-ss.ctx.Done():
 			return
 		}
-	}
-}
-
-func (ss *SSHShellService) reconcileShellLeases() {
-	statePrefix := common.RedisKeys.SchedulerContainerState(shellContainerPrefix)
-	stateKeys, err := ss.rdb.Scan(ss.ctx, statePrefix+"*")
-	if err != nil {
-		log.Error().Err(err).Msg("failed to reconcile shell leases")
-		return
-	}
-	for _, stateKey := range stateKeys {
-		containerId := shellContainerPrefix + strings.TrimPrefix(stateKey, statePrefix)
-		ss.stopShellWithoutLease(containerId)
 	}
 }
 

--- a/pkg/abstractions/taskqueue/taskqueue.go
+++ b/pkg/abstractions/taskqueue/taskqueue.go
@@ -80,10 +80,7 @@ func NewRedisTaskQueueService(
 	ctx context.Context,
 	opts TaskQueueServiceOpts,
 ) (TaskQueueService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(opts.RedisClient)
 
 	tq := &RedisTaskQueue{
 		ctx:                ctx,

--- a/pkg/cache/metadata.go
+++ b/pkg/cache/metadata.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/bsm/redislock"
@@ -17,8 +18,10 @@ const (
 )
 
 type Metadata struct {
-	rdb  *RedisClient
-	lock *RedisLock
+	rdb           *RedisClient
+	lock          *RedisLock
+	compactReads  atomic.Bool
+	compactWrites atomic.Bool
 }
 
 func NewMetadata(cfg MetadataConfig) (*Metadata, error) {
@@ -69,13 +72,35 @@ func (m *Metadata) RemoveClientLock(ctx context.Context, clientId, hash string) 
 }
 
 func (m *Metadata) GetFsNode(ctx context.Context, id string) (*FSMetadata, error) {
-	key := MetadataKeys.MetadataFsNode(id)
-
-	res, err := m.rdb.HGetAll(ctx, key).Result()
-	if err != nil && err != redis.Nil {
+	compactFirst := m.compactReads.Load()
+	if compactFirst {
+		metadata, err := m.getCompactFsNode(ctx, id)
+		var notFound *ErrNodeNotFound
+		if !errors.As(err, &notFound) {
+			return metadata, err
+		}
+	}
+	metadata, err := m.getLegacyFsNode(ctx, id)
+	var notFound *ErrNodeNotFound
+	if !errors.As(err, &notFound) {
+		return metadata, err
+	}
+	if compactFirst {
 		return nil, err
 	}
+	metadata, err = m.getCompactFsNode(ctx, id)
+	if err == nil {
+		m.compactReads.Store(true)
+	}
+	return metadata, err
+}
 
+func (m *Metadata) getLegacyFsNode(ctx context.Context, id string) (*FSMetadata, error) {
+	key := MetadataKeys.MetadataFsNode(id)
+	res, err := m.rdb.HGetAll(ctx, key).Result()
+	if err != nil {
+		return nil, err
+	}
 	if len(res) == 0 {
 		return nil, &ErrNodeNotFound{Id: id}
 	}
@@ -88,30 +113,78 @@ func (m *Metadata) GetFsNode(ctx context.Context, id string) (*FSMetadata, error
 	return metadata, nil
 }
 
+func (m *Metadata) getCompactFsNode(ctx context.Context, id string) (*FSMetadata, error) {
+	key := MetadataKeys.MetadataFsNodeData(id)
+	data, err := m.rdb.HGet(ctx, key, id).Bytes()
+	if err == redis.Nil {
+		return nil, &ErrNodeNotFound{Id: id}
+	}
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := UnmarshalFSMetadata(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize cachefs node metadata <%v>: %w", key, err)
+	}
+	return metadata, nil
+}
+
 func (m *Metadata) SetFsNode(ctx context.Context, id string, metadata *FSMetadata) error {
 	key := MetadataKeys.MetadataFsNode(id)
 
-	// If metadata exists, increment inode generation #
-	res, err := m.rdb.HGetAll(ctx, key).Result()
-	if err != nil && err != redis.Nil {
+	existing, err := m.GetFsNode(ctx, id)
+	var notFound *ErrNodeNotFound
+	if err != nil && !errors.As(err, &notFound) {
+		return err
+	}
+	if existing != nil {
+		metadata.Gen = existing.Gen + 1
+	}
+
+	compact, err := m.compactEnabled(ctx)
+	if err != nil {
 		return err
 	}
 
-	if len(res) > 0 {
-		existingMetadata := &FSMetadata{}
-		if err = ToStruct(res, existingMetadata); err != nil {
+	pipe := m.rdb.TxPipeline()
+	if compact {
+		data, err := MarshalFSMetadata(metadata)
+		if err != nil {
 			return err
 		}
-
-		metadata.Gen = existingMetadata.Gen + 1
+		pipe.HSet(ctx, MetadataKeys.MetadataFsNodeData(id), id, data)
+		pipe.Del(ctx, key)
+		pipe.ZAdd(ctx, MetadataKeys.MetadataFsNodeIndex(id), redis.Z{
+			Score:  float64(time.Now().Unix()),
+			Member: id,
+		})
+	} else {
+		pipe.HSet(ctx, key, ToSlice(metadata))
 	}
-
-	err = m.rdb.HSet(ctx, key, ToSlice(metadata)).Err()
-	if err != nil {
+	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("failed to set cachefs node metadata <%v>: %w", key, err)
 	}
 
 	return nil
+}
+
+func (m *Metadata) compactEnabled(ctx context.Context) (bool, error) {
+	if m.compactWrites.Load() {
+		return true, nil
+	}
+	version, err := m.rdb.Get(ctx, MetadataKeys.MetadataFsFormat()).Result()
+	if err == redis.Nil {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if version == FSMetadataFormatCompact {
+		m.compactReads.Store(true)
+		m.compactWrites.Store(true)
+		return true, nil
+	}
+	return false, nil
 }
 
 func (m *Metadata) GetFsNodeChildren(ctx context.Context, id string) ([]*FSMetadata, error) {
@@ -212,7 +285,13 @@ func (m *Metadata) AddFsNodeChild(ctx context.Context, pid, id string) error {
 }
 
 func (m *Metadata) RemoveFsNode(ctx context.Context, id string) error {
-	return m.rdb.Del(ctx, MetadataKeys.MetadataFsNode(id)).Err()
+	_, err := m.rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.Del(ctx, MetadataKeys.MetadataFsNode(id))
+		pipe.HDel(ctx, MetadataKeys.MetadataFsNodeData(id), id)
+		pipe.ZRem(ctx, MetadataKeys.MetadataFsNodeIndex(id), id)
+		return nil
+	})
+	return err
 }
 
 func (m *Metadata) RemoveFsNodeChild(ctx context.Context, pid, id string) error {
@@ -367,12 +446,20 @@ var (
 	metadataLocation             string = "cache:location:%s"
 	metadataFsNode               string = "cache:fs:node:%s"
 	metadataFsNodeChildren       string = "cache:fs:node:%s:children"
+	metadataFsNodeData           string = "cache:fs:nodes:%02x"
+	metadataFsNodeIndex          string = "cache:fs:nodes:%02x:mtime"
+	metadataFsFormat             string = "cache:fs:format"
 	metadataHostKeepAlive        string = "cache:host:keepalive:%s:%s"
 	metadataStoreFromContentLock string = "cache:store_from_content_lock:%s:%s"
 	metadataReconcileRecent      string = "cache:reconcile:recent:%s"
 	metadataReconcileRecentAll   string = "cache:reconcile:recent"
 	metadataReconcileLock        string = "cache:reconcile:lock:%s:%s:%s"
 	metadataReconcileReported    string = "cache:reconcile:reported:%s:%s"
+)
+
+const (
+	FSMetadataFormatCompact = "2"
+	FSMetadataShardCount    = 256
 )
 
 // Metadata keys
@@ -398,6 +485,26 @@ func (k *metadataKeys) MetadataFsNode(id string) string {
 
 func (k *metadataKeys) MetadataFsNodeChildren(id string) string {
 	return fmt.Sprintf(metadataFsNodeChildren, id)
+}
+
+func (k *metadataKeys) MetadataFsNodeData(id string) string {
+	return k.MetadataFsNodeDataShard(FSMetadataShard(id))
+}
+
+func (k *metadataKeys) MetadataFsNodeDataShard(shard int) string {
+	return fmt.Sprintf(metadataFsNodeData, shard)
+}
+
+func (k *metadataKeys) MetadataFsNodeIndex(id string) string {
+	return k.MetadataFsNodeIndexShard(FSMetadataShard(id))
+}
+
+func (k *metadataKeys) MetadataFsNodeIndexShard(shard int) string {
+	return fmt.Sprintf(metadataFsNodeIndex, shard)
+}
+
+func (k *metadataKeys) MetadataFsFormat() string {
+	return metadataFsFormat
 }
 
 func (k *metadataKeys) MetadataClientLock(hostId, hash string) string {

--- a/pkg/cache/metadata_test.go
+++ b/pkg/cache/metadata_test.go
@@ -1,8 +1,12 @@
 package cache
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 )
 
 func TestMetadataHostKeepAliveKeyIncludesLocalityAndHost(t *testing.T) {
@@ -44,5 +48,63 @@ func TestFSMetadataWorkerCacheProtoRoundTrip(t *testing.T) {
 
 	if !reflect.DeepEqual(got, metadata) {
 		t.Fatalf("got %#v, want %#v", got, metadata)
+	}
+
+	encoded, err := MarshalFSMetadata(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = UnmarshalFSMetadata(encoded)
+	if err != nil || !reflect.DeepEqual(got, metadata) {
+		t.Fatalf("compact round trip: got %#v, err %v", got, err)
+	}
+}
+
+func TestMetadataReadsMixedCacheFSFormats(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	metadata := NewMetadataWithRedisClient(client)
+	ctx := context.Background()
+
+	legacy := &FSMetadata{ID: "legacy", PID: "root", Name: "legacy"}
+	if err := metadata.SetFsNode(ctx, legacy.ID, legacy); err != nil {
+		t.Fatal(err)
+	}
+	if got := client.Type(ctx, MetadataKeys.MetadataFsNode(legacy.ID)).Val(); got != "hash" {
+		t.Fatalf("legacy type = %q", got)
+	}
+
+	if err := client.Set(ctx, MetadataKeys.MetadataFsFormat(), FSMetadataFormatCompact, 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+	compact := &FSMetadata{ID: "compact", PID: "root", Name: "compact"}
+	if err := metadata.SetFsNode(ctx, compact.ID, compact); err != nil {
+		t.Fatal(err)
+	}
+	if got := client.HExists(ctx, MetadataKeys.MetadataFsNodeData(compact.ID), compact.ID).Val(); !got {
+		t.Fatal("compact node not stored in shard")
+	}
+
+	for _, want := range []*FSMetadata{legacy, compact} {
+		got, err := metadata.GetFsNode(ctx, want.ID)
+		if err != nil || !reflect.DeepEqual(got, want) {
+			t.Fatalf("read %s: got %#v, err %v", want.ID, got, err)
+		}
+	}
+
+	if err := client.Del(ctx, MetadataKeys.MetadataFsFormat()).Err(); err != nil {
+		t.Fatal(err)
+	}
+	withoutMarker := NewMetadataWithRedisClient(client)
+	if _, err := withoutMarker.GetFsNode(ctx, compact.ID); err != nil {
+		t.Fatal(err)
+	}
+	legacyAfterCompactRead := &FSMetadata{ID: "still-legacy"}
+	if err := withoutMarker.SetFsNode(ctx, legacyAfterCompactRead.ID, legacyAfterCompactRead); err != nil {
+		t.Fatal(err)
+	}
+	if got := client.Type(ctx, MetadataKeys.MetadataFsNode(legacyAfterCompactRead.ID)).Val(); got != "hash" {
+		t.Fatalf("unmarked write type = %q", got)
 	}
 }

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -1,10 +1,13 @@
 package cache
 
 import (
+	"fmt"
+	"hash/crc32"
 	"os"
 	"time"
 
 	proto "github.com/beam-cloud/beta9/proto"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -292,6 +295,34 @@ type FSMetadata struct {
 	Uid       uint32 `redis:"uid" json:"uid"`
 	Gid       uint32 `redis:"gid" json:"gid"`
 	Gen       uint64 `redis:"gen" json:"gen"`
+}
+
+const fsMetadataEncodingVersion byte = 1
+
+func FSMetadataShard(id string) int {
+	return int(crc32.ChecksumIEEE([]byte(id)) % FSMetadataShardCount)
+}
+
+func MarshalFSMetadata(metadata *FSMetadata) ([]byte, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("cachefs metadata is nil")
+	}
+	data, err := gproto.Marshal(metadata.ToWorkerCacheProto())
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{fsMetadataEncodingVersion}, data...), nil
+}
+
+func UnmarshalFSMetadata(data []byte) (*FSMetadata, error) {
+	if len(data) == 0 || data[0] != fsMetadataEncodingVersion {
+		return nil, fmt.Errorf("unsupported cachefs metadata encoding")
+	}
+	metadata := &proto.WorkerCacheFSMetadata{}
+	if err := gproto.Unmarshal(data[1:], metadata); err != nil {
+		return nil, err
+	}
+	return FSMetadataFromWorkerCacheProto(metadata), nil
 }
 
 func (m *FSMetadata) ToProto() *proto.CacheFSMetadata {

--- a/pkg/common/key_events.go
+++ b/pkg/common/key_events.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog/log"
 )
 
@@ -37,33 +39,45 @@ func (kem *KeyEventManager) TrimKeyspacePrefix(key string) string {
 	return strings.TrimPrefix(key, keyspacePrefix)
 }
 
-func (kem *KeyEventManager) fetchExistingKeys(patternPrefix string) ([]string, error) {
-	pattern := fmt.Sprintf("%s*", patternPrefix)
-
-	keys, err := kem.rdb.Scan(context.Background(), pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	trimmedKeys := make([]string, len(keys))
-	for i, key := range keys {
-		trimmedKeys[i] = strings.TrimPrefix(key, patternPrefix)
-	}
-
-	return trimmedKeys, nil
+// ListenForPatternEvents watches future keyspace events without replaying
+// existing keys. Use it when only expiry/delete events are meaningful.
+func (kem *KeyEventManager) ListenForPatternEvents(ctx context.Context, patternPrefix string, keyEventChan chan KeyEvent) error {
+	return kem.listenForSubscriptionPattern(ctx, patternPrefix, keyspacePrefix+patternPrefix+"*", keyEventChan, nil)
 }
 
-func (kem *KeyEventManager) ListenForPattern(ctx context.Context, patternPrefix string, keyEventChan chan KeyEvent) error {
-	keyspacePattern := fmt.Sprintf("%s%s*", keyspacePrefix, patternPrefix)
-	return kem.listenForSubscriptionPattern(ctx, patternPrefix, keyspacePattern, keyEventChan, func() ([]string, error) {
-		return kem.fetchExistingKeys(patternPrefix)
+// ListenForContainerPattern replays active container state from its explicit
+// index instead of scanning the entire Redis keyspace.
+func (kem *KeyEventManager) ListenForContainerPattern(ctx context.Context, containerPrefix string, keyEventChan chan KeyEvent) error {
+	patternPrefix := RedisKeys.SchedulerContainerState(containerPrefix)
+	return kem.listenForSubscriptionPattern(ctx, patternPrefix, keyspacePrefix+patternPrefix+"*", keyEventChan, func() ([]string, error) {
+		now := fmt.Sprint(time.Now().Unix())
+		pipe := kem.rdb.TxPipeline()
+		active := pipe.ZRangeByScore(ctx, RedisKeys.SchedulerContainerStateIndex(), &redis.ZRangeBy{
+			Min: now,
+			Max: "+inf",
+		})
+		pipe.ZRemRangeByScore(ctx, RedisKeys.SchedulerContainerStateIndex(), "-inf", now)
+		if _, err := pipe.Exec(ctx); err != nil {
+			return nil, err
+		}
+		keys := active.Val()
+		existing := make([]string, 0, len(keys))
+		for _, key := range keys {
+			if strings.HasPrefix(key, patternPrefix) {
+				existing = append(existing, strings.TrimPrefix(key, patternPrefix))
+			}
+		}
+		return existing, nil
 	})
 }
 
-func (kem *KeyEventManager) ListenForPublishedPattern(ctx context.Context, patternPrefix string, keyEventChan chan KeyEvent) error {
-	pattern := fmt.Sprintf("%s*", patternPrefix)
-	return kem.listenForSubscriptionPattern(ctx, patternPrefix, pattern, keyEventChan, func() ([]string, error) {
-		return kem.fetchExistingKeys(patternPrefix)
+func (kem *KeyEventManager) ListenForPublishedKey(ctx context.Context, key string, keyEventChan chan KeyEvent) error {
+	return kem.listenForSubscriptionPattern(ctx, key, key, keyEventChan, func() ([]string, error) {
+		exists, err := kem.rdb.Exists(ctx, key).Result()
+		if err != nil || exists == 0 {
+			return nil, err
+		}
+		return []string{""}, nil
 	})
 }
 
@@ -88,16 +102,17 @@ func (kem *KeyEventManager) listenForSubscriptionPattern(
 ) error {
 	messages, errs, close := kem.rdb.PSubscribe(ctx, pattern)
 
-	keys, err := existingKeys()
-	if err != nil {
-		close()
-		return err
-	}
-
-	for _, key := range keys {
-		keyEventChan <- KeyEvent{
-			Key:       key,
-			Operation: KeyOperationSet,
+	if existingKeys != nil {
+		keys, err := existingKeys()
+		if err != nil {
+			close()
+			return err
+		}
+		for _, key := range keys {
+			keyEventChan <- KeyEvent{
+				Key:       key,
+				Operation: KeyOperationSet,
+			}
 		}
 	}
 

--- a/pkg/common/key_events.go
+++ b/pkg/common/key_events.go
@@ -31,12 +31,8 @@ const (
 	KeyOperationExpired string = "expired"
 )
 
-func NewKeyEventManager(rdb *RedisClient) (*KeyEventManager, error) {
-	return &KeyEventManager{rdb: rdb}, nil
-}
-
-func (kem *KeyEventManager) TrimKeyspacePrefix(key string) string {
-	return strings.TrimPrefix(key, keyspacePrefix)
+func NewKeyEventManager(rdb *RedisClient) *KeyEventManager {
+	return &KeyEventManager{rdb: rdb}
 }
 
 // ListenForPatternEvents watches future keyspace events without replaying
@@ -109,9 +105,14 @@ func (kem *KeyEventManager) listenForSubscriptionPattern(
 			return err
 		}
 		for _, key := range keys {
-			keyEventChan <- KeyEvent{
+			select {
+			case keyEventChan <- KeyEvent{
 				Key:       key,
 				Operation: KeyOperationSet,
+			}:
+			case <-ctx.Done():
+				close()
+				return ctx.Err()
 			}
 		}
 	}

--- a/pkg/common/key_events_test.go
+++ b/pkg/common/key_events_test.go
@@ -33,8 +33,7 @@ func TestKeyEventManagerListensForExistingKey(t *testing.T) {
 	require.NoError(t, rdb.Set(context.Background(), key, 0, time.Minute).Err())
 
 	events := make(chan KeyEvent, 1)
-	manager, err := NewKeyEventManager(rdb)
-	require.NoError(t, err)
+	manager := NewKeyEventManager(rdb)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	require.NoError(t, manager.ListenForKey(ctx, key, events))
@@ -74,8 +73,7 @@ func TestKeyEventManagerReplaysIndexedContainerState(t *testing.T) {
 	).Err())
 
 	events := make(chan KeyEvent, 1)
-	manager, err := NewKeyEventManager(rdb)
-	require.NoError(t, err)
+	manager := NewKeyEventManager(rdb)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	require.NoError(t, manager.ListenForContainerPattern(ctx, "pod-", events))

--- a/pkg/common/key_events_test.go
+++ b/pkg/common/key_events_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,4 +57,28 @@ func TestKeyEventManagerParsesKeyspaceMessage(t *testing.T) {
 	if event.Operation != "incr" {
 		t.Fatalf("operation = %q, want incr", event.Operation)
 	}
+}
+
+func TestKeyEventManagerReplaysIndexedContainerState(t *testing.T) {
+	server := miniredis.RunT(t)
+	rdb, err := NewRedisClient(types.RedisConfig{Addrs: []string{server.Addr()}, Mode: types.RedisModeSingle})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	active := RedisKeys.SchedulerContainerState("pod-active")
+	expired := RedisKeys.SchedulerContainerState("pod-expired")
+	now := time.Now().Unix()
+	require.NoError(t, rdb.ZAdd(context.Background(), RedisKeys.SchedulerContainerStateIndex(),
+		redis.Z{Score: float64(now + 60), Member: active},
+		redis.Z{Score: float64(now - 60), Member: expired},
+	).Err())
+
+	events := make(chan KeyEvent, 1)
+	manager, err := NewKeyEventManager(rdb)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, manager.ListenForContainerPattern(ctx, "pod-", events))
+	require.Equal(t, KeyEvent{Key: "active", Operation: KeyOperationSet}, <-events)
+	require.Equal(t, float64(0), rdb.ZScore(context.Background(), RedisKeys.SchedulerContainerStateIndex(), expired).Val())
 }

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -17,6 +17,7 @@ var (
 	schedulerWorkerState              string = "scheduler:worker:state:%s"
 	schedulerContainerConfig          string = "scheduler:container:config:%s"
 	schedulerContainerState           string = "scheduler:container:state:%s"
+	schedulerContainerStateIndex      string = "scheduler:container:state_index"
 	schedulerContainerAddress         string = "scheduler:container:container_addr:%s"
 	schedulerContainerAddressMap      string = "scheduler:container:container_addr_map:%s"
 	schedulerBackendRoute             string = "scheduler:route:%s"
@@ -72,6 +73,7 @@ var (
 	taskClaim       string = "task:%s:%s:%s:claim"
 	taskCancel      string = "task:%s:%s:%s:cancel"
 	taskRetryLock   string = "task:%s:%s:%s:retry_lock"
+	taskMonitorLock string = "task:monitor_lock"
 	taskPhase       string = "task:%s:%s:phase:%s"
 	taskPhaseLabels string = "task:%s:%s:phase_labels"
 )
@@ -204,6 +206,10 @@ func (rk *redisKeys) SchedulerServeLock(workspaceName, stubId string) string {
 
 func (rk *redisKeys) SchedulerContainerState(containerId string) string {
 	return fmt.Sprintf(schedulerContainerState, containerId)
+}
+
+func (rk *redisKeys) SchedulerContainerStateIndex() string {
+	return schedulerContainerStateIndex
 }
 
 func (rk *redisKeys) SchedulerContainerConfig(containerId string) string {
@@ -465,6 +471,10 @@ func (rk *redisKeys) TaskClaimIndex(workspaceName, stubId string) string {
 
 func (rk *redisKeys) TaskEntry(workspaceName, stubId, taskId string) string {
 	return fmt.Sprintf(taskEntry, workspaceName, stubId, taskId)
+}
+
+func (rk *redisKeys) TaskMonitorLock() string {
+	return taskMonitorLock
 }
 
 func (rk *redisKeys) TaskClaim(workspaceName, stubId, taskId string) string {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -189,10 +189,7 @@ func NewGateway() (*Gateway, error) {
 	gateway.workerRepo = workerRepo
 	gateway.DefaultStorageClient = storageClient
 
-	keyEventManager, err := common.NewKeyEventManager(redisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(redisClient)
 	gateway.ComputeService = computesvc.New(computesvc.Options{
 		Config:           config,
 		BackendRepo:      backendRepo,

--- a/pkg/gateway/services/compute/agent.go
+++ b/pkg/gateway/services/compute/agent.go
@@ -401,7 +401,7 @@ func (s *Service) StreamAgent(in *pb.StreamAgentRequest, stream pb.GatewayServic
 	events := make(chan common.KeyEvent, 32)
 	if s.keyEventManager != nil {
 		revisionKey := agentSnapshotRevisionKey(agentState)
-		if err := s.keyEventManager.ListenForPublishedPattern(ctx, revisionKey, events); err != nil {
+		if err := s.keyEventManager.ListenForPublishedKey(ctx, revisionKey, events); err != nil {
 			return err
 		}
 	}

--- a/pkg/gateway/services/service.go
+++ b/pkg/gateway/services/service.go
@@ -58,10 +58,7 @@ type GatewayServiceOpts struct {
 }
 
 func NewGatewayService(opts *GatewayServiceOpts) (*GatewayService, error) {
-	keyEventManager, err := common.NewKeyEventManager(opts.RedisClient)
-	if err != nil {
-		return nil, err
-	}
+	keyEventManager := common.NewKeyEventManager(opts.RedisClient)
 	computeRepo := opts.ComputeRepo
 	if computeRepo == nil {
 		if opts.RedisClient == nil {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -86,7 +86,7 @@ type ContainerRepository interface {
 	SetStubState(stubId, state string) error
 	DeleteStubState(stubId string) error
 	SetBuildContainerTTL(containerId string, ttl time.Duration) error
-	HasBuildContainerTTL(containerId string) bool
+	RefreshBuildContainerTTL(containerId string, ttl time.Duration) (bool, error)
 	GetEndpointRequestTokens(ctx context.Context, workspaceName, stubId, containerId string, maxTokens int, ttl time.Duration) (int, error)
 	AcquireEndpointRequestToken(ctx context.Context, workspaceName, stubId, containerId string, maxTokens int, ttl time.Duration) (bool, error)
 	ReleaseEndpointRequestToken(ctx context.Context, workspaceName, stubId, containerId, taskId string, maxTokens int, ttl time.Duration) error
@@ -276,6 +276,7 @@ type BackendRepository interface {
 }
 
 type TaskRepository interface {
+	WithTaskMonitorLease(ctx context.Context, fn func(context.Context) error) error
 	GetTaskState(ctx context.Context, workspaceName, stubId, taskId string) (*types.TaskMessage, error)
 	SetTaskState(ctx context.Context, workspaceName, stubId, taskId string, msg []byte) error
 	DeleteTaskState(ctx context.Context, workspaceName, stubId, taskId string) error

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -256,6 +256,10 @@ func (cr *ContainerRedisRepository) setContainerState(containerId string, state 
 	pipe.Expire(ctx, stateKey, time.Duration(types.ContainerStateTtlSWhilePending)*time.Second)
 	pipe.SAdd(ctx, stubIndexKey, stateKey)
 	pipe.SAdd(ctx, workspaceIndexKey, stateKey)
+	pipe.ZAdd(ctx, common.RedisKeys.SchedulerContainerStateIndex(), redis.Z{
+		Score:  float64(time.Now().Add(time.Duration(types.ContainerStateTtlSWhilePending) * time.Second).Unix()),
+		Member: stateKey,
+	})
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("failed to set container state and indexes <%v>: %w", stateKey, err)
 	}
@@ -352,14 +356,14 @@ func (cr *ContainerRedisRepository) UpdateContainerStatus(containerId string, st
 	state.Status = status
 
 	// Save state to database
-	err = cr.rdb.HSet(context.TODO(), stateKey, common.ToSlice(state)).Err()
-	if err != nil {
-		return fmt.Errorf("failed to update container state status <%v>: %w", stateKey, err)
-	}
-
-	// Set ttl on state
-	err = cr.rdb.Expire(context.TODO(), stateKey, expiry).Err()
-	if err != nil {
+	pipe := cr.rdb.TxPipeline()
+	pipe.HSet(context.TODO(), stateKey, common.ToSlice(state))
+	pipe.Expire(context.TODO(), stateKey, expiry)
+	pipe.ZAdd(context.TODO(), common.RedisKeys.SchedulerContainerStateIndex(), redis.Z{
+		Score:  float64(time.Now().Add(expiry).Unix()),
+		Member: stateKey,
+	})
+	if _, err = pipe.Exec(context.TODO()); err != nil {
 		return fmt.Errorf("failed to set container state ttl <%v>: %w", stateKey, err)
 	}
 
@@ -384,13 +388,18 @@ if worker_id and worker_id ~= "" then
 end
 redis.call("HSET", KEYS[1], "status", ARGV[2])
 redis.call("EXPIRE", KEYS[1], ARGV[3])
+redis.call("ZADD", KEYS[2], ARGV[4], KEYS[1])
 return 1
 `)
 
 func (cr *ContainerRedisRepository) MarkPendingContainerStoppingIfUnassigned(containerId string, expirySeconds int64) (bool, error) {
 	stateKey := common.RedisKeys.SchedulerContainerState(containerId)
-	marked, err := markPendingContainerStoppingIfUnassignedScript.Run(context.TODO(), cr.rdb, []string{stateKey},
+	marked, err := markPendingContainerStoppingIfUnassignedScript.Run(context.TODO(), cr.rdb, []string{
+		stateKey,
+		common.RedisKeys.SchedulerContainerStateIndex(),
+	},
 		string(types.ContainerStatusPending), string(types.ContainerStatusStopping), expirySeconds,
+		time.Now().Add(time.Duration(expirySeconds)*time.Second).Unix(),
 	).Bool()
 	if err != nil {
 		return false, fmt.Errorf("failed to stop unassigned pending container <%s>: %w", containerId, err)
@@ -423,6 +432,9 @@ func (cr *ContainerRedisRepository) DeleteContainerState(containerId string) err
 	err = cr.rdb.Del(context.TODO(), stateKey).Err()
 	if err != nil {
 		return fmt.Errorf("failed to delete container state <%v>: %w", stateKey, err)
+	}
+	if err := cr.rdb.ZRem(context.TODO(), common.RedisKeys.SchedulerContainerStateIndex(), stateKey).Err(); err != nil {
+		return fmt.Errorf("failed to remove container state index <%v>: %w", stateKey, err)
 	}
 
 	addrKey := common.RedisKeys.SchedulerContainerAddress(containerId)

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -429,30 +429,14 @@ func (cr *ContainerRedisRepository) DeleteContainerState(containerId string) err
 		}
 	}
 
-	err = cr.rdb.Del(context.TODO(), stateKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to delete container state <%v>: %w", stateKey, err)
-	}
-	if err := cr.rdb.ZRem(context.TODO(), common.RedisKeys.SchedulerContainerStateIndex(), stateKey).Err(); err != nil {
-		return fmt.Errorf("failed to remove container state index <%v>: %w", stateKey, err)
-	}
-
 	addrKey := common.RedisKeys.SchedulerContainerAddress(containerId)
-	err = cr.rdb.Del(context.TODO(), addrKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to delete container addr <%v>: %w", addrKey, err)
-	}
-
 	addrMapKey := common.RedisKeys.SchedulerContainerAddressMap(containerId)
-	err = cr.rdb.Del(context.TODO(), addrMapKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to delete container addrMap <%v>: %w", addrMapKey, err)
-	}
-
 	workerAddrKey := common.RedisKeys.SchedulerWorkerAddress(containerId)
-	err = cr.rdb.Del(context.TODO(), workerAddrKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to delete worker addr <%v>: %w", workerAddrKey, err)
+	pipe := cr.rdb.TxPipeline()
+	pipe.Del(context.TODO(), stateKey, addrKey, addrMapKey, workerAddrKey)
+	pipe.ZRem(context.TODO(), common.RedisKeys.SchedulerContainerStateIndex(), stateKey)
+	if _, err := pipe.Exec(context.TODO()); err != nil {
+		return fmt.Errorf("failed to delete container state <%v>: %w", stateKey, err)
 	}
 
 	if err := cr.DeleteBackendRoutesByContainerID(context.TODO(), containerId); err != nil {
@@ -1464,8 +1448,8 @@ func (cr *ContainerRedisRepository) SetBuildContainerTTL(containerId string, ttl
 	return cr.rdb.Set(context.TODO(), common.RedisKeys.ImageBuildContainerTTL(containerId), "1", ttl).Err()
 }
 
-func (cr *ContainerRedisRepository) HasBuildContainerTTL(containerId string) bool {
-	return cr.rdb.Exists(context.TODO(), common.RedisKeys.ImageBuildContainerTTL(containerId)).Val() != 0
+func (cr *ContainerRedisRepository) RefreshBuildContainerTTL(containerId string, ttl time.Duration) (bool, error) {
+	return cr.rdb.ExpireXX(context.TODO(), common.RedisKeys.ImageBuildContainerTTL(containerId), ttl).Result()
 }
 
 func (c *ContainerRedisRepository) SetPodKeepWarmLock(ctx context.Context, workspaceName, stubId, containerId string, keepWarmSeconds int) error {

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -1407,6 +1407,42 @@ func TestContainerRepositoryKeepWarmLocksApplySharedSemantics(t *testing.T) {
 	}
 }
 
+func TestRefreshBuildContainerTTLDoesNotRecreateExpiredLease(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	const containerId = "build-expired"
+
+	if err := repo.SetBuildContainerTTL(containerId, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := repo.RefreshBuildContainerTTL(containerId, 2*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !refreshed {
+		t.Fatal("expected existing lease to refresh")
+	}
+
+	if err := rdb.Del(context.Background(), common.RedisKeys.ImageBuildContainerTTL(containerId)).Err(); err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err = repo.RefreshBuildContainerTTL(containerId, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exists, err := rdb.Exists(context.Background(), common.RedisKeys.ImageBuildContainerTTL(containerId)).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed || exists != 0 {
+		t.Fatal("expired lease was recreated")
+	}
+}
+
 func testContainerRequest(containerId, workspaceId string, cpu int64) *types.ContainerRequest {
 	return &types.ContainerRequest{
 		ContainerId: containerId,

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -103,6 +103,11 @@ func TestSetContainerStateCommitsIndexesWithState(t *testing.T) {
 	} else if !ok {
 		t.Fatal("expected state key to be present in workspace index")
 	}
+	if score, err := rdb.ZScore(context.Background(), common.RedisKeys.SchedulerContainerStateIndex(), stateKey).Result(); err != nil {
+		t.Fatal(err)
+	} else if score <= float64(time.Now().Unix()) {
+		t.Fatal("expected state key to have a future expiry in the global index")
+	}
 
 	byStub, err := repo.GetActiveContainersByStubId(state.StubId)
 	if err != nil {

--- a/pkg/repository/task_redis.go
+++ b/pkg/repository/task_redis.go
@@ -36,16 +36,12 @@ func (r *TaskRedisRepository) ClaimTask(ctx context.Context, workspaceName, stub
 	if entryTTL := r.rdb.TTL(ctx, common.RedisKeys.TaskEntry(workspaceName, stubId, taskId)).Val(); entryTTL > 0 {
 		ttl = entryTTL
 	}
-	err := r.rdb.Set(ctx, claimKey, containerId, ttl).Err()
-	if err != nil {
+	pipe := r.rdb.TxPipeline()
+	pipe.Set(ctx, claimKey, containerId, ttl)
+	pipe.SAdd(ctx, claimIndexKey, taskId)
+	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("failed to claim task <%v>: %w", claimKey, err)
 	}
-
-	err = r.rdb.SAdd(ctx, claimIndexKey, taskId).Err()
-	if err != nil {
-		return fmt.Errorf("failed to add task to claim index <%v>: %w", claimIndexKey, err)
-	}
-
 	return nil
 }
 
@@ -53,16 +49,12 @@ func (r *TaskRedisRepository) RemoveTaskClaim(ctx context.Context, workspaceName
 	claimKey := common.RedisKeys.TaskClaim(workspaceName, stubId, taskId)
 	claimIndexKey := common.RedisKeys.TaskClaimIndex(workspaceName, stubId)
 
-	err := r.rdb.Del(ctx, claimKey).Err()
-	if err != nil {
+	pipe := r.rdb.TxPipeline()
+	pipe.Del(ctx, claimKey)
+	pipe.SRem(ctx, claimIndexKey, taskId)
+	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("failed to remove task claim <%v>: %w", claimKey, err)
 	}
-
-	err = r.rdb.SRem(ctx, claimIndexKey, taskId).Err()
-	if err != nil {
-		return fmt.Errorf("failed to remove task from claim index <%v>: %w", claimIndexKey, err)
-	}
-
 	return nil
 }
 
@@ -90,22 +82,14 @@ func (r *TaskRedisRepository) SetTaskState(ctx context.Context, workspaceName, s
 	stubIndexKey := common.RedisKeys.TaskIndexByStub(workspaceName, stubId)
 	entryKey := common.RedisKeys.TaskEntry(workspaceName, stubId, taskId)
 
-	err := r.rdb.SAdd(ctx, indexKey, entryKey).Err()
-	if err != nil {
-		return fmt.Errorf("failed to add task key to index <%v>: %w", indexKey, err)
-	}
-
-	err = r.rdb.Set(ctx, entryKey, msg, taskStateTTL(msg)).Err()
-	if err != nil {
+	pipe := r.rdb.TxPipeline()
+	pipe.SAdd(ctx, indexKey, entryKey)
+	pipe.Set(ctx, entryKey, msg, taskStateTTL(msg))
+	pipe.SAdd(ctx, stubIndexKey, taskId)
+	if _, err := pipe.Exec(ctx); err != nil {
 		r.DeleteTaskState(ctx, workspaceName, stubId, taskId)
 		return err
 	}
-
-	err = r.rdb.SAdd(ctx, stubIndexKey, taskId).Err()
-	if err != nil {
-		return fmt.Errorf("failed to add task key to stub index <%v>: %w", indexKey, err)
-	}
-
 	return nil
 }
 

--- a/pkg/repository/task_redis.go
+++ b/pkg/repository/task_redis.go
@@ -2,8 +2,10 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -16,6 +18,11 @@ type TaskRedisRepository struct {
 	lock *common.RedisLock
 }
 
+const (
+	taskStateCleanupGrace = 10 * time.Minute
+	taskMonitorLease      = 15 * time.Second
+)
+
 func NewTaskRedisRepository(r *common.RedisClient) TaskRepository {
 	lock := common.NewRedisLock(r)
 	return &TaskRedisRepository{rdb: r, lock: lock}
@@ -25,7 +32,11 @@ func (r *TaskRedisRepository) ClaimTask(ctx context.Context, workspaceName, stub
 	claimKey := common.RedisKeys.TaskClaim(workspaceName, stubId, taskId)
 	claimIndexKey := common.RedisKeys.TaskClaimIndex(workspaceName, stubId)
 
-	err := r.rdb.Set(ctx, claimKey, containerId, 0).Err()
+	ttl := time.Duration(types.MaxTaskTTL) * time.Second
+	if entryTTL := r.rdb.TTL(ctx, common.RedisKeys.TaskEntry(workspaceName, stubId, taskId)).Val(); entryTTL > 0 {
+		ttl = entryTTL
+	}
+	err := r.rdb.Set(ctx, claimKey, containerId, ttl).Err()
 	if err != nil {
 		return fmt.Errorf("failed to claim task <%v>: %w", claimKey, err)
 	}
@@ -84,7 +95,7 @@ func (r *TaskRedisRepository) SetTaskState(ctx context.Context, workspaceName, s
 		return fmt.Errorf("failed to add task key to index <%v>: %w", indexKey, err)
 	}
 
-	err = r.rdb.Set(ctx, entryKey, msg, 0).Err()
+	err = r.rdb.Set(ctx, entryKey, msg, taskStateTTL(msg)).Err()
 	if err != nil {
 		r.DeleteTaskState(ctx, workspaceName, stubId, taskId)
 		return err
@@ -96,6 +107,27 @@ func (r *TaskRedisRepository) SetTaskState(ctx context.Context, workspaceName, s
 	}
 
 	return nil
+}
+
+func taskStateTTL(msg []byte) time.Duration {
+	var state struct {
+		Policy struct {
+			Expires time.Time `json:"expires"`
+		} `json:"policy"`
+	}
+	if json.Unmarshal(msg, &state) == nil && !state.Policy.Expires.IsZero() {
+		if ttl := time.Until(state.Policy.Expires) + taskStateCleanupGrace; ttl > time.Minute {
+			return ttl
+		}
+		return time.Minute
+	}
+	return time.Duration(types.MaxTaskTTL)*time.Second + taskStateCleanupGrace
+}
+
+func (r *TaskRedisRepository) WithTaskMonitorLease(ctx context.Context, fn func(context.Context) error) error {
+	return r.lock.WithLease(ctx, common.RedisKeys.TaskMonitorLock(), common.RedisLockOptions{
+		TtlS: int(taskMonitorLease.Seconds()),
+	}, fn)
 }
 
 func (r *TaskRedisRepository) GetTaskState(ctx context.Context, workspaceName, stubId, taskId string) (*types.TaskMessage, error) {

--- a/pkg/repository/task_redis_test.go
+++ b/pkg/repository/task_redis_test.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+func TestTaskStateAndClaimExpire(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := NewTaskRedisRepository(rdb)
+	task := &types.TaskMessage{
+		TaskId:        "task",
+		WorkspaceName: "workspace",
+		StubId:        "stub",
+		Policy:        types.TaskPolicy{Expires: time.Now().Add(time.Minute)},
+	}
+	msg, err := task.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetTaskState(context.Background(), task.WorkspaceName, task.StubId, task.TaskId, msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.ClaimTask(context.Background(), task.WorkspaceName, task.StubId, task.TaskId, "container"); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{
+		common.RedisKeys.TaskEntry(task.WorkspaceName, task.StubId, task.TaskId),
+		common.RedisKeys.TaskClaim(task.WorkspaceName, task.StubId, task.TaskId),
+	} {
+		if ttl := rdb.TTL(context.Background(), key).Val(); ttl <= 0 {
+			t.Fatalf("%s has no TTL", key)
+		}
+	}
+}

--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -38,10 +38,6 @@ type Dispatcher struct {
 	storageClientCache sync.Map
 }
 
-type taskMonitorLeaser interface {
-	WithTaskMonitorLease(context.Context, func(context.Context) error) error
-}
-
 var taskMessagePool = sync.Pool{
 	New: func() interface{} {
 		return &types.TaskMessage{
@@ -188,23 +184,15 @@ func (d *Dispatcher) monitor(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			run := func(leaseCtx context.Context) error {
-				d.monitorTasks(leaseCtx)
-				return nil
-			}
-			if leaser, ok := d.taskRepo.(taskMonitorLeaser); ok {
-				_ = leaser.WithTaskMonitorLease(ctx, run)
-			} else {
-				_ = run(ctx)
-			}
+			_ = d.taskRepo.WithTaskMonitorLease(ctx, d.monitorTasks)
 		}
 	}
 }
 
-func (d *Dispatcher) monitorTasks(ctx context.Context) {
+func (d *Dispatcher) monitorTasks(ctx context.Context) error {
 	tasks, err := d.taskRepo.GetTasksInFlight(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	for _, taskMessage := range tasks {
 		taskFactory, exists := d.executors.Get(taskMessage.Executor)
@@ -233,6 +221,7 @@ func (d *Dispatcher) monitorTasks(ctx context.Context) {
 			d.RetryTask(ctx, task)
 		}
 	}
+	return nil
 }
 
 func (d *Dispatcher) RetryTask(ctx context.Context, task types.TaskInterface) error {

--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -209,7 +209,6 @@ func (d *Dispatcher) monitorTasks(ctx context.Context) {
 	for _, taskMessage := range tasks {
 		taskFactory, exists := d.executors.Get(taskMessage.Executor)
 		if !exists {
-			d.Complete(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
 			continue
 		}
 		task, err := taskFactory(ctx, *taskMessage)

--- a/pkg/task/dispatch.go
+++ b/pkg/task/dispatch.go
@@ -38,6 +38,10 @@ type Dispatcher struct {
 	storageClientCache sync.Map
 }
 
+type taskMonitorLeaser interface {
+	WithTaskMonitorLease(context.Context, func(context.Context) error) error
+}
+
 var taskMessagePool = sync.Pool{
 	New: func() interface{} {
 		return &types.TaskMessage{
@@ -184,51 +188,50 @@ func (d *Dispatcher) monitor(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			tasks, err := d.taskRepo.GetTasksInFlight(ctx)
-			if err != nil {
-				continue
+			run := func(leaseCtx context.Context) error {
+				d.monitorTasks(leaseCtx)
+				return nil
 			}
-
-			for _, taskMessage := range tasks {
-				taskFactory, exists := d.executors.Get(taskMessage.Executor)
-				if !exists {
-					d.Complete(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
-					continue
-				}
-
-				task, err := taskFactory(ctx, *taskMessage)
-				if err != nil {
-					continue
-				}
-
-				claimed, err := d.taskRepo.IsClaimed(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
-				if err != nil {
-					continue
-				}
-
-				if !claimed {
-					if time.Now().After(taskMessage.Policy.Expires) {
-						err = task.Cancel(ctx, types.TaskExpired)
-						if err != nil {
-							log.Error().Str("task_id", task.Metadata().TaskId).Err(err).Msg("dispatcher unable to cancel task")
-						}
-
-						d.Complete(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
-					}
-
-					continue
-				}
-
-				heartbeat, err := task.HeartBeat(ctx)
-				if err != nil {
-					continue
-				}
-
-				if !heartbeat {
-					d.RetryTask(ctx, task)
-					continue
-				}
+			if leaser, ok := d.taskRepo.(taskMonitorLeaser); ok {
+				_ = leaser.WithTaskMonitorLease(ctx, run)
+			} else {
+				_ = run(ctx)
 			}
+		}
+	}
+}
+
+func (d *Dispatcher) monitorTasks(ctx context.Context) {
+	tasks, err := d.taskRepo.GetTasksInFlight(ctx)
+	if err != nil {
+		return
+	}
+	for _, taskMessage := range tasks {
+		taskFactory, exists := d.executors.Get(taskMessage.Executor)
+		if !exists {
+			d.Complete(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
+			continue
+		}
+		task, err := taskFactory(ctx, *taskMessage)
+		if err != nil {
+			continue
+		}
+		claimed, err := d.taskRepo.IsClaimed(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
+		if err != nil {
+			continue
+		}
+		if !claimed {
+			if time.Now().After(taskMessage.Policy.Expires) {
+				if err := task.Cancel(ctx, types.TaskExpired); err != nil {
+					log.Error().Str("task_id", task.Metadata().TaskId).Err(err).Msg("dispatcher unable to cancel task")
+				}
+				d.Complete(ctx, taskMessage.WorkspaceName, taskMessage.StubId, taskMessage.TaskId)
+			}
+			continue
+		}
+		heartbeat, err := task.HeartBeat(ctx)
+		if err == nil && !heartbeat {
+			d.RetryTask(ctx, task)
 		}
 	}
 }

--- a/pkg/task/dispatch_test.go
+++ b/pkg/task/dispatch_test.go
@@ -1,0 +1,35 @@
+package task
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
+)
+
+type monitorTaskRepository struct {
+	repository.TaskRepository
+	deleted bool
+}
+
+func (r *monitorTaskRepository) GetTasksInFlight(context.Context) ([]*types.TaskMessage, error) {
+	return []*types.TaskMessage{{Executor: "not-registered-yet"}}, nil
+}
+
+func (r *monitorTaskRepository) DeleteTaskState(context.Context, string, string, string) error {
+	r.deleted = true
+	return nil
+}
+
+func TestMonitorKeepsTasksUntilExecutorRegisters(t *testing.T) {
+	repo := &monitorTaskRepository{}
+	(&Dispatcher{
+		taskRepo:  repo,
+		executors: common.NewSafeMap[func(context.Context, types.TaskMessage) (types.TaskInterface, error)](),
+	}).monitorTasks(context.Background())
+	if repo.deleted {
+		t.Fatal("monitor deleted a task before its executor registered")
+	}
+}

--- a/pkg/task/dispatch_test.go
+++ b/pkg/task/dispatch_test.go
@@ -25,10 +25,12 @@ func (r *monitorTaskRepository) DeleteTaskState(context.Context, string, string,
 
 func TestMonitorKeepsTasksUntilExecutorRegisters(t *testing.T) {
 	repo := &monitorTaskRepository{}
-	(&Dispatcher{
+	if err := (&Dispatcher{
 		taskRepo:  repo,
 		executors: common.NewSafeMap[func(context.Context, types.TaskMessage) (types.TaskInterface, error)](),
-	}).monitorTasks(context.Background())
+	}).monitorTasks(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if repo.deleted {
 		t.Fatal("monitor deleted a task before its executor registered")
 	}

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -99,6 +99,7 @@ func (s *Worker) handleStopContainerArgs(stopArgs types.StopContainerArgs, sourc
 				types.EventAttrForce: fmt.Sprintf("%t", stopArgs.Force),
 			},
 		})
+		s.cancelBuild(stopArgs.ContainerId)
 		s.stopContainerChan <- stopContainerEvent{ContainerId: stopArgs.ContainerId, Kill: stopArgs.Force}
 	}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -678,7 +678,7 @@ func (s *Worker) runContainerRequest(request *types.ContainerRequest) {
 	if request.IsBuildRequest() {
 		s.registerBuildCancel(containerId, cancel)
 		defer s.unregisterBuildCancel(containerId)
-		go s.cancelBuildIfAlreadyStopping(ctx, cancel, containerId)
+		go s.cancelBuildIfAlreadyStopping(cancel, containerId)
 	}
 
 	if err := s.hydrateRuntimeCredentials(ctx, request); err != nil {
@@ -740,7 +740,7 @@ func (s *Worker) failContainerRequest(containerId string, request *types.Contain
 }
 
 // cancelBuildIfAlreadyStopping checks if a build has already been cancelled and cancels the context if it has.
-func (s *Worker) cancelBuildIfAlreadyStopping(ctx context.Context, cancel context.CancelFunc, containerId string) {
+func (s *Worker) cancelBuildIfAlreadyStopping(cancel context.CancelFunc, containerId string) {
 	containerState, err := handleGRPCResponse(s.containerRepoClient.GetContainerState(context.Background(), &pb.GetContainerStateRequest{ContainerId: containerId}))
 	if err != nil {
 		log.Error().Str("container_id", containerId).Err(err).Msg("failed to get container state")

--- a/pkg/worker/worker_events.go
+++ b/pkg/worker/worker_events.go
@@ -31,6 +31,7 @@ func (s *Worker) listenForWorkerEvents() {
 		}
 
 		delay = workerEventStreamReconnectMin
+		s.cancelStoppingBuilds()
 
 		for {
 			event, err := stream.Recv()
@@ -142,4 +143,15 @@ func (s *Worker) cancelBuild(containerID string) bool {
 	log.Info().Str("container_id", containerID).Msg("received stop build event")
 	cancel()
 	return true
+}
+
+func (s *Worker) cancelStoppingBuilds() {
+	if s.buildCancels == nil {
+		return
+	}
+	s.buildCancels.Range(func(containerID string, cancel context.CancelFunc) bool {
+		// One slow state lookup must not delay the rest of a burst.
+		go s.cancelBuildIfAlreadyStopping(cancel, containerID)
+		return true
+	})
 }

--- a/pkg/worker/worker_events_test.go
+++ b/pkg/worker/worker_events_test.go
@@ -15,8 +15,11 @@ func TestHandleWorkerEventStopsOwnedContainer(t *testing.T) {
 	worker := &Worker{
 		workerId:           "worker-1",
 		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		buildCancels:       common.NewSafeMap[context.CancelFunc](),
 		stopContainerChan:  make(chan stopContainerEvent, 1),
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.registerBuildCancel("container-1", cancel)
 	worker.containerInstances.Set("container-1", &ContainerInstance{
 		Id: "container-1",
 		Request: &types.ContainerRequest{
@@ -38,6 +41,7 @@ func TestHandleWorkerEventStopsOwnedContainer(t *testing.T) {
 	instance, ok := worker.containerInstances.Get("container-1")
 	require.True(t, ok)
 	require.Equal(t, types.StopContainerReasonUser, instance.StopReason)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
 
 	select {
 	case event := <-worker.stopContainerChan:
@@ -109,21 +113,29 @@ func TestHandleWorkerEventCancelsMatchingBuild(t *testing.T) {
 	}
 }
 
-func TestCancelBuildIfAlreadyStoppingCancelsContext(t *testing.T) {
+func TestReconnectCancelsStoppingBuilds(t *testing.T) {
 	repoClient := &fakeContainerRepoClient{
 		state: &pb.ContainerState{
 			ContainerId: "build-1",
 			Status:      string(types.ContainerStatusStopping),
 		},
 	}
-	worker := &Worker{containerRepoClient: repoClient}
-	ctx, cancel := context.WithCancel(context.Background())
+	worker := &Worker{
+		containerRepoClient: repoClient,
+		buildCancels:        common.NewSafeMap[context.CancelFunc](),
+	}
+	first, cancelFirst := context.WithCancel(context.Background())
+	second, cancelSecond := context.WithCancel(context.Background())
+	worker.registerBuildCancel("build-1", cancelFirst)
+	worker.registerBuildCancel("build-2", cancelSecond)
 
-	worker.cancelBuildIfAlreadyStopping(ctx, cancel, "build-1")
+	worker.cancelStoppingBuilds()
 
-	select {
-	case <-ctx.Done():
-	case <-time.After(time.Second):
-		t.Fatal("expected build context to be cancelled")
+	for _, done := range []<-chan struct{}{first.Done(), second.Done()} {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("expected build context to be cancelled")
+		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Eliminates Redis SCAN spikes by moving gateway/services to indexed lookups and event-driven listeners, and introduces a small lease manager to stop expired containers without rescans. Adds a compact CacheFS v2 format with migration/cleanup tools and ensures tasks aren’t deleted before executors register.

- **Bug Fixes**
  - Key events: replaced scans with indexed/event listeners in `pkg/common/key_events` (`ListenForContainerPattern`, `ListenForPatternEvents`, `ListenForPublishedKey`); container state replay now uses `scheduler:container:state_index` instead of scanning.
  - Container leases: added `pkg/abstractions/common.ContainerLeaseManager` and wired it into shells and image builds to stop expired containers via TTL/index events; build TTL refresh now uses `ExpireXX` so expired leases aren’t recreated; workers cancel stopping builds on reconnect and when handling stop requests.
  - CacheFS: added v2 compact encoding with sharded storage and a ZSET mtime index; mixed-format reads and indexed writes; safe removal cleans both legacy and compact entries; proxy cancellation fix prevents early header finalization.
  - Tasks: dispatcher uses a monitor lease (`task:monitor_lock`) and defers cleanup until executors register; task state and claims get TTLs based on policy with a small grace to avoid premature deletion.

- **Migration**
  - Enable compact CacheFS writes and migrate: run `hack/cachefs_redis_migrate --apply` (dry-run by default; `--rollback` supported). Reports bytes saved and conversion stats.
  - Optional cleanup: run `hack/redis_cleanup --apply` to remove expired tasks and orphaned CacheFS leaves by index (defaults to 30d).
  - No config changes required; the container state index is auto-maintained on set/update/delete.

<sup>Written for commit 1f77d2f8d4bff74404158b33309744d33475922c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

