### PR TITLE
Improve cache locality reconciliation and node disk eviction

### DIFF
--- a/deploy/charts/beta9/templates/cache-server-daemonset.yaml
+++ b/deploy/charts/beta9/templates/cache-server-daemonset.yaml
@@ -96,6 +96,8 @@ spec:
           readOnly: true
         - name: cache
           mountPath: {{ .Values.cacheServer.mountPath }}
+        - name: images
+          mountPath: /images
         {{- with .Values.cacheServer.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -108,4 +110,13 @@ spec:
         hostPath:
           path: {{ .Values.cacheServer.hostPath }}
           type: DirectoryOrCreate
+      - name: images
+        {{- if .Values.config.worker.imagePVCName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.config.worker.imagePVCName }}
+        {{- else }}
+        hostPath:
+          path: {{ .Values.cacheServer.imagesHostPath }}
+          type: DirectoryOrCreate
+        {{- end }}
 {{- end -}}

--- a/deploy/charts/beta9/values.yaml
+++ b/deploy/charts/beta9/values.yaml
@@ -49,6 +49,9 @@ cacheServer:
   serverPort: 2050
   hostPath: /var/lib/beta9/cache
   mountPath: /var/lib/beta9/cache
+  # Must match the host path mounted at /images on workers in this locality.
+  # Ignored when config.worker.imagePVCName is set.
+  imagesHostPath: /images
   hostNetwork: true
   priorityClassName:
   image:

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -65,13 +65,10 @@ const (
 	cacheDefaultReconcileMaxDiskUsagePct = 0.80
 	cacheDefaultStubCodeEvictWatermark   = 0.80
 	cacheReconcileDiskUsageHysteresisPct = 0.03
-	// cacheReconcileOwnerGracePeriod is how long a key's HRW owner may be
-	// endpoint-less (rolling deploy, pod cycle) before its keys fail over to
-	// the next-ranked host for proactive materialization. Short blips keep
-	// ownership stable so an entire key range isn't duplicated onto peers;
-	// hosts that disappear for good also age out of the ring itself via the
-	// coordinator TTL.
-	cacheReconcileOwnerGracePeriod   = 10 * time.Minute
+	// cacheReconcileOwnerGracePeriod preserves placement for one full owner
+	// lease, then lets a live peer rehydrate recent content. Waiting longer
+	// leaves failover workers routed to an endpoint-less logical host.
+	cacheReconcileOwnerGracePeriod   = cacheDefaultRegistrationTTL
 	cacheDefaultVolumeReportMinBytes = 128 * 1024 * 1024
 	cacheReconcileSuccessBackoff     = time.Hour
 )
@@ -490,6 +487,11 @@ func (s nodeCacheServer) Start() (bool, error) {
 	if err != nil || !acquired {
 		return false, err
 	}
+	if removed, err := cleanupStaleCacheRoots(s.config, m.locality, m.nodeID); err != nil {
+		log.Warn().Err(err).Msg("failed to clean stale node cache roots")
+	} else if removed > 0 {
+		log.Info().Int("removed", removed).Msg("cleaned stale node cache roots")
+	}
 
 	server, advertisedAddr, err := m.createEmbeddedServer(s.config, s.hostID)
 	if err != nil {
@@ -706,6 +708,97 @@ func acquireCacheServerLock(cacheDir string) (*os.File, bool, error) {
 	lockPath := filepath.Join(cacheDir, ".cache-server.lock")
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lock.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return lock, true, nil
+}
+
+// cleanupStaleCacheRoots reclaims cache directories left by prior machine IDs.
+// It only runs while this node owns the canonical <mount>/<locality>/<node>
+// cache, and skips any sibling still owned by another cache server.
+func cleanupStaleCacheRoots(config cache.Config, locality, nodeID string) (int, error) {
+	mountRoot := filepath.Clean(config.Disk.MountPath)
+	localityName, nodeName := safeCacheName(locality), safeCacheName(nodeID)
+	if localityName == "." || localityName == ".." || nodeName == "." || nodeName == ".." {
+		return 0, nil
+	}
+	localityRoot := filepath.Join(mountRoot, localityName)
+	rel, err := filepath.Rel(mountRoot, localityRoot)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return 0, nil
+	}
+	current := filepath.Clean(config.Server.DiskCacheDir)
+	expected := filepath.Join(localityRoot, nodeName)
+	if current != expected {
+		return 0, nil
+	}
+
+	entries, err := os.ReadDir(localityRoot)
+	if err != nil {
+		return 0, err
+	}
+	quarantines := make([]string, 0)
+	defer func() { removeCacheRootsAsync(quarantines) }()
+	removed := 0
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".beta9-stale-cache-") {
+			quarantines = append(quarantines, filepath.Join(localityRoot, entry.Name()))
+			continue
+		}
+		if entry.Name() == filepath.Base(current) || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		stalePath := filepath.Join(localityRoot, entry.Name())
+		lock, acquired, err := acquireExistingCacheServerLock(stalePath)
+		if err != nil {
+			return removed, err
+		}
+		if !acquired {
+			continue
+		}
+
+		quarantine := filepath.Join(localityRoot, fmt.Sprintf(".beta9-stale-cache-%d", time.Now().UnixNano()))
+		if err := os.Rename(stalePath, quarantine); err != nil {
+			_ = releaseCacheServerLock(lock)
+			return removed, err
+		}
+		_ = releaseCacheServerLock(lock)
+		quarantines = append(quarantines, quarantine)
+		removed++
+	}
+	return removed, nil
+}
+
+func removeCacheRootsAsync(paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	go func() {
+		for _, path := range paths {
+			if err := os.RemoveAll(path); err != nil {
+				log.Warn().Err(err).Str("path", path).Msg("failed to remove quarantined cache root")
+			}
+		}
+	}()
+}
+
+func acquireExistingCacheServerLock(cacheDir string) (*os.File, bool, error) {
+	lock, err := os.OpenFile(filepath.Join(cacheDir, ".cache-server.lock"), os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {

--- a/pkg/worker/cache_manager_test.go
+++ b/pkg/worker/cache_manager_test.go
@@ -144,6 +144,56 @@ func TestCacheServerLockAllowsSingleNodeLocalOwner(t *testing.T) {
 	require.NoError(t, releaseCacheServerLock(second))
 }
 
+func TestCleanupStaleCacheRootsRemovesOnlyUnlockedCacheRoots(t *testing.T) {
+	mountPath := t.TempDir()
+	localityRoot := filepath.Join(mountPath, "skynet")
+	current := filepath.Join(localityRoot, "current")
+	stale := filepath.Join(localityRoot, "stale")
+	busy := filepath.Join(localityRoot, "busy")
+	unowned := filepath.Join(localityRoot, "unowned")
+	require.NoError(t, os.MkdirAll(current, 0o755))
+	require.NoError(t, os.MkdirAll(unowned, 0o755))
+
+	staleLock, acquired, err := acquireCacheServerLock(stale)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NoError(t, releaseCacheServerLock(staleLock))
+	require.NoError(t, os.WriteFile(filepath.Join(stale, "content"), []byte("cached"), 0o600))
+
+	busyLock, acquired, err := acquireCacheServerLock(busy)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	defer func() { require.NoError(t, releaseCacheServerLock(busyLock)) }()
+
+	removed, err := cleanupStaleCacheRoots(cache.Config{
+		Disk:   cache.DiskConfig{MountPath: mountPath},
+		Server: cache.ServerConfig{DiskCacheDir: current},
+	}, "skynet", "current")
+	require.NoError(t, err)
+	require.Equal(t, 1, removed)
+	require.NoDirExists(t, stale)
+	require.DirExists(t, current)
+	require.DirExists(t, busy)
+	require.DirExists(t, unowned)
+}
+
+func TestCleanupStaleCacheRootsRejectsTraversalComponents(t *testing.T) {
+	mountPath := t.TempDir()
+	stale := filepath.Join(mountPath, "stale")
+	lock, acquired, err := acquireCacheServerLock(stale)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NoError(t, releaseCacheServerLock(lock))
+
+	removed, err := cleanupStaleCacheRoots(cache.Config{
+		Disk:   cache.DiskConfig{MountPath: mountPath},
+		Server: cache.ServerConfig{DiskCacheDir: filepath.Join(mountPath, "current")},
+	}, ".", "current")
+	require.NoError(t, err)
+	require.Zero(t, removed)
+	require.DirExists(t, stale)
+}
+
 func TestEmbeddedWorkerSkipsCacheServerWhenDaemonSetMarkerFresh(t *testing.T) {
 	t.Setenv(types.CacheServerOnlyEnv, "false")
 

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -37,6 +37,7 @@ import (
 	repo "github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
 	pb "github.com/beam-cloud/beta9/proto"
+	"github.com/beam-cloud/clip/pkg/clip"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -497,7 +498,7 @@ func (m *WorkerCacheManager) reconcileOnce() {
 	}
 	m.pruneOwnerStubCodeCache(server)
 
-	gated, reconcileAllowlist := m.reconcileGatedByDiskUsage(server, localHostID, protectedContent, stubContent, requiredContentComplete)
+	gated, reconcileAllowlist := m.reconcileGatedByDiskUsage(server, localHostID, protectedContent, stubContent, protectedSetComplete)
 	if gated {
 		return
 	}
@@ -709,6 +710,194 @@ func (m *WorkerCacheManager) pruneOwnerLocalCache(server *cache.Server, protecte
 	m.pruneStaleCacheCheckpoints()
 }
 
+type imageCacheProtection struct {
+	names    map[string]struct{}
+	complete bool
+}
+
+type imageCacheEntry struct {
+	path     string
+	name     string
+	size     int64
+	modified time.Time
+}
+
+func (m *WorkerCacheManager) pruneOwnerImageCache(stubs []recentStubContent, softWatermark float64, minFreeBytes int64) int64 {
+	root := getImageCachePath()
+	usage, err := fastDiskUsage(root)
+	if err != nil {
+		return 0
+	}
+	bytesToFree := maxInt64(reconcilePressureBytesToFree(usage, softWatermark, minFreeBytes), 0)
+	var allowlist map[string]struct{}
+	if bytesToFree > 0 {
+		allowlist = pressureProtectedContentFromRecentStubs(stubs, m.accelerator, usage, softWatermark, minFreeBytes)
+	}
+	protected := protectedImageCache(stubs, allowlist, root, filepath.Join(types.AgentImagesPath, "mnt"))
+	evicted, freed := evictImageCache(root, protected, time.Now().Add(-m.recentStubTTL()), bytesToFree)
+	if evicted > 0 {
+		event := log.Info()
+		message := "pruned stale image cache content"
+		if bytesToFree > 0 {
+			event = log.Warn()
+			message = "pressure-evicted image cache content"
+		}
+		event.
+			Int("evicted", evicted).
+			Int64("freed_bytes", freed).
+			Int64("target_free_bytes", bytesToFree).
+			Float64("disk_usage_pct", usage.UsagePct).
+			Bool("mount_protection_complete", protected.complete).
+			Msg(message)
+	}
+	return freed
+}
+
+func protectedImageCache(stubs []recentStubContent, allowlist map[string]struct{}, cacheRoot, mountRoot string) imageCacheProtection {
+	protected := imageCacheProtection{names: map[string]struct{}{}, complete: true}
+	protectImage := func(imageID string) {
+		if imageID == "" {
+			return
+		}
+		for _, suffix := range []string{".clip", ".rclip", ".cache"} {
+			protected.names[imageID+suffix] = struct{}{}
+		}
+	}
+
+	for _, stub := range stubs {
+		for _, item := range stub.items {
+			if allowlist != nil {
+				if _, ok := allowlist[item.Hash]; !ok {
+					continue
+				}
+			}
+			protectImage(item.ImageID)
+			if item.Kind == types.CacheContentKindClipV2 && isSHA256HexDigest(item.Hash) {
+				protected.names[item.Hash] = struct{}{}
+			}
+		}
+	}
+
+	workers, err := os.ReadDir(mountRoot)
+	if err != nil {
+		protected.complete = false
+		return protected
+	}
+	for _, worker := range workers {
+		if !worker.IsDir() || worker.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		images, err := os.ReadDir(filepath.Join(mountRoot, worker.Name()))
+		if err != nil {
+			protected.complete = false
+			continue
+		}
+		for _, image := range images {
+			if !image.IsDir() || image.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			protectImage(image.Name())
+			layers, ok := activeImageLayers(cacheRoot, image.Name())
+			if !ok {
+				protected.complete = false
+				continue
+			}
+			for _, hash := range layers {
+				protected.names[hash] = struct{}{}
+			}
+		}
+	}
+	return protected
+}
+
+func activeImageLayers(cacheRoot, imageID string) ([]string, bool) {
+	for _, suffix := range []string{".rclip", ".clip"} {
+		path := filepath.Join(cacheRoot, imageID+suffix)
+		info, err := os.Stat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+			continue
+		}
+		meta, err := clip.NewClipArchiver().ExtractMetadata(path)
+		if err != nil {
+			continue
+		}
+		oci, ok := ociStorageInfo(meta)
+		if !ok {
+			return nil, true
+		}
+		layers := make([]string, 0, len(oci.DecompressedHashByLayer))
+		for _, hash := range oci.DecompressedHashByLayer {
+			if isSHA256HexDigest(hash) {
+				layers = append(layers, hash)
+			}
+		}
+		return layers, true
+	}
+	return nil, false
+}
+
+func evictImageCache(root string, protected imageCacheProtection, cutoff time.Time, bytesToFree int64) (int, int64) {
+	if !protected.complete || cutoff.IsZero() && bytesToFree <= 0 {
+		return 0, 0
+	}
+	scanStarted := time.Now()
+	entries := listImageCacheEntries(root)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].modified.Before(entries[j].modified) })
+
+	evicted := 0
+	var freed int64
+	lockCtx, cancelLocks := context.WithCancel(context.Background())
+	cancelLocks()
+	for _, entry := range entries {
+		stale := !cutoff.IsZero() && entry.modified.Before(cutoff)
+		pressure := bytesToFree > 0 && freed < bytesToFree
+		if !stale && !pressure {
+			continue
+		}
+		if _, ok := protected.names[entry.name]; ok {
+			continue
+		}
+
+		unlock, err := lockImageArchiveFile(lockCtx, entry.path)
+		if err != nil {
+			continue
+		}
+		info, statErr := os.Stat(entry.path)
+		unchanged := statErr == nil && info.Mode().IsRegular() && info.Size() == entry.size && info.ModTime().Equal(entry.modified) && !info.ModTime().After(scanStarted)
+		if unchanged && os.Remove(entry.path) == nil {
+			evicted++
+			freed += entry.size
+		}
+		unlock()
+	}
+	return evicted, freed
+}
+
+func listImageCacheEntries(root string) []imageCacheEntry {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	out := make([]imageCacheEntry, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		layer := isSHA256HexDigest(name)
+		if !layer {
+			switch filepath.Ext(name) {
+			case ".clip", ".rclip", ".cache":
+			default:
+				continue
+			}
+		}
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 {
+			continue
+		}
+		out = append(out, imageCacheEntry{path: filepath.Join(root, name), name: name, size: info.Size(), modified: info.ModTime()})
+	}
+	return out
+}
+
 const (
 	stubCodeReadyMarker      = ".beta9-cache-ready"
 	stubCodeTempDirGraceTime = 30 * time.Minute
@@ -878,7 +1067,7 @@ func fastDiskUsage(path string) (cache.DiskUsage, error) {
 // pauses the current cycle; between the resume and soft watermarks it reconciles
 // only that ranked set. This avoids download/evict loops while still favoring
 // the newest useful content on a mostly-full node.
-func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, localHostID string, protected map[string]struct{}, stubContent []recentStubContent, requiredContentComplete bool) (bool, map[string]struct{}) {
+func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, localHostID string, protected map[string]struct{}, stubContent []recentStubContent, protectedSetComplete bool) (bool, map[string]struct{}) {
 	usage, err := server.RefreshDiskUsage()
 	if err != nil {
 		log.Debug().Err(err).Str("locality", m.locality).Str("logical_host", localHostID).Msg("cache reconciliation failed to refresh disk usage")
@@ -890,6 +1079,11 @@ func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, loc
 
 	softWatermark := m.reconcileMaxDiskUsagePct()
 	resumeWatermark := reconcileResumeDiskUsagePct(softWatermark)
+	if protectedSetComplete && m.pruneOwnerImageCache(stubContent, softWatermark, server.DiskMinFreeBytes()) > 0 {
+		if refreshed, refreshErr := server.RefreshDiskUsage(); refreshErr == nil {
+			usage = refreshed
+		}
+	}
 	pressureMode := usage.UsagePct >= resumeWatermark
 	if !m.reconcilePausedAt.IsZero() {
 		if usage.UsagePct > resumeWatermark {
@@ -917,7 +1111,7 @@ func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, loc
 	}
 
 	bytesToFree := reconcilePressureBytesToFree(usage, softWatermark, server.DiskMinFreeBytes())
-	if bytesToFree > 0 && !requiredContentComplete {
+	if bytesToFree > 0 && !protectedSetComplete {
 		server.SetProtectedContent(protected)
 		if m.reconcilePausedAt.IsZero() {
 			m.reconcilePausedAt = time.Now()

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -605,6 +605,8 @@ func TestReconcileOnceUsesOnlyCurrentLocalityRecentStubs(t *testing.T) {
 }
 
 func TestLocalHostOwnsForReconcileKeepsOwnershipThroughBriefEndpointLoss(t *testing.T) {
+	require.Equal(t, cacheDefaultRegistrationTTL, cacheReconcileOwnerGracePeriod)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1448,6 +1450,12 @@ func testClipV2Metadata() *clipCommon.ClipArchiveMetadata {
 	}
 }
 
+func reportRequiredContentForTest(client *ImageClient, request *types.ContainerRequest, metadata *clipCommon.ClipArchiveMetadata) {
+	if report, ok := client.imageRequiredContent(context.Background(), request, metadata); ok {
+		client.publishRequiredContent(request, report)
+	}
+}
+
 func TestReportRequiredContentClipV1EmitsSingleArchiveObject(t *testing.T) {
 	fake := &fakeEventRepo{}
 	client := newTestV1ImageClient(newTestReporter(fake), &cache.FSMetadata{Hash: "archive-hash", Size: 4096})
@@ -1457,7 +1465,7 @@ func TestReportRequiredContentClipV1EmitsSingleArchiveObject(t *testing.T) {
 		ImageId:     "image",
 	}
 
-	client.reportRequiredContent(context.Background(), request, testClipV1Metadata(t))
+	reportRequiredContentForTest(client, request, testClipV1Metadata(t))
 	client.contentReporter.flush()
 
 	require.Len(t, fake.pushed, 1)
@@ -1487,7 +1495,7 @@ func TestReportRequiredContentClipV1SkipsWhenArchiveUncached(t *testing.T) {
 		ImageId:     "image",
 	}
 
-	client.reportRequiredContent(context.Background(), request, testClipV1Metadata(t))
+	reportRequiredContentForTest(client, request, testClipV1Metadata(t))
 	client.contentReporter.flush()
 
 	require.Empty(t, fake.pushed)
@@ -1506,7 +1514,7 @@ func TestReportRequiredContentUsesNestedRequestIDs(t *testing.T) {
 		},
 	}
 
-	client.reportRequiredContent(context.Background(), request, testClipV2Metadata())
+	reportRequiredContentForTest(client, request, testClipV2Metadata())
 	client.contentReporter.flush()
 
 	require.Len(t, fake.pushed, 1)
@@ -1528,7 +1536,7 @@ func TestReportRequiredContentQueuesReconciliation(t *testing.T) {
 		ImageId:     "image",
 	}
 
-	client.reportRequiredContent(context.Background(), request, testClipV2Metadata())
+	reportRequiredContentForTest(client, request, testClipV2Metadata())
 	reporter.flush()
 
 	require.True(t, requested)
@@ -1587,7 +1595,7 @@ func TestEnsureV1ArchiveDataCacheUsesExistingLocalArchive(t *testing.T) {
 			ImageService: types.ImageServiceConfig{RegistryStore: registry.S3ImageRegistryStore},
 		},
 	}
-	path, ok := client.ensureV1ArchiveDataCache(context.Background(), &types.ContainerRequest{ImageId: "image"}, nil)
+	path, ok := client.restoreV1ArchiveDataCache(context.Background(), &types.ContainerRequest{ImageId: "image"}, nil)
 	require.True(t, ok)
 	require.Equal(t, archivePath, path)
 }
@@ -1652,6 +1660,62 @@ func TestPressureEvictStubCodeCacheSkipsActiveTempEntries(t *testing.T) {
 	require.NoFileExists(t, oldReady)
 	require.NoDirExists(t, filepath.Dir(oldReady))
 	require.DirExists(t, activeTmpDir)
+}
+
+func TestEvictImageCacheProtectsRecentAndMountedImages(t *testing.T) {
+	cacheRoot := t.TempDir()
+	mountRoot := filepath.Join(t.TempDir(), "mnt")
+	activeHash := strings.Repeat("a", 64)
+	recentHash := strings.Repeat("b", 64)
+	staleHash := strings.Repeat("c", 64)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(mountRoot, "worker", "active"), 0o755))
+	oci := &clipCommon.OCIStorageInfo{DecompressedHashByLayer: map[string]string{"sha256:active": activeHash}}
+	meta := testClipV1Metadata(t)
+	meta.StorageInfo = oci
+	require.NoError(t, clip.NewClipArchiver().CreateRemoteArchive(oci, meta, filepath.Join(cacheRoot, "active.rclip")))
+	for _, name := range []string{activeHash, recentHash, staleHash, "recent.rclip", "stale.rclip"} {
+		require.NoError(t, os.WriteFile(filepath.Join(cacheRoot, name), []byte("cached"), 0o600))
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	for _, entry := range listImageCacheEntries(cacheRoot) {
+		require.NoError(t, os.Chtimes(entry.path, old, old))
+	}
+
+	protected := protectedImageCache([]recentStubContent{{items: []types.CacheRequiredContentItem{{
+		ImageID: "recent", Hash: recentHash, Kind: types.CacheContentKindClipV2,
+	}}}}, nil, cacheRoot, mountRoot)
+	evicted, _ := evictImageCache(cacheRoot, protected, time.Now().Add(-time.Hour), 0)
+
+	require.True(t, protected.complete)
+	require.Equal(t, 2, evicted)
+	require.FileExists(t, filepath.Join(cacheRoot, activeHash))
+	require.FileExists(t, filepath.Join(cacheRoot, recentHash))
+	require.FileExists(t, filepath.Join(cacheRoot, "active.rclip"))
+	require.FileExists(t, filepath.Join(cacheRoot, "recent.rclip"))
+	require.NoFileExists(t, filepath.Join(cacheRoot, staleHash))
+	require.NoFileExists(t, filepath.Join(cacheRoot, "stale.rclip"))
+}
+
+func TestEvictImageCacheFailsClosedForLayersWithoutMountedMetadata(t *testing.T) {
+	cacheRoot := t.TempDir()
+	mountRoot := filepath.Join(t.TempDir(), "mnt")
+	layerHash := strings.Repeat("d", 64)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountRoot, "worker", "active-without-metadata"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheRoot, layerHash), []byte("layer"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheRoot, "stale.clip"), []byte("archive"), 0o600))
+	old := time.Now().Add(-2 * time.Hour)
+	for _, entry := range listImageCacheEntries(cacheRoot) {
+		require.NoError(t, os.Chtimes(entry.path, old, old))
+	}
+
+	protected := protectedImageCache(nil, nil, cacheRoot, mountRoot)
+	evicted, _ := evictImageCache(cacheRoot, protected, time.Now().Add(-time.Hour), 0)
+
+	require.False(t, protected.complete)
+	require.Zero(t, evicted)
+	require.FileExists(t, filepath.Join(cacheRoot, layerHash))
+	require.FileExists(t, filepath.Join(cacheRoot, "stale.clip"))
 }
 
 func writeStubCodeCacheEntry(t *testing.T, root, name string, readyTime time.Time) string {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -153,6 +154,7 @@ type ImageClient struct {
 	logger             *ContainerLogger
 	eventRepo          repo.EventRepository
 	contentReporter    *cacheContentReporter
+	v1CacheGroup       singleflight.Group
 	originCredsMu      sync.Mutex
 	originCredsCache   map[string]*originCredentials
 	// archiveContentMetadata resolves the cached image archive object (hash/size)
@@ -275,11 +277,9 @@ func ociStorageInfo(meta *clipCommon.ClipArchiveMetadata) (*clipCommon.OCIStorag
 
 func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger, preload bool) (time.Duration, error) {
 	startTime := time.Now()
-	if c.contentReporter != nil && request != nil {
-		c.contentReporter.touchRecentStub(cacheRequestWorkspaceID(request), cacheRequestStubID(request))
-	}
 
 	if elapsed, ok := c.mountedImageHit(startTime, request, "clip_mounted_fuse_hit"); ok {
+		c.recordSuccessfulImageLoad(ctx, request, nil)
 		return elapsed, nil
 	}
 
@@ -289,6 +289,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	defer unlockMount()
 
 	if elapsed, ok := c.mountedImageHit(startTime, request, "clip_mounted_fuse_hit_after_local_lock"); ok {
+		c.recordSuccessfulImageLoad(ctx, request, nil)
 		return elapsed, nil
 	}
 
@@ -310,6 +311,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	}
 
 	if elapsed, ok := c.mountedImageHit(startTime, request, "clip_mounted_fuse_hit"); ok {
+		c.recordSuccessfulImageLoad(ctx, request, archive.metadata)
 		return elapsed, nil
 	}
 
@@ -322,6 +324,7 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	defer releaseImageLock()
 
 	if elapsed, ok := c.mountedImageHit(startTime, request, "clip_mounted_fuse_hit_after_lock"); ok {
+		c.recordSuccessfulImageLoad(ctx, request, archive.metadata)
 		return elapsed, nil
 	}
 
@@ -335,8 +338,29 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 	c.recordImageLifecycle(request, types.ContainerLifecycleID("image.mount_archive"), mountStart, time.Since(mountStart), true, map[string]string{
 		"storage_mode": archive.storageMode,
 	})
+	c.recordSuccessfulImageLoad(ctx, request, archive.metadata)
 
 	return time.Since(startTime), nil
+}
+
+// recordSuccessfulImageLoad activates reconciliation only in a locality that
+// actually served the workload. A failed failover attempt must not retain or
+// proactively materialize that stub's content.
+func (c *ImageClient) recordSuccessfulImageLoad(ctx context.Context, request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) {
+	if c == nil || c.contentReporter == nil || request == nil {
+		return
+	}
+	if meta == nil && c.v2ArchiveMetadata != nil {
+		meta, _ = c.v2ArchiveMetadata.Get(request.ImageId)
+	}
+	if _, isOCI := ociStorageInfo(meta); isOCI {
+		if report, ok := c.imageRequiredContent(ctx, request, meta); ok {
+			c.publishRequiredContent(request, report)
+		}
+	} else {
+		c.queueV1ArchiveCache(request)
+	}
+	c.contentReporter.touchRecentStub(cacheRequestWorkspaceID(request), cacheRequestStubID(request))
 }
 
 func imageLayerPrepareProgressLogger(outputLogger *slog.Logger) func(clipStorage.PrepareProgress) {
@@ -448,33 +472,13 @@ func (c *ImageClient) prepareLazyImageArchive(ctx context.Context, request *type
 		if archive.sourceRegistry == nil || archive.sourceRegistry.BucketName == "" {
 			archive.sourceRegistry = c.imageArchiveSourceRegistry(ctx, request)
 		}
-		if localArchivePath, ok := c.ensureV1ArchiveDataCache(ctx, request, archive.sourceRegistry); ok {
+		if localArchivePath, ok := c.restoreV1ArchiveDataCache(ctx, request, archive.sourceRegistry); ok {
 			archive.path = localArchivePath
 			archive.sourceRegistry = nil
 			archive.storageMode = string(clipCommon.StorageModeLocal)
 		}
 	}
-	c.reportRequiredContent(ctx, request, meta)
-
 	return archive, nil
-}
-
-// reportRequiredContent enumerates the content a stub's image requires and feeds
-// it to the cache reconciliation reporter. It runs at image-load time (off the
-// read hot path) and is a no-op when reconciliation is disabled.
-func (c *ImageClient) reportRequiredContent(ctx context.Context, request *types.ContainerRequest, meta *clipCommon.ClipArchiveMetadata) {
-	if request == nil || meta == nil {
-		return
-	}
-
-	report, ok := c.imageRequiredContent(ctx, request, meta)
-	if !ok {
-		// Nothing to report; do not claim the one-time generation so a later
-		// load that does yield content can still publish it.
-		return
-	}
-
-	c.publishRequiredContent(request, report)
 }
 
 func (c *ImageClient) publishRequiredContent(request *types.ContainerRequest, report requiredContentReport) {
@@ -595,13 +599,6 @@ func (c *ImageClient) clipV1ArchiveRequiredContent(ctx context.Context, request 
 	}, true
 }
 
-// imageArchiveSourceKey returns the image registry object key for a stub's
-// archive (e.g. "{imageId}.rclip"), matching the key used by the embedded-cache
-// pull that originally stored it.
-func (c *ImageClient) imageArchiveSourceKey(imageId string) string {
-	return fmt.Sprintf("%s.%s", imageId, c.registry.ImageFileExtension)
-}
-
 // ociLayerReference builds a fully-qualified, non-secret OCI layer digest
 // reference (registry/repository@sha256:...) used as the required-content source
 // descriptor so a cache host can fetch and decompress the layer from origin.
@@ -666,16 +663,16 @@ func isOCIStorageMode(mode string) bool {
 }
 
 func (c *ImageClient) lazyMountOptions(ctx context.Context, request *types.ContainerRequest, archive lazyImageArchive) clip.MountOptions {
-	cacheKind := "legacy-file-runtime"
+	cachePath := c.contentCachePath(request, archive)
+	var contentCache *imageContentCache
 	if archive.usesOCIStorage() {
-		cacheKind = "oci-layer-runtime"
+		contentCache = newImageContentCache(c.cacheClient, request.ImageId, "oci-layer-runtime", c.imageContentCacheObserver(request))
 	}
-	contentCache := newImageContentCache(c.cacheClient, request.ImageId, cacheKind, c.imageContentCacheObserver(request))
 	mountOptions := clip.MountOptions{
 		ArchivePath:           archive.path,
 		Metadata:              archive.metadata,
 		MountPoint:            c.imageMountPoint(request.ImageId),
-		CachePath:             c.contentCachePath(request, archive),
+		CachePath:             cachePath,
 		ContentCache:          contentCache,
 		ContentCacheAvailable: contentCache != nil,
 	}
@@ -729,7 +726,7 @@ func (c *ImageClient) contentCachePath(request *types.ContainerRequest, archive 
 	return ""
 }
 
-func (c *ImageClient) ensureV1ArchiveDataCache(ctx context.Context, request *types.ContainerRequest, sourceRegistry *types.S3ImageRegistryConfig) (string, bool) {
+func (c *ImageClient) restoreV1ArchiveDataCache(ctx context.Context, request *types.ContainerRequest, sourceRegistry *types.S3ImageRegistryConfig) (path string, ok bool) {
 	if request == nil || c.config.ImageService.RegistryStore != registry.S3ImageRegistryStore {
 		return "", false
 	}
@@ -737,140 +734,157 @@ func (c *ImageClient) ensureV1ArchiveDataCache(ctx context.Context, request *typ
 	imageID := request.ImageId
 	targetPath := c.clipV1ArchiveDataCachePath(imageID)
 	if c.localImageArchiveReady(targetPath, imageID) {
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, time.Now(), 0, true, map[string]string{"source": "local"})
 		return targetPath, true
 	}
 
 	cachePath := c.clipV1ArchiveCachePath(imageID)
-	if sourceRegistry == nil || sourceRegistry.BucketName == "" {
-		sourceRegistry = c.imageArchiveSourceRegistry(ctx, request)
-	}
-
-	if deferRestore, size := c.deferV1ArchiveDataRestore(ctx, imageID, cachePath, sourceRegistry); deferRestore {
-		attrs := map[string]string{
-			"reason":          "large_archive_with_remote_source",
-			"size_bytes":      fmt.Sprintf("%d", size),
-			"threshold_bytes": fmt.Sprintf("%d", maxSyncV1ArchiveDataRestoreBytes),
+	var metadata *cache.FSMetadata
+	if c.cacheClient != nil && c.archiveContentMetadata != nil {
+		var err error
+		metadata, err = c.archiveContentMetadata(ctx, cachePath)
+		if err != nil && !isEmbeddedImageCacheMiss(err) {
+			log.Debug().Err(err).Str("image_id", imageID).Str("cache_path", cachePath).Msg("v1 image data archive cache metadata unavailable")
 		}
-		c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheDeferred, time.Now(), 0, true, attrs)
-		c.warmV1ArchiveDataCacheAsync(imageID, targetPath, cachePath, *sourceRegistry)
-		return "", false
 	}
 
-	restoreStart := time.Now()
-	path, ok := c.materializeV1ArchiveDataCache(ctx, request, imageID, targetPath, cachePath, sourceRegistry)
-	c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, restoreStart, time.Since(restoreStart), ok, nil)
-	return path, ok
-}
-
-func (c *ImageClient) materializeV1ArchiveDataCache(ctx context.Context, request *types.ContainerRequest, imageID, targetPath, cachePath string, sourceRegistry *types.S3ImageRegistryConfig) (string, bool) {
-	unlock, err := lockImageArchiveFile(ctx, targetPath)
+	brokeredOnly := (sourceRegistry == nil || sourceRegistry.BucketName == "") && c.brokeredImageAccessRequest(request)
+	lockWait := embeddedImageCacheLockWaitTimeout
+	if brokeredOnly {
+		// URL-only workers cannot fall back to a credentialed remote mount. Wait
+		// for the current downloader, then recheck the archive under its lock.
+		lockWait = imageArchiveDownloadTimeout
+	}
+	startedAt := time.Now()
+	lockCtx, cancel := context.WithTimeout(ctx, lockWait)
+	unlock, err := lockImageArchiveFile(lockCtx, targetPath)
+	cancel()
 	if err != nil {
-		log.Debug().Err(err).Str("image_id", imageID).Str("path", targetPath).Msg("v1 image data archive lock failed")
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheDeferred, startedAt, time.Since(startedAt), true, map[string]string{"reason": "archive_lock_busy"})
 		return "", false
 	}
 	defer unlock()
-
 	if c.localImageArchiveReady(targetPath, imageID) {
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, startedAt, time.Since(startedAt), true, map[string]string{"source": "local_after_lock"})
 		return targetPath, true
 	}
-
-	if c.cacheClient != nil {
-		if ok, err := c.copyImageArchiveFromContentCachePath(ctx, targetPath, imageID, cachePath); err != nil {
-			log.Debug().Err(err).Str("image_id", imageID).Str("cache_path", cachePath).Msg("v1 image data archive content cache restore failed")
-		} else if ok {
-			return targetPath, true
+	if info, statErr := os.Stat(targetPath); statErr == nil && (info.IsDir() || info.Size() > 0) {
+		if err := os.RemoveAll(targetPath); err != nil {
+			log.Debug().Err(err).Str("image_id", imageID).Str("path", targetPath).Msg("v1 image data archive cleanup failed")
+			return "", false
 		}
 	}
 
-	if sourceRegistry == nil || sourceRegistry.BucketName == "" {
-		if request != nil && c.downloadV1ArchiveDataFromBrokeredURL(ctx, request, targetPath, cachePath) {
-			return targetPath, true
+	if metadata != nil && metadata.Hash != "" && metadata.Size > 0 {
+		if metadata.Size > maxSyncV1ArchiveDataRestoreBytes && sourceRegistry != nil && sourceRegistry.BucketName != "" {
+			c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheDeferred, startedAt, time.Since(startedAt), true, map[string]string{
+				"reason":          "large_archive_with_remote_source",
+				"size_bytes":      fmt.Sprintf("%d", metadata.Size),
+				"threshold_bytes": fmt.Sprintf("%d", maxSyncV1ArchiveDataRestoreBytes),
+			})
+			return "", false
 		}
-		return "", false
-	}
-	if c.cacheClient == nil {
-		return "", false
-	}
-
-	key := c.clipV1ArchiveDataSourceKey(imageID)
-	routingKey := cachePath
-	hash, err := c.cacheClient.StoreContentFromS3Source(cache.S3ContentSource{
-		Path:           key,
-		CachePath:      cachePath,
-		BucketName:     sourceRegistry.BucketName,
-		Region:         sourceRegistry.Region,
-		EndpointURL:    sourceRegistry.Endpoint,
-		AccessKey:      sourceRegistry.AccessKey,
-		SecretKey:      sourceRegistry.SecretKey,
-		ForcePathStyle: sourceRegistry.ForcePathStyle,
-	}, cache.StoreContentOptions{RoutingKey: routingKey, Lock: true})
-	if err != nil {
-		if errors.Is(err, cache.ErrUnableToAcquireLock) {
-			if ok, waitErr := c.waitForImageArchiveContentCachePath(ctx, targetPath, imageID, cachePath); ok {
+		if metadata.Size <= uint64(^uint(0)>>1) {
+			err := c.writeImageArchiveFromContentCache(ctx, targetPath, imageID, metadata.Hash, int64(metadata.Size), cachePath)
+			if err == nil {
+				c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, startedAt, time.Since(startedAt), true, map[string]string{"source": "content_cache"})
 				return targetPath, true
-			} else if waitErr != nil {
-				log.Debug().Err(waitErr).Str("image_id", imageID).Str("cache_path", cachePath).Msg("v1 image data archive content cache lock wait failed")
 			}
-		} else {
-			log.Debug().Err(err).Str("image_id", imageID).Str("cache_path", cachePath).Str("source", key).Msg("v1 image data archive content cache store failed")
-		}
-		return "", false
-	}
-
-	size, err := c.imageArchiveSize(ctx, imageID, key, sourceRegistry)
-	if err != nil {
-		log.Debug().Err(err).Str("image_id", imageID).Str("source", key).Msg("v1 image data archive size lookup failed")
-		return "", false
-	}
-	if err := c.writeImageArchiveFromContentCache(ctx, targetPath, imageID, hash, size, routingKey); err != nil {
-		log.Debug().Err(err).Str("image_id", imageID).Str("cache_path", cachePath).Msg("v1 image data archive content cache write failed")
-		return "", false
-	}
-	return targetPath, true
-}
-
-func (c *ImageClient) deferV1ArchiveDataRestore(ctx context.Context, imageID, cachePath string, sourceRegistry *types.S3ImageRegistryConfig) (bool, int64) {
-	if sourceRegistry == nil || sourceRegistry.BucketName == "" {
-		return false, 0
-	}
-
-	if c.cacheClient != nil {
-		if metadata, err := c.cacheClient.CacheFSMetadata(ctx, cachePath); err == nil && metadata != nil && metadata.Size > 0 {
-			size := int64(metadata.Size)
-			return size > maxSyncV1ArchiveDataRestoreBytes, size
+			if !isEmbeddedImageCacheMiss(err) {
+				log.Debug().Err(err).Str("image_id", imageID).Str("cache_path", cachePath).Msg("v1 image data archive content cache restore failed")
+				c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, startedAt, time.Since(startedAt), false, nil)
+			}
 		}
 	}
 
-	size, err := c.imageArchiveSize(ctx, imageID, c.clipV1ArchiveDataSourceKey(imageID), sourceRegistry)
-	if err != nil {
-		return false, 0
+	if brokeredOnly {
+		if c.downloadV1ArchiveDataFromBrokeredURL(ctx, request, targetPath) {
+			c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, startedAt, time.Since(startedAt), true, map[string]string{"source": "brokered_url"})
+			return targetPath, true
+		}
+		c.recordImageLifecycle(request, types.ContainerLifecycleImageV1DataCacheRestore, startedAt, time.Since(startedAt), false, map[string]string{"source": "brokered_url"})
 	}
-	return size > maxSyncV1ArchiveDataRestoreBytes, size
+	// S3-backed v1 images are mounted remotely. CLIP owns the only origin
+	// downloader and atomically fills CachePath after the mount is live.
+	return "", false
 }
 
-func (c *ImageClient) warmV1ArchiveDataCacheAsync(imageID, targetPath, cachePath string, sourceRegistry types.S3ImageRegistryConfig) {
-	if c.cacheClient == nil || imageID == "" || targetPath == "" || sourceRegistry.BucketName == "" {
+func (c *ImageClient) queueV1ArchiveCache(request *types.ContainerRequest) {
+	workspaceID := cacheRequestWorkspaceID(request)
+	stubID := cacheRequestStubID(request)
+	if request == nil || request.ImageId == "" || workspaceID == "" || stubID == "" ||
+		c.cacheClient == nil || c.archiveContentMetadata == nil ||
+		c.config.ImageService.RegistryStore != registry.S3ImageRegistryStore {
 		return
 	}
 
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), imageArchiveDownloadTimeout)
-		defer cancel()
+	go c.completeV1ArchiveCache(&types.ContainerRequest{
+		WorkspaceId: workspaceID,
+		StubId:      stubID,
+		ImageId:     request.ImageId,
+	})
+}
 
-		if c.localImageArchiveReady(targetPath, imageID) {
+// completeV1ArchiveCache waits for CLIP to atomically fill the whole v1
+// archive, coalesces cache seeding by image, then publishes this stub's normal
+// required-content report. Each caller owns its timeout, so a late workload
+// cannot be lost at the boundary of an earlier cache attempt.
+func (c *ImageClient) completeV1ArchiveCache(request *types.ContainerRequest) {
+	ctx, cancel := context.WithTimeout(context.Background(), imageArchiveDownloadTimeout)
+	defer cancel()
+
+	imageID := request.ImageId
+	for ctx.Err() == nil {
+		result := c.v1CacheGroup.DoChan(imageID, func() (any, error) {
+			return c.waitForV1ArchiveCache(imageID)
+		})
+		select {
+		case <-ctx.Done():
 			return
+		case outcome := <-result:
+			if item, ok := outcome.Val.(types.CacheRequiredContentItem); outcome.Err == nil && ok && item.Hash != "" {
+				c.publishRequiredContent(request, requiredContentReport{kind: types.CacheContentKindClipV1, items: []types.CacheRequiredContentItem{item}})
+				return
+			}
 		}
-		if _, ok := c.materializeV1ArchiveDataCache(ctx, nil, imageID, targetPath, cachePath, &sourceRegistry); !ok {
-			log.Debug().Str("image_id", imageID).Str("cache_path", cachePath).Msg("background v1 image data archive warm skipped")
+	}
+}
+
+// waitForV1ArchiveCache is the single shared retry loop for an image. A late
+// caller that joins an expiring flight can start a fresh flight using its own
+// remaining deadline, without multiplying cache metadata traffic.
+func (c *ImageClient) waitForV1ArchiveCache(imageID string) (types.CacheRequiredContentItem, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), imageArchiveDownloadTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	request := &types.ContainerRequest{ImageId: imageID}
+	localPath := c.clipV1ArchiveDataCachePath(imageID)
+	cachePath := c.clipV1ArchiveCachePath(imageID)
+	localReady, seeded := false, false
+	for {
+		if item, ok := c.clipV1ArchiveRequiredContent(ctx, request); ok {
+			return item, nil
 		}
-	}()
+		if !localReady {
+			localReady = c.localImageArchiveReady(localPath, imageID)
+		}
+		if localReady && !seeded {
+			seeded = c.seedV1ArchiveDataInEmbeddedCache(localPath, cachePath, imageID) == nil
+		}
+		select {
+		case <-ctx.Done():
+			return types.CacheRequiredContentItem{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 // downloadV1ArchiveDataFromBrokeredURL restores the CLIP v1 data archive
 // through a gateway-presigned URL when no S3 source is available. Agent-hosted
-// pools hold no image registry credentials, so the archive lands on local disk
-// and is then seeded into the embedded cache off the hot path.
-func (c *ImageClient) downloadV1ArchiveDataFromBrokeredURL(ctx context.Context, request *types.ContainerRequest, targetPath, cachePath string) bool {
+// pools hold no image registry credentials, so the archive lands on local disk.
+func (c *ImageClient) downloadV1ArchiveDataFromBrokeredURL(ctx context.Context, request *types.ContainerRequest, targetPath string) bool {
 	if !c.brokeredImageAccessRequest(request) {
 		return false
 	}
@@ -890,21 +904,22 @@ func (c *ImageClient) downloadV1ArchiveDataFromBrokeredURL(ctx context.Context, 
 		return false
 	}
 
-	go c.seedV1ArchiveDataInEmbeddedCache(targetPath, cachePath, request.ImageId)
 	log.Info().Str("image_id", request.ImageId).Msg("restored v1 image data archive from brokered URL")
 	return true
 }
 
-func (c *ImageClient) seedV1ArchiveDataInEmbeddedCache(localPath, cachePath, imageId string) {
+func (c *ImageClient) seedV1ArchiveDataInEmbeddedCache(localPath, cachePath, imageId string) error {
 	if c.cacheClient == nil {
-		return
+		return errors.New("image content cache is disabled")
 	}
-	if _, err := c.cacheClient.StoreContentFromLocalFile(cache.LocalContentSource{
+	_, err := c.cacheClient.StoreContentFromLocalFile(cache.LocalContentSource{
 		Path:      localPath,
 		CachePath: cachePath,
-	}, cache.StoreContentOptions{RoutingKey: cachePath, Lock: true}); err != nil {
+	}, cache.StoreContentOptions{RoutingKey: cachePath, Lock: true})
+	if err != nil {
 		log.Debug().Err(err).Str("image_id", imageId).Str("cache_path", cachePath).Msg("v1 image data archive embedded cache seed failed")
 	}
+	return err
 }
 
 func (c *ImageClient) localImageArchiveReady(archivePath, imageID string) bool {
@@ -913,12 +928,10 @@ func (c *ImageClient) localImageArchiveReady(archivePath, imageID string) bool {
 		return false
 	}
 	if info.IsDir() || info.Size() <= 0 {
-		_ = os.RemoveAll(archivePath)
 		return false
 	}
 	if err := c.validateRestoredImageArchive(archivePath, imageID, info.Size()); err != nil {
-		log.Debug().Err(err).Str("image_id", imageID).Str("path", archivePath).Msg("discarding invalid local image archive")
-		_ = os.Remove(archivePath)
+		log.Debug().Err(err).Str("image_id", imageID).Str("path", archivePath).Msg("local image archive is not ready")
 		return false
 	}
 	return true
@@ -2289,7 +2302,7 @@ func (c *ImageClient) createOCIImageWithProgress(ctx context.Context, outputLogg
 		CheckpointMiB:    checkpointMiB,
 		ProgressChan:     progressChan,
 		CredProvider:     c.getCredentialProviderForImage(ctx, request.ImageId, request),
-		ContentCache:     newImageContentCache(c.cacheClient, request.ImageId, "oci-layer-build"),
+		ContentCache:     newImageContentCache(c.cacheClient, request.ImageId, "oci-layer-build", nil),
 		ContentCacheDir:  filepath.Dir(outputPath),
 		LayerIndexCache:  newImageLayerIndexCache(c.cacheClient),
 		IndexConcurrency: imageLayerPrepareConcurrency,

--- a/pkg/worker/image_cache.go
+++ b/pkg/worker/image_cache.go
@@ -213,19 +213,11 @@ type imageContentCacheStoreTrace struct {
 	trace      cache.OperationTrace
 }
 
-func newImageContentCache(client *cache.Client, imageID string, kind string, observers ...imageContentCacheObserver) *imageContentCache {
+func newImageContentCache(client *cache.Client, imageID, kind string, observer imageContentCacheObserver) *imageContentCache {
 	if client == nil {
 		return nil
 	}
-	cacheKind := "content"
-	if kind != "" {
-		cacheKind = kind
-	}
-	var observer imageContentCacheObserver
-	if len(observers) > 0 {
-		observer = observers[0]
-	}
-	return &imageContentCache{client: client, imageID: imageID, kind: cacheKind, observe: observer}
+	return &imageContentCache{client: client, imageID: imageID, kind: kind, observe: observer}
 }
 
 func imageLayerContentCachePath(hash string) string {
@@ -275,7 +267,7 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 		case imageContentCacheResultShortRead:
 			c.readShortReads.Add(1)
 		}
-		if err != nil || read != length {
+		if result != imageContentCacheResultHit && result != imageContentCacheResultMiss {
 			c.readErrors.Add(1)
 			log.Warn().
 				Err(err).
@@ -301,6 +293,10 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 				Dur("elapsed", elapsed).
 				Msg("clip image content cache slow read")
 		}
+		traceErr := err
+		if result == imageContentCacheResultMiss {
+			traceErr = nil
+		}
 		c.maybeLogSummary()
 		c.observeContentCacheTrace(imageContentCacheTrace{
 			Operation:  imageContentCacheOperationReadInto,
@@ -315,7 +311,7 @@ func (c *imageContentCache) ReadContentInto(hash string, offset int64, dest []by
 			Bytes:      read,
 			StartedAt:  started,
 			Duration:   elapsed,
-			Error:      imageContentCacheErrorString(err),
+			Error:      imageContentCacheErrorString(traceErr),
 			Trace:      cacheTrace,
 		})
 	}()
@@ -789,7 +785,7 @@ func (c *imageContentCache) maybeLogSummary() {
 }
 
 func (c *imageContentCache) bestEffortRuntimeStore() bool {
-	return c != nil && (c.kind == "legacy-file-runtime" || c.kind == "oci-layer-runtime")
+	return c != nil && c.kind == "oci-layer-runtime"
 }
 
 func (c *imageContentCache) skipRuntimeStoreWhenUnavailable(hash string, routingKey string) bool {

--- a/pkg/worker/image_cache_test.go
+++ b/pkg/worker/image_cache_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/types"
+	clipCommon "github.com/beam-cloud/clip/pkg/common"
 	clipStorage "github.com/beam-cloud/clip/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +19,59 @@ func TestImageContentCacheErrorClassifiesMissAndUnavailable(t *testing.T) {
 
 	other := errors.New("other")
 	require.Same(t, other, imageContentCacheError(other))
+}
+
+func TestClipReadAggregateTreatsContentCacheMissAsExpected(t *testing.T) {
+	tests := []struct {
+		name             string
+		result           string
+		wantSuccess      bool
+		wantErrorCount   int64
+		wantFirstError   string
+		wantRollupErrors int64
+	}{
+		{name: "miss", result: imageContentCacheResultMiss, wantSuccess: true},
+		{name: "unavailable", result: imageContentCacheResultUnavailable, wantErrorCount: 1, wantFirstError: "cache unavailable", wantRollupErrors: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aggregate := newClipReadAggregate(&types.ContainerRequest{})
+			aggregate.add(clipCommon.ReadTraceEvent{
+				Operation: string(types.ContainerLifecycleClipContentCacheRead),
+				Success:   false,
+				Error:     "cache unavailable",
+				Attrs:     map[string]string{"cache_result": tt.result},
+			})
+
+			require.Equal(t, tt.wantSuccess, aggregate.success)
+			require.Equal(t, tt.wantErrorCount, aggregate.errorCount)
+			require.Equal(t, tt.wantFirstError, aggregate.firstError)
+			require.Equal(t, tt.wantRollupErrors, aggregate.byOperation[string(types.ContainerLifecycleClipContentCacheRead)].ErrorCount)
+		})
+	}
+}
+
+func TestClipReadAggregateDoesNotCountContentCacheMissAsError(t *testing.T) {
+	aggregate := newClipReadAggregate(&types.ContainerRequest{})
+	aggregate.addContentCache(imageContentCacheTrace{
+		Operation: imageContentCacheOperationReadInto,
+		Result:    imageContentCacheResultMiss,
+		Error:     "content cache miss: content not found",
+		Trace: cache.OperationTrace{Attempts: []cache.OperationTraceAttempt{{
+			HostID: "cache-host",
+			Source: "remote",
+			Result: imageContentCacheResultMiss,
+			Error:  "content cache miss: content not found",
+		}}},
+	})
+
+	require.EqualValues(t, 1, aggregate.cacheMissCount)
+	require.Zero(t, aggregate.cacheErrorCount)
+	require.Empty(t, aggregate.firstError)
+	require.Zero(t, aggregate.byCacheOperation[clipReadRollupKey(imageContentCacheOperationReadInto, imageContentCacheResultMiss)].ErrorCount)
+	require.Zero(t, aggregate.byCacheSource[clipReadRollupKey(imageContentCacheOperationReadInto, "remote", imageContentCacheResultMiss, "")].ErrorCount)
+	require.Zero(t, aggregate.byCacheHost[clipReadRollupKey("cache-host", "remote", imageContentCacheResultMiss, "")].ErrorCount)
 }
 
 func TestImageContentCacheFinishStoreClassifiesResults(t *testing.T) {

--- a/pkg/worker/image_events.go
+++ b/pkg/worker/image_events.go
@@ -186,6 +186,10 @@ func (a *clipReadAggregate) add(event clipCommon.ReadTraceEvent) {
 	if event.StartedAt.IsZero() {
 		event.StartedAt = time.Now().Add(-event.Duration)
 	}
+	if isExpectedClipContentCacheMiss(event) {
+		event.Success = true
+		event.Error = ""
+	}
 	endedAt := event.StartedAt.Add(event.Duration)
 	if !event.Success {
 		a.success = false
@@ -236,6 +240,9 @@ func (a *clipReadAggregate) add(event clipCommon.ReadTraceEvent) {
 func (a *clipReadAggregate) addContentCache(event imageContentCacheTrace) {
 	if a == nil {
 		return
+	}
+	if event.Result == imageContentCacheResultMiss {
+		event.Error = ""
 	}
 
 	durationUs := event.Duration.Microseconds()
@@ -369,7 +376,7 @@ func (a *clipReadAggregate) addCacheRollup(target map[string]*clipCacheRollup, k
 	}
 
 	rollup.Count++
-	if err != "" || result == imageContentCacheResultMiss || result == imageContentCacheResultUnavailable || result == imageContentCacheResultError {
+	if (err != "" && result != imageContentCacheResultMiss) || result == imageContentCacheResultUnavailable || result == imageContentCacheResultError {
 		rollup.ErrorCount++
 	}
 	rollup.TotalUs += durationUs
@@ -490,6 +497,11 @@ func clipReadCacheResult(event clipCommon.ReadTraceEvent) string {
 		event.Attrs["cache_result"],
 		event.Attrs["content_cache_result"],
 	)
+}
+
+func isExpectedClipContentCacheMiss(event clipCommon.ReadTraceEvent) bool {
+	return event.Operation == string(types.ContainerLifecycleClipContentCacheRead) &&
+		clipReadCacheResult(event) == imageContentCacheResultMiss
 }
 
 func clipReadRollupKey(parts ...string) string {

--- a/pkg/worker/image_test.go
+++ b/pkg/worker/image_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -14,6 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/beam-cloud/beta9/pkg/cache"
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/registry"
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/beam-cloud/clip/pkg/clip"
 	clipStorage "github.com/beam-cloud/clip/pkg/storage"
@@ -166,6 +170,100 @@ func TestEmbeddedImageCacheFallbackLogLevel(t *testing.T) {
 	logEmbeddedImageCacheFallback(errors.New("cache unavailable"), "runtime-image", &types.ContainerRequest{})
 	require.Contains(t, buf.String(), `"level":"warn"`)
 	require.Contains(t, buf.String(), "falling back to registry")
+}
+
+func TestLazyMountOptionsUsesWholeArchiveCacheOnlyForV1(t *testing.T) {
+	client := &ImageClient{
+		cacheClient:    &cache.Client{},
+		imageCachePath: "/images/cache",
+		config: types.AppConfig{ImageService: types.ImageServiceConfig{
+			RegistryStore: registry.S3ImageRegistryStore,
+		}},
+	}
+	request := &types.ContainerRequest{ImageId: "image-v1"}
+
+	options := client.lazyMountOptions(context.Background(), request, lazyImageArchive{})
+
+	require.Equal(t, "/images/cache/image-v1.clip", options.CachePath)
+	require.Nil(t, options.ContentCache)
+	require.False(t, options.ContentCacheAvailable)
+}
+
+func TestLazyMountOptionsRetainsPerLayerCacheForOCI(t *testing.T) {
+	client := &ImageClient{
+		cacheClient:    &cache.Client{},
+		imageCachePath: "/images/cache",
+		v2ImageRefs:    common.NewSafeMap[string](),
+	}
+	request := &types.ContainerRequest{ImageId: "image-v2"}
+
+	options := client.lazyMountOptions(context.Background(), request, lazyImageArchive{storageMode: "oci"})
+
+	require.NotNil(t, options.ContentCache)
+	require.True(t, options.ContentCacheAvailable)
+}
+
+func TestSuccessfulImageLoadActivatesExecutingLocality(t *testing.T) {
+	reporter := &cacheContentReporter{
+		metadata: cache.NewMockCacheMetadataStore(),
+		recent:   make(map[reporterStubKey]struct{}),
+	}
+	client := &ImageClient{contentReporter: reporter}
+	request := &types.ContainerRequest{WorkspaceId: "workspace", StubId: "stub"}
+
+	client.recordSuccessfulImageLoad(context.Background(), request, nil)
+
+	reporter.mu.Lock()
+	defer reporter.mu.Unlock()
+	require.Contains(t, reporter.recent, reporterStubKey{workspaceID: "workspace", stubID: "stub"})
+}
+
+func TestLocalImageArchiveReadyPreservesInProgressPlaceholder(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "image.clip")
+	require.NoError(t, os.WriteFile(archivePath, nil, 0o600))
+
+	client := &ImageClient{}
+	require.False(t, client.localImageArchiveReady(archivePath, "image"))
+	require.FileExists(t, archivePath)
+}
+
+func TestRestoreV1ArchiveDataCacheRemovesDirectoryTarget(t *testing.T) {
+	cacheDir := t.TempDir()
+	targetPath := filepath.Join(cacheDir, "image.clip")
+	require.NoError(t, os.Mkdir(targetPath, 0o700))
+
+	client := &ImageClient{
+		imageCachePath: cacheDir,
+		config: types.AppConfig{ImageService: types.ImageServiceConfig{
+			RegistryStore: registry.S3ImageRegistryStore,
+		}},
+	}
+	_, ok := client.restoreV1ArchiveDataCache(context.Background(), &types.ContainerRequest{ImageId: "image"}, nil)
+
+	require.False(t, ok)
+	require.NoDirExists(t, targetPath)
+}
+
+func TestRestoreV1ArchiveDataCacheDefersLargeRemoteArchive(t *testing.T) {
+	client := &ImageClient{
+		cacheClient:    &cache.Client{},
+		imageCachePath: t.TempDir(),
+		config: types.AppConfig{ImageService: types.ImageServiceConfig{
+			RegistryStore: registry.S3ImageRegistryStore,
+		}},
+		archiveContentMetadata: func(context.Context, string) (*cache.FSMetadata, error) {
+			return &cache.FSMetadata{Hash: "archive", Size: maxSyncV1ArchiveDataRestoreBytes + 1}, nil
+		},
+	}
+
+	path, ok := client.restoreV1ArchiveDataCache(
+		context.Background(),
+		&types.ContainerRequest{ImageId: "image"},
+		&types.S3ImageRegistryConfig{BucketName: "images"},
+	)
+
+	require.False(t, ok)
+	require.Empty(t, path)
 }
 
 func TestGetBuildContextDoesNotFallBackToWorkspaceFuseMount(t *testing.T) {


### PR DESCRIPTION
## Summary

This is a surgical cache-locality fix across **11 existing files**. It keeps the v1 and v2 image paths on the current architecture and does not add or extend JuiceFS behavior.

- Include image archives and stub-code data in the node cache disk-pressure/TTL eviction budget, while protecting active mounts and recently used content.
- Enforce one node-local cache-server/reconciler owner per node and quarantine stale machine-identity roots only after ownership is established.
- Publish locality requirements only after a successful image load, then rehydrate required v1 archives and v2 OCI layers on a failover locality through the normal cache path.
- Align reconcile ownership grace with the 30-second cache registration lease so a dead host cannot retain layer ownership for ten minutes after failover.
- Treat v1 images as one archive cache object, coalesce concurrent work, preserve the normal remote-mount path for large archives, and seed the local cache after successful downloads.
- Classify expected v2 cache misses as misses rather than warning/error spam; unavailable cache hosts and real failures remain visible.
- Mount the configured image-cache host path into the cache-server DaemonSet so eviction accounts for the storage that actually fills the node disk.

## Root cause

Cache reconciliation bounded the embedded cache but did not include image archives sharing the same filesystem. Old per-machine cache roots could also survive worker failover. During locality failover, a dead cache host's registration expired after 30 seconds, but reconciliation deferred ownership for ten minutes, leaving some HRW-selected layers unavailable even though the new node was healthy. The legacy image path compounded this with fine-grained cache activity instead of one archive-level restore/seed operation.

## Scope

- 1 commit: `f7d23b1b79fc9e9613887f27ad5bf210306e767f`
- 11 modified existing files (the original draft changed 55)
- 0 added, deleted, or renamed files
- No JuiceFS, protobuf/generated, schema, or migration changes

## Validation

- `go test ./pkg/worker -count=1`
- Focused cache/image race tests
- Linux amd64 and arm64 worker compile checks
- Helm render checks for host-path and PVC cache configurations
- `git diff --check origin/main...HEAD`
- Exact multi-arch staging image build: https://github.com/beam-cloud/beta9/actions/runs/30689780996
  - tag: `codex-locality-f7d23b1b`
  - digest: `sha256:9d0331405632eacd0a88f07fb863028539a5f22b58c388472a5043d4e01bad0b`

### Okteto staging failover proof

Ran an 8-phase cold/warm/failover probe on real workers across two distinct staging nodes:

- worker A `20f3d9eb` on `ip-10-100-55-85.ec2.internal`
- worker B `54e1d2de` on `ip-10-100-52-235.ec2.internal`
- v1 cold/warm on A: 348 ms / effectively 0 ms
- v2 cold/warm on A: 316 ms / effectively 0 ms; 528 hits and 13 expected first-load misses, with 0 errors/unavailable
- v1 after cross-node failover: restored from cache in 567 ms; next load effectively 0 ms
- v2 after cross-node failover: 573 ms with 593/593 cache hits; next load effectively 0 ms
- all 8 phases completed with 0 cache errors and 0 unavailable results
- failover worker recorded exactly one cache owner, materialized 1 v1 archive and all 6 v2 layers, and emitted 0 content-miss or unavailable/error warning lines

The isolated Okteto setup was removed after the run and the normal staging gateway/cache-server workloads were verified healthy.
