### PR TITLE
fetch pinned criu commit explicitly

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -285,6 +285,7 @@ if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "aarch64" ]; then
         git
     git clone https://github.com/checkpoint-restore/criu.git
     cd criu
+    git fetch origin ${CRIU_COMMIT}
     git reset --hard ${CRIU_COMMIT}
     git apply --check --unidiff-zero /tmp/criu-network-remap.patch
     git apply --unidiff-zero /tmp/criu-network-remap.patch


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Explicitly fetch the pinned `criu` commit before `git reset` in `docker/Dockerfile.worker`. This prevents build failures when the commit isn’t in the initial clone (e.g., shallow clone) and keeps the worker build reproducible.

<sup>Written for commit ad83fb929d4128295ccda0ce068b09880c836414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

