### PR TITLE
fix worker capacity and startup cancellation races

### DIFF
--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -327,6 +327,39 @@ local version = redis.call("HINCRBY", KEYS[1], "resource_version", ARGV[4])
 return {1, redis.call("HGET", KEYS[1], "machine_id") or "", free_cpu, free_memory, free_gpu, version}
 `)
 
+// updateExistingWorkerScript updates controller-owned worker fields without
+// replacing live scheduler capacity. It runs atomically with capacity updates,
+// preserving the resources already in use if the machine's totals changed.
+var updateExistingWorkerScript = redis.NewScript(`
+if redis.call("EXISTS", KEYS[1]) == 0 then
+    return 0
+end
+
+local old_total_cpu = tonumber(redis.call("HGET", KEYS[1], "total_cpu") or "0")
+local old_total_memory = tonumber(redis.call("HGET", KEYS[1], "total_memory") or "0")
+local old_total_gpu = tonumber(redis.call("HGET", KEYS[1], "total_gpu_count") or "0")
+local old_free_cpu = tonumber(redis.call("HGET", KEYS[1], "free_cpu") or "0")
+local old_free_memory = tonumber(redis.call("HGET", KEYS[1], "free_memory") or "0")
+local old_free_gpu = tonumber(redis.call("HGET", KEYS[1], "gpu_count") or "0")
+
+local used_cpu = math.max(old_total_cpu - old_free_cpu, 0)
+local used_memory = math.max(old_total_memory - old_free_memory, 0)
+local used_gpu = math.max(old_total_gpu - old_free_gpu, 0)
+
+for i = 4, #ARGV, 2 do
+    redis.call("HSET", KEYS[1], ARGV[i], ARGV[i + 1])
+end
+
+local new_total_cpu = tonumber(ARGV[1])
+local new_total_memory = tonumber(ARGV[2])
+local new_total_gpu = tonumber(ARGV[3])
+redis.call("HSET", KEYS[1],
+    "free_cpu", math.max(new_total_cpu - used_cpu, 0),
+    "free_memory", math.max(new_total_memory - used_memory, 0),
+    "gpu_count", math.max(new_total_gpu - used_gpu, 0))
+return 1
+`)
+
 func NewWorkerRedisRepository(r *common.RedisClient, config types.WorkerConfig) WorkerRepository {
 	lock := common.NewRedisLock(r)
 	return &WorkerRedisRepository{rdb: r, lock: lock, config: config}
@@ -368,10 +401,26 @@ func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 		}
 	}
 
-	worker.ResourceVersion = 0
-
 	pipe := r.rdb.TxPipeline()
-	pipe.HSet(ctx, stateKey, common.ToSlice(worker))
+	if oldWorker == nil {
+		worker.ResourceVersion = 0
+		pipe.HSet(ctx, stateKey, common.ToSlice(worker))
+	} else {
+		fields := make([]interface{}, 0)
+		allFields := common.ToSlice(worker)
+		for i := 0; i < len(allFields); i += 2 {
+			name := allFields[i].(string)
+			if name == "free_cpu" || name == "free_memory" || name == "gpu_count" || name == "resource_version" {
+				continue
+			}
+			fields = append(fields, name, allFields[i+1])
+		}
+		args := []interface{}{worker.TotalCpu, worker.TotalMemory, worker.TotalGpuCount}
+		args = append(args, fields...)
+		if err := updateExistingWorkerScript.Run(ctx, r.rdb, []string{stateKey}, args...).Err(); err != nil {
+			return fmt.Errorf("failed to update existing worker <%s>: %w", stateKey, err)
+		}
+	}
 	pipe.Expire(ctx, stateKey, r.config.CleanupPendingWorkerAgeLimit)
 	for _, indexKey := range r.workerIndexKeys(worker) {
 		pipe.SAdd(ctx, indexKey, stateKey)
@@ -841,7 +890,13 @@ func (r *WorkerRedisRepository) workerHasOutstandingWork(ctx context.Context, wo
 		if err != nil {
 			return false, err
 		}
-		if exists && state != nil {
+		// STOPPING is not live work that should block an agent slot rollout.
+		// The agent stops and removes the old worker container before starting
+		// its replacement, so any runtime still lingering behind a STOPPING
+		// record is terminated without overlapping the replacement worker.
+		// Keep scheduler capacity accounting separate: capacity is still held
+		// until the runtime itself exits and completes the container.
+		if exists && state != nil && state.Status != types.ContainerStatusStopping {
 			return true, nil
 		}
 	}

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -33,6 +33,43 @@ func TestNewWorkerRedisRepository(t *testing.T) {
 	assert.NotNil(t, repo)
 }
 
+func TestPrepareWorkerRolloutDoesNotBlockOnStoppingContainerState(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:         "worker-stopping-rollout",
+		Status:     types.WorkerStatusAvailable,
+		FreeCpu:    1000,
+		FreeMemory: 1000,
+	}
+	assert.NoError(t, repo.AddWorker(worker))
+
+	stoppingKey := common.RedisKeys.SchedulerContainerState("container-stopping-rollout")
+	assert.NoError(t, rdb.HSet(context.Background(), stoppingKey,
+		"container_id", "container-stopping-rollout",
+		"worker_id", worker.Id,
+		"status", string(types.ContainerStatusStopping),
+	).Err())
+	assert.NoError(t, rdb.SAdd(context.Background(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), stoppingKey).Err())
+
+	prepared, err := repo.PrepareWorkerRollout(worker.Id, "generation-stopping")
+	assert.NoError(t, err)
+	assert.True(t, prepared)
+
+	runningKey := common.RedisKeys.SchedulerContainerState("container-running-rollout")
+	assert.NoError(t, rdb.HSet(context.Background(), runningKey,
+		"container_id", "container-running-rollout",
+		"worker_id", worker.Id,
+		"status", string(types.ContainerStatusRunning),
+	).Err())
+	assert.NoError(t, rdb.SAdd(context.Background(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), runningKey).Err())
+
+	prepared, err = repo.PrepareWorkerRollout(worker.Id, "generation-running")
+	assert.NoError(t, err)
+	assert.False(t, prepared)
+}
+
 func TestAddAndRemoveWorker(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)
@@ -66,6 +103,56 @@ func TestAddAndRemoveWorker(t *testing.T) {
 
 	_, ok := err.(*types.ErrWorkerNotFound)
 	assert.True(t, ok) // assert that error is of type ErrWorkerNotFound
+}
+
+func TestAddWorkerDoesNotOverwriteLiveCapacityWithStaleSnapshot(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NotNil(t, rdb)
+	assert.NoError(t, err)
+
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:                  "worker-stale-reconcile",
+		Status:              types.WorkerStatusAvailable,
+		TotalCpu:            8_000,
+		TotalMemory:         8_000,
+		TotalGpuCount:       8,
+		FreeCpu:             8_000,
+		FreeMemory:          8_000,
+		FreeGpuCount:        8,
+		Runtime:             "runc",
+		ControlPlaneManaged: true,
+	}
+	assert.NoError(t, repo.AddWorker(worker))
+
+	stale, err := repo.GetWorkerById(worker.Id)
+	assert.NoError(t, err)
+	assert.NoError(t, repo.UpdateWorkerCapacity(worker, &types.ContainerRequest{
+		Cpu:      1_000,
+		Memory:   100,
+		Gpu:      "RTX4090",
+		GpuCount: 2,
+	}, types.RemoveCapacity))
+
+	// Simulate managed-pool reconciliation using a snapshot read before the
+	// scheduler reserved resources. Spec changes must still apply, but the
+	// stale free-capacity fields must not.
+	stale.Runtime = "gvisor"
+	stale.TotalCpu = 10_000
+	stale.TotalMemory = 10_000
+	stale.TotalGpuCount = 10
+	stale.FreeCpu = stale.TotalCpu
+	stale.FreeMemory = stale.TotalMemory
+	stale.FreeGpuCount = stale.TotalGpuCount
+	assert.NoError(t, repo.AddWorker(stale))
+
+	updated, err := repo.GetWorkerById(worker.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, "gvisor", updated.Runtime)
+	assert.Equal(t, int64(9_000), updated.FreeCpu)
+	assert.Equal(t, int64(9_875), updated.FreeMemory)
+	assert.Equal(t, uint32(8), updated.FreeGpuCount)
+	assert.Equal(t, int64(1), updated.ResourceVersion)
 }
 
 func TestRemoveWorkerRequeuesPendingWorkerRequests(t *testing.T) {

--- a/pkg/scheduler/pool_external_test.go
+++ b/pkg/scheduler/pool_external_test.go
@@ -154,10 +154,15 @@ func TestAgentWorkerPoolControllerAddWorkerCreatesDesiredSlot(t *testing.T) {
 		t.Fatalf("second worker = %q, want stable worker %q", secondWorker.Id, worker.Id)
 	}
 
-	secondWorker.FreeCpu -= 2000
-	secondWorker.FreeMemory -= 1024
-	secondWorker.FreeGpuCount--
-	if err := workerRepo.AddWorker(secondWorker); err != nil {
+	// Reserve resources through the scheduler's atomic capacity path. AddWorker
+	// is a controller spec refresh and must not accept a stale free-capacity
+	// snapshot for an existing worker.
+	if err := workerRepo.UpdateWorkerCapacity(secondWorker, &types.ContainerRequest{
+		Cpu:      2000,
+		Memory:   1024,
+		Gpu:      "A10G",
+		GpuCount: 1,
+	}, types.RemoveCapacity); err != nil {
 		t.Fatal(err)
 	}
 	machine.CPUCount = 16
@@ -177,8 +182,9 @@ func TestAgentWorkerPoolControllerAddWorkerCreatesDesiredSlot(t *testing.T) {
 	if resizedWorker.TotalCpu != 16000 || resizedWorker.FreeCpu != 14000 {
 		t.Fatalf("resized worker cpu = %d/%d, want 16000/14000", resizedWorker.TotalCpu, resizedWorker.FreeCpu)
 	}
-	if resizedWorker.TotalMemory != 65536 || resizedWorker.FreeMemory != 64512 {
-		t.Fatalf("resized worker memory = %d/%d, want 65536/64512", resizedWorker.TotalMemory, resizedWorker.FreeMemory)
+	// Memory capacity reserves the runtime's 1.25x cgroup hard limit.
+	if resizedWorker.TotalMemory != 65536 || resizedWorker.FreeMemory != 64256 {
+		t.Fatalf("resized worker memory = %d/%d, want 65536/64256", resizedWorker.TotalMemory, resizedWorker.FreeMemory)
 	}
 	if resizedWorker.TotalGpuCount != 4 || resizedWorker.FreeGpuCount != 3 {
 		t.Fatalf("resized worker gpu = %d/%d, want 4/3", resizedWorker.TotalGpuCount, resizedWorker.FreeGpuCount)

--- a/pkg/worker/criu.go
+++ b/pkg/worker/criu.go
@@ -102,9 +102,9 @@ func (r *checkpointFilesystemRestore) discard() error {
 	return os.RemoveAll(r.overlayRoot)
 }
 
-func (s *Worker) startCheckpointFilesystemRestore(request *types.ContainerRequest, outputLogger *slog.Logger) *checkpointFilesystemRestore {
+func (s *Worker) startCheckpointFilesystemRestore(parentCtx context.Context, request *types.ContainerRequest, outputLogger *slog.Logger) *checkpointFilesystemRestore {
 	overlayRoot := filepath.Join(s.containerOverlayBasePath(request), request.ContainerId)
-	restoreCtx, cancel := context.WithCancel(s.ctx)
+	restoreCtx, cancel := context.WithCancel(parentCtx)
 	restore := &checkpointFilesystemRestore{
 		startedAt:   time.Now(),
 		overlayRoot: overlayRoot,
@@ -115,7 +115,11 @@ func (s *Worker) startCheckpointFilesystemRestore(request *types.ContainerReques
 
 	go func() {
 		defer cancel()
-		restore.err = s.restoreCheckpointFilesystem(restoreCtx, request, outputLogger, restore.upperPath)
+		if err := restoreCtx.Err(); err != nil {
+			restore.err = err
+		} else {
+			restore.err = s.restoreCheckpointFilesystem(restoreCtx, request, outputLogger, restore.upperPath)
+		}
 		close(restore.done)
 	}()
 	return restore

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -108,6 +108,15 @@ func (s *Worker) handleStopContainerArgs(stopArgs types.StopContainerArgs, sourc
 
 // stopContainer stops a container. When force is true, a SIGKILL signal is sent to the container.
 func (s *Worker) stopContainer(containerId string, kill bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeStopTimeout)
+	defer cancel()
+	return s.stopContainerWithContext(ctx, containerId, kill)
+}
+
+// stopContainerWithContext keeps runtime control calls bounded. A wedged
+// runsc kill command must not monopolize processStopContainerEvents and block
+// every other container on the worker from receiving its stop signal.
+func (s *Worker) stopContainerWithContext(ctx context.Context, containerId string, kill bool) error {
 	instance, exists := s.containerInstances.Get(containerId)
 	if !exists {
 		log.Info().Str("container_id", containerId).Msg("container not found")
@@ -131,15 +140,23 @@ func (s *Worker) stopContainer(containerId string, kill bool) error {
 	if rt == nil {
 		rt = s.runtime
 	}
+	if rt == nil {
+		return fmt.Errorf("runtime unavailable for container %s", containerId)
+	}
 
 	// Kill the container - this will cause the runtime.Run() call to exit
 	// which triggers all the defers (overlay cleanup, mount cleanup, etc.)
-	err := rt.Kill(context.Background(), instance.Id, signal, &runtime.KillOpts{All: true})
+	err := rt.Kill(ctx, instance.Id, signal, &runtime.KillOpts{All: true})
 	if err != nil {
-		log.Debug().Str("container_id", containerId).Err(err).Msg("error killing container (may already be stopped)")
+		if runtimeContainerNotFound(err) {
+			log.Debug().Str("container_id", containerId).Err(err).Msg("container runtime already stopped")
+			return nil
+		}
+		log.Warn().Str("container_id", containerId).Str("signal", signal.String()).Err(err).Msg("runtime stop command failed")
+		return err
 	}
 
-	log.Info().Str("container_id", containerId).Msg("container stop signal sent")
+	log.Info().Str("container_id", containerId).Str("signal", signal.String()).Msg("container stop signal sent")
 	return nil
 }
 
@@ -154,6 +171,12 @@ func (s *Worker) finalizeContainer(containerId string, request *types.ContainerR
 }
 
 func (s *Worker) clearContainer(containerId string, request *types.ContainerRequest, exitCode int, exitReported bool) {
+	// The startup context stays registered after RunContainer hands work to the
+	// spawn goroutine. Keep it alive for stop events until all runtime work has
+	// ended, then release it here on every success and failure path.
+	s.cancelContainer(containerId)
+	s.unregisterContainerCancel(containerId)
+
 	if request != nil && request.HasDurableDiskMount() {
 		if err := s.syncDurableDiskMounts(request); err != nil {
 			log.Error().Str("container_id", containerId).Err(err).Msg("failed to sync durable disks during container cleanup")
@@ -343,7 +366,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 
 	var filesystemRestore *checkpointFilesystemRestore
 	if s.canRestoreCheckpoint(request, s.runtime) {
-		filesystemRestore = s.startCheckpointFilesystemRestore(request, outputLogger)
+		filesystemRestore = s.startCheckpointFilesystemRestore(ctx, request, outputLogger)
 	}
 	filesystemRestoreHandedOff := false
 	defer func() {
@@ -461,7 +484,7 @@ func (s *Worker) RunContainer(ctx context.Context, request *types.ContainerReque
 		portsHandedOff = true
 		filesystemRestoreHandedOff = true
 		s.containerWg.Add(1)
-		go s.spawn(request, spec, outputLogger, opts)
+		go s.spawn(ctx, request, spec, outputLogger, opts)
 		metrics.RecordWorkerStartupPhase("spawn_enqueue", time.Since(phaseStart), request, nil)
 	}
 
@@ -520,7 +543,7 @@ func (s *Worker) loadContainerImage(ctx context.Context, request *types.Containe
 
 	select {
 	case <-ctx.Done():
-		return elapsed, false, nil
+		return elapsed, false, ctx.Err()
 	default:
 	}
 
@@ -1156,8 +1179,8 @@ func validateContainerSpec(spec *specs.Spec) error {
 }
 
 // spawn a container using runc binary
-func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, outputLogger *slog.Logger, opts *ContainerOptions) {
-	ctx, cancel := context.WithCancel(s.ctx)
+func (s *Worker) spawn(parentCtx context.Context, request *types.ContainerRequest, spec *specs.Spec, outputLogger *slog.Logger, opts *ContainerOptions) {
+	ctx, cancel := context.WithCancel(parentCtx)
 	defer s.containerNetworkManager.ReleasePortReservations(request.ContainerId)
 
 	defer func() {
@@ -1219,7 +1242,13 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 				return
 			}
 			restoreFilesystemCleanupNeeded = false
+			if ctx.Err() != nil {
+				return
+			}
 		}
+	}
+	if ctx.Err() != nil {
+		return
 	}
 	phaseStart := time.Now()
 	err = containerInstance.Overlay.Setup()
@@ -1247,6 +1276,9 @@ func (s *Worker) spawn(request *types.ContainerRequest, spec *specs.Spec, output
 
 	// Only inject GPU devices if runtime supports GPU
 	if request.RequiresGPU() && s.runtime.Capabilities().GPU {
+		if ctx.Err() != nil {
+			return
+		}
 		// Assign n-number of GPUs to a container
 		phaseStart = time.Now()
 		assignedDevices, err := s.containerGPUManager.AssignGPUDevices(request.ContainerId, request.GpuCount)
@@ -1936,7 +1968,15 @@ func (s *Worker) markContainerRunning(ctx context.Context, request *types.Contai
 
 	if resp.State.Status == string(types.ContainerStatusStopping) {
 		log.Info().Str("container_id", containerId).Msg("container started after stop request, sending stop signal")
+		if instance, exists := s.containerInstances.Get(containerId); exists {
+			// A grace timer may have fired before the runtime existed. Starting a
+			// runtime is a new enforcement point, so it must receive its own
+			// SIGTERM-to-SIGKILL escalation.
+			instance.StopEscalationStarted.Store(false)
+			s.containerInstances.Set(containerId, instance)
+		}
 		s.stopContainer(containerId, false)
+		s.ensureContainerStopEscalation(request)
 		return
 	}
 

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -1410,13 +1410,76 @@ func TestCheckpointFilesystemRestorePreparesInitialUpperLayer(t *testing.T) {
 			Status:       string(types.CheckpointStatusAvailable),
 		},
 	}
-	restore := worker.startCheckpointFilesystemRestore(request, nil)
+	restore := worker.startCheckpointFilesystemRestore(context.Background(), request, nil)
 	t.Cleanup(restore.cleanup)
 
 	require.NoError(t, restore.wait())
 	data, err := os.ReadFile(filepath.Join(restore.upperPath, "state", "ready"))
 	require.NoError(t, err)
 	require.Equal(t, "yes", string(data))
+}
+
+func TestCheckpointFilesystemRestoreUsesContainerContext(t *testing.T) {
+	checkpointRoot := t.TempDir()
+	checkpointID := "checkpoint-cancelled-restore"
+	checkpointPath := filepath.Join(checkpointRoot, checkpointID)
+	require.NoError(t, os.MkdirAll(filepath.Join(checkpointPath, checkpointFsDir), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(checkpointPath, "inventory.img"), []byte("runtime"), 0644))
+
+	worker := &Worker{
+		ctx:          context.Background(),
+		cacheManager: &WorkerCacheManager{checkpointRoot: checkpointRoot},
+	}
+	request := &types.ContainerRequest{
+		ContainerId: "checkpoint-cancelled-restore-test",
+		Checkpoint: &types.Checkpoint{
+			CheckpointId: checkpointID,
+			Status:       string(types.CheckpointStatusAvailable),
+		},
+	}
+	containerCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	restore := worker.startCheckpointFilesystemRestore(containerCtx, request, nil)
+	t.Cleanup(restore.cleanup)
+
+	require.ErrorIs(t, restore.wait(), context.Canceled)
+}
+
+func TestMarkContainerRunningRearmsEscalationAfterPreRuntimeStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	containerID := "container-started-after-stop"
+	killNotify := make(chan syscall.Signal, 2)
+	rt := &mockRuntime{
+		state: func(context.Context, string) (runtime.State, error) {
+			return runtime.State{Status: types.RuncContainerStatusRunning}, nil
+		},
+		killNotify: killNotify,
+	}
+	repoClient := &fakeContainerRepoClient{state: &pb.ContainerState{
+		ContainerId: containerID,
+		Status:      string(types.ContainerStatusStopping),
+	}}
+	worker := &Worker{
+		ctx:                 ctx,
+		runtime:             rt,
+		containerInstances:  common.NewSafeMap[*ContainerInstance](),
+		containerRepoClient: repoClient,
+		stopContainerChan:   make(chan stopContainerEvent, 1),
+	}
+	instance := &ContainerInstance{Id: containerID, Runtime: rt, ExitCode: -1}
+	instance.StopEscalationStarted.Store(true) // the pre-runtime timer was already consumed
+	worker.containerInstances.Set(containerID, instance)
+
+	worker.markContainerRunning(context.Background(), &types.ContainerRequest{ContainerId: containerID}, time.Time{})
+
+	require.Equal(t, syscall.SIGTERM, <-killNotify)
+	select {
+	case signal := <-killNotify:
+		require.Equal(t, syscall.SIGKILL, signal)
+	case <-time.After(time.Second):
+		t.Fatal("runtime start did not re-arm SIGKILL escalation")
+	}
 }
 
 func TestCheckpointFilesystemRestoreDiscardRemovesPartialUpperLayer(t *testing.T) {
@@ -2380,6 +2443,109 @@ type mockRuntime struct {
 	signals      []syscall.Signal
 	killOpts     []*runtime.KillOpts
 	killErr      error
+	killNotify   chan syscall.Signal
+}
+
+type stuckControlRuntime struct {
+	mockRuntime
+	killFn       func(context.Context) error
+	stopOnDelete bool
+	deleted      atomic.Bool
+	killCalls    atomic.Int32
+	deleteCalls  atomic.Int32
+}
+
+func (m *stuckControlRuntime) Kill(ctx context.Context, _ string, _ syscall.Signal, _ *runtime.KillOpts) error {
+	m.killCalls.Add(1)
+	if m.killFn != nil {
+		return m.killFn(ctx)
+	}
+	return nil
+}
+
+func (m *stuckControlRuntime) Delete(context.Context, string, *runtime.DeleteOpts) error {
+	m.deleteCalls.Add(1)
+	m.deleted.Store(true)
+	return nil
+}
+
+func (m *stuckControlRuntime) State(context.Context, string) (runtime.State, error) {
+	if m.stopOnDelete && m.deleted.Load() {
+		return runtime.State{}, runtime.ErrContainerNotFound{ContainerID: "container-1"}
+	}
+	return runtime.State{Status: types.RuncContainerStatusRunning}, nil
+}
+
+func TestStopContainerRuntimeControlHonorsDeadline(t *testing.T) {
+	rt := &stuckControlRuntime{
+		mockRuntime: mockRuntime{name: types.ContainerRuntimeGvisor.String()},
+		killFn: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	worker := &Worker{containerInstances: common.NewSafeMap[*ContainerInstance](), runtime: rt}
+	worker.containerInstances.Set("container-1", &ContainerInstance{Id: "container-1", Runtime: rt})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := worker.stopContainerWithContext(ctx, "container-1", false)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(started), time.Second)
+	require.Equal(t, int32(1), rt.killCalls.Load())
+}
+
+func TestForceStopRuntimeRetriesThenForceDeletes(t *testing.T) {
+	rt := &stuckControlRuntime{
+		mockRuntime:  mockRuntime{name: types.ContainerRuntimeGvisor.String()},
+		stopOnDelete: true,
+	}
+	worker := &Worker{
+		ctx:                context.Background(),
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		runtime:            rt,
+	}
+	worker.containerInstances.Set("container-1", &ContainerInstance{Id: "container-1", Runtime: rt})
+	policy := runtimeStopPolicy{
+		controlTimeout: 25 * time.Millisecond,
+		verifyTimeout:  5 * time.Millisecond,
+		verifyInterval: time.Millisecond,
+		deleteTimeout:  25 * time.Millisecond,
+		killAttempts:   2,
+	}
+
+	require.True(t, worker.forceStopRuntime("container-1", policy))
+	require.Equal(t, int32(2), rt.killCalls.Load())
+	require.Equal(t, int32(1), rt.deleteCalls.Load())
+}
+
+func TestStuckRuntimeRecoveryRestartsWorkerWithoutReleasingCapacity(t *testing.T) {
+	rt := &stuckControlRuntime{mockRuntime: mockRuntime{name: types.ContainerRuntimeGvisor.String()}}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	worker := &Worker{
+		ctx:                workerCtx,
+		cancel:             cancel,
+		containerInstances: common.NewSafeMap[*ContainerInstance](),
+		runtime:            rt,
+		completedRequests:  make(chan *types.ContainerRequest, 1),
+	}
+	worker.containerInstances.Set("container-1", &ContainerInstance{Id: "container-1", Runtime: rt})
+	policy := runtimeStopPolicy{
+		controlTimeout: 25 * time.Millisecond,
+		verifyTimeout:  5 * time.Millisecond,
+		verifyInterval: time.Millisecond,
+		deleteTimeout:  25 * time.Millisecond,
+		killAttempts:   1,
+	}
+
+	require.False(t, worker.forceStopRuntime("container-1", policy))
+	worker.restartWorkerForStuckRuntime("container-1")
+
+	require.ErrorIs(t, workerCtx.Err(), context.Canceled)
+	require.Len(t, worker.completedRequests, 0)
+	require.Equal(t, 1, worker.containerInstances.Len())
 }
 
 func (m *mockRuntime) Name() string {
@@ -2404,6 +2570,9 @@ func (m *mockRuntime) Exec(ctx context.Context, containerID string, proc specs.P
 
 func (m *mockRuntime) Kill(ctx context.Context, containerID string, sig syscall.Signal, opts *runtime.KillOpts) error {
 	m.signals = append(m.signals, sig)
+	if m.killNotify != nil {
+		m.killNotify <- sig
+	}
 	if opts == nil {
 		opts = &runtime.KillOpts{}
 	}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -51,8 +51,32 @@ const (
 	workerShutdownRPCTimeout       time.Duration = 5 * time.Second
 	containerStartupTimeout        time.Duration = 15 * time.Minute
 	stuckContainerAbortDelay       time.Duration = 2 * time.Minute
+	runtimeStopTimeout             time.Duration = 5 * time.Second
+	runtimeStopVerifyTimeout       time.Duration = 2 * time.Second
+	runtimeStopVerifyInterval      time.Duration = 100 * time.Millisecond
+	runtimeForceDeleteTimeout      time.Duration = 10 * time.Second
+	runtimeForceStopRetryDelay     time.Duration = time.Second
+	runtimeForceStopAttempts                     = 2
 	gvisorShmemTHPPath                           = "/sys/kernel/mm/transparent_hugepage/shmem_enabled"
 )
+
+type runtimeStopPolicy struct {
+	controlTimeout time.Duration
+	verifyTimeout  time.Duration
+	verifyInterval time.Duration
+	retryDelay     time.Duration
+	deleteTimeout  time.Duration
+	killAttempts   int
+}
+
+var defaultRuntimeStopPolicy = runtimeStopPolicy{
+	controlTimeout: runtimeStopTimeout,
+	verifyTimeout:  runtimeStopVerifyTimeout,
+	verifyInterval: runtimeStopVerifyInterval,
+	retryDelay:     runtimeForceStopRetryDelay,
+	deleteTimeout:  runtimeForceDeleteTimeout,
+	killAttempts:   runtimeForceStopAttempts,
+}
 
 func ensureGVisorShmemTHP(path string) (bool, error) {
 	policy, err := os.ReadFile(path)
@@ -686,10 +710,8 @@ func (s *Worker) runContainerRequest(request *types.ContainerRequest) {
 	log.Info().Str("container_id", containerId).Msg("running container")
 
 	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
 
 	s.registerContainerCancel(containerId, cancel)
-	defer s.unregisterContainerCancel(containerId)
 	go s.cancelContainerIfAlreadyStopping(cancel, containerId)
 
 	if err := s.hydrateRuntimeCredentials(ctx, request); err != nil {
@@ -935,57 +957,74 @@ func (s *Worker) updateContainerStatusOnce(request *types.ContainerRequest) (boo
 	// If container is supposed to be stopped, but isn't gone after TerminationGracePeriod seconds
 	// ensure it is killed after that
 	if status == types.ContainerStatusStopping {
-		_, stopReason := instance.lifecycleState()
-		if stopReason == "" {
-			instance.setStopReason(types.StopContainerReasonUnknown)
-			s.containerInstances.Set(request.ContainerId, instance)
-		}
-		if !instance.StopEscalationStarted.CompareAndSwap(false, true) {
-			return false, nil
-		}
-		go func() {
-			time.Sleep(time.Duration(s.config.Worker.TerminationGracePeriod) * time.Second)
-
-			instance, exists := s.containerInstances.Get(request.ContainerId)
-			if !exists {
-				return
-			}
-			rt := instance.Runtime
-			if rt == nil {
-				rt = s.runtime
-			}
-			stateCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			needsStop := runtimeNeedsGraceKill(stateCtx, rt, request.ContainerId)
-			cancel()
-			if needsStop {
-				log.Info().Str("container_id", request.ContainerId).Int64("grace_period_seconds", s.config.Worker.TerminationGracePeriod).Msg("container still running after stop event")
-				_, stopReason := instance.lifecycleState()
-				s.recordContainerEvent(context.Background(), request, types.EventContainerEventSchema{
-					ID:          types.ContainerEventWorkerStoppingGraceKill,
-					ContainerID: request.ContainerId,
-					Reason:      string(stopReason),
-					Source:      types.EventSourceWorkerStatusHeartbeat.String(),
-					Message:     types.EventMessageStoppingGraceKill.String(),
-					Attrs: map[string]string{
-						types.EventAttrGracePeriodSeconds: fmt.Sprintf("%d", s.config.Worker.TerminationGracePeriod),
-					},
-				})
-				s.stopContainerChan <- stopContainerEvent{
-					ContainerId: request.ContainerId,
-					Kill:        true,
-				}
-			}
-
-			select {
-			case <-time.After(stuckContainerAbortDelay):
-			case <-s.ctx.Done():
-				return
-			}
-			s.abortStuckWorkspaceMount(request)
-		}()
+		s.ensureContainerStopEscalation(request)
 	}
 
 	return false, nil
+}
+
+func (s *Worker) ensureContainerStopEscalation(request *types.ContainerRequest) {
+	instance, exists := s.containerInstances.Get(request.ContainerId)
+	if !exists {
+		return
+	}
+	_, stopReason := instance.lifecycleState()
+	if stopReason == "" {
+		instance.setStopReason(types.StopContainerReasonUnknown)
+		s.containerInstances.Set(request.ContainerId, instance)
+	}
+	if !instance.StopEscalationStarted.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		timer := time.NewTimer(time.Duration(s.config.Worker.TerminationGracePeriod) * time.Second)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-s.ctx.Done():
+			return
+		}
+
+		instance, exists := s.containerInstances.Get(request.ContainerId)
+		if !exists {
+			return
+		}
+		rt := instance.Runtime
+		if rt == nil {
+			rt = s.runtime
+		}
+		stateCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		needsStop := runtimeNeedsGraceKill(stateCtx, rt, request.ContainerId)
+		cancel()
+		if needsStop {
+			log.Info().Str("container_id", request.ContainerId).Int64("grace_period_seconds", s.config.Worker.TerminationGracePeriod).Msg("container still running after stop event")
+			_, stopReason := instance.lifecycleState()
+			s.recordContainerEvent(context.Background(), request, types.EventContainerEventSchema{
+				ID:          types.ContainerEventWorkerStoppingGraceKill,
+				ContainerID: request.ContainerId,
+				Reason:      string(stopReason),
+				Source:      types.EventSourceWorkerStatusHeartbeat.String(),
+				Message:     types.EventMessageStoppingGraceKill.String(),
+				Attrs: map[string]string{
+					types.EventAttrGracePeriodSeconds: fmt.Sprintf("%d", s.config.Worker.TerminationGracePeriod),
+				},
+			})
+			// Do not queue the force kill behind the original stop call. This
+			// goroutine is independent so one wedged runtime control process
+			// cannot prevent every other container from escalating.
+			if !s.forceStopRuntime(request.ContainerId, defaultRuntimeStopPolicy) {
+				s.restartWorkerForStuckRuntime(request.ContainerId)
+				return
+			}
+		}
+
+		select {
+		case <-time.After(stuckContainerAbortDelay):
+		case <-s.ctx.Done():
+			return
+		}
+		s.abortStuckWorkspaceMount(request)
+	}()
 }
 
 // abortStuckWorkspaceMount recovers the shutdown path even when the runtime
@@ -1046,6 +1085,113 @@ func runtimeNeedsGraceKill(ctx context.Context, rt runtime.Runtime, containerID 
 		return !runtimeContainerNotFound(err)
 	}
 	return state.Status == types.RuncContainerStatusRunning
+}
+
+// forceStopRuntime retries a bounded SIGKILL, verifies local runtime state,
+// then uses the runtime's force-delete path as a final container-scoped
+// recovery. It returns false only when the runtime still appears live after
+// every bounded operation, in which case the worker process must be replaced.
+func (s *Worker) forceStopRuntime(containerID string, policy runtimeStopPolicy) bool {
+	if policy.killAttempts < 1 {
+		policy.killAttempts = 1
+	}
+	for attempt := 1; attempt <= policy.killAttempts; attempt++ {
+		if _, exists := s.containerInstances.Get(containerID); !exists {
+			return true
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), policy.controlTimeout)
+		err := s.stopContainerWithContext(ctx, containerID, true)
+		cancel()
+		if err != nil {
+			log.Warn().Str("container_id", containerID).Int("attempt", attempt).Err(err).Msg("force stop attempt failed")
+		}
+		if s.waitForRuntimeStopped(containerID, policy.verifyTimeout, policy.verifyInterval) {
+			return true
+		}
+		if attempt < policy.killAttempts && policy.retryDelay > 0 {
+			timer := time.NewTimer(policy.retryDelay)
+			var workerDone <-chan struct{}
+			if s.ctx != nil {
+				workerDone = s.ctx.Done()
+			}
+			select {
+			case <-timer.C:
+			case <-workerDone:
+				timer.Stop()
+				return true
+			}
+		}
+	}
+
+	instance, exists := s.containerInstances.Get(containerID)
+	if !exists {
+		return true
+	}
+	rt := instance.Runtime
+	if rt == nil {
+		rt = s.runtime
+	}
+	if rt == nil {
+		return false
+	}
+	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), policy.deleteTimeout)
+	err := rt.Delete(deleteCtx, instance.Id, &runtime.DeleteOpts{Force: true})
+	deleteCancel()
+	if err != nil && !runtimeContainerNotFound(err) {
+		log.Warn().Str("container_id", containerID).Err(err).Msg("runtime force delete failed")
+	}
+	return s.waitForRuntimeStopped(containerID, policy.verifyTimeout, policy.verifyInterval)
+}
+
+func (s *Worker) waitForRuntimeStopped(containerID string, timeout, interval time.Duration) bool {
+	instance, exists := s.containerInstances.Get(containerID)
+	if !exists {
+		return true
+	}
+	rt := instance.Runtime
+	if rt == nil {
+		rt = s.runtime
+	}
+	if rt == nil {
+		return true
+	}
+	if timeout <= 0 {
+		timeout = time.Millisecond
+	}
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if !runtimeNeedsGraceKill(ctx, rt, instance.Id) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Worker) restartWorkerForStuckRuntime(containerID string) {
+	log.Error().
+		Str("container_id", containerID).
+		Msg("runtime survived bounded SIGKILL and force delete; restarting worker")
+	// Stop new scheduling before ending the worker process. Agent-managed
+	// workers are then restarted by their supervisor; ephemeral workers are
+	// replaced by the pool controller. Neither path releases container
+	// capacity until the old worker process is actually gone.
+	if s.workerRepoClient != nil {
+		s.disableSchedulingForShutdown()
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
 }
 
 func (s *Worker) processStopContainerEvents() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes two races: controller worker updates no longer overwrite live scheduler capacity, and container startup/stop now honor cancellation and escalation reliably. Improves runtime stop handling with bounded timeouts, verification, and safe worker restart if the runtime is wedged.

- **Bug Fixes**
  - Preserve live capacity on existing workers using an atomic Redis script that updates controller-owned fields and recomputes free resources from “used” values.
  - Ignore STOPPING container states when checking for outstanding work during worker rollout; capacity is still accounted for by the runtime.
  - Bound runtime control calls with `stopContainerWithContext`; add retry + verify + force-delete path, and restart the worker if the runtime remains live (without releasing capacity).
  - Re-arm SIGTERM→SIGKILL escalation when a container starts after a pre-runtime stop request.
  - Propagate request context to spawn and checkpoint restore so startup cancels correctly and doesn’t proceed after cancellation.
  - Return context error when image load is canceled.
  - Correct memory free calculation on resize (test expectation updated).
  - Tests added for rollout behavior, stale-capacity protection, bounded stop, force-delete, stuck-runtime recovery, and checkpoint-restore cancellation.

<sup>Written for commit 9ea85440f7f89a17ebbcddfd4e9fc8ba24b62bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

