### PR TITLE
Cost containment: default concurrency limit on API-provisioned workspaces + 10-minute worker spindown

### DIFF
--- a/pkg/api/v1/workspace.go
+++ b/pkg/api/v1/workspace.go
@@ -56,6 +56,17 @@ func (g *WorkspaceGroup) CreateWorkspace(ctx echo.Context) error {
 		return HTTPInternalServerError("Unable to create workspace")
 	}
 
+	// Every workspace gets the platform default concurrency limit at creation
+	// so callers that provision workspaces directly through this API cannot
+	// end up with unlimited capacity. Control planes that manage per-tier
+	// quotas overwrite this row afterwards.
+	if defaults := g.config.GatewayService.DefaultConcurrencyLimit; defaults.CPUMillicores > 0 && defaults.GPUCount > 0 {
+		if _, err := g.backendRepo.CreateConcurrencyLimit(ctx.Request().Context(), workspace.Id, defaults.GPUCount, defaults.CPUMillicores); err != nil {
+			log.Error().Err(err).Msgf("Failed to create default concurrency limit for workspace %d", workspace.Id)
+			return HTTPInternalServerError("Unable to create workspace concurrency limit")
+		}
+	}
+
 	token, err := g.backendRepo.CreateToken(ctx.Request().Context(), workspace.Id, types.TokenTypeWorkspacePrimary, true)
 	if err != nil {
 		return HTTPInternalServerError("Unable to create workspace token")

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	containerLogsPath              string        = types.AgentLogsPath
-	defaultWorkerSpindownTimeS     float64       = 300 // 5 minutes
+	defaultWorkerSpindownTimeS     float64       = 600 // 10 min: outlives 5-min cron periods so recurring jobs reuse workers instead of churning nodes
 	defaultCacheWaitTime           time.Duration = 30 * time.Second
 	containerStatusUpdateInterval  time.Duration = 30 * time.Second
 	containerRequestStreamInterval time.Duration = 100 * time.Millisecond

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	containerLogsPath              string        = types.AgentLogsPath
-	defaultWorkerSpindownTimeS     float64       = 600 // 10 min: outlives 5-min cron periods so recurring jobs reuse workers instead of churning nodes
+	defaultWorkerSpindownTimeS     float64       = 600 // 10 min
 	defaultCacheWaitTime           time.Duration = 30 * time.Second
 	containerStatusUpdateInterval  time.Duration = 30 * time.Second
 	containerRequestStreamInterval time.Duration = 100 * time.Millisecond


### PR DESCRIPTION
## Summary

Two remaining cost-containment changes not yet in main (follow-ups to #1841):

- **Default concurrency limit for API-provisioned workspaces** (`pkg/api/v1/workspace.go`): workspaces created directly via `POST /api/v1/workspace` (e.g. by tama) now get the platform default concurrency limit at creation, so they can never start out unlimited. Control planes that manage per-tier quotas overwrite the row afterwards. No-op unless `gateway.defaultConcurrencyLimit` is configured.

- **Worker spindown 5 → 10 minutes** (`pkg/worker/worker.go`): prod demand includes 5-minute cron jobs; a 300s spindown killed idle workers moments before the next tick re-provisioned identical capacity, churning nodes, image pulls, and cross-AZ traffic every cycle. 10 minutes lets recurring jobs reuse warm workers. Takes effect on the next worker image release.

## Test plan

- [x] `go build ./pkg/worker/ ./pkg/api/...`
- [x] Existing scheduler/API tests pass
- [ ] After worker image release: confirm workers survive across 5-minute cron ticks and node churn drops