### PR TITLE
Harden NVIDIA agent installation

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1338,7 +1338,7 @@ func TestResolveAgentCapacityDefaultsToDetectedGPUIDs(t *testing.T) {
 	}
 }
 
-func TestDetectNvidiaGPUDevicesSkipsFailedProcAdapter(t *testing.T) {
+func TestDetectNvidiaGPUDevicesSkipsExcludedProcAdapter(t *testing.T) {
 	previousQuery := queryNvidiaGPUDevices
 	queryNvidiaGPUDevices = func() ([]byte, error) {
 		return []byte(`0, GPU-bad, NVIDIA GeForce RTX 4090, 0x0000, 00000000:01:00.0
@@ -1347,8 +1347,8 @@ func TestDetectNvidiaGPUDevicesSkipsFailedProcAdapter(t *testing.T) {
 	t.Cleanup(func() { queryNvidiaGPUDevices = previousQuery })
 
 	root := t.TempDir()
-	writeNvidiaProcGPUInfo(t, root, "0000:01:00.0", "GPU-bad", "N/A", "??.??.??.??.?")
-	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-good", "580.126.18", "95.02.3c.40.b8")
+	writeNvidiaProcGPUInfo(t, root, "0000:01:00.0", "GPU-bad", "N/A", "??.??.??.??.?", true)
+	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-good", "580.126.18", "95.02.3c.40.b8", false)
 
 	previousRoot := nvidiaProcGPUInfoRoot
 	nvidiaProcGPUInfoRoot = root
@@ -1363,10 +1363,30 @@ func TestDetectNvidiaGPUDevicesSkipsFailedProcAdapter(t *testing.T) {
 	}
 }
 
+func TestDetectNvidiaGPUDevicesAllowsUnknownVideoBIOS(t *testing.T) {
+	previousQuery := queryNvidiaGPUDevices
+	queryNvidiaGPUDevices = func() ([]byte, error) {
+		return []byte(`0, GPU-a, NVIDIA GeForce RTX 4090, 0x0000, 00000000:01:00.0`), nil
+	}
+	t.Cleanup(func() { queryNvidiaGPUDevices = previousQuery })
+
+	root := t.TempDir()
+	writeNvidiaProcGPUInfo(t, root, "0000:01:00.0", "GPU-a", "N/A", "??.??.??.??.?", false)
+
+	previousRoot := nvidiaProcGPUInfoRoot
+	nvidiaProcGPUInfoRoot = root
+	t.Cleanup(func() { nvidiaProcGPUInfoRoot = previousRoot })
+
+	devices := detectNvidiaGPUDevices()
+	if len(devices) != 1 {
+		t.Fatalf("devices = %#v, want GPU with working nvidia-smi despite unknown Video BIOS metadata", devices)
+	}
+}
+
 func TestNvidiaProcDriverStateReportsFailedAdapterWithoutHardFail(t *testing.T) {
 	root := t.TempDir()
-	writeNvidiaProcGPUInfo(t, root, "0000:01:00.0", "GPU-bad", "N/A", "??.??.??.??.?")
-	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-good", "580.126.18", "95.02.3c.40.b8")
+	writeNvidiaProcGPUInfo(t, root, "0000:01:00.0", "GPU-bad", "N/A", "??.??.??.??.?", true)
+	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-good", "580.126.18", "95.02.3c.40.b8", false)
 
 	previous := nvidiaProcGPUInfoRoot
 	nvidiaProcGPUInfoRoot = root
@@ -1386,8 +1406,8 @@ func TestNvidiaProcDriverStateReportsFailedAdapterWithoutHardFail(t *testing.T) 
 
 func TestNvidiaProcDriverStateReportsProcSmiMismatchWithoutHardFail(t *testing.T) {
 	root := t.TempDir()
-	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-a", "580.126.18", "95.02.3c.40.b8")
-	writeNvidiaProcGPUInfo(t, root, "0000:41:00.0", "GPU-b", "580.126.18", "95.02.3c.40.b8")
+	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-a", "580.126.18", "95.02.3c.40.b8", false)
+	writeNvidiaProcGPUInfo(t, root, "0000:41:00.0", "GPU-b", "580.126.18", "95.02.3c.40.b8", false)
 
 	previous := nvidiaProcGPUInfoRoot
 	nvidiaProcGPUInfoRoot = root
@@ -1404,7 +1424,7 @@ func TestNvidiaProcDriverStateReportsProcSmiMismatchWithoutHardFail(t *testing.T
 
 func TestNvidiaProcDriverStateAllowsHealthyDetectedGPUs(t *testing.T) {
 	root := t.TempDir()
-	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-a", "580.126.18", "95.02.3c.40.b8")
+	writeNvidiaProcGPUInfo(t, root, "0000:24:00.0", "GPU-a", "580.126.18", "95.02.3c.40.b8", false)
 
 	previous := nvidiaProcGPUInfoRoot
 	nvidiaProcGPUInfoRoot = root
@@ -1531,7 +1551,7 @@ func TestWriteWorkerConfigUsesGeeseForWorkspaceStorage(t *testing.T) {
 	}
 }
 
-func writeNvidiaProcGPUInfo(t *testing.T, root, busID, uuid, firmware, videoBIOS string) {
+func writeNvidiaProcGPUInfo(t *testing.T, root, busID, uuid, firmware, videoBIOS string, excluded bool) {
 	t.Helper()
 	dir := filepath.Join(root, busID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -1544,6 +1564,7 @@ func writeNvidiaProcGPUInfo(t *testing.T, root, busID, uuid, firmware, videoBIOS
 		"Bus Location: \t " + busID,
 		"Device Minor: \t 0",
 		"GPU Firmware: \t " + firmware,
+		fmt.Sprintf("GPU Excluded:\t %v", map[bool]string{true: "Yes", false: "No"}[excluded]),
 	}, "\n")
 	if err := os.WriteFile(filepath.Join(dir, "information"), []byte(info), 0644); err != nil {
 		t.Fatal(err)

--- a/pkg/agent/preflight.go
+++ b/pkg/agent/preflight.go
@@ -303,8 +303,8 @@ func nvidiaProcInfoLooksFailed(info string) bool {
 		}
 		value = strings.TrimSpace(value)
 		switch strings.TrimSpace(name) {
-		case "Video BIOS":
-			if value == "" || strings.HasPrefix(value, "??") {
+		case "GPU Excluded":
+			if strings.EqualFold(value, "yes") {
 				return true
 			}
 		}

--- a/pkg/gateway/agent_install.go
+++ b/pkg/gateway/agent_install.go
@@ -33,6 +33,7 @@ SERVICE_NAME="${BEAM_AGENT_SERVICE_NAME:-beam-agent}"
 STATE_DIR="${BEAM_AGENT_STATE_DIR:-}"
 CACHE_DIR="${BEAM_AGENT_CACHE_DIR:-}"
 INSTALL_DOCKER="${BEAM_AGENT_INSTALL_DOCKER:-auto}"
+INSTALL_NVIDIA_TOOLKIT="${BEAM_AGENT_INSTALL_NVIDIA_TOOLKIT:-auto}"
 TRANSPORT=""
 EXECUTOR="${BEAM_AGENT_EXECUTOR:-}"
 WORKER_IMAGE="${BEAM_WORKER_IMAGE:-}"
@@ -75,6 +76,7 @@ main() {
   fi
 
   ensure_linux_docker
+  ensure_linux_nvidia_container_runtime
 
   if use_source_agent; then
     say "Starting Beam agent from source"
@@ -317,6 +319,86 @@ ensure_linux_docker() {
   fi
   if ! docker_ready; then
     fail "Docker is installed but not running. Start Docker and rerun this command." 1
+  fi
+}
+
+ensure_linux_nvidia_container_runtime() {
+  if [ "$OS" != "linux" ] || ! needs_worker_container; then
+    return
+  fi
+  if ! command -v nvidia-smi >/dev/null 2>&1; then
+    return
+  fi
+  if ! NVIDIA_GPU_IDS="$(nvidia-smi --query-gpu=index --format=csv,noheader,nounits 2>/dev/null)" || [ -z "$NVIDIA_GPU_IDS" ]; then
+    fail "nvidia-smi is installed but did not report any usable GPUs. Repair the NVIDIA driver and rerun this command." 1
+  fi
+  if docker_has_nvidia_runtime; then
+    return
+  fi
+  if ! command -v nvidia-ctk >/dev/null 2>&1; then
+    if [ "$DEV" = "1" ] || is_false "$INSTALL_NVIDIA_TOOLKIT"; then
+      fail "NVIDIA GPUs were detected but NVIDIA Container Toolkit is missing. Install nvidia-container-toolkit or rerun with BEAM_AGENT_INSTALL_NVIDIA_TOOLKIT=1." 1
+    fi
+    install_nvidia_container_toolkit
+  fi
+
+  say "Configuring NVIDIA Container Toolkit"
+  nvidia-ctk runtime configure --runtime=docker >/dev/null
+  restart_linux_docker
+  if ! docker_has_nvidia_runtime; then
+    fail "NVIDIA Container Toolkit is installed but Docker does not expose the nvidia runtime." 1
+  fi
+}
+
+install_nvidia_container_toolkit() {
+  say "Installing NVIDIA Container Toolkit"
+  if command -v apt-get >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg
+    install -d -m 0755 /usr/share/keyrings /etc/apt/sources.list.d
+    NVIDIA_KEY_TMP="$(mktemp)"
+    NVIDIA_LIST_TMP="$(mktemp)"
+    download_file "https://nvidia.github.io/libnvidia-container/gpgkey" "$NVIDIA_KEY_TMP"
+    download_file "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list" "$NVIDIA_LIST_TMP"
+    gpg --dearmor --yes -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg "$NVIDIA_KEY_TMP"
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' "$NVIDIA_LIST_TMP" > /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    rm -f "$NVIDIA_KEY_TMP" "$NVIDIA_LIST_TMP"
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nvidia-container-toolkit
+    return
+  fi
+
+  if command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+    install -d -m 0755 /etc/yum.repos.d
+    NVIDIA_REPO_TMP="$(mktemp)"
+    download_file "https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo" "$NVIDIA_REPO_TMP"
+    install -m 0644 "$NVIDIA_REPO_TMP" /etc/yum.repos.d/nvidia-container-toolkit.repo
+    rm -f "$NVIDIA_REPO_TMP"
+    if command -v dnf >/dev/null 2>&1; then
+      dnf install -y nvidia-container-toolkit
+    else
+      yum install -y nvidia-container-toolkit
+    fi
+    return
+  fi
+
+  fail "NVIDIA GPUs were detected but this Linux distribution cannot install NVIDIA Container Toolkit automatically. Install nvidia-container-toolkit and rerun this command." 1
+}
+
+docker_has_nvidia_runtime() {
+  docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q '"nvidia"'
+}
+
+restart_linux_docker() {
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart docker
+  elif command -v service >/dev/null 2>&1; then
+    service docker restart
+  else
+    fail "NVIDIA Container Toolkit was configured, but Docker could not be restarted automatically." 1
+  fi
+  if ! docker_ready; then
+    fail "Docker did not become ready after configuring NVIDIA Container Toolkit." 1
   fi
 }
 

--- a/pkg/gateway/agent_install_test.go
+++ b/pkg/gateway/agent_install_test.go
@@ -31,8 +31,13 @@ func TestAgentInstallScriptDownloadsAgentFromGateway(t *testing.T) {
 		"${GATEWAY}/install/agent/${OS_NAME}/${ARCH_NAME}",
 		"${GATEWAY}/install/agent/linux/${ARCH}",
 		"ensure_linux_docker",
+		"ensure_linux_nvidia_container_runtime",
 		"--cache-dir",
 		"BEAM_AGENT_CACHE_DIR",
+		"BEAM_AGENT_INSTALL_NVIDIA_TOOLKIT",
+		"https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list",
+		"https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo",
+		"nvidia-ctk runtime configure --runtime=docker",
 	} {
 		if !strings.Contains(agentInstallScript, want) {
 			t.Fatalf("install script missing %q", want)
@@ -108,6 +113,70 @@ func TestAgentInstallScriptDefaultsMacOSWorkerPlatform(t *testing.T) {
 		if !strings.Contains(agentInstallScript, want) {
 			t.Fatalf("install script missing %q", want)
 		}
+	}
+}
+
+func TestAgentInstallScriptConfiguresExistingNvidiaToolkit(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeMarker := filepath.Join(tmp, "nvidia-runtime")
+	restartMarker := filepath.Join(tmp, "docker-restart")
+	fakes := map[string]string{
+		"nvidia-smi": `#!/bin/sh
+set -eu
+[ "${1:-}" = "--query-gpu=index" ]
+printf '0\n'
+`,
+		"docker": `#!/bin/sh
+set -eu
+[ "${1:-}" = "info" ]
+if [ -f "$NVIDIA_RUNTIME_MARKER" ]; then
+  printf '{"nvidia":{}}\n'
+else
+  printf '{"runc":{}}\n'
+fi
+`,
+		"nvidia-ctk": `#!/bin/sh
+set -eu
+[ "$*" = "runtime configure --runtime=docker" ]
+printf 'configured\n' > "$NVIDIA_RUNTIME_MARKER"
+`,
+		"systemctl": `#!/bin/sh
+set -eu
+printf '%s\n' "$*" > "$NVIDIA_RESTART_MARKER"
+`,
+	}
+	for name, contents := range fakes {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(contents), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	script := strings.TrimSuffix(agentInstallScript, "\nmain \"$@\"\n") + `
+OS=linux
+EXECUTOR=worker-container
+ensure_linux_nvidia_container_runtime
+`
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"NVIDIA_RUNTIME_MARKER="+runtimeMarker,
+		"NVIDIA_RESTART_MARKER="+restartMarker,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("NVIDIA runtime configuration failed: %v\n%s", err, out)
+	}
+	if data, err := os.ReadFile(runtimeMarker); err != nil || string(data) != "configured\n" {
+		t.Fatalf("runtime marker = %q, %v", data, err)
+	}
+	if data, err := os.ReadFile(restartMarker); err != nil || string(data) != "restart docker\n" {
+		t.Fatalf("restart marker = %q, %v", data, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- install and configure NVIDIA Container Toolkit when an agent pool resolves to the `nvidia` runtime
- make the installer idempotently configure Docker and verify that the NVIDIA runtime is actually registered
- stop treating an unpopulated legacy procfs Video BIOS field as a failed GPU; reject GPUs only when the driver explicitly marks them excluded
- add gateway installer and agent preflight regression coverage

## Root cause

The agent installer treated a loaded NVIDIA driver as sufficient, even when Docker did not have the NVIDIA container runtime configured. Separately, preflight treated `Video BIOS: ??.??.??.??.??` in `/proc/driver/nvidia` as hardware failure even though NVML and `nvidia-smi` could initialize the GPU and read the real VBIOS metadata.

## Impact

NVIDIA-backed serverless agents now converge on a usable Docker GPU runtime during installation and do not reject healthy headless GPUs because of stale or unpopulated procfs metadata.

## Validation

- `go test ./pkg/gateway ./pkg/agent`
- verified the production host reports all eight RTX 4090s through NVML and inside the worker container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically installs and configures the NVIDIA Container Toolkit when an agent pool uses the `nvidia` runtime and ensures Docker exposes the `nvidia` runtime. Also relaxes GPU preflight so healthy headless GPUs aren’t rejected due to missing VBIOS metadata.

- **New Features**
  - Auto-detect GPUs via `nvidia-smi` and ensure Docker has the `nvidia` runtime; install `nvidia-container-toolkit` on apt/dnf/yum systems if needed, run `nvidia-ctk runtime configure --runtime=docker`, and restart Docker.
  - Idempotent checks: skip work if the runtime exists; fail fast if `nvidia-smi` reports no GPUs or Docker can’t be restarted.
  - Toggle with `BEAM_AGENT_INSTALL_NVIDIA_TOOLKIT` (`auto` by default).
  - Added installer and gateway tests covering NVIDIA toolkit configuration.

- **Bug Fixes**
  - Preflight no longer treats unknown “Video BIOS” in `/proc/driver/nvidia` as a failure.
  - GPUs are rejected only when procfs shows `GPU Excluded: Yes`; updated agent tests to cover both cases.

<sup>Written for commit e833f18cfd3ca50c7e3044827850f4152ee82f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

