### PR TITLE
Contain runaway worker provisioning from unbounded workspaces

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -96,6 +96,12 @@ gateway:
     memory: 32768
     maxReplicas: 10
     maxGpuCount: 2
+  # Per-workspace cap on concurrently reserved capacity, applied only to
+  # workspaces without an explicit concurrency limit row. Disabled when
+  # either value is 0.
+  defaultConcurrencyLimit:
+    cpuMillicores: 0
+    gpuCount: 0
 fileService:
   enabled: true
   endpointUrl: http://juicefs-s3-gateway.beta9.svc.cluster.local:9900

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -29,7 +29,10 @@ const (
 	requestProcessingInterval      time.Duration = 50 * time.Millisecond
 	requestProcessingBatchSize                   = 512
 	provisioningWorkerRequeueDelay time.Duration = 250 * time.Millisecond
-	pendingWorkerReservationTTL    time.Duration = 30 * time.Second
+	// Must cover node provision + worker registration (2-4 min on EKS with
+	// Karpenter). A shorter TTL forgets capacity reserved on still-booting
+	// workers, and the orphaned requests provision duplicate workers.
+	pendingWorkerReservationTTL time.Duration = 3 * time.Minute
 	maxWorkerProvisioningAttempts                = 3
 )
 
@@ -440,7 +443,10 @@ func (s *Scheduler) managedConcurrencyLimit(request *types.ContainerRequest) (*t
 	if quota == nil {
 		quota, err = s.backendRepo.GetConcurrencyLimitByWorkspaceId(s.ctx, request.WorkspaceId)
 		if err != nil && err == sql.ErrNoRows {
-			return nil, nil // No quota set for this workspace
+			// No explicit quota for this workspace — fall back to the
+			// platform-wide default so a single workspace cannot fan out
+			// unbounded capacity. Nil when the default is not configured.
+			return s.defaultConcurrencyLimit(), nil
 		}
 		if err != nil {
 			return nil, err
@@ -453,6 +459,21 @@ func (s *Scheduler) managedConcurrencyLimit(request *types.ContainerRequest) (*t
 	}
 
 	return quota, nil
+}
+
+// defaultConcurrencyLimit returns the platform-wide concurrency limit applied
+// to workspaces without an explicit quota row. GPULimit==0 means "no GPUs
+// allowed" in quota checks, so the default only activates when both values
+// are configured to be positive.
+func (s *Scheduler) defaultConcurrencyLimit() *types.ConcurrencyLimit {
+	cfg := s.config.GatewayService.DefaultConcurrencyLimit
+	if cfg.CPUMillicores == 0 || cfg.GPUCount == 0 {
+		return nil
+	}
+	return &types.ConcurrencyLimit{
+		CPUMillicoreLimit: cfg.CPUMillicores,
+		GPULimit:          cfg.GPUCount,
+	}
 }
 
 func (s *Scheduler) privatePoolQuotaExempt(request *types.ContainerRequest) bool {
@@ -1322,7 +1343,9 @@ func (s *Scheduler) selectWorkerFromWorkersByStatus(workers []*types.Worker, req
 		if scoredWorkers[i].score != scoredWorkers[j].score {
 			return scoredWorkers[i].score > scoredWorkers[j].score
 		}
-		return workerFreeCapacityScore(scoredWorkers[i].worker, request) > workerFreeCapacityScore(scoredWorkers[j].worker, request)
+		// Best-fit: prefer the fullest worker that still fits so idle workers
+		// drain to zero, hit their spindown timeout, and release their nodes.
+		return workerFreeCapacityScore(scoredWorkers[i].worker, request) < workerFreeCapacityScore(scoredWorkers[j].worker, request)
 	})
 
 	return scoredWorkers[0].worker, nil

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"slices"
@@ -1567,7 +1568,7 @@ func TestProcessRequestBatchDoesNotOverScheduleWorkerSnapshot(t *testing.T) {
 	assert.Equal(t, int64(2), updatedWorker.ResourceVersion)
 }
 
-func TestProcessRequestBatchSpreadsAcrossEqualWorkers(t *testing.T) {
+func TestProcessRequestBatchPacksOntoSingleWorker(t *testing.T) {
 	wb, err := NewSchedulerForTest()
 	assert.Nil(t, err)
 
@@ -1616,14 +1617,24 @@ func TestProcessRequestBatchSpreadsAcrossEqualWorkers(t *testing.T) {
 
 	wb.processRequestBatch(requests, workers)
 
-	firstQueued, err := wb.workerRepo.GetNextContainerRequest(firstWorker.Id)
-	assert.Nil(t, err)
-	secondQueued, err := wb.workerRepo.GetNextContainerRequest(secondWorker.Id)
-	assert.Nil(t, err)
-
-	assert.NotNil(t, firstQueued)
-	assert.NotNil(t, secondQueued)
-	assert.NotEqual(t, firstQueued.ContainerId, secondQueued.ContainerId)
+	// Best-fit packing: both requests should land on the same worker so the
+	// other worker can drain, spin down, and release its node.
+	perWorker := []int{}
+	for _, w := range []*types.Worker{firstWorker, secondWorker} {
+		queued := 0
+		for {
+			request, err := wb.workerRepo.GetNextContainerRequest(w.Id)
+			assert.Nil(t, err)
+			if request == nil {
+				break
+			}
+			queued++
+		}
+		perWorker = append(perWorker, queued)
+	}
+	assert.Equal(t, 2, perWorker[0]+perWorker[1])
+	assert.Contains(t, perWorker, 2)
+	assert.Contains(t, perWorker, 0)
 }
 
 func TestProcessRequestBatchEmitsContainerPlaced(t *testing.T) {
@@ -1720,6 +1731,9 @@ func TestProcessRequestBatchSchedulesTinySandboxBurstByRequestedCapacity(t *test
 	assert.Nil(t, err)
 	wb.processRequestBatch(requests, workerSnapshot)
 
+	// All 70 tiny requests fit on one 16-CPU worker only when scheduled by
+	// their actual requested capacity; best-fit packs them onto one worker.
+	queuedPerWorker := []int{}
 	for _, worker := range workers {
 		queued := 0
 		for {
@@ -1730,8 +1744,10 @@ func TestProcessRequestBatchSchedulesTinySandboxBurstByRequestedCapacity(t *test
 			}
 			queued++
 		}
-		assert.Equal(t, 35, queued)
+		queuedPerWorker = append(queuedPerWorker, queued)
 	}
+	assert.Equal(t, 70, queuedPerWorker[0]+queuedPerWorker[1])
+	assert.Contains(t, queuedPerWorker, 70)
 }
 
 func TestProcessRequestBatchKeepsCPUAndGPUCapacitySeparate(t *testing.T) {
@@ -3479,6 +3495,33 @@ func (b *BackendRepoConcurrencyLimitsForTest) GetConcurrencyLimitByWorkspaceId(c
 		GPULimit:          b.GPUConcurrencyLimit,
 		CPUMillicoreLimit: b.CPUConcurrencyLimit,
 	}, nil
+}
+
+type BackendRepoNoConcurrencyLimitForTest struct {
+	repo.BackendRepository
+}
+
+func (b *BackendRepoNoConcurrencyLimitForTest) GetConcurrencyLimitByWorkspaceId(ctx context.Context, workspaceId string) (*types.ConcurrencyLimit, error) {
+	return nil, sql.ErrNoRows
+}
+
+func TestDefaultConcurrencyLimitForWorkspacesWithoutQuota(t *testing.T) {
+	wb, err := NewSchedulerForTest()
+	assert.Nil(t, err)
+	wb.backendRepo = &BackendRepoNoConcurrencyLimitForTest{}
+
+	// Default not configured: workspaces without a quota row stay unlimited.
+	quota, err := wb.managedConcurrencyLimit(&types.ContainerRequest{WorkspaceId: uuid.New().String()})
+	assert.Nil(t, err)
+	assert.Nil(t, quota)
+
+	// Default configured: applied to workspaces without a quota row.
+	wb.config.GatewayService.DefaultConcurrencyLimit = types.DefaultConcurrencyLimitConfig{CPUMillicores: 64000, GPUCount: 10}
+	quota, err = wb.managedConcurrencyLimit(&types.ContainerRequest{WorkspaceId: uuid.New().String()})
+	assert.Nil(t, err)
+	assert.NotNil(t, quota)
+	assert.Equal(t, uint32(64000), quota.CPUMillicoreLimit)
+	assert.Equal(t, uint32(10), quota.GPULimit)
 }
 
 func TestConcurrencyLimit(t *testing.T) {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -184,6 +184,15 @@ type GatewayServiceConfig struct {
 	HTTP            HTTPConfig    `key:"http" json:"http"`
 	ShutdownTimeout time.Duration `key:"shutdownTimeout" json:"shutdown_timeout"`
 	StubLimits      StubLimits    `key:"stubLimits" json:"stub_limits"`
+	// Applied to workspaces that have no explicit concurrency limit row.
+	// Both values must be > 0 for the default to take effect; otherwise
+	// workspaces without a row remain unlimited (legacy behavior).
+	DefaultConcurrencyLimit DefaultConcurrencyLimitConfig `key:"defaultConcurrencyLimit" json:"default_concurrency_limit"`
+}
+
+type DefaultConcurrencyLimitConfig struct {
+	CPUMillicores uint32 `key:"cpuMillicores" json:"cpu_millicores"`
+	GPUCount      uint32 `key:"gpuCount" json:"gpu_count"`
 }
 
 type FileServiceConfig struct {


### PR DESCRIPTION
A workspace with no concurrency_limit row fanned out to 272 workers and 91 nodes on 2026-08-12 because nothing bounds demand or provisioning:

- Switch the worker selection tie-breaker from worst-fit to best-fit so requests pack onto the fullest worker that fits, letting idle workers drain to zero, hit their spindown timeout, and release their nodes.
- Add gateway.defaultConcurrencyLimit, a per-workspace cap on concurrently reserved CPU/GPU applied to workspaces without an explicit quota row. Disabled unless both values are configured, preserving legacy behavior.
- Raise pendingWorkerReservationTTL 30s -> 3m to cover node provision plus worker registration; the shorter TTL forgot capacity reserved on still-booting workers and orphaned requests provisioned duplicates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds worker provisioning for workspaces without explicit quotas and reduces node churn. Previously, workspaces without a concurrency limit could fan out unlimited workers and the scheduler spread requests across equal workers; now we use best-fit packing, apply an optional platform-wide default concurrency limit to such workspaces, and extend `pendingWorkerReservationTTL` from 30s to 3m to prevent duplicate provisioning.

- The scheduler’s tie-breaker switches to best-fit, consolidating requests on the fullest worker that fits so idle workers drain and spin down.
- Adds `gateway.defaultConcurrencyLimit` with `cpuMillicores` and `gpuCount`; it applies only to workspaces without a quota row and only when both values are > 0 (otherwise legacy unlimited behavior remains).
- Increases `pendingWorkerReservationTTL` to 3m to cover node provisioning and worker registration; avoids forgetting reserved capacity and provisioning duplicate workers.
- No migration required. Optional: set `gateway.defaultConcurrencyLimit.cpuMillicores` and `.gpuCount` to enable a platform-wide cap for workspaces without quotas. Monitor for placement consolidation and faster node spindown.

<sup>Written for commit df641b38a93ba47c77454362b872581af438343c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

