### PR TITLE
Clean up SSH host information

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -75,7 +75,7 @@ func RunJoin(ctx context.Context, opts types.AgentJoinOptions) error {
 	}
 
 	transport := normalizeTransport(firstNonEmpty(opts.TransportOverride, res.Bootstrap.Transport))
-	if err := runRouteProxy(ctx, grpcClient, res.AgentToken, transport, workers, telemetry, agentStdout, agentStderr); err != nil {
+	if err := runRouteProxy(ctx, grpcClient, res.AgentToken, res.MachineID, transport, workers, telemetry, agentStdout, agentStderr); err != nil {
 		if agentInterrupted(ctx, err) {
 			statusf(agentStdout, "Disconnecting machine %q", res.MachineID)
 			return ErrInterrupted

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -76,7 +76,7 @@ func TestRouteProxyMarksRouteReadyForReachableLocalTarget(t *testing.T) {
 	target := backend.Addr().String()
 	updates := make(chan *pb.UpdateAgentRouteStatusRequest, 1)
 	client := &routeStatusClient{updates: updates}
-	proxy := newRouteProxy(client, "agent-token", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
+	proxy := newRouteProxy(client, "agent-token", "machine-one", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -121,7 +121,7 @@ func TestRouteProxyPollsOpeningRouteWithoutBackoff(t *testing.T) {
 	}()
 
 	updates := make(chan *pb.UpdateAgentRouteStatusRequest, 1)
-	proxy := newRouteProxy(&routeStatusClient{updates: updates}, "agent-token", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
+	proxy := newRouteProxy(&routeStatusClient{updates: updates}, "agent-token", "machine-one", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	proxy.setRoute("route-one", target)
@@ -150,7 +150,7 @@ func TestRouteProxyRechecksOpeningRouteThatRacesReadyUpdate(t *testing.T) {
 		updates:      make(chan *pb.UpdateAgentRouteStatusRequest, 2),
 		releaseFirst: make(chan struct{}),
 	}
-	proxy := newRouteProxy(client, "agent-token", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
+	proxy := newRouteProxy(client, "agent-token", "machine-one", nil, "agent.tailnet:29443", nil, io.Discard, io.Discard)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/pkg/agent/route_proxy.go
+++ b/pkg/agent/route_proxy.go
@@ -28,7 +28,7 @@ const (
 	routeProxyMaxConsecutiveFailures = 3
 )
 
-func newRouteProxy(client pb.GatewayServiceClient, agentToken string, listener net.Listener, proxyTarget string, workers *workerRuntimeManager, stdout, stderr io.Writer) *routeProxy {
+func newRouteProxy(client pb.GatewayServiceClient, agentToken, machineID string, listener net.Listener, proxyTarget string, workers *workerRuntimeManager, stdout, stderr io.Writer) *routeProxy {
 	if stdout == nil {
 		stdout = io.Discard
 	}
@@ -48,7 +48,7 @@ func newRouteProxy(client pb.GatewayServiceClient, agentToken string, listener n
 		readinessPending: map[string]string{},
 		failureCounts:    map[string]int{},
 		statusSlots:      make(chan struct{}, routeStatusConcurrency),
-		hostSSH:          newHostSSHManager(client, agentToken, stderr),
+		hostSSH:          newHostSSHManager(client, agentToken, machineID, stderr),
 	}
 }
 

--- a/pkg/agent/ssh.go
+++ b/pkg/agent/ssh.go
@@ -30,16 +30,23 @@ const (
 	managedSSHCommandTimeout = 2 * time.Minute
 	managedSSHPublicIPLookup = "https://api.ipify.org?format=text"
 	managedSSHAuthorizedKeys = "/home/beam/.ssh/authorized_keys"
+	managedSSHHushLogin      = "/home/beam/.hushlogin"
 	managedSSHSudoers        = "/etc/sudoers.d/90-beam-managed"
 	managedSSHDMainConfig    = "/etc/ssh/sshd_config"
 	managedSSHDConfig        = "/etc/ssh/sshd_config.d/90-beam-managed.conf"
 	managedSSHHostPublicKey  = "/etc/ssh/ssh_host_ed25519_key.pub"
 	managedSSHPasswordMarker = "NP"
+	managedSSHHostnamePath   = "/etc/hostname"
+	managedSSHHostsPath      = "/etc/hosts"
+	managedSSHHostnamePrefix = "beam-"
+	managedSSHHostsBegin     = "# BEGIN BEAM MANAGED HOSTNAME"
+	managedSSHHostsEnd       = "# END BEAM MANAGED HOSTNAME"
 )
 
 type hostSSHManager struct {
 	client      pb.GatewayServiceClient
 	agentToken  string
+	machineID   string
 	stderr      io.Writer
 	httpClient  *http.Client
 	publicIPURL string
@@ -60,14 +67,20 @@ type managedSSHCommand struct {
 }
 
 type managedSSHHost struct {
-	lookPath func(string) (string, error)
-	run      func(context.Context, string, string, ...string) error
+	lookPath     func(string) (string, error)
+	run          func(context.Context, string, string, ...string) error
+	hostname     func() (string, error)
+	hostnamePath string
+	hostsPath    string
 }
 
 func newManagedSSHHost() managedSSHHost {
 	return managedSSHHost{
-		lookPath: exec.LookPath,
-		run:      runManagedSSHCommandInput,
+		lookPath:     exec.LookPath,
+		run:          runManagedSSHCommandInput,
+		hostname:     os.Hostname,
+		hostnamePath: managedSSHHostnamePath,
+		hostsPath:    managedSSHHostsPath,
 	}
 }
 
@@ -80,13 +93,14 @@ func (h managedSSHHost) runCommand(ctx context.Context, command managedSSHComman
 	return h.run(ctx, command.stdin, command.name, command.args...)
 }
 
-func newHostSSHManager(client pb.GatewayServiceClient, agentToken string, stderr io.Writer) *hostSSHManager {
+func newHostSSHManager(client pb.GatewayServiceClient, agentToken, machineID string, stderr io.Writer) *hostSSHManager {
 	if stderr == nil {
 		stderr = io.Discard
 	}
 	return &hostSSHManager{
 		client:      client,
 		agentToken:  agentToken,
+		machineID:   machineID,
 		stderr:      stderr,
 		httpClient:  &http.Client{Timeout: 3 * time.Second},
 		publicIPURL: managedSSHPublicIPLookup,
@@ -174,6 +188,9 @@ func (m *hostSSHManager) apply(ctx context.Context, desired *pb.AgentSSHConfig) 
 		return "", err
 	}
 	if err := host.ensureUser(ctx); err != nil {
+		return "", err
+	}
+	if err := host.ensureHostname(ctx, m.machineID); err != nil {
 		return "", err
 	}
 	if err := ensureManagedSSHFiles(desired.PublicKey); err != nil {
@@ -279,6 +296,119 @@ func (h managedSSHHost) disablePasswordCommand() (managedSSHCommand, error) {
 	}
 }
 
+func managedSSHHostname(machineID string) string {
+	// The control-plane machine ID is stable and provider-neutral, unlike the
+	// hostname baked into many provider images.
+	var value strings.Builder
+	lastHyphen := false
+	for _, char := range strings.ToLower(strings.TrimSpace(machineID)) {
+		valid := char >= 'a' && char <= 'z' || char >= '0' && char <= '9'
+		if valid {
+			value.WriteRune(char)
+			lastHyphen = false
+			continue
+		}
+		if value.Len() > 0 && !lastHyphen {
+			value.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	suffix := strings.Trim(value.String(), "-")
+	if suffix == "" {
+		suffix = "instance"
+	}
+	const maxSuffixLength = 63 - len(managedSSHHostnamePrefix)
+	if len(suffix) > maxSuffixLength {
+		suffix = strings.TrimRight(suffix[:maxSuffixLength], "-")
+	}
+	return managedSSHHostnamePrefix + suffix
+}
+
+func (h managedSSHHost) ensureHostname(ctx context.Context, machineID string) error {
+	desired := managedSSHHostname(machineID)
+	current, err := h.hostname()
+	if err != nil {
+		return fmt.Errorf("read current hostname: %w", err)
+	}
+	if current != desired {
+		var setErr error
+		if h.commandExists("hostnamectl") {
+			setErr = h.runCommand(ctx, managedSSHCommand{name: "hostnamectl", args: []string{"set-hostname", desired}})
+		}
+		if setErr != nil || !h.commandExists("hostnamectl") {
+			if !h.commandExists("hostname") {
+				return errors.New("neither a working hostnamectl nor hostname command is available")
+			}
+			if err := h.runCommand(ctx, managedSSHCommand{name: "hostname", args: []string{desired}}); err != nil {
+				return fmt.Errorf("set managed hostname: %w", err)
+			}
+		}
+	}
+	if err := writeManagedFilePreservingMetadata(h.hostnamePath, []byte(desired+"\n"), 0o644); err != nil {
+		return fmt.Errorf("persist managed hostname: %w", err)
+	}
+	if err := ensureManagedHostnameMapping(h.hostsPath, desired); err != nil {
+		return fmt.Errorf("map managed hostname: %w", err)
+	}
+	return nil
+}
+
+func ensureManagedHostnameMapping(path, hostname string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	begin, end := -1, -1
+	for index, line := range lines {
+		switch strings.TrimSpace(line) {
+		case managedSSHHostsBegin:
+			if begin != -1 {
+				return errors.New("multiple managed hostname blocks in hosts file")
+			}
+			begin = index
+		case managedSSHHostsEnd:
+			if end != -1 {
+				return errors.New("multiple managed hostname blocks in hosts file")
+			}
+			end = index
+		}
+	}
+	if (begin == -1) != (end == -1) || end < begin {
+		return errors.New("malformed managed hostname block in hosts file")
+	}
+	filtered := make([]string, 0, len(lines)+3)
+	if begin == -1 {
+		filtered = append(filtered, lines...)
+	} else {
+		filtered = append(filtered, lines[:begin]...)
+		filtered = append(filtered, lines[end+1:]...)
+	}
+	for len(filtered) > 0 && strings.TrimSpace(filtered[len(filtered)-1]) == "" {
+		filtered = filtered[:len(filtered)-1]
+	}
+	filtered = append(filtered,
+		managedSSHHostsBegin,
+		"127.0.1.1 "+hostname,
+		managedSSHHostsEnd,
+	)
+	return writeManagedFilePreservingMetadata(path, []byte(strings.Join(filtered, "\n")+"\n"), 0o644)
+}
+
+func writeManagedFilePreservingMetadata(path string, data []byte, defaultMode os.FileMode) error {
+	mode := defaultMode
+	uid, gid := os.Getuid(), os.Getgid()
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+		if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+			uid, gid = int(stat.Uid), int(stat.Gid)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return writeManagedFileAtomic(path, data, mode, uid, gid)
+}
+
 func ensureManagedSSHFiles(publicKey string) error {
 	account, err := user.Lookup("beam")
 	if err != nil {
@@ -304,6 +434,9 @@ func ensureManagedSSHFiles(publicKey string) error {
 		return err
 	}
 	if err := writeManagedFileAtomic(managedSSHAuthorizedKeys, []byte(strings.TrimSpace(publicKey)+"\n"), 0o600, uid, gid); err != nil {
+		return err
+	}
+	if err := writeManagedFileAtomic(managedSSHHushLogin, nil, 0o600, uid, gid); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(managedSSHSudoers), 0o750); err != nil {

--- a/pkg/agent/ssh_test.go
+++ b/pkg/agent/ssh_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -154,6 +155,109 @@ func TestManagedSSHDisablePasswordCommandKeepsAccountAvailableForPublicKeys(t *t
 	}
 }
 
+func TestManagedSSHHostnameIsStableAndPortable(t *testing.T) {
+	longHostname := managedSSHHostname(strings.Repeat("a", 80) + "-ignored")
+	tests := map[string]string{
+		"3fbb8cb7":             "beam-3fbb8cb7",
+		"  INSTANCE_ABC/123  ": "beam-instance-abc-123",
+		"":                     "beam-instance",
+	}
+	for machineID, want := range tests {
+		if got := managedSSHHostname(machineID); got != want {
+			t.Errorf("managedSSHHostname(%q) = %q, want %q", machineID, got, want)
+		}
+	}
+	if len(longHostname) != 63 || strings.Trim(longHostname, "abcdefghijklmnopqrstuvwxyz0123456789-") != "" {
+		t.Errorf("long managed hostname = %q, want a portable 63-character hostname", longHostname)
+	}
+}
+
+func TestEnsureManagedSSHHostnameIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	hostnamePath := filepath.Join(dir, "hostname")
+	hostsPath := filepath.Join(dir, "hosts")
+	if err := os.WriteFile(hostnamePath, []byte("shadecloud\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hostsPath, []byte("127.0.0.1 localhost\n127.0.1.1 shadecloud\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var commands []managedSSHCommand
+	currentHostname := "shadecloud"
+	host := managedSSHHost{
+		lookPath: fakeLookPath(map[string]bool{"hostnamectl": true}),
+		run: func(_ context.Context, stdin, name string, args ...string) error {
+			commands = append(commands, managedSSHCommand{name: name, args: args, stdin: stdin})
+			currentHostname = args[len(args)-1]
+			return nil
+		},
+		hostname:     func() (string, error) { return currentHostname, nil },
+		hostnamePath: hostnamePath,
+		hostsPath:    hostsPath,
+	}
+	for range 2 {
+		if err := host.ensureHostname(context.Background(), "3fbb8cb7"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(commands) != 1 {
+		t.Fatalf("hostname commands = %d, want one", len(commands))
+	}
+	wantCommand := managedSSHCommand{name: "hostnamectl", args: []string{"set-hostname", "beam-3fbb8cb7"}}
+	if !reflect.DeepEqual(commands[0], wantCommand) {
+		t.Fatalf("hostname command = %#v, want %#v", commands[0], wantCommand)
+	}
+	data, err := os.ReadFile(hostnamePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "beam-3fbb8cb7\n" {
+		t.Fatalf("hostname file = %q", data)
+	}
+	data, err = os.ReadFile(hostsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(data), managedSSHHostsBegin) != 1 ||
+		strings.Count(string(data), "127.0.1.1 beam-3fbb8cb7") != 1 ||
+		!strings.Contains(string(data), "127.0.1.1 shadecloud") {
+		t.Fatalf("managed hosts mapping is not idempotent: %q", data)
+	}
+}
+
+func TestEnsureManagedSSHHostnameFallsBackWithoutSystemd(t *testing.T) {
+	dir := t.TempDir()
+	hostnamePath := filepath.Join(dir, "hostname")
+	hostsPath := filepath.Join(dir, "hosts")
+	if err := os.WriteFile(hostnamePath, []byte("provider-host\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hostsPath, []byte("127.0.0.1 localhost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var got managedSSHCommand
+	host := managedSSHHost{
+		lookPath: fakeLookPath(map[string]bool{"hostnamectl": true, "hostname": true}),
+		run: func(_ context.Context, stdin, name string, args ...string) error {
+			if name == "hostnamectl" {
+				return errors.New("systemd is not running")
+			}
+			got = managedSSHCommand{name: name, args: args, stdin: stdin}
+			return nil
+		},
+		hostname:     func() (string, error) { return "provider-host", nil },
+		hostnamePath: hostnamePath,
+		hostsPath:    hostsPath,
+	}
+	if err := host.ensureHostname(context.Background(), "machine-one"); err != nil {
+		t.Fatal(err)
+	}
+	want := managedSSHCommand{name: "hostname", args: []string{"beam-machine-one"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback command = %#v, want %#v", got, want)
+	}
+}
+
 func fakeLookPath(available map[string]bool) func(string) (string, error) {
 	return func(command string) (string, error) {
 		if available[command] {
@@ -187,7 +291,7 @@ func TestHostSSHManagerRefreshIsNonFatal(t *testing.T) {
 	}))
 	defer server.Close()
 	client := &recordingSSHStatusClient{requests: make(chan *pb.UpdateAgentSSHStatusRequest, 1)}
-	manager := newHostSSHManager(client, "agent-token", io.Discard)
+	manager := newHostSSHManager(client, "agent-token", "machine-one", io.Discard)
 	manager.applied = 7
 	manager.httpClient = server.Client()
 	manager.publicIPURL = server.URL

--- a/pkg/agent/transport.go
+++ b/pkg/agent/transport.go
@@ -40,7 +40,7 @@ type tsnetSnapshotReporter struct {
 	lastFailureEvent time.Time
 }
 
-func runRouteProxy(ctx context.Context, client pb.GatewayServiceClient, agentToken, transport string, workers *workerRuntimeManager, telemetry *agentTelemetry, stdout, stderr io.Writer) error {
+func runRouteProxy(ctx context.Context, client pb.GatewayServiceClient, agentToken, machineID, transport string, workers *workerRuntimeManager, telemetry *agentTelemetry, stdout, stderr io.Writer) error {
 	if stdout == nil {
 		stdout = io.Discard
 	}
@@ -50,13 +50,13 @@ func runRouteProxy(ctx context.Context, client pb.GatewayServiceClient, agentTok
 	transport = normalizeTransport(transport)
 	switch transport {
 	case types.BackendRouteTransportTSNet:
-		return runTSNetRouteProxy(ctx, client, agentToken, transport, workers, telemetry, stdout, stderr)
+		return runTSNetRouteProxy(ctx, client, agentToken, machineID, transport, workers, telemetry, stdout, stderr)
 	default:
 		return fmt.Errorf("unsupported agent transport %q", transport)
 	}
 }
 
-func runTSNetRouteProxy(ctx context.Context, client pb.GatewayServiceClient, agentToken, transport string, workers *workerRuntimeManager, telemetry *agentTelemetry, stdout, stderr io.Writer) error {
+func runTSNetRouteProxy(ctx context.Context, client pb.GatewayServiceClient, agentToken, machineID, transport string, workers *workerRuntimeManager, telemetry *agentTelemetry, stdout, stderr io.Writer) error {
 	credential, err := requestTransportCredential(ctx, client, agentToken, transport)
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func runTSNetRouteProxy(ctx context.Context, client pb.GatewayServiceClient, age
 	if localClient, err := server.LocalClient(); err == nil {
 		go emitTSNetSnapshots(ctx, telemetry, localClient, proxyTarget)
 	}
-	return newRouteProxy(client, agentToken, listener, proxyTarget, workers, stdout, stderr).run(ctx)
+	return newRouteProxy(client, agentToken, machineID, listener, proxyTarget, workers, stdout, stderr).run(ctx)
 }
 
 func emitTSNetSnapshots(ctx context.Context, telemetry *agentTelemetry, client tsnetStatusClient, proxyTarget string) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set a stable, Beam-branded hostname for managed SSH hosts derived from the machine ID and persist it to system files. Also threads `machineID` through the route proxy to support hostname management and adds a hush login.

- **New Features**
  - Generate portable hostnames from the control-plane machine ID (e.g., beam-<id>), capped to 63 chars.
  - Update `/etc/hostname` and maintain a managed block in `/etc/hosts`; idempotent and preserves file mode/ownership; falls back to `hostname` when `hostnamectl` fails or is missing.
  - Thread `machineID` into the route proxy and host SSH manager in `pkg/agent` to apply the hostname during join.
  - Create `/home/beam/.hushlogin` to silence the login banner.
  - Add tests for hostname generation, idempotency, and non-systemd fallback; update route proxy tests.

<sup>Written for commit 2117aa2a889d017f051a03b288441242eb034fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

