### PR TITLE
fix: burst cache

### DIFF
--- a/pkg/abstractions/image/base_image_digest.go
+++ b/pkg/abstractions/image/base_image_digest.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
 )
@@ -24,11 +25,13 @@ type baseImageDigestCache struct {
 	mu      sync.Mutex
 	entries map[string]baseImageDigestCacheEntry
 	group   singleflight.Group
+	rdb     *common.RedisClient
 }
 
-func newBaseImageDigestCache() baseImageDigestCache {
+func newBaseImageDigestCache(rdb *common.RedisClient) baseImageDigestCache {
 	return baseImageDigestCache{
 		entries: make(map[string]baseImageDigestCacheEntry),
+		rdb:     rdb,
 	}
 }
 
@@ -139,18 +142,18 @@ func (c *baseImageDigestCache) resolve(
 	creds string,
 	inspect func(context.Context, string, string) string,
 ) (string, bool) {
-	if digest := c.get(sourceImage); digest != "" {
+	if digest := c.get(ctx, sourceImage); digest != "" {
 		return digest, false
 	}
 
 	digest, _, shared := c.group.Do(sourceImage, func() (interface{}, error) {
-		if digest := c.get(sourceImage); digest != "" {
+		if digest := c.get(ctx, sourceImage); digest != "" {
 			return digest, nil
 		}
 
 		digest := inspect(ctx, sourceImage, creds)
 		if digest != "" {
-			c.set(sourceImage, digest)
+			c.set(ctx, sourceImage, digest)
 		}
 		return digest, nil
 	})
@@ -175,22 +178,38 @@ func (is *ContainerImageService) inspectBaseImageDigest(ctx context.Context, sou
 	return metadata.Digest
 }
 
-func (c *baseImageDigestCache) get(sourceImage string) string {
+func (c *baseImageDigestCache) get(ctx context.Context, sourceImage string) string {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	entry, ok := c.entries[sourceImage]
-	if !ok {
-		return ""
+	if ok && time.Now().Before(entry.expiresAt) {
+		c.mu.Unlock()
+		return entry.digest
 	}
-	if time.Now().After(entry.expiresAt) {
+	if ok {
 		delete(c.entries, sourceImage)
+	}
+	c.mu.Unlock()
+
+	if c.rdb == nil {
 		return ""
 	}
-	return entry.digest
+
+	digest, err := c.rdb.Get(ctx, common.RedisKeys.ImageBaseDigest(sourceImage)).Result()
+	if err != nil {
+		return ""
+	}
+	c.setLocal(sourceImage, digest)
+	return digest
 }
 
-func (c *baseImageDigestCache) set(sourceImage, digest string) {
+func (c *baseImageDigestCache) set(ctx context.Context, sourceImage, digest string) {
+	c.setLocal(sourceImage, digest)
+	if c.rdb != nil {
+		_ = c.rdb.SetEx(ctx, common.RedisKeys.ImageBaseDigest(sourceImage), digest, baseImageDigestCacheTTL).Err()
+	}
+}
+
+func (c *baseImageDigestCache) setLocal(sourceImage, digest string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/abstractions/image/base_image_digest_test.go
+++ b/pkg/abstractions/image/base_image_digest_test.go
@@ -1,8 +1,12 @@
 package image
 
 import (
+	"context"
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,4 +58,22 @@ func TestPinImageRefToDigestPreservesRegistryPort(t *testing.T) {
 		"registry.example.com:5000/team/image@"+digest,
 		pinImageRefToDigest("registry.example.com:5000/team/image:latest", digest),
 	)
+}
+
+func TestBaseImageDigestCacheSharedAcrossInstances(t *testing.T) {
+	server := miniredis.RunT(t)
+	rdb := &common.RedisClient{UniversalClient: redis.NewClient(&redis.Options{Addr: server.Addr()})}
+	first := newBaseImageDigestCache(rdb)
+	second := newBaseImageDigestCache(rdb)
+	lookups := 0
+	inspect := func(context.Context, string, string) string {
+		lookups++
+		return "sha256:digest"
+	}
+
+	digest, _ := first.resolve(context.Background(), "node:20-slim", "", inspect)
+	require.Equal(t, "sha256:digest", digest)
+	digest, _ = second.resolve(context.Background(), "node:20-slim", "", inspect)
+	require.Equal(t, "sha256:digest", digest)
+	require.Equal(t, 1, lookups)
 }

--- a/pkg/abstractions/image/build_test.go
+++ b/pkg/abstractions/image/build_test.go
@@ -216,7 +216,7 @@ func TestPrepareBuildOptionsForImageID_V2ExistingImageAddsRuntimeRequirements(t 
 		builder: &Builder{
 			config: cfg,
 		},
-		baseImageDigests: newBaseImageDigestCache(),
+		baseImageDigests: newBaseImageDigestCache(nil),
 	}
 	req := &pb.VerifyImageBuildRequest{
 		PythonVersion:    "python3.10",
@@ -254,7 +254,7 @@ func TestPrepareBuildOptionsForImageID_V2ExistingImageIgnorePythonSkipsRuntimeRe
 		builder: &Builder{
 			config: cfg,
 		},
-		baseImageDigests: newBaseImageDigestCache(),
+		baseImageDigests: newBaseImageDigestCache(nil),
 	}
 	req := &pb.VerifyImageBuildRequest{
 		PythonVersion:    "python3.10",
@@ -297,7 +297,7 @@ func TestPrepareBuildOptionsForImageID_V2ExistingImageIgnorePythonKeepsUserPacka
 		builder: &Builder{
 			config: cfg,
 		},
-		baseImageDigests: newBaseImageDigestCache(),
+		baseImageDigests: newBaseImageDigestCache(nil),
 	}
 	req := &pb.VerifyImageBuildRequest{
 		PythonVersion:    "python3.10",

--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -62,7 +62,7 @@ func NewContainerImageService(
 		builder:          builder,
 		config:           opts.Config,
 		backendRepo:      opts.BackendRepo,
-		baseImageDigests: newBaseImageDigestCache(),
+		baseImageDigests: newBaseImageDigestCache(opts.RedisClient),
 	}
 
 	leases := abstractions.NewContainerLeaseManager(

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -25,6 +25,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc/metadata"
 )
 
 type PodServiceOpts struct {
@@ -629,6 +630,9 @@ func (s *GenericPodService) CreatePod(ctx context.Context, in *pb.CreatePodReque
 	}
 
 	if stub == nil {
+		if in.StubId == "" {
+			in.StubId = s.preparedStubID(ctx, authInfo.Workspace.ExternalId)
+		}
 		stub, err = s.loadStub(ctx, in.StubId)
 		if err != nil {
 			return &pb.CreatePodResponse{
@@ -652,6 +656,7 @@ func (s *GenericPodService) CreatePod(ctx context.Context, in *pb.CreatePodReque
 			return &pb.CreatePodResponse{
 				Ok:       false,
 				ErrorMsg: err.Error(),
+				StubId:   stub.ExternalId,
 			}, nil
 		}
 
@@ -664,6 +669,7 @@ func (s *GenericPodService) CreatePod(ctx context.Context, in *pb.CreatePodReque
 			return &pb.CreatePodResponse{
 				Ok:       false,
 				ErrorMsg: err.Error(),
+				StubId:   stub.ExternalId,
 			}, nil
 		}
 	}
@@ -680,6 +686,22 @@ func (s *GenericPodService) CreatePod(ctx context.Context, in *pb.CreatePodReque
 		TaskId:      taskId,
 		AppId:       appId,
 	}, nil
+}
+
+func (s *GenericPodService) preparedStubID(ctx context.Context, workspaceID string) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok || s.rdb == nil {
+		return ""
+	}
+	cacheKeys := md.Get(common.PreparedStubCacheMetadata)
+	if len(cacheKeys) == 0 {
+		return ""
+	}
+	stubID, _ := s.rdb.Get(
+		ctx,
+		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKeys[0]),
+	).Result()
+	return stubID
 }
 
 func (s *GenericPodService) loadStub(ctx context.Context, stubId string) (*types.StubWithRelated, error) {

--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -697,9 +697,10 @@ func (s *GenericPodService) preparedStubID(ctx context.Context, workspaceID stri
 	if len(cacheKeys) == 0 {
 		return ""
 	}
-	stubID, _ := s.rdb.Get(
+	stubID, _ := s.rdb.GetEx(
 		ctx,
 		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKeys[0]),
+		common.PreparedStubCacheTTL,
 	).Result()
 	return stubID
 }

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -17,8 +17,30 @@ import (
 	pb "github.com/beam-cloud/beta9/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+func TestPreparedStubID(t *testing.T) {
+	rdb, err := repository.NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	key := common.RedisKeys.GatewayPreparedStub("workspace-1", "cache-key")
+	if err := rdb.Set(context.Background(), key, "stub-1", time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs(common.PreparedStubCacheMetadata, "cache-key"),
+	)
+
+	if got := (&GenericPodService{rdb: rdb}).preparedStubID(ctx, "workspace-1"); got != "stub-1" {
+		t.Fatalf("preparedStubID() = %q, want stub-1", got)
+	}
+}
 
 func TestSandboxConnectErrorMessageDoesNotLeakDetails(t *testing.T) {
 	got := sandboxConnectErrorMessage(errors.New("container state not found: sandbox-123 on worker 10.0.0.12"))

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -40,6 +40,9 @@ func TestPreparedStubID(t *testing.T) {
 	if got := (&GenericPodService{rdb: rdb}).preparedStubID(ctx, "workspace-1"); got != "stub-1" {
 		t.Fatalf("preparedStubID() = %q, want stub-1", got)
 	}
+	if ttl := rdb.TTL(context.Background(), key).Val(); ttl < 4*time.Minute {
+		t.Fatalf("prepared stub TTL = %s, want refreshed TTL", ttl)
+	}
 }
 
 func TestSandboxConnectErrorMessageDoesNotLeakDetails(t *testing.T) {

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -43,6 +43,7 @@ var (
 	gatewayDefaultDeployment           string = "gateway:default_deployment:%s"
 	gatewayDeploymentMinContainerCount string = "gateway:min_containers:%s"
 	gatewayAuthKey                     string = "gateway:auth:%s:%s"
+	gatewayPreparedStub                string = "gateway:prepared_stub:%s:%s"
 )
 
 var (
@@ -149,9 +150,12 @@ var (
 
 var (
 	imageBuildContainerTTL string = "image:build_container_ttl:%s"
+	imageBaseDigest        string = "image:base_digest:%s"
 )
 
 var RedisKeys = &redisKeys{}
+
+const PreparedStubCacheMetadata = "preparation-cache-key"
 
 type redisKeys struct{}
 
@@ -297,6 +301,10 @@ func (rk *redisKeys) GatewayDeploymentMinContainerCount(appId string) string {
 	return fmt.Sprintf(gatewayDeploymentMinContainerCount, appId)
 }
 
+func (rk *redisKeys) GatewayPreparedStub(workspaceId, cacheKey string) string {
+	return fmt.Sprintf(gatewayPreparedStub, workspaceId, cacheKey)
+}
+
 // Worker keys
 func (rk *redisKeys) WorkerPrefix() string {
 	return workerPrefix
@@ -308,6 +316,10 @@ func (rk *redisKeys) WorkerContainerResourceUsage(workerId string, containerId s
 
 func (rk *redisKeys) WorkerImageLock(workerId string, imageId string) string {
 	return fmt.Sprintf(workerImageLock, workerId, imageId)
+}
+
+func (rk *redisKeys) ImageBaseDigest(sourceImage string) string {
+	return fmt.Sprintf(imageBaseDigest, sourceImage)
 }
 
 func (rk *redisKeys) WorkerNetworkLock(networkPrefix string) string {

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 )
 
 var (
@@ -155,7 +156,10 @@ var (
 
 var RedisKeys = &redisKeys{}
 
-const PreparedStubCacheMetadata = "preparation-cache-key"
+const (
+	PreparedStubCacheMetadata = "preparation-cache-key"
+	PreparedStubCacheTTL      = 5 * time.Minute
+)
 
 type redisKeys struct{}
 

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/metadata"
 )
 
 // Capacity verdict values reported in GetOrCreateStubResponse.CapacityStatus.
@@ -26,6 +27,7 @@ const (
 	StubCapacityStatusAvailable = "available"
 	StubCapacityStatusLow       = "low"
 	StubCapacityStatusNone      = "none"
+	preparedStubCacheTTL        = 5 * time.Minute
 )
 
 func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCreateStubRequest) (*pb.GetOrCreateStubResponse, error) {
@@ -346,6 +348,8 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		}
 	}
 
+	gws.cachePreparedStub(ctx, authInfo.Workspace.ExternalId, stub.ExternalId)
+
 	return &pb.GetOrCreateStubResponse{
 		Ok:                 err == nil,
 		StubId:             stub.ExternalId,
@@ -354,6 +358,23 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		UnsupportedGpus:    capacity.unsupportedGpus,
 		MatchedPrivatePool: capacity.matchedPrivatePool,
 	}, nil
+}
+
+func (gws *GatewayService) cachePreparedStub(ctx context.Context, workspaceID, stubID string) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok || gws.redisClient == nil {
+		return
+	}
+	cacheKeys := md.Get(common.PreparedStubCacheMetadata)
+	if len(cacheKeys) == 0 || cacheKeys[0] == "" {
+		return
+	}
+	_ = gws.redisClient.SetEx(
+		ctx,
+		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKeys[0]),
+		stubID,
+		preparedStubCacheTTL,
+	).Err()
 }
 
 type stubCapacityVerdict struct {

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -27,7 +27,6 @@ const (
 	StubCapacityStatusAvailable = "available"
 	StubCapacityStatusLow       = "low"
 	StubCapacityStatusNone      = "none"
-	preparedStubCacheTTL        = 5 * time.Minute
 )
 
 func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCreateStubRequest) (*pb.GetOrCreateStubResponse, error) {
@@ -373,7 +372,7 @@ func (gws *GatewayService) cachePreparedStub(ctx context.Context, workspaceID, s
 		ctx,
 		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKeys[0]),
 		stubID,
-		preparedStubCacheTTL,
+		common.PreparedStubCacheTTL,
 	).Err()
 }
 

--- a/pkg/gateway/services/stub_test.go
+++ b/pkg/gateway/services/stub_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 type checkpointVolumeBackendRepo struct {
@@ -30,6 +32,25 @@ type fakePrivatePoolFinder struct {
 
 func (f fakePrivatePoolFinder) FindReadyPrivatePoolForGPU(ctx context.Context, workspaceID string, gpus []types.GpuType) (string, error) {
 	return f.pool, f.err
+}
+
+func TestCachePreparedStub(t *testing.T) {
+	rdb, err := repository.NewRedisClientForTest()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs(common.PreparedStubCacheMetadata, "cache-key"),
+	)
+	(&GatewayService{redisClient: rdb}).cachePreparedStub(ctx, "workspace-1", "stub-1")
+
+	stubID, err := rdb.Get(
+		context.Background(),
+		common.RedisKeys.GatewayPreparedStub("workspace-1", "cache-key"),
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, "stub-1", stubID)
 }
 
 func TestComputeCapacityVerdictAvailableWhenAnyGPUSupported(t *testing.T) {

--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -29,8 +29,8 @@ const (
 	// 4. Wait up to 30s for dockerd to be ready (usually takes 2-5s)
 	goprocReadyTimeout            = 30 * time.Second
 	goprocReadyProbeTimeout       = 50 * time.Millisecond
-	goprocInitialBackoff          = 10 * time.Millisecond
-	goprocMaxBackoff              = 50 * time.Millisecond
+	goprocInitialBackoff          = 5 * time.Millisecond
+	goprocMaxBackoff              = 15 * time.Millisecond
 	goprocBackoffMultiplier       = 1.5
 	sandboxSetupCommandTimeout    = 10 * time.Second
 	dockerDaemonStartupTimeout    = 30 * time.Second


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Redis-backed caches for base image digests and prepared sandbox stubs to cut duplicate work across processes and speed cold starts. Also tuned sandbox readiness probes to reduce startup latency.

- **New Features**
  - Share base image digest lookups across processes via Redis (`RedisKeys.ImageBaseDigest`), with in-memory cache as fast path.
  - Cache prepared stub IDs in Redis (`RedisKeys.GatewayPreparedStub`) keyed by workspace and `preparation-cache-key` request metadata; Gateway sets on prepare, Pod reads and refreshes TTL and auto-fills `StubId` when missing.
  - Shortened sandbox readiness probe backoff to 5–15ms to probe within TTI budget.

<sup>Written for commit e3b53d3e447e197971114b0af0c8161ecdacb539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

