### PR TITLE
fix: pool selector bug

### DIFF
--- a/pkg/scheduler/reserve_test.go
+++ b/pkg/scheduler/reserve_test.go
@@ -241,11 +241,15 @@ func TestPrivatePoolMissFallsBackToRegularAvailableWorker(t *testing.T) {
 	}
 	withoutStorage := request.Clone()
 	withoutStorage.Workspace = types.Workspace{}
+	withoutStorage.Env = []string{"BETA9_TOKEN=user-token"}
+	withoutStorage = withoutStorage.PrivateWorkerRequest()
 	privateController.hasCapacity = true
 	fallback, poolName, ok := newSchedulingAttempt(scheduler, withoutStorage, nil).privatePoolFallbackRequest()
 	assert.True(t, ok)
 	assert.Equal(t, "private-cpu", poolName)
 	assert.Empty(t, fallback.PoolSelector)
+	assert.True(t, fallback.RuntimeTokenRequired)
+	assert.Empty(t, fallback.Env)
 	privateController.hasCapacity = false
 
 	setPendingSchedulerRequests(t, scheduler, request)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -118,13 +118,54 @@ func TestPrivateWorkerRequestUsesPoolMode(t *testing.T) {
 	manager := NewWorkerPoolManager()
 	privateState := &compute.PoolState{Selector: "private-pool"}
 	manager.SetPoolAt(agentPoolControllerKey("workspace-1", privateState), "private-pool", types.WorkerPoolConfig{Mode: types.PoolModePrivate}, nil)
+	manager.SetPool("serverless-pool", types.WorkerPoolConfig{Mode: types.PoolModeExternal}, nil)
 	manager.SetPool("local-pool", types.WorkerPoolConfig{Mode: types.PoolModeLocal}, nil)
 	scheduler := &Scheduler{workerPoolManager: manager}
 
 	request := &types.ContainerRequest{WorkspaceId: "workspace-1"}
 	assert.True(t, scheduler.privateWorkerRequest(&types.Worker{PoolName: "private-pool"}, request))
+	assert.False(t, scheduler.privateWorkerRequest(&types.Worker{PoolName: "serverless-pool", ControlPlaneManaged: true}, request))
 	assert.False(t, scheduler.privateWorkerRequest(&types.Worker{PoolName: "local-pool"}, request))
 	assert.False(t, scheduler.privateWorkerRequest(&types.Worker{PoolName: "missing-pool"}, request))
+}
+
+func TestPrepareWorkerRequestCredentialsByPoolMode(t *testing.T) {
+	manager := NewWorkerPoolManager()
+	privateState := &compute.PoolState{Selector: "private-pool"}
+	manager.SetPoolAt(agentPoolControllerKey("workspace-1", privateState), "private-pool", types.WorkerPoolConfig{Mode: types.PoolModePrivate}, nil)
+	manager.SetPool("serverless-pool", types.WorkerPoolConfig{Mode: types.PoolModeExternal}, nil)
+	scheduler := &Scheduler{
+		workerPoolManager: manager,
+		credentials:       newSchedulerCredentialCache(),
+	}
+	stubConfig, err := json.Marshal(types.StubConfigV1{
+		Secrets: []types.Secret{{Name: "SECRET"}},
+	})
+	assert.NoError(t, err)
+	request := &types.ContainerRequest{
+		ContainerId: "container-1",
+		WorkspaceId: "workspace-1",
+		Env:         []string{"BETA9_TOKEN=inline-token", "SECRET=inline-secret", "SAFE=value"},
+		Stub: types.StubWithRelated{
+			Stub: types.Stub{Config: string(stubConfig)},
+		},
+	}
+
+	privateRequest := scheduler.prepareWorkerRequest(
+		&types.Worker{PoolName: "private-pool", PoolSelector: "private-pool"},
+		request,
+	)
+	assert.Equal(t, []string{"SAFE=value"}, privateRequest.Env)
+	assert.Equal(t, []string{"SECRET"}, privateRequest.RuntimeSecretNames)
+	assert.True(t, privateRequest.RuntimeTokenRequired)
+
+	serverlessRequest := scheduler.prepareWorkerRequest(
+		&types.Worker{PoolName: "serverless-pool", PoolSelector: "serverless-pool", ControlPlaneManaged: true},
+		request,
+	)
+	assert.Equal(t, request.Env, serverlessRequest.Env)
+	assert.Empty(t, serverlessRequest.RuntimeSecretNames)
+	assert.False(t, serverlessRequest.RuntimeTokenRequired)
 }
 
 func TestPrivatePoolRequestsBypassManagedQuotaLookup(t *testing.T) {

--- a/pkg/worker/runtime_credentials.go
+++ b/pkg/worker/runtime_credentials.go
@@ -15,6 +15,8 @@ func (s *Worker) hydrateRuntimeCredentials(ctx context.Context, request *types.C
 		return s.hydrateBuildWorkspaceStorageCredentials(ctx, request)
 	}
 
+	// Credential hydration follows the request, not the worker mode. Private
+	// requests may be reassigned to serverless capacity after sanitization.
 	credentialRequest := runtimeCredentialsRequest(request)
 	if !hasRuntimeCredentialRequest(credentialRequest) {
 		return nil

--- a/pkg/worker/runtime_credentials.go
+++ b/pkg/worker/runtime_credentials.go
@@ -15,10 +15,6 @@ func (s *Worker) hydrateRuntimeCredentials(ctx context.Context, request *types.C
 		return s.hydrateBuildWorkspaceStorageCredentials(ctx, request)
 	}
 
-	if !s.agentWorker() {
-		return nil
-	}
-
 	credentialRequest := runtimeCredentialsRequest(request)
 	if !hasRuntimeCredentialRequest(credentialRequest) {
 		return nil

--- a/pkg/worker/runtime_credentials.go
+++ b/pkg/worker/runtime_credentials.go
@@ -15,8 +15,8 @@ func (s *Worker) hydrateRuntimeCredentials(ctx context.Context, request *types.C
 		return s.hydrateBuildWorkspaceStorageCredentials(ctx, request)
 	}
 
-	// Credential hydration follows the request, not the worker mode. Private
-	// requests may be reassigned to serverless capacity after sanitization.
+	// Runtime credentials belong to the sanitized request. Any worker that
+	// accepts the request must hydrate them, regardless of how it is hosted.
 	credentialRequest := runtimeCredentialsRequest(request)
 	if !hasRuntimeCredentialRequest(credentialRequest) {
 		return nil

--- a/pkg/worker/runtime_credentials_test.go
+++ b/pkg/worker/runtime_credentials_test.go
@@ -97,6 +97,28 @@ func TestHydrateRuntimeCredentialsForBuildOnlyRequestsWorkspaceStorage(t *testin
 	require.Equal(t, "https://storage.example", *request.Workspace.Storage.EndpointUrl)
 }
 
+func TestHydrateRuntimeCredentialsForManagedFallback(t *testing.T) {
+	repo := &fakeRuntimeCredentialsWorkerRepo{
+		resp: &pb.GetContainerRuntimeCredentialsResponse{
+			Ok:  true,
+			Env: []string{"BETA9_TOKEN=restricted-runtime-token"},
+		},
+	}
+	request := &types.ContainerRequest{
+		ContainerId:          "container-1",
+		WorkspaceId:          "workspace-1",
+		StubId:               "stub-1",
+		RuntimeTokenRequired: true,
+	}
+	worker := &Worker{workerRepoClient: repo}
+
+	require.NoError(t, worker.hydrateRuntimeCredentials(context.Background(), request))
+
+	require.NotNil(t, repo.lastReq)
+	require.True(t, repo.lastReq.RuntimeToken)
+	require.Equal(t, []string{"BETA9_TOKEN=restricted-runtime-token"}, request.Env)
+}
+
 type fakeRuntimeCredentialsWorkerRepo struct {
 	pb.WorkerRepositoryServiceClient
 	lastReq *pb.GetContainerRuntimeCredentialsRequest

--- a/pkg/worker/runtime_credentials_test.go
+++ b/pkg/worker/runtime_credentials_test.go
@@ -100,39 +100,31 @@ func TestHydrateRuntimeCredentialsForBuildOnlyRequestsWorkspaceStorage(t *testin
 func TestHydrateRuntimeCredentialsAcrossPoolTypes(t *testing.T) {
 	tests := []struct {
 		name   string
-		worker func(*fakeRuntimeCredentialsWorkerRepo) *Worker
+		worker Worker
 	}{
 		{
 			name: "private agent pool",
-			worker: func(repo *fakeRuntimeCredentialsWorkerRepo) *Worker {
-				return &Worker{
-					workerRepoClient: repo,
-					persistent:       true,
-					machineID:        "private-machine",
-					poolName:         "private-pool",
-					poolConfig:       types.WorkerPoolConfig{Mode: types.PoolModePrivate},
-					routeTransport:   types.BackendRouteTransportTSNet,
-				}
+			worker: Worker{
+				persistent:     true,
+				machineID:      "private-machine",
+				poolName:       "private-pool",
+				poolConfig:     types.WorkerPoolConfig{Mode: types.PoolModePrivate},
+				routeTransport: types.BackendRouteTransportTSNet,
 			},
 		},
 		{
 			name: "admin-managed serverless agent pool",
-			worker: func(repo *fakeRuntimeCredentialsWorkerRepo) *Worker {
-				return &Worker{
-					workerRepoClient: repo,
-					persistent:       true,
-					machineID:        "serverless-machine",
-					poolName:         "serverless-pool",
-					poolConfig:       types.WorkerPoolConfig{Mode: types.PoolModeExternal},
-					routeTransport:   types.BackendRouteTransportTSNet,
-				}
+			worker: Worker{
+				persistent:     true,
+				machineID:      "serverless-machine",
+				poolName:       "serverless-pool",
+				poolConfig:     types.WorkerPoolConfig{Mode: types.PoolModeExternal},
+				routeTransport: types.BackendRouteTransportTSNet,
 			},
 		},
 		{
-			name: "managed fallback pool",
-			worker: func(repo *fakeRuntimeCredentialsWorkerRepo) *Worker {
-				return &Worker{workerRepoClient: repo, poolName: "default"}
-			},
+			name:   "managed fallback pool",
+			worker: Worker{poolName: "default"},
 		},
 	}
 
@@ -151,8 +143,10 @@ func TestHydrateRuntimeCredentialsAcrossPoolTypes(t *testing.T) {
 				RuntimeSecretNames:   []string{"SECRET"},
 				RuntimeTokenRequired: true,
 			}
+			worker := test.worker
+			worker.workerRepoClient = repo
 
-			require.NoError(t, test.worker(repo).hydrateRuntimeCredentials(context.Background(), request))
+			require.NoError(t, worker.hydrateRuntimeCredentials(context.Background(), request))
 
 			require.NotNil(t, repo.lastReq)
 			require.True(t, repo.lastReq.RuntimeToken)

--- a/pkg/worker/runtime_credentials_test.go
+++ b/pkg/worker/runtime_credentials_test.go
@@ -97,26 +97,92 @@ func TestHydrateRuntimeCredentialsForBuildOnlyRequestsWorkspaceStorage(t *testin
 	require.Equal(t, "https://storage.example", *request.Workspace.Storage.EndpointUrl)
 }
 
-func TestHydrateRuntimeCredentialsForManagedFallback(t *testing.T) {
-	repo := &fakeRuntimeCredentialsWorkerRepo{
-		resp: &pb.GetContainerRuntimeCredentialsResponse{
-			Ok:  true,
-			Env: []string{"BETA9_TOKEN=restricted-runtime-token"},
+func TestHydrateRuntimeCredentialsAcrossPoolTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		worker func(*fakeRuntimeCredentialsWorkerRepo) *Worker
+	}{
+		{
+			name: "private agent pool",
+			worker: func(repo *fakeRuntimeCredentialsWorkerRepo) *Worker {
+				return &Worker{
+					workerRepoClient: repo,
+					persistent:       true,
+					machineID:        "private-machine",
+					poolName:         "private-pool",
+					poolConfig:       types.WorkerPoolConfig{Mode: types.PoolModePrivate},
+					routeTransport:   types.BackendRouteTransportTSNet,
+				}
+			},
+		},
+		{
+			name: "admin-managed serverless agent pool",
+			worker: func(repo *fakeRuntimeCredentialsWorkerRepo) *Worker {
+				return &Worker{
+					workerRepoClient: repo,
+					persistent:       true,
+					machineID:        "serverless-machine",
+					poolName:         "serverless-pool",
+					poolConfig:       types.WorkerPoolConfig{Mode: types.PoolModeExternal},
+					routeTransport:   types.BackendRouteTransportTSNet,
+				}
+			},
+		},
+		{
+			name: "managed fallback pool",
+			worker: func(repo *fakeRuntimeCredentialsWorkerRepo) *Worker {
+				return &Worker{workerRepoClient: repo, poolName: "default"}
+			},
 		},
 	}
-	request := &types.ContainerRequest{
-		ContainerId:          "container-1",
-		WorkspaceId:          "workspace-1",
-		StubId:               "stub-1",
-		RuntimeTokenRequired: true,
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := &fakeRuntimeCredentialsWorkerRepo{
+				resp: &pb.GetContainerRuntimeCredentialsResponse{
+					Ok:  true,
+					Env: []string{"BETA9_TOKEN=restricted-runtime-token", "SECRET=runtime-secret"},
+				},
+			}
+			request := &types.ContainerRequest{
+				ContainerId:          "container-1",
+				WorkspaceId:          "workspace-1",
+				StubId:               "stub-1",
+				RuntimeSecretNames:   []string{"SECRET"},
+				RuntimeTokenRequired: true,
+			}
+
+			require.NoError(t, test.worker(repo).hydrateRuntimeCredentials(context.Background(), request))
+
+			require.NotNil(t, repo.lastReq)
+			require.True(t, repo.lastReq.RuntimeToken)
+			require.Equal(t, []string{"SECRET"}, repo.lastReq.SecretNames)
+			require.Equal(t, []string{"BETA9_TOKEN=restricted-runtime-token", "SECRET=runtime-secret"}, request.Env)
+		})
 	}
-	worker := &Worker{workerRepoClient: repo}
+}
+
+func TestHydrateRuntimeCredentialsSkipsInlineServerlessCredentials(t *testing.T) {
+	repo := &fakeRuntimeCredentialsWorkerRepo{}
+	request := &types.ContainerRequest{
+		ContainerId: "container-1",
+		WorkspaceId: "workspace-1",
+		StubId:      "stub-1",
+		Env:         []string{"BETA9_TOKEN=inline-token", "SECRET=inline-secret"},
+	}
+	worker := &Worker{
+		workerRepoClient: repo,
+		persistent:       true,
+		machineID:        "serverless-machine",
+		poolName:         "serverless-pool",
+		poolConfig:       types.WorkerPoolConfig{Mode: types.PoolModeExternal},
+		routeTransport:   types.BackendRouteTransportTSNet,
+	}
 
 	require.NoError(t, worker.hydrateRuntimeCredentials(context.Background(), request))
 
-	require.NotNil(t, repo.lastReq)
-	require.True(t, repo.lastReq.RuntimeToken)
-	require.Equal(t, []string{"BETA9_TOKEN=restricted-runtime-token"}, request.Env)
+	require.Nil(t, repo.lastReq)
+	require.Equal(t, []string{"BETA9_TOKEN=inline-token", "SECRET=inline-secret"}, request.Env)
 }
 
 type fakeRuntimeCredentialsWorkerRepo struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes pool selector handling to correctly distinguish private vs serverless pools and sanitize worker requests so credentials are handled safely across pool types. Prevents inline tokens/secrets from leaking during private → managed fallback.

- **Bug Fixes**
  - `pkg/scheduler`: `privateWorkerRequest` treats serverless/external pools as non-private; `prepareWorkerRequest` strips inline env for private pools, sets `RuntimeTokenRequired`, and passes `RuntimeSecretNames` from stub secrets; serverless/external pools keep env and do not request runtime creds.
  - `pkg/scheduler`: Private pool fallback now clears `PoolSelector`, requires a runtime token, and empties env when falling back to a managed pool.
  - `pkg/worker`: `hydrateRuntimeCredentials` runs for any worker that accepts a sanitized request (not just agent workers), fixing managed fallback cases; skips hydration when serverless requests already include inline credentials.
  - Added tests covering private, serverless/external, and managed fallback pools.

<sup>Written for commit b60b7d085eb9a5138cdffb78033d83659aa07154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

