### PR TITLE
Speed up durable disk snapshots and stop 502s on published ports

### DIFF
--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -33,12 +33,15 @@ const (
 	containerDiscoveryInterval       time.Duration = time.Millisecond * 250
 	queuedContainerDiscoveryInterval time.Duration = time.Millisecond * 50
 	containerDialTimeoutDurationS    time.Duration = time.Second * 30
-	containerPinnedDialTimeout       time.Duration = time.Millisecond * 900
-	containerAvailableTimeout        time.Duration = time.Second * 2
-	containerPrimeTimeout            time.Duration = time.Second * 3
-	connectionKeepAliveInterval      time.Duration = time.Second * 1
-	connectionReadTimeout            time.Duration = time.Minute * 5
-	backendDialRetryLimit                          = 1
+	// Bounds waiting on a route that is still opening, so it stays short.
+	containerPinnedRouteDialTimeout time.Duration = time.Millisecond * 900
+	// A full accept queue drops the SYN, which the kernel leaves unanswered for a second.
+	containerPinnedDialTimeout  time.Duration = time.Second * 3
+	containerAvailableTimeout   time.Duration = time.Second * 2
+	containerPrimeTimeout       time.Duration = time.Second * 3
+	connectionKeepAliveInterval time.Duration = time.Second * 1
+	connectionReadTimeout       time.Duration = time.Minute * 5
+	backendDialRetryLimit                     = 1
 )
 
 type container struct {
@@ -57,6 +60,7 @@ type connection struct {
 	dialTimeout      time.Duration
 	llm              *llmRequestInfo
 	retryBackendDial bool
+	pinned           bool
 	retryCount       int
 	state            atomic.Int32
 }
@@ -265,7 +269,12 @@ func (pb *PodProxyBuffer) ForwardContainerRequest(ctx echo.Context, containerId 
 	}
 
 	done := make(chan struct{})
-	conn := &connection{ctx: ctx, done: done, dialTimeout: containerPinnedDialTimeout}
+	conn := &connection{ctx: ctx, done: done, dialTimeout: containerPinnedRouteDialTimeout}
+	if _, isRoute := types.ParseBackendRouteAddress(addressMap[int32(port)]); !isRoute {
+		conn.dialTimeout = containerPinnedDialTimeout
+		conn.retryBackendDial = true
+		conn.pinned = true
+	}
 	conn.claim()
 	pb.handleConnection(conn, container{
 		id:         containerId,
@@ -793,13 +802,21 @@ func (pb *PodProxyBuffer) handleConnection(conn *connection, container container
 	// The transport closes its outbound request body even when dialing fails.
 	// Keep the inbound body open until the one safe pre-connect retry is decided.
 	requestBody := request.Body
-	func() {
+	serve := func() {
 		if conn.retryBackendDial && conn.retryCount < backendDialRetryLimit && requestBody != nil {
 			request.Body = preservedRequestBody{ReadCloser: requestBody}
 			defer func() { request.Body = requestBody }()
 		}
 		proxy.ServeHTTP(conn.ctx.Response(), request)
-	}()
+	}
+	serve()
+
+	// A pinned request names one container, so there is nowhere to requeue it: dial again.
+	if retryErr != nil && conn.pinned {
+		conn.retryCount++
+		retryErr = nil
+		serve()
+	}
 
 	if retryErr == nil {
 		return false

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -549,6 +549,11 @@ func TestForwardContainerRequestProxiesPinnedContainerWithoutQueueing(t *testing
 		if r.URL.String() != "/health?probe=1" {
 			t.Fatalf("backend URL = %q, want /health?probe=1", r.URL.String())
 		}
+		// Pinned requests hold their body open for a possible second dial, so it still has to arrive whole.
+		body, err := io.ReadAll(r.Body)
+		if err != nil || string(body) != "payload" {
+			t.Fatalf("backend body = %q (%v), want %q", body, err, "payload")
+		}
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	t.Cleanup(backend.Close)
@@ -563,7 +568,7 @@ func TestForwardContainerRequestProxiesPinnedContainerWithoutQueueing(t *testing
 	}
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/health?probe=1", nil)
+	req := httptest.NewRequest(http.MethodPost, "/health?probe=1", bytes.NewReader([]byte("payload")))
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 	ctx.SetParamNames("port", "subPath")
@@ -979,6 +984,58 @@ func TestPrimeContainerPortMissingPortDoesNotPublishContainer(t *testing.T) {
 	}
 	if _, ok, hasContainers, hasPort := pb.reserveContainerForPort(8765); ok || hasContainers || hasPort {
 		t.Fatalf("missing port was published, ok=%v hasContainers=%v hasPort=%v", ok, hasContainers, hasPort)
+	}
+}
+
+func TestForwardContainerRequestGivesDirectAddressesRoomToRetransmit(t *testing.T) {
+	// An address nobody answers, so the request fails without a backend to talk to.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	listener.Close()
+
+	rdb := newPodProxyTestRedis(t)
+	repo := repository.NewContainerRedisRepositoryForTest(rdb)
+	containerID := "sandbox-e9c29586-c465-4a67-9c9b-25293d1ce77b-abc12345"
+	if err := repo.SetContainerAddressMap(containerID, map[int32]string{8765: address}); err != nil {
+		t.Fatal(err)
+	}
+
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+	ctx.SetParamNames("port", "subPath")
+	ctx.SetParamValues("8765", "")
+
+	pb := &PodProxyBuffer{
+		ctx:           context.Background(),
+		rdb:           rdb,
+		workspace:     &types.Workspace{Name: "workspace"},
+		stubId:        "e9c29586-c465-4a67-9c9b-25293d1ce77b",
+		stubConfig:    &types.StubConfigV1{},
+		containerRepo: repo,
+	}
+
+	if err := pb.ForwardContainerRequest(ctx, containerID); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+
+	// A real connect has to outlast a dropped SYN, unanswered for a second.
+	budgets := []time.Duration{}
+	pb.backendTransports.Range(func(key, _ any) bool {
+		budgets = append(budgets, key.(backendTransportKey).dialTimeout)
+		return true
+	})
+	if len(budgets) != 1 || budgets[0] != containerPinnedDialTimeout {
+		t.Fatalf("dial budgets = %v, want one of %s", budgets, containerPinnedDialTimeout)
+	}
+	if containerPinnedDialTimeout <= time.Second {
+		t.Fatalf("pinned dial budget %s does not outlast a retransmit", containerPinnedDialTimeout)
 	}
 }
 

--- a/pkg/worker/durable_disk_snapshot.go
+++ b/pkg/worker/durable_disk_snapshot.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -29,14 +30,22 @@ import (
 
 const (
 	defaultDurableDiskSnapshotChunkSize  int64 = 16 << 20
-	durableDiskSnapshotUploadConcurrency       = 8
+	durableDiskSnapshotUploadConcurrency       = 16
 	durableDiskRestoreConcurrency              = 8
 	durableDiskSnapshotReadBufferSize          = 1 << 20
 	durableDiskSnapshotUploadAttempts          = 3
 	durableDiskSnapshotRetryDelay              = 250 * time.Millisecond
+	// Chunks up to this size are kept in memory rather than spooled to a temp file.
+	durableDiskSnapshotInlineChunkSize = 1 << 20
 )
 
+// Files read, hashed and uploaded at once. Bounded by memory, not cores: these wait on the store.
+const durableDiskSnapshotFileConcurrency = 16
+
 var durableDiskSnapshotChunkSlots = make(chan struct{}, durableDiskSnapshotUploadConcurrency)
+
+// Chunk downloads in flight across every file being restored, so more files widen the pipe.
+var durableDiskRestoreChunkSlots = make(chan struct{}, durableDiskRestoreConcurrency)
 
 var errDurableDiskSnapshotInactive = errors.New("durable disk snapshot made no progress before the inactivity deadline")
 
@@ -292,35 +301,61 @@ func createDurableDiskDirectorySnapshot(ctx context.Context, store durableDiskSn
 
 	previousFiles := durableDiskSnapshotFilesByPath(previous)
 	chunkPrefix := durableDiskSnapshotChunkPrefix(objectPrefix)
-	files := map[string]types.DiskSnapshotFile{}
 	seen := durableDiskSnapshotSeenChunks(previous, chunkPrefix)
 
-	if err := walkDurableDiskSnapshotTree(ctx, sourceDir, true, durableDiskProgressEvent{files: 1}, func(name string, file types.DiskSnapshotFile) error {
-		switch file.Type {
-		case "file":
-			previousFile := previousFiles[file.Path]
-			if durableDiskSnapshotFileReusable(previousFile, file) {
-				file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
-			} else if durableDiskSnapshotAppendOnlyFile(manifest.Format, file.Path) && durableDiskSnapshotFileAppendReusable(previousFile, file) {
-				reusePrefix, err := durableDiskSnapshotFileChunksReusable(ctx, name, previousFile)
+	var filesMu sync.Mutex
+	files := map[string]types.DiskSnapshotFile{}
+	record := func(file types.DiskSnapshotFile) {
+		filesMu.Lock()
+		files[file.Path] = file
+		filesMu.Unlock()
+	}
+
+	// On a pool: walking serially kept the upload pool one chunk deep, a round trip per file.
+	content, contentCtx := errgroup.WithContext(ctx)
+	content.SetLimit(durableDiskSnapshotFileConcurrency)
+
+	walkErr := walkDurableDiskSnapshotTree(ctx, sourceDir, true, durableDiskProgressEvent{files: 1}, func(name string, file types.DiskSnapshotFile) error {
+		if file.Type != "file" {
+			record(file)
+			return nil
+		}
+
+		// Metadata settles an unchanged file without reading it, for less than a worker costs.
+		previousFile := previousFiles[file.Path]
+		if durableDiskSnapshotFileReusable(previousFile, file) {
+			file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
+			record(file)
+			return nil
+		}
+
+		reuseAppendPrefix := durableDiskSnapshotAppendOnlyFile(manifest.Format, file.Path) &&
+			durableDiskSnapshotFileAppendReusable(previousFile, file)
+		content.Go(func() error {
+			if reuseAppendPrefix {
+				reusePrefix, err := durableDiskSnapshotFileChunksReusable(contentCtx, name, previousFile)
 				if err != nil {
 					return err
 				}
 				if reusePrefix {
 					file.Chunks = append([]types.DiskSnapshotChunk(nil), previousFile.Chunks...)
 				}
-				if err := snapshotDurableDiskFile(ctx, store, name, chunkPrefix, chunkSize, seen, &file); err != nil {
-					return err
-				}
-			} else if err := snapshotDurableDiskFile(ctx, store, name, chunkPrefix, chunkSize, seen, &file); err != nil {
+			}
+			if err := snapshotDurableDiskFile(contentCtx, store, name, chunkPrefix, chunkSize, seen, &file); err != nil {
 				return err
 			}
-		}
-
-		files[file.Path] = file
-		return nil
-	}); err != nil {
+			record(file)
+			return nil
+		})
+		// One file failing makes the rest of the walk pointless.
+		return contentCtx.Err()
+	})
+	// Waited on first, so a walk that stopped reports the file rather than the cancellation.
+	if err := content.Wait(); err != nil {
 		return nil, nil, err
+	}
+	if walkErr != nil {
+		return nil, nil, walkErr
 	}
 
 	manifest.Files = durableDiskSnapshotSortedFiles(files)
@@ -664,25 +699,47 @@ func durableDiskSnapshotPostgresWALFile(name string) bool {
 	return strings.HasPrefix(name, "pgdata/pg_wal/")
 }
 
-func durableDiskSnapshotSeenChunks(previous *types.DiskSnapshotManifest, chunkPrefix string) map[string]struct{} {
-	seen := map[string]struct{}{}
+// durableDiskSnapshotChunkSet is every chunk the snapshot already has, claimed in one step
+// because concurrent files holding the same bytes must produce one upload between them.
+type durableDiskSnapshotChunkSet struct {
+	mu   sync.Mutex
+	keys map[string]struct{}
+}
+
+func newDurableDiskSnapshotChunkSet() *durableDiskSnapshotChunkSet {
+	return &durableDiskSnapshotChunkSet{keys: map[string]struct{}{}}
+}
+
+// claim reports whether this caller is the one that has to upload the chunk.
+func (s *durableDiskSnapshotChunkSet) claim(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.keys[key]; ok {
+		return false
+	}
+	s.keys[key] = struct{}{}
+	return true
+}
+
+func durableDiskSnapshotSeenChunks(previous *types.DiskSnapshotManifest, chunkPrefix string) *durableDiskSnapshotChunkSet {
+	seen := newDurableDiskSnapshotChunkSet()
 	if previous == nil {
 		return seen
 	}
 	for _, file := range previous.Files {
 		for _, chunk := range file.Chunks {
 			if chunk.ObjectKey != "" {
-				seen[chunk.ObjectKey] = struct{}{}
+				seen.claim(chunk.ObjectKey)
 			}
 			if digest := strings.TrimPrefix(chunk.Digest, "sha256:"); digest != "" {
-				seen[path.Join(chunkPrefix, digest)] = struct{}{}
+				seen.claim(path.Join(chunkPrefix, digest))
 			}
 		}
 	}
 	return seen
 }
 
-func snapshotDurableDiskFile(ctx context.Context, store durableDiskSnapshotStore, filename, chunkPrefix string, chunkSize int64, seen map[string]struct{}, file *types.DiskSnapshotFile) error {
+func snapshotDurableDiskFile(ctx context.Context, store durableDiskSnapshotStore, filename, chunkPrefix string, chunkSize int64, seen *durableDiskSnapshotChunkSet, file *types.DiskSnapshotFile) error {
 	in, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -691,7 +748,7 @@ func snapshotDurableDiskFile(ctx context.Context, store durableDiskSnapshotStore
 	return snapshotDurableDiskReader(ctx, store, in, filename, chunkPrefix, chunkSize, seen, file)
 }
 
-func snapshotDurableDiskReader(ctx context.Context, store durableDiskSnapshotStore, source io.ReaderAt, sourceName, chunkPrefix string, chunkSize int64, seen map[string]struct{}, file *types.DiskSnapshotFile) error {
+func snapshotDurableDiskReader(ctx context.Context, store durableDiskSnapshotStore, source io.ReaderAt, sourceName, chunkPrefix string, chunkSize int64, seen *durableDiskSnapshotChunkSet, file *types.DiskSnapshotFile) error {
 	if chunkSize <= 0 || chunkSize > defaultDurableDiskSnapshotChunkSize {
 		chunkSize = defaultDurableDiskSnapshotChunkSize
 	}
@@ -722,7 +779,7 @@ func snapshotDurableDiskReader(ctx context.Context, store durableDiskSnapshotSto
 		if readErr != nil {
 			break
 		}
-		chunkFile, n, hash, err := spoolDurableDiskSnapshotChunk(uploadCtx, source, sourceName, offset, chunkSize, buffer)
+		body, n, hash, err := spoolDurableDiskSnapshotChunk(uploadCtx, source, sourceName, offset, chunkSize, buffer)
 		if err != nil {
 			<-durableDiskSnapshotChunkSlots
 			// A source read failure makes every sibling upload useless. Cancel
@@ -739,20 +796,19 @@ func snapshotDurableDiskReader(ctx context.Context, store durableDiskSnapshotSto
 			break
 		}
 		key := path.Join(chunkPrefix, hash)
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
+		if seen.claim(key) {
 			chunkSizeBytes := n
 			uploads.Go(func() error {
 				defer func() { <-durableDiskSnapshotChunkSlots }()
-				defer removeDurableDiskSnapshotChunkFile(chunkFile)
-				if err := uploadDurableDiskSnapshotChunk(uploadCtx, store, key, chunkFile, chunkSizeBytes); err != nil {
+				defer body.release()
+				if err := uploadDurableDiskSnapshotChunk(uploadCtx, store, key, body, chunkSizeBytes); err != nil {
 					return fmt.Errorf("upload durable disk snapshot chunk %s: %w", key, err)
 				}
 				reportDurableDiskProgress(uploadCtx, durableDiskProgressEvent{chunks: 1})
 				return nil
 			})
 		} else {
-			removeDurableDiskSnapshotChunkFile(chunkFile)
+			body.release()
 			<-durableDiskSnapshotChunkSlots
 		}
 		file.Chunks = append(file.Chunks, types.DiskSnapshotChunk{
@@ -780,12 +836,12 @@ func snapshotDurableDiskReader(ctx context.Context, store durableDiskSnapshotSto
 	return ctx.Err()
 }
 
-func uploadDurableDiskSnapshotChunk(ctx context.Context, store durableDiskSnapshotStore, key string, chunkFile *os.File, size int64) error {
+func uploadDurableDiskSnapshotChunk(ctx context.Context, store durableDiskSnapshotStore, key string, body *durableDiskSnapshotChunkBody, size int64) error {
 	var err error
 	for attempt := 0; attempt < durableDiskSnapshotUploadAttempts; attempt++ {
 		err = store.UploadWithReader(ctx, key, &durableDiskSnapshotProgressReader{
 			ctx:    ctx,
-			reader: io.NewSectionReader(chunkFile, 0, size),
+			reader: body.reader(size),
 		})
 		if err == nil {
 			return nil
@@ -803,27 +859,74 @@ func uploadDurableDiskSnapshotChunk(ctx context.Context, store durableDiskSnapsh
 	return err
 }
 
-func spoolDurableDiskSnapshotChunk(ctx context.Context, source io.ReaderAt, sourceName string, offset, size int64, buffer []byte) (*os.File, int64, string, error) {
-	chunkFile, err := os.CreateTemp("", "beta9-durable-disk-snapshot-chunk-*")
-	if err != nil {
-		return nil, 0, "", fmt.Errorf("create durable disk snapshot chunk file: %w", err)
-	}
-	cleanup := func() {
-		removeDurableDiskSnapshotChunkFile(chunkFile)
-	}
+func spoolDurableDiskSnapshotChunk(ctx context.Context, source io.ReaderAt, sourceName string, offset, size int64, buffer []byte) (*durableDiskSnapshotChunkBody, int64, string, error) {
+	body := &durableDiskSnapshotChunkBody{}
 
 	sum := sha256.New()
 	reader := io.NewSectionReader(&durableDiskSnapshotContextReaderAt{ctx: ctx, source: source}, offset, size)
-	n, err := io.CopyBuffer(io.MultiWriter(chunkFile, sum, durableDiskSnapshotLogicalProgressWriter{ctx: ctx}), reader, buffer)
+	n, err := io.CopyBuffer(io.MultiWriter(body, sum, durableDiskSnapshotLogicalProgressWriter{ctx: ctx}), reader, buffer)
 	if err != nil {
-		cleanup()
+		body.release()
 		return nil, 0, "", fmt.Errorf("read durable disk snapshot file %s: %w", sourceName, err)
 	}
 	if n == 0 {
-		cleanup()
+		body.release()
 		return nil, 0, "", nil
 	}
-	return chunkFile, n, hex.EncodeToString(sum.Sum(nil)), nil
+	return body, n, hex.EncodeToString(sum.Sum(nil)), nil
+}
+
+// durableDiskSnapshotChunkBody is a chunk waiting to go up, re-readable because a failed
+// upload rewinds. Small ones stay in memory; a temp file each was most of a small-file tree.
+type durableDiskSnapshotChunkBody struct {
+	data []byte
+	file *os.File
+}
+
+func (b *durableDiskSnapshotChunkBody) Write(data []byte) (int, error) {
+	if b.file == nil && len(b.data)+len(data) > durableDiskSnapshotInlineChunkSize {
+		if err := b.spill(); err != nil {
+			return 0, err
+		}
+	}
+	if b.file != nil {
+		return b.file.Write(data)
+	}
+	b.data = append(b.data, data...)
+	return len(data), nil
+}
+
+func (b *durableDiskSnapshotChunkBody) spill() error {
+	file, err := os.CreateTemp("", "beta9-durable-disk-snapshot-chunk-*")
+	if err != nil {
+		return fmt.Errorf("create durable disk snapshot chunk file: %w", err)
+	}
+	if _, err := file.Write(b.data); err != nil {
+		removeDurableDiskSnapshotChunkFile(file)
+		return fmt.Errorf("spool durable disk snapshot chunk: %w", err)
+	}
+	b.file = file
+	b.data = nil
+	return nil
+}
+
+// reader starts at the chunk's first byte, so a retried upload sends all of it, not the tail.
+func (b *durableDiskSnapshotChunkBody) reader(size int64) durableDiskSnapshotChunkReader {
+	if b.file != nil {
+		return io.NewSectionReader(b.file, 0, size)
+	}
+	return bytes.NewReader(b.data)
+}
+
+func (b *durableDiskSnapshotChunkBody) release() {
+	if b == nil {
+		return
+	}
+	if b.file != nil {
+		removeDurableDiskSnapshotChunkFile(b.file)
+		b.file = nil
+	}
+	b.data = nil
 }
 
 type durableDiskSnapshotLogicalProgressWriter struct {
@@ -835,16 +938,39 @@ func (w durableDiskSnapshotLogicalProgressWriter) Write(data []byte) (int, error
 	return len(data), nil
 }
 
+// durableDiskSnapshotChunkReader is what the S3 uploader slices in place; a plain reader is
+// copied through a buffer sized for the largest part it might ever send, allocated per upload.
+type durableDiskSnapshotChunkReader interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+}
+
+// durableDiskSnapshotProgressReader passes that seekability through rather than hiding it.
 type durableDiskSnapshotProgressReader struct {
 	ctx    context.Context
-	reader io.Reader
+	reader durableDiskSnapshotChunkReader
 }
 
 func (r *durableDiskSnapshotProgressReader) Read(data []byte) (int, error) {
 	if err := r.ctx.Err(); err != nil {
 		return 0, err
 	}
-	n, err := r.reader.Read(data)
+	return r.report(r.reader.Read(data))
+}
+
+func (r *durableDiskSnapshotProgressReader) ReadAt(data []byte, offset int64) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.report(r.reader.ReadAt(data, offset))
+}
+
+func (r *durableDiskSnapshotProgressReader) Seek(offset int64, whence int) (int64, error) {
+	return r.reader.Seek(offset, whence)
+}
+
+func (r *durableDiskSnapshotProgressReader) report(n int, err error) (int, error) {
 	if n > 0 {
 		// Upload reads prove the request is still consuming bytes, but do not
 		// double-count them as logical disk bytes or completed chunks.
@@ -918,38 +1044,63 @@ func restoreDurableDiskDirectoryManifest(ctx context.Context, store durableDiskS
 		return fmt.Errorf("create durable disk restore directory %s: %w", targetDir, err)
 	}
 
-	for _, file := range manifest.Files {
-		targetPath, err := durableDiskRestoreTarget(targetDir, file.Path)
-		if err != nil {
-			return err
+	// Contents on a pool, for the reason snapshotting is. Directories and symlinks stay here,
+	// in sorted manifest order, so a parent exists and owns its mode before anything fills it.
+	contents, contentsCtx := errgroup.WithContext(ctx)
+	contents.SetLimit(durableDiskRestoreConcurrency)
+
+	entriesErr := func() error {
+		for _, file := range manifest.Files {
+			if err := contentsCtx.Err(); err != nil {
+				return err
+			}
+			targetPath, err := durableDiskRestoreTarget(targetDir, file.Path)
+			if err != nil {
+				return err
+			}
+			mode := os.FileMode(file.Mode)
+			switch file.Type {
+			case "dir":
+				if err := os.MkdirAll(targetPath, mode.Perm()); err != nil {
+					return err
+				}
+			case "symlink":
+				if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+					return err
+				}
+				if err := os.Symlink(file.LinkName, targetPath); err != nil && !os.IsExist(err) {
+					return err
+				}
+			case "file":
+				contents.Go(func() error {
+					if err := restoreDurableDiskManifestFile(contentsCtx, store, cacheReader, file, targetPath, mode.Perm()); err != nil {
+						return err
+					}
+					applyDurableDiskRestoreMetadata(targetPath, file)
+					return nil
+				})
+				continue
+			default:
+				continue
+			}
+			applyDurableDiskRestoreMetadata(targetPath, file)
 		}
-		mode := os.FileMode(file.Mode)
-		switch file.Type {
-		case "dir":
-			if err := os.MkdirAll(targetPath, mode.Perm()); err != nil {
-				return err
-			}
-		case "symlink":
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-				return err
-			}
-			if err := os.Symlink(file.LinkName, targetPath); err != nil && !os.IsExist(err) {
-				return err
-			}
-		case "file":
-			if err := restoreDurableDiskManifestFile(ctx, store, cacheReader, file, targetPath, mode.Perm()); err != nil {
-				return err
-			}
-		default:
-			continue
-		}
-		_ = os.Chown(targetPath, file.Uid, file.Gid)
-		if file.ModTimeUnixNano > 0 {
-			modTime := time.Unix(0, file.ModTimeUnixNano)
-			_ = os.Chtimes(targetPath, modTime, modTime)
-		}
+		return nil
+	}()
+
+	// Waited on either way: a pass that stopped early still has files writing into the directory.
+	if contentsErr := contents.Wait(); contentsErr != nil {
+		return contentsErr
 	}
-	return nil
+	return entriesErr
+}
+
+func applyDurableDiskRestoreMetadata(targetPath string, file types.DiskSnapshotFile) {
+	_ = os.Chown(targetPath, file.Uid, file.Gid)
+	if file.ModTimeUnixNano > 0 {
+		modTime := time.Unix(0, file.ModTimeUnixNano)
+		_ = os.Chtimes(targetPath, modTime, modTime)
+	}
 }
 
 func restoreDurableDiskManifestFile(ctx context.Context, store durableDiskSnapshotStore, cacheReader durableDiskSnapshotCacheReader, file types.DiskSnapshotFile, targetPath string, mode os.FileMode) error {
@@ -970,6 +1121,13 @@ func restoreDurableDiskManifestFile(ctx context.Context, store durableDiskSnapsh
 	for _, chunk := range file.Chunks {
 		chunk := chunk
 		group.Go(func() error {
+			// One pool across all files, so the bound does not multiply by the files open.
+			select {
+			case durableDiskRestoreChunkSlots <- struct{}{}:
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			}
+			defer func() { <-durableDiskRestoreChunkSlots }()
 			return restoreDurableDiskManifestChunk(groupCtx, store, cacheReader, out, chunk)
 		})
 	}

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -440,10 +440,9 @@ func TestChunkSpoolingAndUploadExposeStreamingProgress(t *testing.T) {
 	})
 
 	t.Run("upload read", func(t *testing.T) {
-		chunk, err := os.CreateTemp(t.TempDir(), "chunk-*")
-		require.NoError(t, err)
-		defer removeDurableDiskSnapshotChunkFile(chunk)
-		_, err = chunk.Write(make([]byte, 4<<20))
+		chunk := &durableDiskSnapshotChunkBody{}
+		defer chunk.release()
+		_, err := chunk.Write(make([]byte, 4<<20))
 		require.NoError(t, err)
 
 		baseCtx, cancel := context.WithCancel(context.Background())
@@ -676,6 +675,112 @@ func TestCreateDurableDiskDirectorySnapshotUploadsChunksInParallel(t *testing.T)
 	require.LessOrEqual(t, store.maxActive, durableDiskSnapshotUploadConcurrency)
 }
 
+// A real tree is mostly small files of one chunk, so the chunk pool is one deep unless
+// separate files are in flight. This is what a package install's snapshot time turns on.
+func TestCreateDurableDiskDirectorySnapshotSnapshotsSeparateFilesInParallel(t *testing.T) {
+	source := t.TempDir()
+	for i := range 16 {
+		require.NoError(t, os.WriteFile(filepath.Join(source, fmt.Sprintf("file-%d", i)), []byte(fmt.Sprintf("contents-%d", i)), 0o600))
+	}
+
+	store := &parallelUploadDurableDiskSnapshotStore{fakeDurableDiskSnapshotStore: &fakeDurableDiskSnapshotStore{}}
+	_, manifest, err := createDurableDiskDirectorySnapshot(
+		context.Background(), store, source, "durable-disks/workspace/snapshots/1",
+		types.DiskSnapshot{DiskName: "workspace", Format: types.DiskSnapshotFormatDirV1},
+		defaultDurableDiskSnapshotChunkSize, nil, false,
+	)
+	require.NoError(t, err)
+	require.Len(t, manifest.Files, 16)
+	require.Greater(t, store.maxActive, 1)
+	require.LessOrEqual(t, store.maxActive, durableDiskSnapshotFileConcurrency)
+}
+
+// Identical files must cost one upload even when read at the same moment, or concurrency
+// would undo the deduplication it was added to speed up.
+func TestCreateDurableDiskDirectorySnapshotUploadsIdenticalFilesOnce(t *testing.T) {
+	source := t.TempDir()
+	for i := range 16 {
+		require.NoError(t, os.WriteFile(filepath.Join(source, fmt.Sprintf("copy-%d", i)), []byte("identical contents"), 0o600))
+	}
+
+	store := &fakeDurableDiskSnapshotStore{}
+	snapshot, manifest, err := createDurableDiskDirectorySnapshot(
+		context.Background(), store, source, "durable-disks/workspace/snapshots/1",
+		types.DiskSnapshot{DiskName: "workspace", Format: types.DiskSnapshotFormatDirV1},
+		defaultDurableDiskSnapshotChunkSize, nil, false,
+	)
+	require.NoError(t, err)
+	require.Len(t, manifest.Files, 16)
+
+	_, chunkUploads := store.uploadCounts()
+	require.Equal(t, 1, chunkUploads)
+	require.Equal(t, int64(16), snapshot.ChunkCount, "every file still records the chunk it shares")
+	for _, file := range manifest.Files {
+		require.Len(t, file.Chunks, 1)
+		require.Equal(t, manifest.Files[0].Chunks[0].ObjectKey, file.Chunks[0].ObjectKey)
+	}
+}
+
+func TestDurableDiskSnapshotChunkBodyKeepsSmallChunksOutOfTheFilesystem(t *testing.T) {
+	t.Run("small", func(t *testing.T) {
+		body := &durableDiskSnapshotChunkBody{}
+		defer body.release()
+		payload := bytes.Repeat([]byte{0x5a}, durableDiskSnapshotInlineChunkSize)
+		written, err := body.Write(payload)
+
+		require.NoError(t, err)
+		require.Equal(t, len(payload), written)
+		require.Nil(t, body.file, "a chunk that fits in hand should not cost a temp file")
+		read, err := io.ReadAll(body.reader(int64(len(payload))))
+		require.NoError(t, err)
+		require.Equal(t, payload, read)
+	})
+
+	t.Run("large", func(t *testing.T) {
+		body := &durableDiskSnapshotChunkBody{}
+		payload := bytes.Repeat([]byte{0x5a}, durableDiskSnapshotInlineChunkSize+1)
+		for _, part := range [][]byte{payload[:len(payload)-1], payload[len(payload)-1:]} {
+			_, err := body.Write(part)
+			require.NoError(t, err)
+		}
+
+		require.NotNil(t, body.file, "a chunk too large to hold should spill rather than be kept")
+		name := body.file.Name()
+		read, err := io.ReadAll(body.reader(int64(len(payload))))
+		require.NoError(t, err)
+		require.Equal(t, payload, read, "spilling keeps the bytes written before it in order")
+
+		body.release()
+		_, err = os.Stat(name)
+		require.True(t, os.IsNotExist(err), "a released chunk should leave nothing behind")
+	})
+
+	// In memory or spilled, a chunk must arrive seekable, or every one pays for the
+	// per-upload buffer the S3 manager allocates for a plain reader.
+	t.Run("seekable either way", func(t *testing.T) {
+		for _, size := range []int{durableDiskSnapshotInlineChunkSize, durableDiskSnapshotInlineChunkSize + 1} {
+			body := &durableDiskSnapshotChunkBody{}
+			_, err := body.Write(bytes.Repeat([]byte{0x5a}, size))
+			require.NoError(t, err)
+
+			var uploaded io.Reader = &durableDiskSnapshotProgressReader{
+				ctx:    context.Background(),
+				reader: body.reader(int64(size)),
+			}
+			_, seekable := uploaded.(io.Seeker)
+			at, readableAt := uploaded.(io.ReaderAt)
+			require.True(t, seekable, "the uploader was offered a chunk it cannot seek")
+			require.True(t, readableAt, "the uploader was offered a chunk it cannot read at an offset")
+
+			tail := make([]byte, 1)
+			_, err = at.ReadAt(tail, int64(size)-1)
+			require.NoError(t, err)
+			require.Equal(t, []byte{0x5a}, tail)
+			body.release()
+		}
+	})
+}
+
 func TestSnapshotDurableDiskReaderReturnsMidStreamReadError(t *testing.T) {
 	readErr := fmt.Errorf("injected read failure")
 	source := &failingDurableDiskSnapshotReaderAt{
@@ -686,7 +791,7 @@ func TestSnapshotDurableDiskReaderReturnsMidStreamReadError(t *testing.T) {
 	store := &fakeDurableDiskSnapshotStore{}
 	file := &types.DiskSnapshotFile{Path: "model", Type: "file"}
 
-	err := snapshotDurableDiskReader(context.Background(), store, source, "model", "chunks", 8, map[string]struct{}{}, file)
+	err := snapshotDurableDiskReader(context.Background(), store, source, "model", "chunks", 8, newDurableDiskSnapshotChunkSet(), file)
 
 	require.ErrorIs(t, err, readErr)
 	require.Len(t, file.Chunks, 1)
@@ -711,7 +816,7 @@ func TestSnapshotDurableDiskReaderCancelsSiblingUploadsOnReadError(t *testing.T)
 
 	done := make(chan error, 1)
 	go func() {
-		done <- snapshotDurableDiskReader(ctx, store, source, "model", "chunks", 8, map[string]struct{}{}, file)
+		done <- snapshotDurableDiskReader(ctx, store, source, "model", "chunks", 8, newDurableDiskSnapshotChunkSet(), file)
 	}()
 
 	select {
@@ -740,7 +845,7 @@ func TestSnapshotDurableDiskReaderSpoolsChunksWithFixedMemoryBuffer(t *testing.T
 		"model",
 		"chunks",
 		4*durableDiskSnapshotReadBufferSize,
-		map[string]struct{}{},
+		newDurableDiskSnapshotChunkSet(),
 		file,
 	)
 
@@ -760,7 +865,7 @@ func TestSnapshotDurableDiskReaderRetriesFromTheStartOfTheChunk(t *testing.T) {
 
 	err := snapshotDurableDiskReader(
 		context.Background(), store, bytes.NewReader(payload), "model", "chunks", int64(len(payload)),
-		map[string]struct{}{}, file,
+		newDurableDiskSnapshotChunkSet(), file,
 	)
 
 	require.NoError(t, err)
@@ -1184,6 +1289,36 @@ func TestRestoreDurableDiskDirectorySnapshotDownloadsChunksInParallel(t *testing
 	require.Equal(t, payload, restored)
 }
 
+func TestRestoreDurableDiskDirectorySnapshotDownloadsSeparateFilesInParallel(t *testing.T) {
+	source := t.TempDir()
+	for i := range 16 {
+		require.NoError(t, os.WriteFile(filepath.Join(source, fmt.Sprintf("file-%d", i)), []byte(fmt.Sprintf("contents-%d", i)), 0o600))
+	}
+
+	store := &fakeDurableDiskSnapshotStore{}
+	snapshot, _, err := createDurableDiskDirectorySnapshot(
+		context.Background(), store, source, "durable-disks/workspace/snapshots/1",
+		types.DiskSnapshot{DiskName: "workspace", Format: types.DiskSnapshotFormatDirV1},
+		defaultDurableDiskSnapshotChunkSize, nil, false,
+	)
+	require.NoError(t, err)
+
+	parallelStore := &parallelDownloadDurableDiskSnapshotStore{fakeDurableDiskSnapshotStore: store}
+	target := filepath.Join(t.TempDir(), "restored")
+	_, err = restoreDurableDiskDirectorySnapshotWithCache(
+		context.Background(), parallelStore, nil,
+		snapshot.ManifestKey, snapshot.ManifestDigest, snapshot.ManifestSizeBytes, target,
+	)
+	require.NoError(t, err)
+	require.Greater(t, parallelStore.maxActive, 1)
+	require.LessOrEqual(t, parallelStore.maxActive, durableDiskRestoreConcurrency)
+	for i := range 16 {
+		restored, err := os.ReadFile(filepath.Join(target, fmt.Sprintf("file-%d", i)))
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("contents-%d", i), string(restored))
+	}
+}
+
 func TestRestoreDurableDiskDirectorySnapshotPreservesTargetOnFailure(t *testing.T) {
 	source := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(source, "new"), []byte("new payload"), 0o600))
@@ -1293,6 +1428,77 @@ func BenchmarkDurableDiskModelSnapshot(b *testing.B) {
 			})
 		})
 	}
+}
+
+// A real workspace is thousands of small files, bounded by round trips rather than by the
+// bytes the large-file benchmark above measures.
+func BenchmarkDurableDiskWorkspaceSnapshot(b *testing.B) {
+	source := b.TempDir()
+	writeDurableDiskWorkspaceFixture(b, source, 2000, 4<<10)
+
+	for b.Loop() {
+		store := &latentDurableDiskSnapshotStore{fakeDurableDiskSnapshotStore: &fakeDurableDiskSnapshotStore{}, latency: 2 * time.Millisecond}
+		_, _, err := createDurableDiskDirectorySnapshot(
+			context.Background(), store, source, "durable-disks/workspace/snapshots/1",
+			types.DiskSnapshot{DiskName: "workspace", Format: types.DiskSnapshotFormatDirV1},
+			defaultDurableDiskSnapshotChunkSize, nil, false,
+		)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkDurableDiskWorkspaceRestore(b *testing.B) {
+	source := b.TempDir()
+	writeDurableDiskWorkspaceFixture(b, source, 2000, 4<<10)
+
+	store := &latentDurableDiskSnapshotStore{fakeDurableDiskSnapshotStore: &fakeDurableDiskSnapshotStore{}, latency: 2 * time.Millisecond}
+	snapshot, _, err := createDurableDiskDirectorySnapshot(
+		context.Background(), store, source, "durable-disks/workspace/snapshots/1",
+		types.DiskSnapshot{DiskName: "workspace", Format: types.DiskSnapshotFormatDirV1},
+		defaultDurableDiskSnapshotChunkSize, nil, false,
+	)
+	require.NoError(b, err)
+
+	for b.Loop() {
+		target := filepath.Join(b.TempDir(), "restored")
+		_, err := restoreDurableDiskDirectorySnapshotWithCache(
+			context.Background(), store, nil,
+			snapshot.ManifestKey, snapshot.ManifestDigest, snapshot.ManifestSizeBytes, target,
+		)
+		require.NoError(b, err)
+	}
+}
+
+// A package install, with contents unique per file so nothing dedupes away and the count is real.
+func writeDurableDiskWorkspaceFixture(tb testing.TB, root string, files, size int) {
+	tb.Helper()
+	for i := range files {
+		dir := filepath.Join(root, "node_modules", fmt.Sprintf("package-%02d", i%100))
+		require.NoError(tb, os.MkdirAll(dir, 0o755))
+		content := bytes.Repeat([]byte{byte(i), byte(i >> 8)}, size/2)
+		require.NoError(tb, os.WriteFile(filepath.Join(dir, fmt.Sprintf("file-%d.js", i)), content, 0o600))
+	}
+}
+
+// An object store with a round trip, which is what a snapshot of many small files spends on.
+type latentDurableDiskSnapshotStore struct {
+	*fakeDurableDiskSnapshotStore
+	latency time.Duration
+}
+
+func (s *latentDurableDiskSnapshotStore) Upload(ctx context.Context, key string, data []byte) error {
+	time.Sleep(s.latency)
+	return s.fakeDurableDiskSnapshotStore.Upload(ctx, key, data)
+}
+
+func (s *latentDurableDiskSnapshotStore) UploadWithReader(ctx context.Context, key string, data io.Reader) error {
+	time.Sleep(s.latency)
+	return s.fakeDurableDiskSnapshotStore.UploadWithReader(ctx, key, data)
+}
+
+func (s *latentDurableDiskSnapshotStore) DownloadWithReader(ctx context.Context, key string) (io.ReadCloser, error) {
+	time.Sleep(s.latency)
+	return s.fakeDurableDiskSnapshotStore.DownloadWithReader(ctx, key)
 }
 
 func snapshotTestFile(manifest *types.DiskSnapshotManifest, name string) types.DiskSnapshotFile {


### PR DESCRIPTION
## Durable disk snapshots

- read, hash and upload files on a pool rather than one file at a time, and restore them the same way
- hold chunks under a megabyte in memory instead of spooling each one through a temp file
- hand the uploader a chunk it can seek, so it slices the body where it lies rather than copying it through a buffer it allocates per upload
- deduplicate identical chunks safely across concurrent uploads

Snapshotting a package install took a round trip per file, in series: the upload pool had eight slots and the walk kept it one deep, because it did not move on until the file in hand was uploaded. Parallelizing that took 20,000 files from 75.1s to 40.4s, which was well short of what the pool should have bought.

The rest was in how a chunk was offered to the object store. The S3 upload manager chooses how to send a body by what it implements: a body it can seek is sliced in place, while a plain reader is copied through a buffer sized for the largest multipart part it might ever send — 64 MiB, and allocated per upload. The chunks were seekable underneath, but the progress-reporting wrapper hid that behind a plain Read, so every 4 KiB file in the tree paid for a part it was never going to need.

Together, on a 20,000 file tree: 75.1s to 13.6s, and 2,000 files from 6.15s to 2.05s. An unchanged re-snapshot stays at about half a second. Restoring a 5,000 file tree reproduces it byte for byte, symlinks included.

## Pinned proxy dials

A request to a published port is pinned to one container, and that dial had 900ms to connect. A backend whose accept queue is full does not refuse the connection, it drops the SYN, and the kernel leaves it unanswered for a second before trying again, so the budget expired 100ms before the retransmit that would have succeeded and the caller got a 502. The pinned path also never retried, though a connect that fails has delivered nothing and is the one attempt every proxy considers safe to repeat.

The 900ms was there for a different case: a backend route that is still opening waits for readiness inside the dial, and that should fail fast. That budget stays where it was, while an ordinary TCP connect now gets three seconds and one further attempt, the way nginx treats a connect error against a single upstream.

Bursting a published port whose backend closes every connection, 3,000 requests per run: 1.5% of them failed at 32 concurrent and 15.5% at 256, and none fail now. An address nobody listens on is still refused in milliseconds, so a container that is really gone is reported as quickly as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up durable disk snapshots and eliminates spurious 502s on published ports. Snapshots now process files concurrently and avoid per-upload copy/alloc overhead; pinned proxy dials keep route checks fast and give direct container addresses time to retransmit with one safe retry.

- 20k-file snapshot: 75.1s → 13.6s; 2k files: 6.15s → 2.05s. Unchanged re-snapshot ~0.5s. Under load, published ports no longer return 502s; unopened routes still fail fast.

**Durable disk snapshots**
- Read, hash, and upload files on a pool; restore file contents on a pool as well.
- Keep chunks ≤1 MiB in memory; spill larger chunks to temp files only when needed.
- Hand the uploader a seekable chunk body to avoid per-upload large-copy buffering.
- Deduplicate identical chunks across concurrent uploads so identical files cost one upload.
- No API changes. Watch memory during rollout due to higher concurrency and in-memory chunks.

**Published port proxy**
- Keep 900ms dial budget for pinned route readiness checks; give direct container addresses a 3s dial budget to outlast a dropped SYN and allow the kernel retransmit.
- Retry a pinned connect once on failure (safe pre-connect retry), preserving the request body between dials.
- Refused addresses still fail in milliseconds; behavior for truly gone containers is unchanged.

<sup>Written for commit 781644bec1a1e65880c1ebddb6aa388aeddfb139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

