### PR TITLE
redact bearer tokens from captured deploy logs

### DIFF
--- a/sdk/src/beta9/logging.py
+++ b/sdk/src/beta9/logging.py
@@ -2,8 +2,21 @@ import contextvars
 import functools
 import io
 import json
+import re
 import sys
 from typing import Any, Callable, Dict
+
+# Matches the token value in printed Authorization headers (the curl/websocat
+# invocation examples). Restricted to the RFC 6750 token68 charset so
+# surrounding quotes survive redaction.
+_BEARER_TOKEN_PATTERN = re.compile(
+    r"(Authorization:\s*Bearer\s+)[A-Za-z0-9\-._~+/=]+", re.IGNORECASE
+)
+
+
+def redact_bearer_tokens(text: str) -> str:
+    """Replace bearer token values with [REDACTED], keeping the header shape."""
+    return _BEARER_TOKEN_PATTERN.sub(r"\1[REDACTED]", text)
 
 
 _stdout_json_context: contextvars.ContextVar[Dict[str, Any]] = contextvars.ContextVar(
@@ -147,6 +160,11 @@ class StoredStdoutInterceptor(io.TextIOBase):
         sys.stdout = sys.__stdout__
 
     def write(self, data: str):
+        if self.capture_logs:
+            # Captured logs end up in machine-readable output (e.g. deploy
+            # --format json) that gets piped into CI logs and files, so strip
+            # credentials that are fine to show interactively.
+            data = redact_bearer_tokens(data)
         self.logs.append(data)
         if not self.capture_logs:
             sys.__stdout__.write(data)

--- a/sdk/tests/test_logging.py
+++ b/sdk/tests/test_logging.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+from beta9.logging import StoredStdoutInterceptor, redact_bearer_tokens
+
+
+class TestRedactBearerTokens(TestCase):
+    def test_redacts_curl_style_header(self):
+        line = "-H 'Authorization: Bearer sk_abc123-XYZ=' \\"
+        self.assertEqual(
+            redact_bearer_tokens(line),
+            "-H 'Authorization: Bearer [REDACTED]' \\",
+        )
+
+    def test_redacts_websocat_style_header(self):
+        line = "websocat 'wss://app.example.com' -H 'Authorization: Bearer abc123'"
+        self.assertEqual(
+            redact_bearer_tokens(line),
+            "websocat 'wss://app.example.com' -H 'Authorization: Bearer [REDACTED]'",
+        )
+
+    def test_leaves_other_output_untouched(self):
+        line = "=> Invocation details"
+        self.assertEqual(redact_bearer_tokens(line), line)
+
+
+class TestStoredStdoutInterceptor(TestCase):
+    def test_captured_logs_redact_bearer_tokens(self):
+        with StoredStdoutInterceptor(capture_logs=True) as interceptor:
+            print("curl -X POST 'https://app.example.com' \\")
+            print("-H 'Authorization: Bearer abc123' \\")
+
+        joined = "".join(interceptor.logs)
+        self.assertNotIn("abc123", joined)
+        self.assertIn("Authorization: Bearer [REDACTED]", joined)


### PR DESCRIPTION
## Summary

- `beam deploy --format json` captures everything printed during the deploy into the JSON `logs` array — including the "Invocation details" curl/websocat examples, which embed the full workspace bearer token (`sdk/src/beta9/abstractions/base/runner.py`). Anyone piping `--format json` output into CI logs or files was persisting a live credential; a user hit exactly this and had to rotate their tokens.
- `StoredStdoutInterceptor` now redacts `Authorization: Bearer <token>` values in captured logs (`Bearer [REDACTED]`), at the capture choke point so any current or future print during a JSON-formatted deploy is covered.
- The interactive (non-JSON) invocation snippet is unchanged, so copy-paste curl examples still work.

Fixes #1828

## Test plan

- [x] New unit tests: curl-style and websocat-style header redaction, non-matching output untouched, and end-to-end capture through `StoredStdoutInterceptor` (`sdk/tests/test_logging.py`)

Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)