### PR TITLE
fix: Tama create reliability and resource isolation

### DIFF
--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -398,11 +399,35 @@ func (ps *GenericPodService) deletePodInstance(stubId string, instance *podInsta
 // in which case the container id is pre-generated so the task record can
 // reference it before scheduling.
 type runOptions struct {
-	imageId     *string
-	checkpoint  *types.Checkpoint
-	machineId   string
-	taskId      string
-	containerId string
+	imageId             *string
+	checkpoint          *types.Checkpoint
+	machineId           string
+	forceResourceLimits bool
+	taskId              string
+	containerId         string
+}
+
+func createPodRunOptions(ctx context.Context, in *pb.CreatePodRequest, checkpoint *types.Checkpoint) runOptions {
+	return runOptions{
+		imageId:             in.ImageId,
+		checkpoint:          checkpoint,
+		machineId:           in.GetMachineId(),
+		forceResourceLimits: forceResourceLimitsRequested(ctx),
+	}
+}
+
+func forceResourceLimitsRequested(ctx context.Context) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	for _, value := range md.Get(types.ForceResourceLimitsMetadata) {
+		enabled, err := strconv.ParseBool(strings.TrimSpace(value))
+		if err == nil && enabled {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, stub *types.StubWithRelated, opts runOptions) (string, error) {
@@ -497,6 +522,13 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 	if stub.App != nil {
 		appId = stub.App.ExternalId
 	}
+	requestStub := *stub
+	if opts.forceResourceLimits {
+		requestStub.Config, err = types.StubConfigWithForcedResourceLimits(stub.Config)
+		if err != nil {
+			return "", err
+		}
+	}
 
 	runRequest := &types.ContainerRequest{
 		ContainerId:       containerId,
@@ -509,7 +541,7 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 		GpuRequest:        gpuRequest,
 		GpuCount:          uint32(gpuCount),
 		Mounts:            mounts,
-		Stub:              *stub,
+		Stub:              requestStub,
 		ImageId:           *imageId,
 		WorkspaceId:       workspace.ExternalId,
 		Workspace:         *workspace,
@@ -649,11 +681,7 @@ func (s *GenericPodService) CreatePod(ctx context.Context, in *pb.CreatePodReque
 		}
 	}
 
-	opts := runOptions{
-		imageId:    in.ImageId,
-		checkpoint: checkpoint,
-		machineId:  in.GetMachineId(),
-	}
+	opts := createPodRunOptions(ctx, in, checkpoint)
 
 	var containerId, taskId string
 	if s.trackRunAsTask(stub) {

--- a/pkg/abstractions/pod/pod_run_test.go
+++ b/pkg/abstractions/pod/pod_run_test.go
@@ -8,7 +8,9 @@ import (
 	computemodel "github.com/beam-cloud/beta9/pkg/compute"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 type podMachinePlacementRepo struct {
@@ -44,4 +46,29 @@ func TestConfigureMachinePlacementRejectsPoolMismatch(t *testing.T) {
 
 	err := service.configureMachinePlacement(context.Background(), "workspace-1", "machine-1", config)
 	require.ErrorContains(t, err, "does not belong to pool")
+}
+
+func TestCreatePodRunOptionsPreserveResourceOverrideForColdAndCheckpointLaunches(t *testing.T) {
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs(types.ForceResourceLimitsMetadata, "true"),
+	)
+	request := &pb.CreatePodRequest{StubId: "legacy-stub"}
+	checkpoint := &types.Checkpoint{CheckpointId: "checkpoint-1"}
+
+	for _, test := range []struct {
+		name       string
+		checkpoint *types.Checkpoint
+	}{
+		{name: "cold launch"},
+		{name: "checkpoint clone", checkpoint: checkpoint},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			opts := createPodRunOptions(ctx, request, test.checkpoint)
+			require.True(t, opts.forceResourceLimits)
+			require.Same(t, test.checkpoint, opts.checkpoint)
+		})
+	}
+
+	require.False(t, createPodRunOptions(context.Background(), request, nil).forceResourceLimits)
 }

--- a/pkg/abstractions/pod/sandbox.go
+++ b/pkg/abstractions/pod/sandbox.go
@@ -262,6 +262,15 @@ func (s *GenericPodService) sandboxExitedStatus(ctx context.Context, containerId
 		return nil, errors.New("invalid workspace")
 	}
 
+	requestStatus, requestStatusErr := s.containerRepo.GetContainerRequestStatus(containerId)
+	if requestStatusErr == nil && requestStatus == types.ContainerRequestStatusFailed {
+		return &pb.PodSandboxStatusResponse{
+			Ok:       true,
+			Status:   string(types.SandboxStatusExited),
+			ExitCode: 1,
+		}, nil
+	}
+
 	exitCode, err := s.containerRepo.GetContainerExitCode(containerId)
 	if err != nil {
 		return nil, stateErr

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -209,10 +209,13 @@ func TestSandboxExecEnvironmentInjectsOnlySecretsThatExist(t *testing.T) {
 
 type sandboxStatusContainerRepository struct {
 	repository.ContainerRepository
-	stateErr     error
-	exitCode     int
-	exitCodeErr  error
-	exitCodeRead bool
+	stateErr          error
+	requestStatus     types.ContainerRequestStatus
+	requestStatusErr  error
+	requestStatusRead bool
+	exitCode          int
+	exitCodeErr       error
+	exitCodeRead      bool
 }
 
 func (r *sandboxStatusContainerRepository) GetContainerState(string) (*types.ContainerState, error) {
@@ -224,22 +227,32 @@ func (r *sandboxStatusContainerRepository) GetContainerExitCode(string) (int, er
 	return r.exitCode, r.exitCodeErr
 }
 
+func (r *sandboxStatusContainerRepository) GetContainerRequestStatus(string) (types.ContainerRequestStatus, error) {
+	r.requestStatusRead = true
+	return r.requestStatus, r.requestStatusErr
+}
+
 func TestSandboxContainerStatusAfterStateExpiry(t *testing.T) {
 	const containerId = "sandbox-11111111-2222-3333-4444-555555555555-deadbeef"
 	ownedStub := &types.StubWithRelated{Stub: types.Stub{WorkspaceId: 7}}
 	tests := []struct {
-		name         string
-		workspaceID  uint
-		stub         *types.StubWithRelated
-		exitCode     int
-		exitCodeErr  error
-		wantExited   bool
-		wantStateErr bool
-		wantExitRead bool
+		name             string
+		workspaceID      uint
+		stub             *types.StubWithRelated
+		exitCode         int
+		exitCodeErr      error
+		requestStatus    types.ContainerRequestStatus
+		requestStatusErr error
+		wantExited       bool
+		wantExitCode     int
+		wantStateErr     bool
+		wantRequestRead  bool
+		wantExitRead     bool
 	}{
-		{name: "exited", workspaceID: 7, stub: ownedStub, exitCode: 1, wantExited: true, wantExitRead: true},
+		{name: "exited", workspaceID: 7, stub: ownedStub, requestStatusErr: errors.New("not found"), exitCode: 1, wantExited: true, wantExitCode: 1, wantRequestRead: true, wantExitRead: true},
+		{name: "scheduling failed", workspaceID: 7, stub: ownedStub, requestStatus: types.ContainerRequestStatusFailed, wantExited: true, wantExitCode: 1, wantRequestRead: true},
 		{name: "other workspace", workspaceID: 8, stub: ownedStub},
-		{name: "expired exit code", workspaceID: 7, stub: ownedStub, exitCodeErr: errors.New("not found"), wantStateErr: true, wantExitRead: true},
+		{name: "expired exit code", workspaceID: 7, stub: ownedStub, requestStatusErr: errors.New("not found"), exitCodeErr: errors.New("not found"), wantStateErr: true, wantRequestRead: true, wantExitRead: true},
 		{name: "missing stub", workspaceID: 7, wantStateErr: true},
 	}
 
@@ -247,7 +260,8 @@ func TestSandboxContainerStatusAfterStateExpiry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			stateErr := &types.ErrContainerStateNotFound{ContainerId: containerId}
 			containerRepo := &sandboxStatusContainerRepository{
-				stateErr: stateErr, exitCode: tt.exitCode, exitCodeErr: tt.exitCodeErr,
+				stateErr: stateErr, requestStatus: tt.requestStatus, requestStatusErr: tt.requestStatusErr,
+				exitCode: tt.exitCode, exitCodeErr: tt.exitCodeErr,
 			}
 			service := &GenericPodService{
 				containerRepo: containerRepo,
@@ -259,7 +273,7 @@ func TestSandboxContainerStatusAfterStateExpiry(t *testing.T) {
 
 			switch {
 			case tt.wantExited:
-				if err != nil || resp == nil || !resp.Ok || resp.Status != string(types.SandboxStatusExited) || resp.ExitCode != int32(tt.exitCode) {
+				if err != nil || resp == nil || !resp.Ok || resp.Status != string(types.SandboxStatusExited) || resp.ExitCode != int32(tt.wantExitCode) {
 					t.Fatalf("sandboxContainerStatus() = (%#v, %v)", resp, err)
 				}
 			case tt.wantStateErr:
@@ -273,6 +287,9 @@ func TestSandboxContainerStatusAfterStateExpiry(t *testing.T) {
 			}
 			if containerRepo.exitCodeRead != tt.wantExitRead {
 				t.Fatalf("exit code read = %t, want %t", containerRepo.exitCodeRead, tt.wantExitRead)
+			}
+			if containerRepo.requestStatusRead != tt.wantRequestRead {
+				t.Fatalf("request status read = %t, want %t", containerRepo.requestStatusRead, tt.wantRequestRead)
 			}
 		})
 	}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -71,6 +71,7 @@ type ContainerRepository interface {
 	MarkPendingContainerStoppingIfUnassigned(containerId string, expirySeconds int64) (bool, error)
 	DeleteContainerState(containerId string) error
 	SetContainerRequestStatus(containerId string, status types.ContainerRequestStatus) error
+	GetContainerRequestStatus(containerId string) (types.ContainerRequestStatus, error)
 	SetWorkerAddress(containerId string, addr string) error
 	GetWorkerAddress(ctx context.Context, containerId string) (string, error)
 	SetContainerAddressMap(containerId string, addressMap map[int32]string) error

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -30,6 +30,7 @@ const (
 	schedulerAssignmentIDField    = "schedule_assignment_id"
 	schedulerDeliveryTokenField   = "schedule_delivery_token"
 	schedulerDeliveryAttemptField = "schedule_delivery_attempt"
+	schedulerLastBatchIDField     = "last_schedule_batch_id"
 )
 
 var schedulerWorkerLockOptions = common.RedisLockOptions{
@@ -156,12 +157,60 @@ redis.call("DEL", index_key, ref_counts_key)
 return #ips
 `)
 
-var drainWorkerRequestsScript = redis.NewScript(`
-local requests = redis.call("LRANGE", KEYS[1], 0, -1)
-if #requests > 0 then
-	redis.call("DEL", KEYS[1])
+var requeueWorkerRequestsScript = redis.NewScript(`
+local queue_type = redis.call("TYPE", KEYS[1]).ok
+local pending_type = redis.call("TYPE", KEYS[2]).ok
+local index_type = redis.call("TYPE", KEYS[3]).ok
+local backlog_type = redis.call("TYPE", KEYS[4]).ok
+if (queue_type ~= "none" and queue_type ~= "list")
+	or (pending_type ~= "none" and pending_type ~= "hash")
+	or (index_type ~= "none" and index_type ~= "set")
+	or (backlog_type ~= "none" and backlog_type ~= "zset") then
+	return redis.error_reply("invalid worker request state type")
 end
-return requests
+
+local requests = {}
+for _, raw in ipairs(redis.call("LRANGE", KEYS[1], 0, -1)) do
+	table.insert(requests, {request = raw})
+end
+local pending = redis.call("HGETALL", KEYS[2])
+for i = 1, #pending, 2 do
+	local delivery = cjson.decode(pending[i + 1])
+	table.insert(requests, {request = delivery.request, assignment = pending[i]})
+end
+
+local updated = {}
+for i = 7, #ARGV, 2 do
+	updated[ARGV[i]] = ARGV[i + 1]
+end
+local valid = {}
+for _, item in ipairs(requests) do
+	local request = cjson.decode(item.request)
+	if not request.container_id or request.container_id == "" then
+		return redis.error_reply("container request is missing container_id")
+	end
+	if not updated[request.container_id] then
+		return redis.error_reply("container request changed during worker removal")
+	end
+	local state = ARGV[2] .. request.container_id
+	local state_type = redis.call("TYPE", state).ok
+	if state_type == "hash" and redis.call("HGET", state, "worker_id") == ARGV[1] then
+		local assignment = redis.call("HGET", state, ARGV[3])
+		if assignment and assignment ~= "" and (not item.assignment or assignment == item.assignment) then
+			item.state = state
+			item.container_id = request.container_id
+			table.insert(valid, item)
+		end
+	end
+end
+
+redis.call("DEL", KEYS[1], KEYS[2])
+for _, item in ipairs(valid) do
+	redis.call("HDEL", item.state, "worker_id", "machine_id", "gpu", ARGV[3], ARGV[4], ARGV[5])
+	redis.call("SREM", KEYS[3], item.state)
+	redis.call("ZADD", KEYS[4], ARGV[6], updated[item.container_id])
+end
+return #valid
 `)
 
 var reserveWorkerRequestsScript = redis.NewScript(`
@@ -290,42 +339,98 @@ redis.call("DEL", KEYS[2])
 return recovered
 `)
 
-var commitScheduledContainerRequestsScript = redis.NewScript(`
+var scheduleContainerRequestsScript = redis.NewScript(`
 local status = redis.call("HGET", KEYS[1], "status")
 if not status then
-	return -1
+	return {-1}
+end
+if redis.call("HGET", KEYS[1], "last_schedule_batch_id") == ARGV[9] then
+	local cpu = tonumber(redis.call("HGET", KEYS[1], "free_cpu") or "0")
+	local memory = tonumber(redis.call("HGET", KEYS[1], "free_memory") or "0")
+	local gpu = tonumber(redis.call("HGET", KEYS[1], "gpu_count") or "0")
+	local version = tonumber(redis.call("HGET", KEYS[1], "resource_version") or "0")
+	if not cpu or not memory or not gpu or not version then
+		return {-5}
+	end
+	return {1, redis.call("HGET", KEYS[1], "machine_id") or "", cpu, memory, gpu, version}
 end
 if status ~= "available" then
-	return -2
+	return {-2, status}
 end
 
-for i = 6, #ARGV, 4 do
-	if redis.call("HGET", ARGV[i], "status") ~= "PENDING" then
-		return -3
+local requested_cpu = tonumber(ARGV[1])
+local requested_memory = tonumber(ARGV[2])
+local requested_gpu = tonumber(ARGV[3])
+local version_delta = tonumber(ARGV[4])
+if not requested_cpu or requested_cpu < 0
+	or not requested_memory or requested_memory < 0
+	or not requested_gpu or requested_gpu < 0
+	or not version_delta or version_delta <= 0 then
+	return {-5}
+end
+
+local queue_type = redis.call("TYPE", KEYS[2]).ok
+local index_type = redis.call("TYPE", KEYS[3]).ok
+if (queue_type ~= "none" and queue_type ~= "list") or (index_type ~= "none" and index_type ~= "set") then
+	return {-5}
+
+end
+for i = 10, #ARGV, 4 do
+	local state_type = redis.call("TYPE", ARGV[i]).ok
+	if state_type ~= "hash" then
+		return {-4}
+	end
+	local owner = redis.call("HGET", ARGV[i], "worker_id")
+	local assignment = redis.call("HGET", ARGV[i], ARGV[6])
+	local delivery = redis.call("HGET", ARGV[i], ARGV[7])
+	if redis.call("HGET", ARGV[i], "status") ~= "PENDING"
+		or (owner and owner ~= "")
+		or (assignment and assignment ~= "")
+		or (delivery and delivery ~= "") then
+		return {-4}
 	end
 end
 
-for i = 6, #ARGV, 4 do
+local current_cpu = tonumber(redis.call("HGET", KEYS[1], "free_cpu") or "0")
+local current_memory = tonumber(redis.call("HGET", KEYS[1], "free_memory") or "0")
+local current_gpu = tonumber(redis.call("HGET", KEYS[1], "gpu_count") or "0")
+local current_version = tonumber(redis.call("HGET", KEYS[1], "resource_version") or "0")
+if not current_cpu or not current_memory or not current_gpu or not current_version then
+	return {-5}
+end
+local free_cpu = current_cpu - requested_cpu
+local free_memory = current_memory - requested_memory
+local free_gpu = current_gpu - requested_gpu
+if free_cpu < 0 or free_memory < 0 or free_gpu < 0 then
+	return {-3}
+end
+
+local version = current_version + version_delta
+redis.call("HSET", KEYS[1],
+	"free_cpu", free_cpu,
+	"free_memory", free_memory,
+	"gpu_count", free_gpu,
+	"resource_version", version,
+	"last_schedule_batch_id", ARGV[9])
+local machine_id = redis.call("HGET", KEYS[1], "machine_id") or ""
+for i = 10, #ARGV, 4 do
 	local state = ARGV[i]
 	redis.call("RPUSH", KEYS[2], ARGV[i + 1])
 	redis.call("HSET", state,
-		"worker_id", ARGV[1],
-		"machine_id", ARGV[2],
+		"worker_id", ARGV[5],
+		"machine_id", machine_id,
 		"gpu", ARGV[i + 2],
-		ARGV[3], ARGV[i + 3])
-	redis.call("HDEL", state, ARGV[4], ARGV[5])
+		ARGV[6], ARGV[i + 3])
+	redis.call("HDEL", state, ARGV[7], ARGV[8])
 	redis.call("SADD", KEYS[3], state)
 end
-return 1
+return {1, machine_id, free_cpu, free_memory, free_gpu, version}
 `)
 
 var adjustWorkerCapacityScript = redis.NewScript(`
 local status = redis.call("HGET", KEYS[1], "status")
 if not status then
     return {-1}
-end
-if ARGV[5] == "1" and status ~= "available" then
-    return {-2, status}
 end
 
 local free_cpu = tonumber(redis.call("HGET", KEYS[1], "free_cpu") or "0") + tonumber(ARGV[1])
@@ -358,12 +463,12 @@ func NewWorkerRedisRepository(r *common.RedisClient, config types.WorkerConfig) 
 // AddWorker adds or updates a worker
 func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 	ctx := context.TODO()
-	err := r.lock.Acquire(ctx, common.RedisKeys.SchedulerWorkerLock(worker.Id), schedulerWorkerLockOptions)
-	if err != nil {
-		return err
-	}
-	defer r.lock.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id))
+	return r.lock.WithLease(ctx, common.RedisKeys.SchedulerWorkerLock(worker.Id), schedulerWorkerLockOptions, func(ctx context.Context) error {
+		return r.addWorker(ctx, worker)
+	})
+}
 
+func (r *WorkerRedisRepository) addWorker(ctx context.Context, worker *types.Worker) error {
 	stateKey := common.RedisKeys.SchedulerWorkerState(worker.Id)
 	var oldWorker *types.Worker
 	if existingWorker, err := r.getWorkerFromKey(stateKey); err == nil {
@@ -391,7 +496,16 @@ func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 		}
 	}
 
+	if err := r.reconcileWorkerCapacity(ctx, worker); err != nil {
+		return err
+	}
 	worker.ResourceVersion = 0
+	if oldWorker != nil {
+		worker.ResourceVersion = oldWorker.ResourceVersion
+		if workerCapacityChanged(oldWorker, worker) {
+			worker.ResourceVersion++
+		}
+	}
 
 	pipe := r.rdb.TxPipeline()
 	pipe.HSet(ctx, stateKey, common.ToSlice(worker))
@@ -414,22 +528,31 @@ func (r *WorkerRedisRepository) AddWorker(worker *types.Worker) error {
 	return nil
 }
 
+func workerCapacityChanged(oldWorker, worker *types.Worker) bool {
+	return oldWorker.TotalCpu != worker.TotalCpu || oldWorker.TotalMemory != worker.TotalMemory ||
+		oldWorker.TotalGpuCount != worker.TotalGpuCount || oldWorker.FreeCpu != worker.FreeCpu ||
+		oldWorker.FreeMemory != worker.FreeMemory || oldWorker.FreeGpuCount != worker.FreeGpuCount
+}
+
 func (r *WorkerRedisRepository) RemoveWorker(workerId string) error {
 	ctx := context.TODO()
-	err := r.lock.Acquire(ctx, common.RedisKeys.SchedulerWorkerLock(workerId), schedulerWorkerLockOptions)
-	if err != nil {
-		return err
+	err := r.lock.WithLease(ctx, common.RedisKeys.SchedulerWorkerLock(workerId), schedulerWorkerLockOptions, func(ctx context.Context) error {
+		return r.removeWorker(ctx, workerId)
+	})
+	var notFound *types.ErrWorkerNotFound
+	if errors.As(err, &notFound) {
+		return notFound
 	}
-	defer r.lock.Release(common.RedisKeys.SchedulerWorkerLock(workerId))
+	return err
+}
 
+func (r *WorkerRedisRepository) removeWorker(ctx context.Context, workerId string) error {
 	stateKey := common.RedisKeys.SchedulerWorkerState(workerId)
 	res, err := r.rdb.Exists(ctx, stateKey).Result()
 	if err != nil {
 		return err
 	}
-
-	exists := res > 0
-	if !exists {
+	if res == 0 {
 		return &types.ErrWorkerNotFound{WorkerId: workerId}
 	}
 
@@ -437,101 +560,77 @@ func (r *WorkerRedisRepository) RemoveWorker(workerId string) error {
 	if err != nil {
 		return err
 	}
-
 	requeued, err := r.requeueWorkerRequests(ctx, workerId)
 	if err != nil {
 		return err
 	}
-
 	if err := r.removeWorkerIndexEntries(ctx, stateKey, worker); err != nil {
 		return err
 	}
-
-	err = r.rdb.Del(ctx, stateKey).Err()
-	if err != nil {
+	if err := r.rdb.Del(ctx, stateKey).Err(); err != nil {
 		return err
 	}
-
 	if requeued > 0 {
 		log.Info().Str("worker_id", workerId).Int("request_count", requeued).Msg("requeued requests from removed worker")
 	}
-
 	return nil
 }
 
 func (r *WorkerRedisRepository) requeueWorkerRequests(ctx context.Context, workerId string) (int, error) {
-	if err := r.RecoverPendingContainerRequests(workerId); err != nil {
-		return 0, err
-	}
-	queueKey := common.RedisKeys.SchedulerWorkerRequests(workerId)
-	result, err := drainWorkerRequestsScript.Run(ctx, r.rdb, []string{queueKey}).Result()
-	if err != nil {
-		return 0, fmt.Errorf("failed to drain worker request queue <%s>: %w", queueKey, err)
-	}
-
-	items, ok := result.([]interface{})
-	if !ok {
-		return 0, fmt.Errorf("unexpected worker request drain result: %T", result)
-	}
-	if len(items) == 0 {
-		return 0, nil
-	}
-
-	rawItems := make([]string, 0, len(items))
-	for _, item := range items {
-		raw, ok := item.(string)
-		if !ok {
-			return 0, fmt.Errorf("unexpected worker request type: %T", item)
-		}
-		rawItems = append(rawItems, raw)
-	}
-
-	pipe := r.rdb.Pipeline()
 	now := time.Now()
-	for _, raw := range rawItems {
+	pipe := r.rdb.TxPipeline()
+	queued := pipe.LRange(ctx, common.RedisKeys.SchedulerWorkerRequests(workerId), 0, -1)
+	pending := pipe.HVals(ctx, common.RedisKeys.SchedulerWorkerPendingRequests(workerId))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, fmt.Errorf("failed to read requests for worker <%s>: %w", workerId, err)
+	}
+	rawRequests := append([]string(nil), queued.Val()...)
+	for _, encoded := range pending.Val() {
+		var delivery pendingContainerRequest
+		if err := json.Unmarshal([]byte(encoded), &delivery); err != nil {
+			return 0, fmt.Errorf("failed to decode pending request for worker <%s>: %w", workerId, err)
+		}
+		rawRequests = append(rawRequests, delivery.Request)
+	}
+	args := []interface{}{workerId, common.RedisKeys.SchedulerContainerState(""), schedulerAssignmentIDField,
+		schedulerDeliveryTokenField, schedulerDeliveryAttemptField, now.UnixNano()}
+	seen := make(map[string]struct{}, len(rawRequests))
+	for _, raw := range rawRequests {
 		var request types.ContainerRequest
 		if err := json.Unmarshal([]byte(raw), &request); err != nil {
-			_ = r.restoreWorkerRequests(ctx, workerId, rawItems)
-			return 0, fmt.Errorf("failed to deserialize queued request for worker <%s>: %w", workerId, err)
+			return 0, fmt.Errorf("failed to decode queued request for worker <%s>: %w", workerId, err)
 		}
-
+		if request.ContainerId == "" {
+			return 0, fmt.Errorf("queued request for worker <%s> is missing container id", workerId)
+		}
+		if _, exists := seen[request.ContainerId]; exists {
+			continue
+		}
+		seen[request.ContainerId] = struct{}{}
 		request.RetryCount++
 		request.Timestamp = now
-		jsonData, err := json.Marshal(&request)
+		updated, err := json.Marshal(&request)
 		if err != nil {
-			_ = r.restoreWorkerRequests(ctx, workerId, rawItems)
-			return 0, fmt.Errorf("failed to serialize requeued request for worker <%s>: %w", workerId, err)
+			return 0, fmt.Errorf("failed to encode requeued request for worker <%s>: %w", workerId, err)
 		}
-
-		pipe.ZAdd(ctx, common.RedisKeys.SchedulerContainerRequests(), redis.Z{
-			Score:  float64(now.UnixNano()),
-			Member: jsonData,
-		})
+		args = append(args, request.ContainerId, updated)
 	}
-
-	if _, err := pipe.Exec(ctx); err != nil {
-		_ = r.restoreWorkerRequests(ctx, workerId, rawItems)
-		return 0, fmt.Errorf("failed to requeue drained requests for worker <%s>: %w", workerId, err)
+	requeued, err := requeueWorkerRequestsScript.Run(ctx, r.rdb, []string{
+		common.RedisKeys.SchedulerWorkerRequests(workerId),
+		common.RedisKeys.SchedulerWorkerPendingRequests(workerId),
+		common.RedisKeys.SchedulerContainerWorkerIndex(workerId),
+		common.RedisKeys.SchedulerContainerRequests(),
+	}, args...).Int()
+	if err != nil {
+		return 0, fmt.Errorf("failed to requeue requests for worker <%s>: %w", workerId, err)
 	}
 
 	metrics.RecordSchedulerBacklogDepth(r.rdb.ZCard(ctx, common.RedisKeys.SchedulerContainerRequests()).Val())
-	return len(rawItems), nil
+	return requeued, nil
 }
 
 type pendingContainerRequest struct {
 	Request string `json:"request"`
-}
-
-func (r *WorkerRedisRepository) restoreWorkerRequests(ctx context.Context, workerId string, requests []string) error {
-	if len(requests) == 0 {
-		return nil
-	}
-
-	values := make([]interface{}, 0, len(requests))
-	for _, request := range requests {
-		values = append(values, request)
-	}
-	return r.rdb.RPush(ctx, common.RedisKeys.SchedulerWorkerRequests(workerId), values...).Err()
 }
 
 func (r *WorkerRedisRepository) UpdateWorkerStatus(workerId string, status types.WorkerStatus) error {
@@ -614,18 +713,37 @@ func (r *WorkerRedisRepository) reconcileWorkerCapacity(ctx context.Context, wor
 	return nil
 }
 
+func (r *WorkerRedisRepository) reconcileStoredWorkerCapacity(ctx context.Context, stateKey string, worker *types.Worker) error {
+	previous := *worker
+	if err := r.reconcileWorkerCapacity(ctx, worker); err != nil {
+		return err
+	}
+	if !workerCapacityChanged(&previous, worker) {
+		return nil
+	}
+	pipe := r.rdb.TxPipeline()
+	pipe.HSet(ctx, stateKey, "free_cpu", worker.FreeCpu, "free_memory", worker.FreeMemory, "gpu_count", worker.FreeGpuCount)
+	version := pipe.HIncrBy(ctx, stateKey, "resource_version", 1)
+	pipe.Expire(ctx, stateKey, time.Duration(types.WorkerStateTtlS)*time.Second)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return err
+	}
+	worker.ResourceVersion = version.Val()
+	return nil
+}
+
 func (r *WorkerRedisRepository) getWorkerReservedCapacity(ctx context.Context, workerId string) (workerReservedCapacity, error) {
 	var usage workerReservedCapacity
 	requestContainerIDs := map[string]struct{}{}
 
-	queuedRequests, err := r.rdb.LRange(ctx, common.RedisKeys.SchedulerWorkerRequests(workerId), 0, -1)
-	if err != nil {
-		return usage, fmt.Errorf("failed to list queued requests for worker <%s>: %w", workerId, err)
+	pipe := r.rdb.TxPipeline()
+	queuedCmd := pipe.LRange(ctx, common.RedisKeys.SchedulerWorkerRequests(workerId), 0, -1)
+	pendingCmd := pipe.HVals(ctx, common.RedisKeys.SchedulerWorkerPendingRequests(workerId))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return usage, fmt.Errorf("failed to list queued and pending requests for worker <%s>: %w", workerId, err)
 	}
-	pendingRequests, err := r.rdb.HVals(ctx, common.RedisKeys.SchedulerWorkerPendingRequests(workerId)).Result()
-	if err != nil {
-		return usage, fmt.Errorf("failed to list pending requests for worker <%s>: %w", workerId, err)
-	}
+	queuedRequests := queuedCmd.Val()
+	pendingRequests := pendingCmd.Val()
 	for _, encoded := range pendingRequests {
 		var pending pendingContainerRequest
 		if err := json.Unmarshal([]byte(encoded), &pending); err != nil {
@@ -658,7 +776,13 @@ func (r *WorkerRedisRepository) getWorkerReservedCapacity(ctx context.Context, w
 		if err != nil {
 			return usage, err
 		}
-		if !exists || state.Status == types.ContainerStatusStopping {
+		if !exists {
+			continue
+		}
+		if state.WorkerId != workerId {
+			if err := r.rdb.SRem(ctx, common.RedisKeys.SchedulerContainerWorkerIndex(workerId), key).Err(); err != nil {
+				return usage, fmt.Errorf("failed to remove mismatched container index entry <%s> for worker <%s>: %w", key, workerId, err)
+			}
 			continue
 		}
 		containerID := state.ContainerId
@@ -1213,10 +1337,26 @@ func (r *WorkerRedisRepository) UpdateWorkerCapacity(worker *types.Worker, reque
 		return errors.New("worker and container request are required")
 	}
 
+	if capacityUpdateType == types.AddCapacity {
+		return r.withWorker(worker.Id, func(ctx context.Context, stateKey string, current *types.Worker) error {
+			if err := r.reconcileStoredWorkerCapacity(ctx, stateKey, current); err != nil {
+				return err
+			}
+			worker.FreeCpu = current.FreeCpu
+			worker.FreeMemory = current.FreeMemory
+			worker.FreeGpuCount = current.FreeGpuCount
+			worker.ResourceVersion = current.ResourceVersion
+			worker.MachineId = current.MachineId
+			return nil
+		})
+	}
+
 	direction := int64(1)
 	if capacityUpdateType == types.RemoveCapacity {
+		// Retained for legacy callers. Scheduling reserves capacity atomically in
+		// ScheduleContainerRequests; reconciliation remains authoritative.
 		direction = -1
-	} else if capacityUpdateType != types.AddCapacity {
+	} else {
 		return errors.New("invalid capacity update type")
 	}
 	result, err := r.adjustWorkerCapacity(
@@ -1225,7 +1365,6 @@ func (r *WorkerRedisRepository) UpdateWorkerCapacity(worker *types.Worker, reque
 		direction*capacityMemoryForRequest(request),
 		direction*int64(gpuCountForCapacity(request.Gpu, request.GpuRequest, request.GpuCount)),
 		1,
-		false,
 	)
 	if err != nil {
 		return err
@@ -1246,11 +1385,7 @@ type workerCapacityResult struct {
 	resourceVersion int64
 }
 
-func (r *WorkerRedisRepository) adjustWorkerCapacity(workerID string, cpu, memory, gpu, version int64, requireAvailable bool) (workerCapacityResult, error) {
-	requireAvailableArg := "0"
-	if requireAvailable {
-		requireAvailableArg = "1"
-	}
+func (r *WorkerRedisRepository) adjustWorkerCapacity(workerID string, cpu, memory, gpu, version int64) (workerCapacityResult, error) {
 	value, err := adjustWorkerCapacityScript.Run(
 		context.TODO(),
 		r.rdb,
@@ -1259,11 +1394,14 @@ func (r *WorkerRedisRepository) adjustWorkerCapacity(workerID string, cpu, memor
 		memory,
 		gpu,
 		version,
-		requireAvailableArg,
 	).Result()
 	if err != nil {
 		return workerCapacityResult{}, err
 	}
+	return parseWorkerCapacityResult(workerID, value)
+}
+
+func parseWorkerCapacityResult(workerID string, value interface{}) (workerCapacityResult, error) {
 	items, ok := value.([]interface{})
 	if !ok || len(items) == 0 {
 		return workerCapacityResult{}, fmt.Errorf("unexpected worker capacity result: %T", value)
@@ -1283,6 +1421,10 @@ func (r *WorkerRedisRepository) adjustWorkerCapacity(workerID string, cpu, memor
 		return workerCapacityResult{}, fmt.Errorf("worker <%s> is not available: %s", workerID, status)
 	case -3:
 		return workerCapacityResult{}, errors.New("unable to schedule container, worker out of cpu, memory, or gpu")
+	case -4:
+		return workerCapacityResult{}, errors.New("container request is no longer pending or is already assigned")
+	case -5:
+		return workerCapacityResult{}, errors.New("worker scheduling state has an invalid Redis type")
 	case 1:
 		if len(items) != 6 {
 			return workerCapacityResult{}, fmt.Errorf("unexpected worker capacity result length: %d", len(items))
@@ -1307,6 +1449,16 @@ func (r *WorkerRedisRepository) adjustWorkerCapacity(workerID string, cpu, memor
 	}
 }
 
+func workerCapacityResultFromWorker(worker *types.Worker) workerCapacityResult {
+	return workerCapacityResult{
+		machineID:       worker.MachineId,
+		freeCPU:         worker.FreeCpu,
+		freeMemory:      worker.FreeMemory,
+		freeGPU:         int64(worker.FreeGpuCount),
+		resourceVersion: worker.ResourceVersion,
+	}
+}
+
 func (r *WorkerRedisRepository) ScheduleContainerRequest(worker *types.Worker, request *types.ContainerRequest) error {
 	return r.ScheduleContainerRequests(worker, []*types.ContainerRequest{request})
 }
@@ -1326,86 +1478,110 @@ func (r *WorkerRedisRepository) ScheduleContainerRequests(worker *types.Worker, 
 		return nil
 	}
 
-	var cpu, memory, gpu int64
+	seenContainerIDs := make(map[string]struct{}, len(requests))
 	queued := make([]queuedContainerRequest, 0, len(requests))
 	for _, request := range requests {
 		if request == nil {
 			return errors.New("cannot schedule a nil container request")
 		}
-		cpu += request.Cpu
-		memory += capacityMemoryForRequest(request)
-		gpu += int64(gpuCountForCapacity(request.Gpu, request.GpuRequest, request.GpuCount))
+		if request.Cpu < 0 || request.Memory < 0 {
+			return errors.New("cannot schedule a request with negative cpu or memory")
+		}
+		if request.ContainerId == "" {
+			return errors.New("cannot schedule a request without a container id")
+		}
+		if _, exists := seenContainerIDs[request.ContainerId]; exists {
+			return fmt.Errorf("cannot schedule duplicate container <%s>", request.ContainerId)
+		}
+		seenContainerIDs[request.ContainerId] = struct{}{}
 		queued = append(queued, queuedContainerRequest{
 			request:    request,
 			stateKey:   common.RedisKeys.SchedulerContainerState(request.ContainerId),
 			assignment: uuid.NewString(),
 		})
 	}
-	capacity, err := r.adjustWorkerCapacity(worker.Id, -cpu, -memory, -gpu, int64(len(requests)), true)
-	if err != nil {
-		return err
-	}
-	releaseCapacity := func() error {
-		_, err := r.adjustWorkerCapacity(worker.Id, cpu, memory, gpu, int64(len(requests)), false)
-		return err
-	}
-
-	now := time.Now()
-	for index := range queued {
-		queuedRequest := *queued[index].request
-		queuedRequest.Timestamp = now
-		queuedRequest.MachineId = capacity.machineID
-		payload, err := json.Marshal(&queuedRequest)
-		if err != nil {
-			return errors.Join(fmt.Errorf("failed to serialize request: %w", err), releaseCapacity())
-		}
-		queued[index].payload = payload
-	}
 
 	ctx := context.TODO()
 	queueKey := common.RedisKeys.SchedulerWorkerRequests(worker.Id)
 	workerContainerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id)
-	args := []interface{}{worker.Id, capacity.machineID, schedulerAssignmentIDField, schedulerDeliveryTokenField, schedulerDeliveryAttemptField}
-	for _, item := range queued {
-		args = append(args, item.stateKey, item.payload, item.request.Gpu, item.assignment)
-	}
-	committed, err := commitScheduledContainerRequestsScript.Run(ctx, r.rdb, []string{
-		common.RedisKeys.SchedulerWorkerState(worker.Id),
-		queueKey,
-		workerContainerIndexKey,
-	}, args...).Int()
-	if err != nil {
-		errs := []error{fmt.Errorf("failed to push requests: %w", err)}
-		for _, item := range queued {
-			err := r.cleanupScheduledContainerRequest(ctx, scheduleCleanup{
-				queue:   queueKey,
-				index:   workerContainerIndexKey,
-				state:   item.stateKey,
-				payload: item.payload,
-				queued:  true,
-				token:   item.assignment,
-				worker:  worker.Id,
-			})
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
-		if err := releaseCapacity(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to restore worker capacity after queue push error: %w", err))
-		}
-		return errors.Join(errs...)
-	}
-	if committed < 1 {
-		if err := releaseCapacity(); err != nil {
+	batchID := uuid.NewString()
+	var capacity workerCapacityResult
+	var scheduledAt time.Time
+	committed := false
+	err := r.lock.WithLease(ctx, common.RedisKeys.SchedulerWorkerLock(worker.Id), schedulerWorkerLockOptions, func(ctx context.Context) error {
+		current, err := r.getWorkerFromKey(common.RedisKeys.SchedulerWorkerState(worker.Id))
+		if err != nil {
 			return err
 		}
-		if committed == -1 {
-			return &types.ErrWorkerNotFound{WorkerId: worker.Id}
+		scheduledAt = time.Now()
+		var cpu, memory, gpu int64
+		for index := range queued {
+			cpu += queued[index].request.Cpu
+			memory += capacityMemoryForRequest(queued[index].request)
+			gpu += int64(gpuCountForCapacity(queued[index].request.Gpu, queued[index].request.GpuRequest, queued[index].request.GpuCount))
+			queuedRequest := *queued[index].request
+			queuedRequest.Timestamp = scheduledAt
+			queuedRequest.MachineId = current.MachineId
+			payload, err := json.Marshal(&queuedRequest)
+			if err != nil {
+				return fmt.Errorf("failed to serialize request: %w", err)
+			}
+			queued[index].payload = payload
 		}
-		if committed == -3 {
-			return errors.New("container request is no longer pending")
+		capacity = workerCapacityResult{
+			machineID:       current.MachineId,
+			freeCPU:         current.FreeCpu - cpu,
+			freeMemory:      current.FreeMemory - memory,
+			freeGPU:         int64(current.FreeGpuCount) - gpu,
+			resourceVersion: current.ResourceVersion + int64(len(requests)),
 		}
-		return fmt.Errorf("worker <%s> is not available", worker.Id)
+
+		args := []interface{}{cpu, memory, gpu, int64(len(requests)), worker.Id,
+			schedulerAssignmentIDField, schedulerDeliveryTokenField, schedulerDeliveryAttemptField, batchID}
+		for _, item := range queued {
+			args = append(args, item.stateKey, item.payload, item.request.Gpu, item.assignment)
+		}
+		value, runErr := scheduleContainerRequestsScript.Run(ctx, r.rdb, []string{
+			common.RedisKeys.SchedulerWorkerState(worker.Id),
+			queueKey,
+			workerContainerIndexKey,
+		}, args...).Result()
+		if runErr != nil {
+			recoveryCtx, cancelRecovery := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancelRecovery()
+			outcome, outcomeErr := r.scheduledBatchCommitted(recoveryCtx, worker.Id, batchID, queued)
+			if outcomeErr != nil {
+				return errors.Join(fmt.Errorf("failed to schedule requests: %w", runErr), outcomeErr)
+			}
+			if outcome {
+				committed = true
+				current, getErr := r.getWorkerFromKey(common.RedisKeys.SchedulerWorkerState(worker.Id))
+				if getErr == nil {
+					capacity = workerCapacityResultFromWorker(current)
+				}
+				return nil
+			}
+			current, reconcileErr := r.getWorkerFromKey(common.RedisKeys.SchedulerWorkerState(worker.Id))
+			if reconcileErr == nil {
+				reconcileErr = r.reconcileStoredWorkerCapacity(recoveryCtx, common.RedisKeys.SchedulerWorkerState(worker.Id), current)
+			}
+			return errors.Join(fmt.Errorf("failed to schedule requests: %w", runErr), reconcileErr)
+		}
+		if items, ok := value.([]interface{}); ok && len(items) > 0 {
+			code, _ := items[0].(int64)
+			committed = code == 1
+		}
+		capacity, err = parseWorkerCapacityResult(worker.Id, value)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil && !committed {
+		return err
+	}
+	if err != nil {
+		log.Warn().Err(err).Str("worker_id", worker.Id).Msg("worker lease ended after requests were committed")
 	}
 	if err := r.rdb.Publish(ctx, common.RedisKeys.SchedulerWorkerRequestChannel(), worker.Id).Err(); err != nil {
 		log.Warn().Err(err).Str("worker_id", worker.Id).Msg("failed to notify worker request stream")
@@ -1418,6 +1594,7 @@ func (r *WorkerRedisRepository) ScheduleContainerRequests(worker *types.Worker, 
 	worker.MachineId = capacity.machineID
 	for _, item := range queued {
 		item.request.MachineId = capacity.machineID
+		item.request.Timestamp = scheduledAt
 	}
 	metrics.RecordWorkerQueueDepth(worker.Id, r.rdb.LLen(ctx, common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
 
@@ -1431,45 +1608,50 @@ func (r *WorkerRedisRepository) ScheduleContainerRequests(worker *types.Worker, 
 	return nil
 }
 
-type scheduleCleanup struct {
-	queue, index, state string
-	payload             []byte
-	queued              bool
-	token, worker       string
-}
-
-var cleanupScheduledContainerRequestScript = redis.NewScript(`
-if ARGV[2] == "1" then
-	redis.call("LREM", KEYS[1], -1, ARGV[1])
-end
-
-local token = redis.pcall("HGET", KEYS[3], "schedule_assignment_id")
-local worker = redis.pcall("HGET", KEYS[3], "worker_id")
-if type(token) == "table" or type(worker) == "table" then
-	redis.call("SREM", KEYS[2], KEYS[3])
-	return 1
-end
-
-if worker == ARGV[4] and token ~= ARGV[3] then
-	return 1
-end
-
-redis.call("SREM", KEYS[2], KEYS[3])
-if worker == ARGV[4] then
-	redis.call("HDEL", KEYS[3], "worker_id", "machine_id", "gpu", "schedule_assignment_id")
-end
-return 1
-`)
-
-func (r *WorkerRedisRepository) cleanupScheduledContainerRequest(ctx context.Context, cleanup scheduleCleanup) error {
-	removeQueuedArg := "0"
-	if cleanup.queued {
-		removeQueuedArg = "1"
+func (r *WorkerRedisRepository) scheduledBatchCommitted(ctx context.Context, workerID, batchID string, queued []queuedContainerRequest) (bool, error) {
+	lastBatchID, err := r.rdb.HGet(ctx, common.RedisKeys.SchedulerWorkerState(workerID), schedulerLastBatchIDField).Result()
+	if err == nil && lastBatchID == batchID {
+		return true, nil
 	}
-	if err := cleanupScheduledContainerRequestScript.Run(ctx, r.rdb, []string{cleanup.queue, cleanup.index, cleanup.state}, string(cleanup.payload), removeQueuedArg, cleanup.token, cleanup.worker).Err(); err != nil {
-		return fmt.Errorf("failed to clean up scheduled container request: %w", err)
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return false, err
 	}
-	return nil
+	queuedPayloads, err := r.rdb.LRange(ctx, common.RedisKeys.SchedulerWorkerRequests(workerID), 0, -1)
+	if err != nil {
+		return false, err
+	}
+	payloads := make(map[string]struct{}, len(queuedPayloads))
+	for _, payload := range queuedPayloads {
+		payloads[payload] = struct{}{}
+	}
+	pendingKey := common.RedisKeys.SchedulerWorkerPendingRequests(workerID)
+	for _, item := range queued {
+		if _, exists := payloads[string(item.payload)]; exists {
+			return true, nil
+		}
+		pending, err := r.rdb.HExists(ctx, pendingKey, item.assignment).Result()
+		if err != nil {
+			return false, err
+		}
+		if pending {
+			return true, nil
+		}
+		fields, err := r.rdb.HMGet(ctx, item.stateKey, "worker_id", schedulerAssignmentIDField, schedulerDeliveryTokenField).Result()
+		if err != nil {
+			return false, err
+		}
+		field := func(index int) string {
+			if index >= len(fields) || fields[index] == nil {
+				return ""
+			}
+			value, _ := fields[index].(string)
+			return value
+		}
+		if field(0) == workerID && (field(1) == item.assignment || strings.HasPrefix(field(2), item.assignment+":")) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (r *WorkerRedisRepository) AddContainerToWorker(workerId, containerId, deliveryToken string) error {

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -3,14 +3,42 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/redis/go-redis/v9"
 	"github.com/tj/assert"
 )
+
+type lostRedisScriptReplyHook struct {
+	hash  string
+	lost  atomic.Bool
+	after func()
+}
+
+func (h *lostRedisScriptReplyHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+
+func (h *lostRedisScriptReplyHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		err := next(ctx, cmd)
+		if err == nil && cmd.Name() == "evalsha" && len(cmd.Args()) > 1 && cmd.Args()[1] == h.hash && h.lost.CompareAndSwap(false, true) {
+			if h.after != nil {
+				h.after()
+			}
+			return errors.New("simulated lost Redis reply")
+		}
+		return err
+	}
+}
+
+func (h *lostRedisScriptReplyHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
 
 func setPendingContainerRequests(t *testing.T, rdb *common.RedisClient, requests ...*types.ContainerRequest) {
 	t.Helper()
@@ -20,6 +48,8 @@ func setPendingContainerRequests(t *testing.T, rdb *common.RedisClient, requests
 			common.RedisKeys.SchedulerContainerState(request.ContainerId),
 			"container_id", request.ContainerId,
 			"status", string(types.ContainerStatusPending),
+			"worker_id", "",
+			"machine_id", "",
 		).Err())
 	}
 }
@@ -64,8 +94,8 @@ func TestAddAndRemoveWorker(t *testing.T) {
 	err = repo.RemoveWorker(newWorker.Id)
 	assert.Error(t, err)
 
-	_, ok := err.(*types.ErrWorkerNotFound)
-	assert.True(t, ok) // assert that error is of type ErrWorkerNotFound
+	var notFound *types.ErrWorkerNotFound
+	assert.True(t, errors.As(err, &notFound))
 }
 
 func TestRemoveWorkerRequeuesPendingWorkerRequests(t *testing.T) {
@@ -86,7 +116,10 @@ func TestRemoveWorkerRequeuesPendingWorkerRequests(t *testing.T) {
 	assert.Nil(t, repo.AddWorker(worker))
 
 	requests := []*types.ContainerRequest{
-		{ContainerId: "container-1", WorkspaceId: "workspace", StubId: "stub", Cpu: 100, Memory: 100, RetryCount: 2},
+		{
+			ContainerId: "container-1", WorkspaceId: "workspace", StubId: "stub", Cpu: 100, Memory: 100, RetryCount: 2,
+			Env: []string{}, Ports: []uint32{}, Checkpoint: &types.Checkpoint{CacheSizeBytes: 9_007_199_254_740_993},
+		},
 		{ContainerId: "container-2", WorkspaceId: "workspace", StubId: "stub", Cpu: 100, Memory: 100, RetryCount: 4},
 	}
 	setPendingContainerRequests(t, rdb, requests...)
@@ -95,6 +128,11 @@ func TestRemoveWorkerRequeuesPendingWorkerRequests(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Nil(t, repo.ScheduleContainerRequest(currentWorker, request))
 	}
+	staleRequest, err := json.Marshal(&types.ContainerRequest{ContainerId: "expired-container"})
+	assert.NoError(t, err)
+	staleDelivery, err := json.Marshal(map[string]string{"request": string(staleRequest), "delivery_token": "expired-assignment:1"})
+	assert.NoError(t, err)
+	assert.NoError(t, rdb.HSet(context.TODO(), common.RedisKeys.SchedulerWorkerPendingRequests(worker.Id), "expired-assignment", staleDelivery).Err())
 
 	assert.Nil(t, repo.RemoveWorker(worker.Id))
 
@@ -111,13 +149,37 @@ func TestRemoveWorkerRequeuesPendingWorkerRequests(t *testing.T) {
 	assert.Equal(t, 2, len(backlog))
 
 	retriesByContainer := map[string]int{}
+	requeuedRequests := make([]*types.ContainerRequest, 0, len(backlog))
 	for _, raw := range backlog {
 		var request types.ContainerRequest
 		assert.Nil(t, json.Unmarshal([]byte(raw), &request))
 		retriesByContainer[request.ContainerId] = request.RetryCount
+		requeuedRequests = append(requeuedRequests, &request)
 	}
 	assert.Equal(t, 3, retriesByContainer["container-1"])
 	assert.Equal(t, 5, retriesByContainer["container-2"])
+	for _, request := range requeuedRequests {
+		if request.ContainerId == "container-1" {
+			assert.Equal(t, []string{}, request.Env)
+			assert.Equal(t, []uint32{}, request.Ports)
+			assert.NotNil(t, request.Checkpoint)
+			assert.Equal(t, int64(9_007_199_254_740_993), request.Checkpoint.CacheSizeBytes)
+		}
+	}
+
+	replacement := &types.Worker{
+		Id:          "replacement-worker",
+		Status:      types.WorkerStatusAvailable,
+		TotalCpu:    10_000,
+		TotalMemory: 10_000,
+		FreeCpu:     10_000,
+		FreeMemory:  10_000,
+	}
+	assert.NoError(t, repo.AddWorker(replacement))
+	for _, request := range requeuedRequests {
+		assert.NoError(t, repo.ScheduleContainerRequest(replacement, request))
+		assert.Equal(t, replacement.Id, rdb.HGet(context.TODO(), common.RedisKeys.SchedulerContainerState(request.ContainerId), "worker_id").Val())
+	}
 }
 
 func TestGetWorkerById(t *testing.T) {
@@ -233,6 +295,7 @@ func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *te
 	queuedState := &types.ContainerState{
 		ContainerId: queuedRequest.ContainerId,
 		Status:      types.ContainerStatusPending,
+		WorkerId:    worker.Id,
 		Cpu:         queuedRequest.Cpu,
 		Memory:      queuedRequest.Memory,
 	}
@@ -245,6 +308,7 @@ func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *te
 	runningState := &types.ContainerState{
 		ContainerId: "container-reconcile-running",
 		Status:      types.ContainerStatusRunning,
+		WorkerId:    worker.Id,
 		Cpu:         1000,
 		Memory:      100,
 		Gpu:         "A10G",
@@ -258,6 +322,9 @@ func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *te
 	staleStateKey := common.RedisKeys.SchedulerContainerState("container-reconcile-missing")
 	err = rdb.SAdd(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), staleStateKey).Err()
 	assert.Nil(t, err)
+	emptyOwnerStateKey := common.RedisKeys.SchedulerContainerState("container-reconcile-empty-owner")
+	assert.NoError(t, rdb.HSet(context.TODO(), emptyOwnerStateKey, "status", string(types.ContainerStatusRunning), "worker_id", "", "cpu", 1000).Err())
+	assert.NoError(t, rdb.SAdd(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), emptyOwnerStateKey).Err())
 
 	err = repo.ToggleWorkerAvailable(worker.Id, "")
 	assert.Nil(t, err)
@@ -273,6 +340,7 @@ func TestToggleWorkerAvailableReconcilesCapacityFromQueueAndContainerIndex(t *te
 	staleIndexExists, err := rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), staleStateKey).Result()
 	assert.Nil(t, err)
 	assert.False(t, staleIndexExists)
+	assert.False(t, rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), emptyOwnerStateKey).Val())
 }
 
 func TestToggleWorkerAvailableCapsReconciledCapacityAtZero(t *testing.T) {
@@ -318,7 +386,93 @@ func TestToggleWorkerAvailableCapsReconciledCapacityAtZero(t *testing.T) {
 	assert.Equal(t, uint32(0), updatedWorker.FreeGpuCount)
 }
 
-func TestUpdateWorkerCapacityForGPUWorker(t *testing.T) {
+func TestStoppingContainerRemainsReservedUntilStateDeletion(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:            "worker-stopping-capacity",
+		Status:        types.WorkerStatusAvailable,
+		TotalCpu:      100,
+		TotalMemory:   125,
+		TotalGpuCount: 1,
+		FreeCpu:       100,
+		FreeMemory:    125,
+		FreeGpuCount:  1,
+		Gpu:           "A10G",
+	}
+	assert.NoError(t, repo.AddWorker(worker))
+	request := &types.ContainerRequest{
+		ContainerId: "container-stopping-capacity",
+		Cpu:         100,
+		Memory:      100,
+		Gpu:         worker.Gpu,
+		GpuCount:    1,
+	}
+	stateKey := common.RedisKeys.SchedulerContainerState(request.ContainerId)
+	assert.NoError(t, rdb.HSet(context.TODO(), stateKey, common.ToSlice(&types.ContainerState{
+		ContainerId: request.ContainerId,
+		Status:      types.ContainerStatusStopping,
+		WorkerId:    worker.Id,
+		Cpu:         request.Cpu,
+		Memory:      request.Memory,
+		Gpu:         request.Gpu,
+		GpuCount:    request.GpuCount,
+	})).Err())
+	assert.NoError(t, rdb.SAdd(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), stateKey).Err())
+
+	heartbeat := *worker
+	assert.NoError(t, repo.AddWorker(&heartbeat))
+	assert.Equal(t, int64(0), heartbeat.FreeCpu)
+	assert.Equal(t, int64(0), heartbeat.FreeMemory)
+	assert.Equal(t, uint32(0), heartbeat.FreeGpuCount)
+	assert.NoError(t, repo.UpdateWorkerCapacity(&heartbeat, request, types.AddCapacity))
+	assert.Equal(t, uint32(0), heartbeat.FreeGpuCount)
+
+	assert.NoError(t, rdb.Del(context.TODO(), stateKey).Err())
+	assert.NoError(t, rdb.SRem(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), stateKey).Err())
+	assert.NoError(t, repo.UpdateWorkerCapacity(&heartbeat, request, types.AddCapacity))
+	assert.Equal(t, int64(100), heartbeat.FreeCpu)
+	assert.Equal(t, int64(125), heartbeat.FreeMemory)
+	assert.Equal(t, uint32(1), heartbeat.FreeGpuCount)
+	releasedVersion := heartbeat.ResourceVersion
+	assert.NoError(t, repo.UpdateWorkerCapacity(&heartbeat, request, types.AddCapacity))
+	assert.Equal(t, releasedVersion, heartbeat.ResourceVersion)
+}
+
+func TestStaleWorkerHeartbeatCannotRestoreScheduledCapacity(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id:            "worker-heartbeat-schedule-race",
+		Status:        types.WorkerStatusAvailable,
+		TotalCpu:      100,
+		TotalMemory:   125,
+		TotalGpuCount: 1,
+		FreeCpu:       100,
+		FreeMemory:    125,
+		FreeGpuCount:  1,
+		Gpu:           "A10G",
+	}
+	assert.NoError(t, repo.AddWorker(worker))
+	request := &types.ContainerRequest{ContainerId: "container-heartbeat-schedule-race", Cpu: 100, Memory: 100, Gpu: worker.Gpu}
+	setPendingContainerRequests(t, rdb, request)
+
+	heartbeat := *worker
+	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
+	assert.NoError(t, repo.AddWorker(&heartbeat))
+
+	updated, err := repo.GetWorkerById(worker.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), updated.FreeCpu)
+	assert.Equal(t, int64(0), updated.FreeMemory)
+	assert.Equal(t, uint32(0), updated.FreeGpuCount)
+	assert.Equal(t, int64(1), updated.ResourceVersion)
+	assert.Equal(t, int64(1), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+}
+
+func TestUpdateWorkerCapacityReconcilesCompletedGPURequestExactlyOnce(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)
 	assert.Nil(t, err)
@@ -326,68 +480,38 @@ func TestUpdateWorkerCapacityForGPUWorker(t *testing.T) {
 	repo := NewWorkerRedisRepositoryForTest(rdb)
 	assert.Nil(t, err)
 
-	newWorker := &types.Worker{
-		Id:           "worker1",
-		Status:       types.WorkerStatusPending,
-		FreeCpu:      0,
-		FreeMemory:   0,
-		Gpu:          "A10G",
-		FreeGpuCount: 0,
+	worker := &types.Worker{
+		Id:            "worker-capacity-release",
+		Status:        types.WorkerStatusAvailable,
+		TotalCpu:      500,
+		TotalMemory:   1250,
+		TotalGpuCount: 1,
+		FreeCpu:       500,
+		FreeMemory:    1250,
+		Gpu:           "A10G",
+		FreeGpuCount:  1,
 	}
-
-	// Create a new worker
-	err = repo.AddWorker(newWorker)
-	assert.Nil(t, err)
-
-	// Retrieve the worker
-	worker, err := repo.GetWorkerById(newWorker.Id)
-	assert.Nil(t, err)
-	assert.Equal(t, newWorker.FreeCpu, worker.FreeCpu)
-	assert.Equal(t, newWorker.FreeMemory, worker.FreeMemory)
-	assert.Equal(t, newWorker.Gpu, worker.Gpu)
-	assert.Equal(t, newWorker.Status, worker.Status)
-	assert.Equal(t, int64(0), newWorker.ResourceVersion)
-
-	// Add some capacity to the worker
 	request := &types.ContainerRequest{
-		ContainerId: "container1",
+		ContainerId: "container-capacity-release",
 		Cpu:         500,
 		Memory:      1000,
 		Gpu:         "A10G",
 		GpuCount:    1,
 	}
-	err = repo.UpdateWorkerCapacity(worker, request, types.AddCapacity)
-	assert.Nil(t, err)
-	freeMemoryAfterAdd := capacityMemoryForRequest(request)
+	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
+	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
+	assert.NoError(t, rdb.Del(context.TODO(), common.RedisKeys.SchedulerContainerState(request.ContainerId)).Err())
+	assert.NoError(t, rdb.Del(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Err())
+	assert.NoError(t, rdb.SRem(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), common.RedisKeys.SchedulerContainerState(request.ContainerId)).Err())
 
-	// Retrieve the updated worker
-	updatedWorker, err := repo.GetWorkerById(newWorker.Id)
-	assert.Nil(t, err)
-	assert.Equal(t, request.Cpu, updatedWorker.FreeCpu)
-	assert.Equal(t, freeMemoryAfterAdd, updatedWorker.FreeMemory)
-	assert.Equal(t, request.Gpu, updatedWorker.Gpu)
-	assert.Equal(t, types.WorkerStatusPending, worker.Status)
-	assert.Equal(t, int64(1), updatedWorker.ResourceVersion)
-
-	// Remove some capacity
-	request = &types.ContainerRequest{
-		ContainerId: "container1",
-		Cpu:         100,
-		Memory:      100,
-		Gpu:         "A10G",
-		GpuCount:    1,
-	}
-	err = repo.UpdateWorkerCapacity(updatedWorker, request, types.RemoveCapacity)
-	assert.Nil(t, err)
-
-	// Retrieve the worker again
-	updatedWorker, err = repo.GetWorkerById(newWorker.Id)
-	assert.Equal(t, int64(2), updatedWorker.ResourceVersion)
-	assert.Nil(t, err)
-
-	assert.Equal(t, int64(400), updatedWorker.FreeCpu)
-	assert.Equal(t, freeMemoryAfterAdd-capacityMemoryForRequest(request), updatedWorker.FreeMemory)
-	assert.Equal(t, request.Gpu, updatedWorker.Gpu)
+	assert.NoError(t, repo.UpdateWorkerCapacity(worker, request, types.AddCapacity))
+	version := worker.ResourceVersion
+	assert.Equal(t, int64(500), worker.FreeCpu)
+	assert.Equal(t, int64(1250), worker.FreeMemory)
+	assert.Equal(t, uint32(1), worker.FreeGpuCount)
+	assert.NoError(t, repo.UpdateWorkerCapacity(worker, request, types.AddCapacity))
+	assert.Equal(t, version, worker.ResourceVersion)
 }
 
 func TestUpdateWorkerCapacityForCPUWorker(t *testing.T) {
@@ -812,85 +936,6 @@ func TestScheduleContainerRequestRemovesQueuedRequestWhenMetadataWriteFails(t *t
 	assert.False(t, indexed)
 }
 
-func TestCleanupScheduledContainerRequestPreservesNewerAssignment(t *testing.T) {
-	rdb, err := NewRedisClientForTest()
-	assert.NotNil(t, rdb)
-	assert.Nil(t, err)
-
-	repo := NewWorkerRedisRepositoryForTest(rdb).(*WorkerRedisRepository)
-	containerStateKey := common.RedisKeys.SchedulerContainerState("container-newer-assignment")
-	oldWorkerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex("worker-old")
-	newWorkerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex("worker-new")
-	queueKey := common.RedisKeys.SchedulerWorkerRequests("worker-old")
-	requestJSON := []byte(`{"container_id":"container-newer-assignment"}`)
-	err = rdb.RPush(context.TODO(), queueKey, requestJSON).Err()
-	assert.Nil(t, err)
-	err = rdb.SAdd(context.TODO(), oldWorkerIndexKey, containerStateKey).Err()
-	assert.Nil(t, err)
-	err = rdb.SAdd(context.TODO(), newWorkerIndexKey, containerStateKey).Err()
-	assert.Nil(t, err)
-	err = rdb.HSet(context.TODO(), containerStateKey,
-		"worker_id", "worker-new",
-		"machine_id", "machine-new",
-		"schedule_assignment_id", "assignment-old",
-	).Err()
-	assert.Nil(t, err)
-
-	err = repo.cleanupScheduledContainerRequest(context.TODO(), scheduleCleanup{
-		queue:   queueKey,
-		index:   oldWorkerIndexKey,
-		state:   containerStateKey,
-		payload: requestJSON,
-		queued:  true,
-		token:   "assignment-old",
-		worker:  "worker-old",
-	})
-	assert.Nil(t, err)
-
-	queueDepth, err := rdb.LLen(context.TODO(), queueKey).Result()
-	assert.Nil(t, err)
-	assert.Equal(t, int64(0), queueDepth)
-	indexedOld, err := rdb.SIsMember(context.TODO(), oldWorkerIndexKey, containerStateKey).Result()
-	assert.Nil(t, err)
-	assert.False(t, indexedOld)
-	indexedNew, err := rdb.SIsMember(context.TODO(), newWorkerIndexKey, containerStateKey).Result()
-	assert.Nil(t, err)
-	assert.True(t, indexedNew)
-	stateFields, err := rdb.HGetAll(context.TODO(), containerStateKey).Result()
-	assert.Nil(t, err)
-	assert.Equal(t, "worker-new", stateFields["worker_id"])
-	assert.Equal(t, "machine-new", stateFields["machine_id"])
-	assert.Equal(t, "assignment-old", stateFields["schedule_assignment_id"])
-
-	sameWorkerStateKey := common.RedisKeys.SchedulerContainerState("container-same-worker-newer-assignment")
-	sameWorkerIndexKey := common.RedisKeys.SchedulerContainerWorkerIndex("worker-same")
-	err = rdb.SAdd(context.TODO(), sameWorkerIndexKey, sameWorkerStateKey).Err()
-	assert.Nil(t, err)
-	err = rdb.HSet(context.TODO(), sameWorkerStateKey,
-		"worker_id", "worker-same",
-		"machine_id", "machine-same",
-		"schedule_assignment_id", "assignment-new",
-	).Err()
-	assert.Nil(t, err)
-
-	err = repo.cleanupScheduledContainerRequest(context.TODO(), scheduleCleanup{
-		index:  sameWorkerIndexKey,
-		state:  sameWorkerStateKey,
-		token:  "assignment-old",
-		worker: "worker-same",
-	})
-	assert.Nil(t, err)
-
-	indexedSameWorker, err := rdb.SIsMember(context.TODO(), sameWorkerIndexKey, sameWorkerStateKey).Result()
-	assert.Nil(t, err)
-	assert.True(t, indexedSameWorker)
-	sameWorkerFields, err := rdb.HGetAll(context.TODO(), sameWorkerStateKey).Result()
-	assert.Nil(t, err)
-	assert.Equal(t, "worker-same", sameWorkerFields["worker_id"])
-	assert.Equal(t, "machine-same", sameWorkerFields["machine_id"])
-	assert.Equal(t, "assignment-new", sameWorkerFields["schedule_assignment_id"])
-}
-
 func TestScheduleContainerRequestRejectsDisabledWorker(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NotNil(t, rdb)
@@ -931,6 +976,29 @@ func TestScheduleContainerRequestRejectsDisabledWorker(t *testing.T) {
 	assert.Equal(t, int64(1000), updatedWorker.FreeMemory)
 }
 
+func TestScheduleContainerRequestRejectsNegativeResources(t *testing.T) {
+	for name, request := range map[string]*types.ContainerRequest{
+		"cpu":    {ContainerId: "container-negative-cpu", Cpu: -1, Memory: 100},
+		"memory": {ContainerId: "container-negative-memory", Cpu: 100, Memory: -1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rdb, err := NewRedisClientForTest()
+			assert.NoError(t, err)
+			repo := NewWorkerRedisRepositoryForTest(rdb)
+			worker := &types.Worker{Id: "worker-negative-" + name, Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
+			assert.NoError(t, repo.AddWorker(worker))
+			setPendingContainerRequests(t, rdb, request)
+
+			assert.Error(t, repo.ScheduleContainerRequest(worker, request))
+			updated, err := repo.GetWorkerById(worker.Id)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(100), updated.FreeCpu)
+			assert.Equal(t, int64(125), updated.FreeMemory)
+			assert.Equal(t, int64(0), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+		})
+	}
+}
+
 func TestScheduleContainerRequestRejectsNonPendingState(t *testing.T) {
 	for _, status := range []types.ContainerStatus{types.ContainerStatusStopping, ""} {
 		t.Run(firstNonEmpty(string(status), "deleted"), func(t *testing.T) {
@@ -966,43 +1034,6 @@ func TestScheduleContainerRequestRejectsNonPendingState(t *testing.T) {
 			assert.Equal(t, int64(0), rdb.SCard(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id)).Val())
 		})
 	}
-}
-
-func TestScheduledRequestCommitRejectsWorkerCordonedAfterReservation(t *testing.T) {
-	rdb, err := NewRedisClientForTest()
-	assert.NoError(t, err)
-	repo := NewWorkerRedisRepositoryForTest(rdb).(*WorkerRedisRepository)
-	worker := &types.Worker{
-		Id:         "worker-cordoned-after-reservation",
-		Status:     types.WorkerStatusAvailable,
-		FreeCpu:    100,
-		FreeMemory: 125,
-	}
-	assert.NoError(t, repo.AddWorker(worker))
-
-	_, err = repo.adjustWorkerCapacity(worker.Id, -100, -125, 0, 1, true)
-	assert.NoError(t, err)
-	assert.NoError(t, repo.UpdateWorkerStatus(worker.Id, types.WorkerStatusDisabled))
-
-	stateKey := common.RedisKeys.SchedulerContainerState("container-cordoned")
-	committed, err := commitScheduledContainerRequestsScript.Run(context.Background(), rdb, []string{
-		common.RedisKeys.SchedulerWorkerState(worker.Id),
-		common.RedisKeys.SchedulerWorkerRequests(worker.Id),
-		common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id),
-	}, worker.Id, "machine-1", schedulerAssignmentIDField, schedulerDeliveryTokenField, schedulerDeliveryAttemptField,
-		stateKey, []byte(`{"container_id":"container-cordoned"}`), "", "assignment-1").Int()
-	assert.NoError(t, err)
-	assert.Equal(t, -2, committed)
-
-	_, err = repo.adjustWorkerCapacity(worker.Id, 100, 125, 0, 1, false)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(0), rdb.LLen(context.Background(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
-	assert.Equal(t, int64(0), rdb.Exists(context.Background(), stateKey).Val())
-	updatedWorker, err := repo.GetWorkerById(worker.Id)
-	assert.NoError(t, err)
-	assert.Equal(t, types.WorkerStatusDisabled, updatedWorker.Status)
-	assert.Equal(t, int64(100), updatedWorker.FreeCpu)
-	assert.Equal(t, int64(125), updatedWorker.FreeMemory)
 }
 
 func TestScheduleContainerRequestRejectsStaleWorkerReservation(t *testing.T) {
@@ -1054,7 +1085,7 @@ func TestScheduleContainerRequestRejectsStaleWorkerReservation(t *testing.T) {
 	assert.Equal(t, int64(1), queueDepth)
 }
 
-func TestScheduleContainerRequestDoesNotWaitForMaintenanceLock(t *testing.T) {
+func TestScheduleContainerRequestSharesWorkerMaintenanceLock(t *testing.T) {
 	rdb, err := NewRedisClientForTest()
 	assert.NoError(t, err)
 	repo := NewWorkerRedisRepositoryForTest(rdb)
@@ -1068,17 +1099,21 @@ func TestScheduleContainerRequestDoesNotWaitForMaintenanceLock(t *testing.T) {
 
 	maintenance := common.NewRedisLock(rdb)
 	assert.NoError(t, maintenance.Acquire(context.Background(), common.RedisKeys.SchedulerWorkerLock(worker.Id), common.RedisLockOptions{TtlS: 10}))
-	defer maintenance.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id))
-
 	request := &types.ContainerRequest{
 		ContainerId: "container-live-scheduling",
 		Cpu:         100,
 		Memory:      100,
 	}
 	setPendingContainerRequests(t, rdb, request)
-	startedAt := time.Now()
-	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
-	assert.Less(t, time.Since(startedAt), 100*time.Millisecond)
+	done := make(chan error, 1)
+	go func() { done <- repo.ScheduleContainerRequest(worker, request) }()
+	select {
+	case err := <-done:
+		t.Fatalf("schedule completed before worker lock was released: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.NoError(t, maintenance.Release(common.RedisKeys.SchedulerWorkerLock(worker.Id)))
+	assert.NoError(t, <-done)
 }
 
 func TestScheduleContainerRequestUsesCurrentCapacityForStaleWorkerReservation(t *testing.T) {
@@ -1220,6 +1255,18 @@ func TestContainerRequestRemainsRecoverableUntilWorkerAcknowledgesIt(t *testing.
 	assert.NoError(t, repo.RemoveWorker(worker.Id))
 	assert.Equal(t, int64(0), rdb.HLen(context.TODO(), common.RedisKeys.SchedulerWorkerPendingRequests(worker.Id)).Val())
 	assert.Equal(t, int64(1), rdb.ZCard(context.TODO(), common.RedisKeys.SchedulerContainerRequests()).Val())
+	stateKey := common.RedisKeys.SchedulerContainerState(request.ContainerId)
+	assert.Empty(t, rdb.HGet(context.TODO(), stateKey, "worker_id").Val())
+	assert.Empty(t, rdb.HGet(context.TODO(), stateKey, schedulerAssignmentIDField).Val())
+	assert.False(t, rdb.SIsMember(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), stateKey).Val())
+	backlog, err := rdb.ZRange(context.TODO(), common.RedisKeys.SchedulerContainerRequests(), 0, 0).Result()
+	assert.NoError(t, err)
+	assert.Len(t, backlog, 1)
+	var requeued types.ContainerRequest
+	assert.NoError(t, json.Unmarshal([]byte(backlog[0]), &requeued))
+	replacement := &types.Worker{Id: "worker-pending-delivery-replacement", Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
+	assert.NoError(t, repo.AddWorker(replacement))
+	assert.NoError(t, repo.ScheduleContainerRequest(replacement, &requeued))
 }
 
 func TestAcknowledgedContainerRequestIsNotReplayedWhenWorkerIsRemoved(t *testing.T) {
@@ -1368,6 +1415,9 @@ func TestScheduleContainerRequestsRejectsBatchWithoutPartialReservation(t *testi
 		FreeMemory: 125,
 	}
 	assert.NoError(t, repo.AddWorker(worker))
+	duplicate := &types.ContainerRequest{ContainerId: "container-batch-duplicate", Cpu: 1, Memory: 1}
+	assert.Error(t, repo.ScheduleContainerRequests(worker, []*types.ContainerRequest{duplicate, duplicate}))
+	assert.Equal(t, int64(0), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
 
 	err = repo.ScheduleContainerRequests(worker, []*types.ContainerRequest{
 		{ContainerId: "container-batch-capacity-1", Cpu: 100, Memory: 100},
@@ -1381,6 +1431,171 @@ func TestScheduleContainerRequestsRejectsBatchWithoutPartialReservation(t *testi
 	assert.Equal(t, int64(125), updatedWorker.FreeMemory)
 	assert.Equal(t, int64(0), updatedWorker.ResourceVersion)
 	assert.Equal(t, int64(0), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+}
+
+func TestScheduleContainerRequestsValidatesCapacityFieldsBeforeWriting(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{Id: "worker-invalid-resource-version", Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
+	request := &types.ContainerRequest{ContainerId: "container-invalid-resource-version", Cpu: 100, Memory: 100}
+	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
+	assert.NoError(t, rdb.HSet(context.TODO(), common.RedisKeys.SchedulerWorkerState(worker.Id), "resource_version", "invalid").Err())
+
+	payload, err := json.Marshal(request)
+	assert.NoError(t, err)
+	result, err := scheduleContainerRequestsScript.Run(context.TODO(), rdb, []string{
+		common.RedisKeys.SchedulerWorkerState(worker.Id),
+		common.RedisKeys.SchedulerWorkerRequests(worker.Id),
+		common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id),
+	}, request.Cpu, capacityMemoryForRequest(request), 0, 1, worker.Id,
+		schedulerAssignmentIDField, schedulerDeliveryTokenField, schedulerDeliveryAttemptField, "batch-invalid-resource-version",
+		common.RedisKeys.SchedulerContainerState(request.ContainerId), payload, "", "assignment-invalid-resource-version").Result()
+	assert.NoError(t, err)
+	_, err = parseWorkerCapacityResult(worker.Id, result)
+	assert.Error(t, err)
+	assert.Equal(t, "100", rdb.HGet(context.TODO(), common.RedisKeys.SchedulerWorkerState(worker.Id), "free_cpu").Val())
+	assert.Equal(t, "125", rdb.HGet(context.TODO(), common.RedisKeys.SchedulerWorkerState(worker.Id), "free_memory").Val())
+	assert.Equal(t, int64(0), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+	assert.Empty(t, rdb.HGet(context.TODO(), common.RedisKeys.SchedulerContainerState(request.ContainerId), "worker_id").Val())
+}
+
+func TestScheduleBatchMarkerSurvivesImmediateContainerFinalization(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb).(*WorkerRedisRepository)
+	worker := &types.Worker{Id: "worker-immediate-finalize", Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
+	request := &types.ContainerRequest{ContainerId: "container-immediate-finalize", Cpu: 100, Memory: 100}
+	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
+
+	payload, err := json.Marshal(request)
+	assert.NoError(t, err)
+	batchID := "batch-immediate-finalize"
+	assignment := "assignment-immediate-finalize"
+	stateKey := common.RedisKeys.SchedulerContainerState(request.ContainerId)
+	result, err := scheduleContainerRequestsScript.Run(context.TODO(), rdb, []string{
+		common.RedisKeys.SchedulerWorkerState(worker.Id),
+		common.RedisKeys.SchedulerWorkerRequests(worker.Id),
+		common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id),
+	}, request.Cpu, capacityMemoryForRequest(request), 0, 1, worker.Id,
+		schedulerAssignmentIDField, schedulerDeliveryTokenField, schedulerDeliveryAttemptField, batchID,
+		stateKey, payload, "", assignment).Result()
+	assert.NoError(t, err)
+	_, err = parseWorkerCapacityResult(worker.Id, result)
+	assert.NoError(t, err)
+	retried, err := scheduleContainerRequestsScript.Run(context.TODO(), rdb, []string{
+		common.RedisKeys.SchedulerWorkerState(worker.Id),
+		common.RedisKeys.SchedulerWorkerRequests(worker.Id),
+		common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id),
+	}, request.Cpu, capacityMemoryForRequest(request), 0, 1, worker.Id,
+		schedulerAssignmentIDField, schedulerDeliveryTokenField, schedulerDeliveryAttemptField, batchID,
+		stateKey, payload, "", assignment).Result()
+	assert.NoError(t, err)
+	_, err = parseWorkerCapacityResult(worker.Id, retried)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+
+	assert.NoError(t, rdb.Del(context.TODO(), stateKey, common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Err())
+	assert.NoError(t, rdb.SRem(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), stateKey).Err())
+	committed, err := repo.scheduledBatchCommitted(context.TODO(), worker.Id, batchID, []queuedContainerRequest{{
+		request: request, payload: payload, stateKey: stateKey, assignment: assignment,
+	}})
+	assert.NoError(t, err)
+	assert.True(t, committed)
+}
+
+func TestScheduleContainerRequestTreatsLostCommitReplyAsSuccess(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{Id: "worker-lost-schedule-reply", Status: types.WorkerStatusAvailable, FreeCpu: 100, FreeMemory: 125}
+	request := &types.ContainerRequest{ContainerId: "container-lost-schedule-reply", Cpu: 100, Memory: 100}
+	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
+	_, err = scheduleContainerRequestsScript.Load(context.TODO(), rdb).Result()
+	assert.NoError(t, err)
+	hook := &lostRedisScriptReplyHook{hash: scheduleContainerRequestsScript.Hash()}
+	rdb.AddHook(hook)
+
+	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
+	assert.True(t, hook.lost.Load())
+	assert.Equal(t, int64(1), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+	updated, err := repo.GetWorkerById(worker.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), updated.FreeCpu)
+	assert.Equal(t, int64(0), updated.FreeMemory)
+	assert.Error(t, repo.ScheduleContainerRequest(updated, request))
+	assert.Equal(t, int64(1), rdb.LLen(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id)).Val())
+}
+
+func TestScheduleContainerRequestReconcilesWhenLostReplyHasNoCommitEvidence(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id: "worker-lost-schedule-evidence", Status: types.WorkerStatusAvailable,
+		TotalCpu: 100, TotalMemory: 125, FreeCpu: 100, FreeMemory: 125,
+	}
+	request := &types.ContainerRequest{ContainerId: "container-lost-schedule-evidence", Cpu: 100, Memory: 100}
+	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
+	_, err = scheduleContainerRequestsScript.Load(context.TODO(), rdb).Result()
+	assert.NoError(t, err)
+	stateKey := common.RedisKeys.SchedulerContainerState(request.ContainerId)
+	hook := &lostRedisScriptReplyHook{hash: scheduleContainerRequestsScript.Hash()}
+	hook.after = func() {
+		assert.NoError(t, rdb.HDel(context.TODO(), common.RedisKeys.SchedulerWorkerState(worker.Id), schedulerLastBatchIDField).Err())
+		assert.NoError(t, rdb.Del(context.TODO(), common.RedisKeys.SchedulerWorkerRequests(worker.Id), stateKey).Err())
+		assert.NoError(t, rdb.SRem(context.TODO(), common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id), stateKey).Err())
+	}
+	rdb.AddHook(hook)
+
+	assert.Error(t, repo.ScheduleContainerRequest(worker, request))
+	assert.True(t, hook.lost.Load())
+	updated, err := repo.GetWorkerById(worker.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(100), updated.FreeCpu)
+	assert.Equal(t, int64(125), updated.FreeMemory)
+}
+
+func TestDelayedCapacityReleaseCannotOvercreditRecreatedWorker(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	assert.NoError(t, err)
+	repo := NewWorkerRedisRepositoryForTest(rdb)
+	worker := &types.Worker{
+		Id: "worker-recreated", Status: types.WorkerStatusAvailable,
+		TotalCpu: 100, TotalMemory: 125, TotalGpuCount: 1,
+		FreeCpu: 100, FreeMemory: 125, FreeGpuCount: 1, Gpu: "A10G",
+	}
+	request := &types.ContainerRequest{ContainerId: "container-recreated", Cpu: 100, Memory: 100, Gpu: worker.Gpu}
+	assert.NoError(t, repo.AddWorker(worker))
+	setPendingContainerRequests(t, rdb, request)
+	assert.NoError(t, repo.ScheduleContainerRequest(worker, request))
+	assert.NoError(t, repo.RemoveWorker(worker.Id))
+	replacement := *worker
+	replacement.Id = "worker-recreated-replacement"
+	assert.NoError(t, repo.AddWorker(&replacement))
+	assert.NoError(t, repo.ScheduleContainerRequest(&replacement, request))
+	stateKey := common.RedisKeys.SchedulerContainerState(request.ContainerId)
+	oldIndex := common.RedisKeys.SchedulerContainerWorkerIndex(worker.Id)
+	assert.NoError(t, rdb.SAdd(context.TODO(), oldIndex, stateKey).Err())
+
+	recreated := *worker
+	recreated.FreeCpu, recreated.FreeMemory, recreated.FreeGpuCount = 100, 125, 1
+	assert.NoError(t, repo.AddWorker(&recreated))
+	current := &types.ContainerRequest{ContainerId: "container-recreated-current", Cpu: 100, Memory: 100, Gpu: worker.Gpu}
+	setPendingContainerRequests(t, rdb, current)
+	assert.NoError(t, repo.ScheduleContainerRequest(&recreated, current))
+	assert.NoError(t, repo.UpdateWorkerCapacity(&recreated, request, types.AddCapacity))
+	assert.Equal(t, int64(0), recreated.FreeCpu)
+	assert.Equal(t, int64(0), recreated.FreeMemory)
+	assert.Equal(t, uint32(0), recreated.FreeGpuCount)
+	assert.False(t, rdb.SIsMember(context.TODO(), oldIndex, stateKey).Val())
+	version := recreated.ResourceVersion
+	assert.NoError(t, repo.UpdateWorkerCapacity(&recreated, request, types.AddCapacity))
+	assert.Equal(t, version, recreated.ResourceVersion)
 }
 
 func TestUpdateWorkerCapacityRejectsGPUOverReservation(t *testing.T) {
@@ -1409,7 +1624,7 @@ func TestUpdateWorkerCapacityRejectsGPUOverReservation(t *testing.T) {
 		Cpu:         100,
 		Memory:      100,
 		Gpu:         "A10G",
-		GpuCount:    1,
+		GpuCount:    2,
 	}
 
 	err = repo.UpdateWorkerCapacity(updatedWorker, request, types.RemoveCapacity)
@@ -1419,7 +1634,7 @@ func TestUpdateWorkerCapacityRejectsGPUOverReservation(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1000), unchangedWorker.FreeCpu)
 	assert.Equal(t, int64(1250), unchangedWorker.FreeMemory)
-	assert.Equal(t, uint32(0), unchangedWorker.FreeGpuCount)
+	assert.Equal(t, uint32(1), unchangedWorker.FreeGpuCount)
 	assert.Equal(t, int64(0), unchangedWorker.ResourceVersion)
 }
 

--- a/pkg/runtime/runsc.go
+++ b/pkg/runtime/runsc.go
@@ -334,11 +334,21 @@ func (r *Runsc) loadState(ctx context.Context, containerID string) (runscState, 
 	cmd := exec.CommandContext(ctx, r.cfg.RunscPath, args...)
 
 	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			return runscState{}, ErrContainerNotFound{ContainerID: containerID}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Newer runsc releases return 128 when the container bundle has
+			// already disappeared; older releases returned 1 for this case.
+			if exitErr.ExitCode() == 1 ||
+				(exitErr.ExitCode() == 128 && strings.Contains(strings.ToLower(stderr.String()), "loading container: file does not exist")) {
+				return runscState{}, ErrContainerNotFound{ContainerID: containerID}
+			}
+		}
+		if output := strings.TrimSpace(stderr.String()); output != "" {
+			return runscState{}, fmt.Errorf("failed to get state: %w (stderr: %s)", err, output)
 		}
 		return runscState{}, fmt.Errorf("failed to get state: %w", err)
 	}

--- a/pkg/runtime/runsc_test.go
+++ b/pkg/runtime/runsc_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,38 @@ func TestNewRunscDefaultsUnsupportedDriverCompatibility(t *testing.T) {
 			require.Len(t, rt.cfg.RunscExtraArgs, 1)
 		})
 	}
+}
+
+func TestRunscStateRecognizesMissingContainerFromCurrentRunsc(t *testing.T) {
+	dir := t.TempDir()
+	runscPath := filepath.Join(dir, "runsc")
+	require.NoError(t, os.WriteFile(runscPath, []byte(`#!/bin/sh
+echo 'FetchSpec failed: loading container: file does not exist' >&2
+exit 128
+`), 0o755))
+
+	rt := &Runsc{cfg: Config{RunscPath: runscPath, RunscRoot: filepath.Join(dir, "root")}}
+	_, err := rt.State(context.Background(), "already-gone")
+
+	var notFound ErrContainerNotFound
+	require.ErrorAs(t, err, &notFound)
+	require.Equal(t, "already-gone", notFound.ContainerID)
+}
+
+func TestRunscStateDoesNotHideUnrelatedExit128(t *testing.T) {
+	dir := t.TempDir()
+	runscPath := filepath.Join(dir, "runsc")
+	require.NoError(t, os.WriteFile(runscPath, []byte(`#!/bin/sh
+echo 'runsc state failed: permission denied' >&2
+exit 128
+`), 0o755))
+
+	rt := &Runsc{cfg: Config{RunscPath: runscPath, RunscRoot: filepath.Join(dir, "root")}}
+	_, err := rt.State(context.Background(), "unreadable")
+
+	var notFound ErrContainerNotFound
+	require.False(t, errors.As(err, &notFound))
+	require.ErrorContains(t, err, "permission denied")
 }
 
 func TestRunscRestoreSignalsStartedAfterStateRunning(t *testing.T) {

--- a/pkg/scheduler/pool_external_test.go
+++ b/pkg/scheduler/pool_external_test.go
@@ -154,9 +154,22 @@ func TestAgentWorkerPoolControllerAddWorkerCreatesDesiredSlot(t *testing.T) {
 		t.Fatalf("second worker = %q, want stable worker %q", secondWorker.Id, worker.Id)
 	}
 
-	secondWorker.FreeCpu -= 2000
-	secondWorker.FreeMemory -= 1024
-	secondWorker.FreeGpuCount--
+	runningState := &types.ContainerState{
+		ContainerId: "agent-worker-resize-running",
+		Status:      types.ContainerStatusRunning,
+		WorkerId:    secondWorker.Id,
+		Cpu:         2000,
+		Memory:      819, // 1.25x capacity accounting reserves 1024 MiB.
+		Gpu:         "A10G",
+		GpuCount:    1,
+	}
+	runningStateKey := common.RedisKeys.SchedulerContainerState(runningState.ContainerId)
+	if err := redisClient.HSet(ctx, runningStateKey, common.ToSlice(runningState)).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := redisClient.SAdd(ctx, common.RedisKeys.SchedulerContainerWorkerIndex(secondWorker.Id), runningStateKey).Err(); err != nil {
+		t.Fatal(err)
+	}
 	if err := workerRepo.AddWorker(secondWorker); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scheduler/pool_sizing.go
+++ b/pkg/scheduler/pool_sizing.go
@@ -152,9 +152,13 @@ func (s *WorkerPoolSizer) poolSupportsProvisioning() bool {
 	if s == nil || s.workerPoolConfig == nil {
 		return true
 	}
-	if s.workerPoolConfig.Mode == types.PoolModeExternal &&
-		s.workerPoolConfig.Provider != nil &&
-		*s.workerPoolConfig.Provider == types.ProviderGeneric {
+	return workerPoolSupportsProvisioning(*s.workerPoolConfig)
+}
+
+func workerPoolSupportsProvisioning(config types.WorkerPoolConfig) bool {
+	if config.Mode == types.PoolModeExternal &&
+		config.Provider != nil &&
+		*config.Provider == types.ProviderGeneric {
 		return false
 	}
 	return true

--- a/pkg/scheduler/private_pool_fallback.go
+++ b/pkg/scheduler/private_pool_fallback.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type privatePoolCapacityChecker interface {
+type workerPoolCapacityChecker interface {
 	HasWorkerCapacity(cpu int64, memory int64, gpuCount uint32) (bool, error)
 }
 
@@ -79,7 +79,7 @@ func (a *schedulingAttempt) privatePoolFallbackRequest() (*types.ContainerReques
 	}
 
 	if a.request.StorageAvailable() {
-		checker, ok := pool.Controller.(privatePoolCapacityChecker)
+		checker, ok := pool.Controller.(workerPoolCapacityChecker)
 		if !ok {
 			return nil, "", false
 		}
@@ -155,6 +155,6 @@ func (a *schedulingAttempt) canProvisionWorker() bool {
 	if err != nil {
 		return false
 	}
-	controller, _ := a.scheduler.workerProvisioningController(controllers)
-	return controller != nil
+	controller, _, err := a.scheduler.workerProvisioningControllerForRequest(controllers, a.request)
+	return err == nil && controller != nil
 }

--- a/pkg/scheduler/provisioning_backoff.go
+++ b/pkg/scheduler/provisioning_backoff.go
@@ -3,6 +3,8 @@ package scheduler
 import (
 	"sync"
 	"time"
+
+	"github.com/beam-cloud/beta9/pkg/types"
 )
 
 const (
@@ -21,23 +23,51 @@ func newWorkerProvisioningBackoff() *workerProvisioningBackoff {
 	}
 }
 
-func (s *Scheduler) workerProvisioningController(controllers []WorkerPoolController) (WorkerPoolController, time.Duration) {
-	if s == nil || s.workerProvisioningBackoff == nil {
-		return firstController(controllers), provisioningWorkerRequeueDelay
+func (s *Scheduler) workerProvisioningControllerForRequest(controllers []WorkerPoolController, request *types.ContainerRequest) (WorkerPoolController, time.Duration, error) {
+	if s == nil {
+		return firstController(controllers), provisioningWorkerRequeueDelay, nil
 	}
 
 	var poolNames []string
+	var capacityErr error
 	for _, controller := range controllers {
 		if controller == nil {
 			continue
 		}
+		if pool, ok := s.poolForController(controller); ok && !workerPoolSupportsProvisioning(pool.Config) {
+			continue
+		}
+		if request != nil {
+			if checker, ok := controller.(workerPoolCapacityChecker); ok {
+				hasCapacity, err := checker.HasWorkerCapacity(
+					s.workerCPUForControllerRequest(controller, request),
+					s.workerMemoryForControllerRequest(controller, request),
+					s.workerGPUCountForControllerRequest(controller, request),
+				)
+				if err != nil {
+					if capacityErr == nil {
+						capacityErr = err
+					}
+					continue
+				}
+				if !hasCapacity {
+					continue
+				}
+			}
+		}
 		poolNames = append(poolNames, controller.Name())
-		if s.workerProvisioningBackoff.canAttempt(controller.Name()) {
-			return controller, provisioningWorkerRequeueDelay
+		if s.workerProvisioningBackoff == nil || s.workerProvisioningBackoff.canAttempt(controller.Name()) {
+			return controller, provisioningWorkerRequeueDelay, nil
 		}
 	}
 
-	return nil, s.workerProvisioningBackoff.nextDelay(poolNames)
+	if capacityErr != nil {
+		return nil, provisioningWorkerRequeueDelay, capacityErr
+	}
+	if s.workerProvisioningBackoff == nil {
+		return nil, provisioningWorkerRequeueDelay, nil
+	}
+	return nil, s.workerProvisioningBackoff.nextDelay(poolNames), nil
 }
 
 func firstController(controllers []WorkerPoolController) WorkerPoolController {

--- a/pkg/scheduler/reserve.go
+++ b/pkg/scheduler/reserve.go
@@ -144,7 +144,14 @@ func (a *schedulingAttempt) provisionWorker() {
 		return
 	}
 
-	controller, delay := a.scheduler.workerProvisioningController(controllers)
+	controller, delay, err := a.scheduler.workerProvisioningControllerForRequest(controllers, a.request)
+	if err != nil {
+		requestLog(log.Warn(), a.request).
+			Err(err).
+			Msg("unable to check worker provisioning capacity")
+		a.requeueForWorkerWaitDelay(provisioningWorkerRequeueDelay, "worker_capacity_check_failed")
+		return
+	}
 	if controller == nil {
 		// Every eligible pool, primary and failover alike, recently refused to
 		// provision. That is the serverless estate being exhausted, and the

--- a/pkg/scheduler/reserve_test.go
+++ b/pkg/scheduler/reserve_test.go
@@ -83,6 +83,245 @@ func TestProvisioningFailureBackoffSkipsImmediateAddWorkerRetry(t *testing.T) {
 	assert.Equal(t, 1, controller.AddWorkerCallCount())
 }
 
+func TestProvisionWorkerSkipsStaticGenericPool(t *testing.T) {
+	scheduler, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	scheduler.workerPoolManager = NewWorkerPoolManager()
+
+	static := &LocalWorkerPoolControllerForTest{
+		ctx:        context.Background(),
+		name:       "static-cpu",
+		config:     scheduler.config,
+		workerRepo: scheduler.workerRepo,
+	}
+	dynamicStarted := make(chan struct{}, 1)
+	dynamic := &LocalWorkerPoolControllerForTest{
+		ctx:              context.Background(),
+		name:             "dynamic-cpu",
+		config:           scheduler.config,
+		workerRepo:       scheduler.workerRepo,
+		addWorkerStarted: dynamicStarted,
+	}
+	provider := types.ProviderGeneric
+	scheduler.workerPoolManager.SetPool(static.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &provider,
+		Priority: 10,
+	}, static)
+	scheduler.workerPoolManager.SetPool(dynamic.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeLocal,
+		Priority: 0,
+	}, dynamic)
+
+	request := &types.ContainerRequest{
+		ContainerId: uuid.NewString(),
+		Cpu:         8000,
+		Memory:      16 * 1024,
+		Timestamp:   time.Now(),
+	}
+	setPendingSchedulerRequests(t, scheduler, request)
+	newSchedulingAttempt(scheduler, request, nil).provisionWorker()
+
+	select {
+	case <-dynamicStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected the dynamic pool to provision a worker")
+	}
+	assert.Equal(t, 0, static.AddWorkerCallCount())
+	assert.Equal(t, 1, dynamic.AddWorkerCallCount())
+}
+
+func TestProvisionWorkerSkipsExhaustedAgentPool(t *testing.T) {
+	scheduler, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	scheduler.workerPoolManager = NewWorkerPoolManager()
+
+	agent := &capacityCheckingWorkerPoolControllerForTest{
+		LocalWorkerPoolControllerForTest: &LocalWorkerPoolControllerForTest{
+			ctx:        context.Background(),
+			name:       "agent-cpu",
+			mode:       types.PoolModeExternal,
+			config:     scheduler.config,
+			workerRepo: scheduler.workerRepo,
+		},
+		hasCapacity: false,
+	}
+	dynamicStarted := make(chan struct{}, 1)
+	dynamic := &LocalWorkerPoolControllerForTest{
+		ctx:              context.Background(),
+		name:             "dynamic-cpu",
+		config:           scheduler.config,
+		workerRepo:       scheduler.workerRepo,
+		addWorkerStarted: dynamicStarted,
+	}
+	provider := types.ProviderAgent
+	scheduler.workerPoolManager.SetPool(agent.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &provider,
+		Priority: 10,
+	}, agent)
+	scheduler.workerPoolManager.SetPool(dynamic.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeLocal,
+		Priority: 0,
+	}, dynamic)
+
+	request := &types.ContainerRequest{
+		ContainerId: uuid.NewString(),
+		Cpu:         8000,
+		Memory:      16 * 1024,
+		Timestamp:   time.Now(),
+	}
+	setPendingSchedulerRequests(t, scheduler, request)
+	newSchedulingAttempt(scheduler, request, nil).provisionWorker()
+
+	select {
+	case <-dynamicStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected the dynamic pool to provision a worker")
+	}
+	assert.Equal(t, 0, agent.AddWorkerCallCount())
+	assert.Equal(t, 1, dynamic.AddWorkerCallCount())
+	assert.Equal(t, 1, request.ProvisioningAttempts)
+}
+
+func TestProvisionWorkerCapacityCheckErrorDoesNotConsumeAttempt(t *testing.T) {
+	scheduler, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	scheduler.workerPoolManager = NewWorkerPoolManager()
+
+	agent := &capacityCheckingWorkerPoolControllerForTest{
+		LocalWorkerPoolControllerForTest: &LocalWorkerPoolControllerForTest{
+			ctx:        context.Background(),
+			name:       "agent-cpu",
+			mode:       types.PoolModeExternal,
+			config:     scheduler.config,
+			workerRepo: scheduler.workerRepo,
+		},
+		capacityErr: context.DeadlineExceeded,
+	}
+	provider := types.ProviderAgent
+	scheduler.workerPoolManager.SetPool(agent.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &provider,
+	}, agent)
+
+	request := &types.ContainerRequest{
+		ContainerId: uuid.NewString(),
+		Cpu:         8000,
+		Memory:      16 * 1024,
+		Timestamp:   time.Now(),
+	}
+	setPendingSchedulerRequests(t, scheduler, request)
+	newSchedulingAttempt(scheduler, request, nil).provisionWorker()
+
+	assert.Equal(t, 0, agent.AddWorkerCallCount())
+	assert.Equal(t, 0, request.ProvisioningAttempts)
+	time.Sleep(provisioningWorkerRequeueDelay + 10*time.Millisecond)
+	requeued, err := scheduler.requestBacklog.Pop()
+	assert.Nil(t, err)
+	assert.Equal(t, request.ContainerId, requeued.ContainerId)
+}
+
+func TestStaticGenericPoolWorkersRemainSchedulable(t *testing.T) {
+	scheduler, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	scheduler.workerPoolManager = NewWorkerPoolManager()
+
+	provider := types.ProviderGeneric
+	controller := &LocalWorkerPoolControllerForTest{
+		ctx:        context.Background(),
+		name:       "static-cpu",
+		config:     scheduler.config,
+		workerRepo: scheduler.workerRepo,
+	}
+	scheduler.workerPoolManager.SetPool(controller.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &provider,
+		Priority: 10,
+	}, controller)
+	worker := &types.Worker{
+		Id:           uuid.NewString(),
+		Status:       types.WorkerStatusAvailable,
+		TotalCpu:     8000,
+		FreeCpu:      8000,
+		TotalMemory:  20 * 1024,
+		FreeMemory:   20 * 1024,
+		PoolName:     controller.name,
+		BuildVersion: scheduler.config.Worker.ImageTag,
+	}
+	assert.Nil(t, scheduler.workerRepo.AddWorker(worker))
+
+	request := &types.ContainerRequest{
+		ContainerId: uuid.NewString(),
+		Cpu:         8000,
+		Memory:      16 * 1024,
+		Timestamp:   time.Now(),
+	}
+	setPendingSchedulerRequests(t, scheduler, request)
+	newSchedulingAttempt(scheduler, request, []*types.Worker{worker}).run()
+
+	queued, err := scheduler.workerRepo.GetNextContainerRequest(worker.Id)
+	assert.Nil(t, err)
+	assert.NotNil(t, queued)
+	assert.Equal(t, request.ContainerId, queued.ContainerId)
+	assert.Equal(t, 0, controller.AddWorkerCallCount())
+}
+
+func TestIncapablePoolsAreSkippedByEverySchedulerReplica(t *testing.T) {
+	first, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	first.workerPoolManager = NewWorkerPoolManager()
+	replicas := []*Scheduler{first, schedulerReplicaForTest(first), schedulerReplicaForTest(first)}
+
+	provider := types.ProviderGeneric
+	static := &LocalWorkerPoolControllerForTest{
+		ctx:        context.Background(),
+		name:       "static-cpu",
+		config:     first.config,
+		workerRepo: first.workerRepo,
+	}
+	dynamic := &LocalWorkerPoolControllerForTest{
+		ctx:        context.Background(),
+		name:       "dynamic-cpu",
+		config:     first.config,
+		workerRepo: first.workerRepo,
+	}
+	agent := &capacityCheckingWorkerPoolControllerForTest{
+		LocalWorkerPoolControllerForTest: &LocalWorkerPoolControllerForTest{
+			ctx:        context.Background(),
+			name:       "agent-cpu",
+			mode:       types.PoolModeExternal,
+			config:     first.config,
+			workerRepo: first.workerRepo,
+		},
+		hasCapacity: false,
+	}
+	agentProvider := types.ProviderAgent
+	first.workerPoolManager.SetPool(static.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &provider,
+		Priority: 20,
+	}, static)
+	first.workerPoolManager.SetPool(agent.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &agentProvider,
+		Priority: 10,
+	}, agent)
+	first.workerPoolManager.SetPool(dynamic.name, types.WorkerPoolConfig{Mode: types.PoolModeLocal}, dynamic)
+
+	request := &types.ContainerRequest{Cpu: 8000, Memory: 16 * 1024}
+	for _, scheduler := range replicas {
+		controllers, err := scheduler.getControllers(request)
+		assert.Nil(t, err)
+		selected, _, err := scheduler.workerProvisioningControllerForRequest(controllers, request)
+		assert.Nil(t, err)
+		assert.NotNil(t, selected)
+		assert.Equal(t, dynamic.name, selected.Name())
+	}
+	assert.Equal(t, 0, static.AddWorkerCallCount())
+	assert.Equal(t, 0, agent.AddWorkerCallCount())
+}
+
 func TestProvisioningAttemptDoesNotFailOverWithinReservation(t *testing.T) {
 	scheduler, err := NewSchedulerForTest()
 	assert.Nil(t, err)
@@ -467,15 +706,12 @@ func TestPrivatePoolMissWithoutRegularCapacityKeepsPrivateSelector(t *testing.T)
 	scheduler.workerPoolManager = NewWorkerPoolManager()
 	workspaceID := "workspace-private-no-capacity"
 
-	started := make(chan struct{}, 1)
 	privateController := &capacityCheckingWorkerPoolControllerForTest{
 		LocalWorkerPoolControllerForTest: &LocalWorkerPoolControllerForTest{
 			ctx:              context.Background(),
 			name:             "private-cpu",
 			config:           scheduler.config,
 			workerRepo:       scheduler.workerRepo,
-			addWorkerStarted: started,
-			addWorkerErr:     types.NewProviderNotImplemented(),
 			requiresSelector: true,
 		},
 		hasCapacity: false,
@@ -498,17 +734,74 @@ func TestPrivatePoolMissWithoutRegularCapacityKeepsPrivateSelector(t *testing.T)
 	setPendingSchedulerRequests(t, scheduler, request)
 	newSchedulingAttempt(scheduler, request, nil).run()
 
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("expected private provisioning attempt")
+	time.Sleep(provisioningWorkerRequeueDelay + requestProcessingInterval)
+	requeued, err := scheduler.requestBacklog.Pop()
+	assert.Nil(t, err)
+	assert.Equal(t, request.ContainerId, requeued.ContainerId)
+	assert.Equal(t, "private-cpu", requeued.PoolSelector)
+	assert.Equal(t, 0, privateController.AddWorkerCallCount())
+	assert.Equal(t, 0, request.ProvisioningAttempts)
+}
+
+func TestPrivatePoolMissWithExhaustedRegularAgentKeepsPrivateSelector(t *testing.T) {
+	scheduler, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	scheduler.workerPoolManager = NewWorkerPoolManager()
+	workspaceID := "workspace-private-exhausted-regular-agent"
+
+	privateController := &capacityCheckingWorkerPoolControllerForTest{
+		LocalWorkerPoolControllerForTest: &LocalWorkerPoolControllerForTest{
+			ctx:              context.Background(),
+			name:             "private-cpu",
+			mode:             types.PoolModePrivate,
+			config:           scheduler.config,
+			workerRepo:       scheduler.workerRepo,
+			requiresSelector: true,
+		},
+		hasCapacity: false,
 	}
+	privateState := &compute.PoolState{Selector: "private-cpu", Mode: string(types.PoolModePrivate)}
+	scheduler.workerPoolManager.SetPoolAt(agentPoolControllerKey(workspaceID, privateState), "private-cpu", types.WorkerPoolConfig{
+		Mode:                 types.PoolModePrivate,
+		RequiresPoolSelector: true,
+	}, privateController)
+
+	regularController := &capacityCheckingWorkerPoolControllerForTest{
+		LocalWorkerPoolControllerForTest: &LocalWorkerPoolControllerForTest{
+			ctx:        context.Background(),
+			name:       "regular-agent-cpu",
+			mode:       types.PoolModeExternal,
+			config:     scheduler.config,
+			workerRepo: scheduler.workerRepo,
+		},
+		hasCapacity: false,
+	}
+	agentProvider := types.ProviderAgent
+	scheduler.workerPoolManager.SetPool(regularController.name, types.WorkerPoolConfig{
+		Mode:     types.PoolModeExternal,
+		Provider: &agentProvider,
+	}, regularController)
+
+	request := &types.ContainerRequest{
+		ContainerId:  uuid.New().String(),
+		WorkspaceId:  workspaceID,
+		Cpu:          1000,
+		Memory:       1000,
+		PoolSelector: "private-cpu",
+		Timestamp:    time.Now(),
+		Workspace:    testWorkspaceWithStorage(),
+	}
+	setPendingSchedulerRequests(t, scheduler, request)
+	newSchedulingAttempt(scheduler, request, nil).run()
 
 	time.Sleep(provisioningWorkerRequeueDelay + requestProcessingInterval)
 	requeued, err := scheduler.requestBacklog.Pop()
 	assert.Nil(t, err)
 	assert.Equal(t, request.ContainerId, requeued.ContainerId)
 	assert.Equal(t, "private-cpu", requeued.PoolSelector)
+	assert.Equal(t, 0, privateController.AddWorkerCallCount())
+	assert.Equal(t, 0, regularController.AddWorkerCallCount())
+	assert.Equal(t, 0, request.ProvisioningAttempts)
 }
 
 type capacityCheckingWorkerPoolControllerForTest struct {

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -560,6 +560,36 @@ type StubConfigV1 struct {
 	Disks     []*pb.DurableDisk `json:"disks,omitempty"`
 }
 
+const (
+	ForceResourceLimitsMetadata  = "x-beta9-force-resource-limits"
+	forceResourceLimitsConfigKey = "_beta9_force_resource_limits"
+)
+
+// StubConfigWithForcedResourceLimits carries the request-scoped override over
+// the existing stub config wire path. Keeping the config as raw JSON preserves
+// fields introduced by newer clients that this gateway does not know yet.
+func StubConfigWithForcedResourceLimits(config string) (string, error) {
+	fields := map[string]json.RawMessage{}
+	if strings.TrimSpace(config) != "" && strings.TrimSpace(config) != "null" {
+		if err := json.Unmarshal([]byte(config), &fields); err != nil {
+			return "", err
+		}
+	}
+	fields[forceResourceLimitsConfigKey] = json.RawMessage("true")
+	updated, err := json.Marshal(fields)
+	if err != nil {
+		return "", err
+	}
+	return string(updated), nil
+}
+
+func StubConfigForcesResourceLimits(config string) bool {
+	marker := struct {
+		Enabled bool `json:"_beta9_force_resource_limits"`
+	}{}
+	return json.Unmarshal([]byte(config), &marker) == nil && marker.Enabled
+}
+
 type ServingConfig struct {
 	AppKind         string                 `json:"app_kind,omitempty" serializer:"app_kind,omitempty"`
 	ServingProtocol string                 `json:"serving_protocol,omitempty" serializer:"serving_protocol,omitempty"`

--- a/pkg/types/backend_test.go
+++ b/pkg/types/backend_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -196,5 +197,27 @@ func TestStubConfigSetReplicaCountZeroPreservesAutoscalerCeiling(t *testing.T) {
 
 	if config.Autoscaler.MinContainers != 0 || config.Autoscaler.MaxContainers != 4 {
 		t.Fatalf("replica bounds = %d/%d, want 0/4", config.Autoscaler.MinContainers, config.Autoscaler.MaxContainers)
+	}
+}
+
+func TestStubConfigResourceLimitOverridePreservesUnknownFields(t *testing.T) {
+	original := `{"runtime":{"cpu":1000},"future":{"enabled":true}}`
+	updated, err := StubConfigWithForcedResourceLimits(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !StubConfigForcesResourceLimits(updated) {
+		t.Fatal("resource-limit override was not carried in stub config")
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(updated), &fields); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(fields["future"]); got != `{"enabled":true}` {
+		t.Fatalf("unknown field = %s, want it preserved", got)
+	}
+	if StubConfigForcesResourceLimits(original) {
+		t.Fatal("ordinary stub config unexpectedly forces resource limits")
 	}
 }

--- a/pkg/worker/container_resources.go
+++ b/pkg/worker/container_resources.go
@@ -104,7 +104,7 @@ func processCPUSet(cpuLimit int64) cpuset.CPUSet {
 
 func (s *Worker) allocateContainerCPUSet(request *types.ContainerRequest) string {
 	if s == nil || s.containerInstances == nil || request == nil || request.IsBuildRequest() ||
-		!s.config.Worker.ContainerResourceLimits.CPUAffinityEnforced {
+		(!s.config.Worker.ContainerResourceLimits.CPUAffinityEnforced && !requestForcesResourceLimits(request)) {
 		return ""
 	}
 
@@ -131,6 +131,25 @@ func (s *Worker) allocateContainerCPUSet(request *types.ContainerRequest) string
 	})
 
 	return selectRequestedCPUs(request.Cpu, available, load)
+}
+
+func requestForcesResourceLimits(request *types.ContainerRequest) bool {
+	return request != nil && types.StubConfigForcesResourceLimits(request.Stub.Config)
+}
+
+func (s *Worker) cpuLimitsEnforced(request *types.ContainerRequest) bool {
+	if request == nil || request.IsBuildRequest() {
+		return false
+	}
+	return requestForcesResourceLimits(request) ||
+		(!request.RequiresGPU() && s.config.Worker.ContainerResourceLimits.CPUEnforced)
+}
+
+func (s *Worker) memoryLimitsEnforced(request *types.ContainerRequest) bool {
+	if request == nil || request.IsBuildRequest() {
+		return false
+	}
+	return requestForcesResourceLimits(request) || s.config.Worker.ContainerResourceLimits.MemoryEnforced
 }
 
 func (r *StandardResources) GetMemory(request *types.ContainerRequest) *specs.LinuxMemory {

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -1162,9 +1162,8 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 		spec.Linux.Resources.CPU.Cpus = cpuAffinity
 	}
 
-	resourceLimitsEnabled := !request.IsBuildRequest()
-	cpuEnforced := resourceLimitsEnabled && !request.RequiresGPU() && s.config.Worker.ContainerResourceLimits.CPUEnforced
-	memoryEnforced := resourceLimitsEnabled && s.config.Worker.ContainerResourceLimits.MemoryEnforced
+	cpuEnforced := s.cpuLimitsEnforced(request)
+	memoryEnforced := s.memoryLimitsEnforced(request)
 	if cpuEnforced || memoryEnforced {
 		resources, err := s.getContainerResources(request)
 		if err != nil {
@@ -1177,7 +1176,11 @@ func (s *Worker) specFromRequest(request *types.ContainerRequest, options *Conta
 				startupCPU.Quota = nil
 				startupCPU.Burst = nil
 				startupCPU.Period = nil
-				startupCPU.Cpus = ""
+				// gVisor fixes the guest CPU topology when the sandbox starts;
+				// a later resource update cannot change what nproc reports.
+				if !requestForcesResourceLimits(request) {
+					startupCPU.Cpus = ""
+				}
 				spec.Linux.Resources.CPU = &startupCPU
 			} else {
 				spec.Linux.Resources.CPU = resources.CPU
@@ -2396,7 +2399,6 @@ func (s *Worker) containerOverlayBasePath(request *types.ContainerRequest) strin
 func (s *Worker) getContainerResources(request *types.ContainerRequest) (*specs.LinuxResources, error) {
 	var resources ContainerResources
 
-	// Get runtime for this container
 	instance, exists := s.containerInstances.Get(request.ContainerId)
 	if exists && instance.Runtime != nil && instance.Runtime.Name() == types.ContainerRuntimeGvisor.String() {
 		resources = NewGvisorResources()

--- a/pkg/worker/lifecycle_test.go
+++ b/pkg/worker/lifecycle_test.go
@@ -520,6 +520,46 @@ func TestSpecFromRequestEnforcesMemoryForGPUWithoutCPUQuota(t *testing.T) {
 	require.Equal(t, int64(42*1024*1024*1024), *spec.Linux.Resources.Memory.Limit)
 }
 
+func TestSpecFromRequestForcesCPUAndMemoryLimitsForGvisorGPU(t *testing.T) {
+	mockRuntime := &mockResourceRuntime{mockRuntime: mockRuntime{name: types.ContainerRuntimeGvisor.String()}}
+	containerInstances := common.NewSafeMap[*ContainerInstance]()
+	containerInstances.Set("container-1", &ContainerInstance{Runtime: mockRuntime, CPUSet: "2-9"})
+	worker := &Worker{
+		config:             types.AppConfig{},
+		runtime:            mockRuntime,
+		containerInstances: containerInstances,
+	}
+
+	spec, err := worker.specFromRequest(&types.ContainerRequest{
+		ContainerId: "container-1",
+		EntryPoint:  []string{"sleep", "60"},
+		Cpu:         8000,
+		Memory:      16 * 1024,
+		GpuRequest:  []string{"A6000"},
+		GpuCount:    1,
+		Stub: types.StubWithRelated{Stub: types.Stub{
+			Type:   types.StubType(types.StubTypeSandbox),
+			Config: `{"_beta9_force_resource_limits":true}`,
+		}},
+	}, &ContainerOptions{BindPorts: []int{8001}})
+	require.NoError(t, err)
+	require.NotNil(t, spec.Linux.Resources.CPU)
+	require.Nil(t, spec.Linux.Resources.CPU.Quota, "sandbox CPU quota is deferred until its process manager is ready")
+	require.Equal(t, "2-9", spec.Linux.Resources.CPU.Cpus, "gVisor must see the requested CPU topology at sandbox boot")
+	require.NotNil(t, spec.Linux.Resources.Memory)
+	require.Equal(t, int64(22*1024*1024*1024), *spec.Linux.Resources.Memory.Limit)
+
+	instance, exists := containerInstances.Get("container-1")
+	require.True(t, exists)
+	require.NotNil(t, instance.DeferredCPUQuota)
+	require.Equal(t, int64(800_000), *instance.DeferredCPUQuota.Quota)
+	require.Equal(t, uint64(100_000), *instance.DeferredCPUQuota.Period)
+	require.Equal(t, "2-9", instance.DeferredCPUQuota.Cpus)
+	require.NoError(t, worker.applyDeferredCPUThrottle(&types.ContainerRequest{ContainerId: "container-1"}, instance))
+	require.Equal(t, int64(800_000), *mockRuntime.updatedResources.CPU.Quota)
+	require.Equal(t, "2-9", mockRuntime.updatedResources.CPU.Cpus)
+}
+
 func TestSpecFromRequestReturnsIndependentSpecs(t *testing.T) {
 	worker := &Worker{runtime: &mockRuntime{name: types.ContainerRuntimeRunc.String()}}
 	initialEnv := make([]string, 1, 8)
@@ -643,6 +683,31 @@ func TestContainerCPUAffinityIsOptInAndLoadBalanced(t *testing.T) {
 	require.Equal(t, 1, firstSet.Size())
 	require.Equal(t, 1, secondSet.Size())
 	require.True(t, firstSet.Intersection(secondSet).IsEmpty())
+}
+
+func TestForcedResourceLimitsOptIntoCPUAffinity(t *testing.T) {
+	instances := common.NewSafeMap[*ContainerInstance]()
+	worker := &Worker{
+		containerInstances: instances,
+		cpuLimit:           64_000,
+	}
+	request := &types.ContainerRequest{
+		ContainerId: "tama-gpu",
+		Cpu:         1000,
+		GpuRequest:  []string{"A6000"},
+		GpuCount:    1,
+		Stub: types.StubWithRelated{Stub: types.Stub{
+			Type:   types.StubType(types.StubTypeSandbox),
+			Config: `{"_beta9_force_resource_limits":true}`,
+		}},
+	}
+
+	require.True(t, worker.reserveContainerInstance(request))
+	instance, exists := instances.Get(request.ContainerId)
+	require.True(t, exists)
+	affinity, err := cpuset.Parse(instance.CPUSet)
+	require.NoError(t, err)
+	require.Equal(t, 1, affinity.Size())
 }
 
 func TestCheckpointRestoreCPUAffinityIsDeferredAndApplied(t *testing.T) {

--- a/pkg/worker/oom.go
+++ b/pkg/worker/oom.go
@@ -44,7 +44,7 @@ func (s *Worker) setupOOMWatcher(
 	}
 
 	if containerRuntime.Name() == types.ContainerRuntimeGvisor.String() {
-		if !s.config.Worker.ContainerResourceLimits.MemoryEnforced {
+		if !s.memoryLimitsEnforced(request) {
 			return
 		}
 		// runsc places the sandbox and gofer in a cgroup named after the

--- a/pkg/worker/oom_test.go
+++ b/pkg/worker/oom_test.go
@@ -32,3 +32,12 @@ func TestSetupOOMWatcherSkipsGvisorWhenMemoryIsNotEnforced(t *testing.T) {
 	require.True(t, exists)
 	require.False(t, instance.hasOOMWatcher())
 }
+
+func TestForcedResourceLimitsEnableGvisorOOMPolicy(t *testing.T) {
+	worker := &Worker{}
+	request := &types.ContainerRequest{Stub: types.StubWithRelated{Stub: types.Stub{
+		Config: `{"_beta9_force_resource_limits":true}`,
+	}}}
+
+	require.True(t, worker.memoryLimitsEnforced(request))
+}


### PR DESCRIPTION
## What changed

- Makes Tama launch resource isolation request-scoped without adding protobuf, OpenAPI, or SDK fields. The gateway carries the opt-in through the existing stub config transport, and the worker only ORs it into the existing CPU-affinity, CPU-quota, memory-limit, and OOM-policy gates.
- Keeps ordinary and build workloads on their existing pool/worker policy.
- Preserves the forced cpuset at gVisor startup so guest CPU topology matches the request.
- Skips static or definitively exhausted worker pools before they consume provisioning attempts, while preserving existing-worker placement and private-pool selectors.
- Surfaces terminal scheduler failures through sandbox status.
- Recognizes newer runsc's precise missing-container state so already-exited sandboxes do not wait the full 30-second grace period.

## Why

Tama cold creates could exhaust their global provisioning-attempt budget on higher-priority pools that could not supply new capacity, then poll an opaque status until timeout. GPU/private workers could also ignore requested CPU and memory isolation when pool policy disabled limits. Finally, an already-removed gVisor runtime was misclassified as live and added a false 30-second shutdown delay.

## Scope

- No protocol or generated-code churn.
- No database migration.
- Existing callers are unchanged unless they send the internal request marker.
- runc uses the existing 1.25x memory policy; gVisor uses the existing 1.25x + 2 GiB policy.
- Temporary CUDA checkpoint headroom is intentionally not part of this PR.

## Validation

- `go test ./pkg/worker ./pkg/gateway ./pkg/types`
- focused worker/resource cases 20x
- scheduler/repository suites and focused scheduler race tests
- local k3d E2E on the exact combined worker image:
  - 8 CPU / 16 GiB request: `nproc=8`, affinity `0-7`, `cpu.max=800000 100000`, `memory.max=21474836480`
  - stop/snapshot/start retained the workspace and the same limits
  - canceled/removed machine completed in about one second rather than 30 seconds

The GPU-capacity reconciliation is split into a stacked follow-up PR so this review stays focused.
