### PR TITLE
fix: shell bug

### DIFF
--- a/pkg/gateway/services/container.go
+++ b/pkg/gateway/services/container.go
@@ -247,8 +247,12 @@ func (gws *GatewayService) AttachToContainer(stream pb.GatewayService_AttachToCo
 		return stream.Send(containerNotFoundResponse)
 	}
 
+	if !auth.HasInteractivePermission(authInfo) || authInfo.Workspace == nil {
+		return stream.Send(containerNotFoundResponse)
+	}
+
 	container, err := gws.containerRepo.GetContainerState(attachReq.ContainerId)
-	if err != nil {
+	if err != nil || container == nil || container.WorkspaceId != authInfo.Workspace.ExternalId {
 		return stream.Send(containerNotFoundResponse)
 	}
 
@@ -353,11 +357,16 @@ func (gws *GatewayService) AttachToContainer(stream pb.GatewayService_AttachToCo
 
 			switch payload := inMsg.Payload.(type) {
 			case *pb.ContainerStreamMessage_SyncContainerWorkspace:
+				syncRequest := bindSyncRequestToContainer(payload.SyncContainerWorkspace, container.ContainerId)
+				if syncRequest == nil {
+					continue
+				}
+
 				if types.StubType(stub.Type).IsServe() {
 					gws.redisClient.Expire(ctx, common.RedisKeys.SchedulerServeLock(stub.Workspace.Name, stub.ExternalId), serveTimeout)
 				}
 
-				syncQueue <- payload.SyncContainerWorkspace
+				syncQueue <- syncRequest
 			default:
 			}
 		}
@@ -371,4 +380,14 @@ func (gws *GatewayService) AttachToContainer(stream pb.GatewayService_AttachToCo
 		cancel()
 		return err
 	}
+}
+
+func bindSyncRequestToContainer(request *pb.SyncContainerWorkspaceRequest, containerId string) *pb.SyncContainerWorkspaceRequest {
+	if request == nil {
+		return nil
+	}
+
+	boundRequest := *request
+	boundRequest.ContainerId = containerId
+	return &boundRequest
 }

--- a/pkg/gateway/services/container_test.go
+++ b/pkg/gateway/services/container_test.go
@@ -1,8 +1,18 @@
 package gatewayservices
 
 import (
+	"context"
+	"errors"
+	"io"
 	"testing"
 	"time"
+
+	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func TestContainerTimestamp(t *testing.T) {
@@ -15,4 +25,131 @@ func TestContainerTimestamp(t *testing.T) {
 	if timestamp == nil || !timestamp.AsTime().Equal(time.Unix(unixSeconds, 0)) {
 		t.Fatalf("unexpected timestamp: %v", timestamp)
 	}
+}
+
+type attachContainerRepository struct {
+	repository.ContainerRepository
+	state              *types.ContainerState
+	err                error
+	requestedContainer string
+}
+
+func (r *attachContainerRepository) GetContainerState(containerId string) (*types.ContainerState, error) {
+	r.requestedContainer = containerId
+	return r.state, r.err
+}
+
+type attachContainerStream struct {
+	grpc.ServerStream
+	ctx      context.Context
+	messages []*pb.ContainerStreamMessage
+	sent     []*pb.AttachToContainerResponse
+}
+
+func (s *attachContainerStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *attachContainerStream) Recv() (*pb.ContainerStreamMessage, error) {
+	if len(s.messages) == 0 {
+		return nil, io.EOF
+	}
+
+	message := s.messages[0]
+	s.messages = s.messages[1:]
+	return message, nil
+}
+
+func (s *attachContainerStream) Send(response *pb.AttachToContainerResponse) error {
+	s.sent = append(s.sent, response)
+	return nil
+}
+
+func TestAttachToContainerRejectsUnauthorizedContainer(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenType string
+		state     *types.ContainerState
+		repoErr   error
+	}{
+		{
+			name:      "foreign workspace",
+			tokenType: types.TokenTypeWorkspace,
+			state: &types.ContainerState{
+				ContainerId: "victim-container",
+				WorkspaceId: "victim-workspace",
+			},
+		},
+		{
+			name:      "restricted token",
+			tokenType: types.TokenTypeWorkspaceRestricted,
+			state: &types.ContainerState{
+				ContainerId: "attacker-container",
+				WorkspaceId: "attacker-workspace",
+			},
+		},
+		{
+			name:      "missing container state",
+			tokenType: types.TokenTypeWorkspace,
+		},
+		{
+			name:      "container lookup error",
+			tokenType: types.TokenTypeWorkspace,
+			repoErr:   errors.New("lookup failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerRepo := &attachContainerRepository{
+				state: tt.state,
+				err:   tt.repoErr,
+			}
+			ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+				Workspace: &types.Workspace{ExternalId: "attacker-workspace"},
+				Token:     &types.Token{TokenType: tt.tokenType},
+			})
+			stream := &attachContainerStream{
+				ctx: ctx,
+				messages: []*pb.ContainerStreamMessage{{
+					Payload: &pb.ContainerStreamMessage_AttachRequest{
+						AttachRequest: &pb.AttachToContainerRequest{ContainerId: "victim-container"},
+					},
+				}},
+			}
+			gws := &GatewayService{containerRepo: containerRepo}
+
+			err := gws.AttachToContainer(stream)
+
+			require.NoError(t, err)
+			require.Len(t, stream.sent, 1)
+			require.Equal(t, &pb.AttachToContainerResponse{
+				Done:     true,
+				ExitCode: 1,
+				Output:   "Container not found",
+			}, stream.sent[0])
+			if tt.tokenType == types.TokenTypeWorkspaceRestricted {
+				require.Empty(t, containerRepo.requestedContainer)
+			} else {
+				require.Equal(t, "victim-container", containerRepo.requestedContainer)
+			}
+		})
+	}
+}
+
+func TestBindSyncRequestToContainer(t *testing.T) {
+	request := &pb.SyncContainerWorkspaceRequest{
+		ContainerId: "client-controlled-container",
+		Path:        "file.txt",
+		Data:        []byte("contents"),
+	}
+
+	bound := bindSyncRequestToContainer(request, "authorized-container")
+
+	require.NotSame(t, request, bound)
+	require.Equal(t, "authorized-container", bound.ContainerId)
+	require.Equal(t, "client-controlled-container", request.ContainerId)
+	require.Equal(t, request.Path, bound.Path)
+	require.Equal(t, request.Data, bound.Data)
+	require.Nil(t, bindSyncRequestToContainer(nil, "authorized-container"))
 }


### PR DESCRIPTION
Credit to @arpitjain099 for reporting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened container shell attach and workspace sync authorization in the gateway to block cross-workspace access and client-controlled container IDs. Prevents unauthorized shell access and misdirected file sync.

- **Bug Fixes**
  - Require interactive permission and a valid workspace before processing attach.
  - Reject attach if the container is missing or belongs to a different workspace.
  - Bind `SyncContainerWorkspace` requests to the server-side container ID; ignore nil requests. Added unit tests for unauthorized scenarios and binding behavior.

<sup>Written for commit 1e02b4931175af9e1cda4a01d273e1e3e2928881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

