### PR TITLE
test: cover PostgreSQL TLS DSN

### DIFF
--- a/pkg/repository/backend_postgres_test.go
+++ b/pkg/repository/backend_postgres_test.go
@@ -18,6 +18,18 @@ import (
 
 const adminWorkspaceQueryPattern = `SELECT w\.id, w\.external_id.*WHERE w\.is_cluster_admin`
 
+func TestGenerateDSNSSLMode(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		dsn := GenerateDSN(types.PostgresConfig{EnableTLS: false})
+		require.Contains(t, dsn, "sslmode=disable")
+	})
+
+	t.Run("required", func(t *testing.T) {
+		dsn := GenerateDSN(types.PostgresConfig{EnableTLS: true})
+		require.Contains(t, dsn, "sslmode=require")
+	})
+}
+
 func TestListTaskWithRelated(t *testing.T) {
 	// Remove this skip if you are testing on local data
 	t.Skip()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests to verify PostgreSQL DSN TLS behavior. Ensures `GenerateDSN` includes `sslmode=disable` when `EnableTLS` is false and `sslmode=require` when true.

<sup>Written for commit f15df99c1eda8ce4057218819904aa3789f97b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

