### PR TITLE
tailscale network fix

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -97,8 +97,6 @@ const (
 	gatewayDrainPropagationDelay = 10 * time.Second
 	gatewayGRPCShutdownMaxWait   = 5 * time.Second
 	gatewayTailscaleStartTimeout = 30 * time.Second
-	gatewayAgentWarmupTimeout    = 10 * time.Second
-	gatewayAgentKeepalive        = 30 * time.Second
 	gatewayLivenessService       = "liveness"
 	gatewayReadinessService      = "readiness"
 )
@@ -612,10 +610,9 @@ func (g *Gateway) Start() error {
 		if err != nil {
 			return fmt.Errorf("failed to connect gateway to tailnet: %w", err)
 		}
-		warmupCtx, cancel := context.WithTimeout(g.ctx, gatewayAgentWarmupTimeout)
-		g.Tailscale.WarmPeers(warmupCtx, types.AgentTailnetHostnamePrefix)
-		cancel()
-		go g.Tailscale.KeepPeersAlive(g.ctx, types.AgentTailnetHostnamePrefix, gatewayAgentKeepalive)
+		// Agent routes are warmed with an end-to-end dial when they become ready.
+		// Do not enumerate and ping every tailnet peer here: that makes gateway
+		// startup and periodic keepalives scale with the entire tailnet.
 	}
 
 	if g.Config.Monitoring.Telemetry.Enabled {

--- a/pkg/gateway/services/compute/route_prewarm.go
+++ b/pkg/gateway/services/compute/route_prewarm.go
@@ -2,8 +2,6 @@ package compute
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,16 +13,16 @@ import (
 )
 
 const (
-	routePrewarmInterval = 30 * time.Second
-	routePrewarmTimeout  = 3 * time.Second
+	routePrewarmTimeout     = 3 * time.Second
+	routePrewarmConcurrency = 4
 )
 
 type routePrewarmer struct {
-	mu          sync.Mutex
-	lastAttempt map[string]time.Time
+	mu            sync.Mutex
+	activeTargets map[string]struct{}
 }
 
-func (p *routePrewarmer) shouldAttempt(proxyTarget string, now time.Time) bool {
+func (p *routePrewarmer) tryStart(proxyTarget string) bool {
 	proxyTarget = strings.TrimSpace(proxyTarget)
 	if proxyTarget == "" {
 		return false
@@ -32,25 +30,46 @@ func (p *routePrewarmer) shouldAttempt(proxyTarget string, now time.Time) bool {
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.lastAttempt == nil {
-		p.lastAttempt = map[string]time.Time{}
+	if p.activeTargets == nil {
+		p.activeTargets = map[string]struct{}{}
 	}
-	if last := p.lastAttempt[proxyTarget]; !last.IsZero() && now.Sub(last) < routePrewarmInterval {
+	if _, active := p.activeTargets[proxyTarget]; active {
 		return false
 	}
-	p.lastAttempt[proxyTarget] = now
+	if len(p.activeTargets) >= routePrewarmConcurrency {
+		return false
+	}
+	p.activeTargets[proxyTarget] = struct{}{}
 	return true
 }
 
+func (p *routePrewarmer) finish(proxyTarget string) {
+	proxyTarget = strings.TrimSpace(proxyTarget)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.activeTargets, proxyTarget)
+}
+
+func routeEligibleForPrewarm(route types.BackendRoute) bool {
+	return route.State == types.BackendRouteStateReady &&
+		route.Transport == types.BackendRouteTransportTSNet &&
+		strings.TrimSpace(route.ProxyTarget) != ""
+}
+
 func (s *Service) prewarmRoute(route types.BackendRoute, agentState *model.AgentTokenState) {
-	if s.tailscale == nil || route.Transport != types.BackendRouteTransportTSNet || strings.TrimSpace(route.ProxyTarget) == "" {
+	if s.tailscale == nil || !routeEligibleForPrewarm(route) {
 		return
 	}
-	if !s.routePrewarm.shouldAttempt(route.ProxyTarget, time.Now()) {
+	// All routes on an agent share one tailnet proxy target. Deduplicate
+	// concurrent ready updates so each admitted dial warms that shared path.
+	if !s.routePrewarm.tryStart(route.ProxyTarget) {
 		return
 	}
 
-	go s.prewarmRouteOnce(route, agentState)
+	go func() {
+		defer s.routePrewarm.finish(route.ProxyTarget)
+		s.prewarmRouteOnce(route, agentState)
+	}()
 }
 
 func (s *Service) prewarmRouteOnce(route types.BackendRoute, agentState *model.AgentTokenState) {
@@ -63,6 +82,7 @@ func (s *Service) prewarmRouteOnce(route types.BackendRoute, agentState *model.A
 		s.appConfig.Tailscale,
 		s.containerRepo,
 		routePrewarmTimeout,
+		network.WithBackgroundDialSlots(),
 	).Dial(ctx, types.BackendRouteAddress(route.RouteID))
 	dialLatency := time.Since(start)
 	if conn != nil {
@@ -72,9 +92,6 @@ func (s *Service) prewarmRouteOnce(route types.BackendRoute, agentState *model.A
 	attrs := map[string]string{
 		"proxy_target": route.ProxyTarget,
 		"dial_ms":      strconv.FormatInt(dialLatency.Milliseconds(), 10),
-	}
-	for key, value := range s.routePeerAttrs(route.ProxyTarget) {
-		attrs[key] = value
 	}
 
 	status := "ready"
@@ -98,60 +115,4 @@ func (s *Service) prewarmRouteOnce(route types.BackendRoute, agentState *model.A
 		Message:     message,
 		Attrs:       attrs,
 	})
-}
-
-func (s *Service) routePeerAttrs(proxyTarget string) map[string]string {
-	if s.tailscale == nil || s.tailscale.GetServer() == nil {
-		return nil
-	}
-	host, _, err := net.SplitHostPort(proxyTarget)
-	if err != nil {
-		host = proxyTarget
-	}
-	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
-	if host == "" {
-		return nil
-	}
-
-	client, err := s.tailscale.GetServer().LocalClient()
-	if err != nil {
-		return map[string]string{"peer_status_error": err.Error()}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	status, err := client.Status(ctx)
-	if err != nil {
-		return map[string]string{"peer_status_error": err.Error()}
-	}
-
-	for _, peer := range status.Peer {
-		if peer == nil || !peerMatchesHost(peer.HostName, peer.DNSName, host) {
-			continue
-		}
-		attrs := map[string]string{
-			"peer_online": strconv.FormatBool(peer.Online),
-			"peer_active": strconv.FormatBool(peer.Active),
-			"peer_direct": strconv.FormatBool(peer.CurAddr != ""),
-		}
-		if peer.Relay != "" {
-			attrs["peer_relay"] = peer.Relay
-		}
-		if !peer.LastHandshake.IsZero() {
-			age := time.Since(peer.LastHandshake)
-			if age < 0 {
-				age = 0
-			}
-			attrs["peer_last_handshake_age_ms"] = fmt.Sprintf("%d", age.Milliseconds())
-		}
-		return attrs
-	}
-	return map[string]string{"peer_status": "not_found"}
-}
-
-func peerMatchesHost(hostName, dnsName, target string) bool {
-	target = strings.TrimSuffix(target, ".")
-	hostName = strings.TrimSuffix(hostName, ".")
-	dnsName = strings.TrimSuffix(dnsName, ".")
-	return target == hostName || target == dnsName || strings.HasPrefix(dnsName, target+".")
 }

--- a/pkg/gateway/services/compute/route_prewarm_test.go
+++ b/pkg/gateway/services/compute/route_prewarm_test.go
@@ -1,73 +1,162 @@
 package compute
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
-	"time"
+
+	"github.com/beam-cloud/beta9/pkg/types"
 )
 
-func TestRoutePrewarmerThrottlesByProxyTarget(t *testing.T) {
+func TestRoutePrewarmerDeduplicatesInFlightProxyTarget(t *testing.T) {
 	prewarmer := routePrewarmer{}
-	now := time.Unix(100, 0)
 
-	if !prewarmer.shouldAttempt("agent.tailnet:29443", now) {
+	if !prewarmer.tryStart("agent.tailnet:29443") {
 		t.Fatal("expected first prewarm attempt")
 	}
-	if prewarmer.shouldAttempt("agent.tailnet:29443", now.Add(routePrewarmInterval-time.Millisecond)) {
-		t.Fatal("expected second prewarm attempt inside interval to be throttled")
+	if prewarmer.tryStart(" agent.tailnet:29443 ") {
+		t.Fatal("expected duplicate in-flight proxy target to be rejected")
 	}
-	if !prewarmer.shouldAttempt("agent.tailnet:29443", now.Add(routePrewarmInterval)) {
-		t.Fatal("expected prewarm attempt after interval")
+	prewarmer.finish("agent.tailnet:29443")
+	if !prewarmer.tryStart("agent.tailnet:29443") {
+		t.Fatal("expected proxy target to be admitted after its prewarm finished")
 	}
-	if !prewarmer.shouldAttempt("other-agent.tailnet:29443", now.Add(time.Second)) {
-		t.Fatal("expected distinct proxy target to have independent throttle")
-	}
+	prewarmer.finish("agent.tailnet:29443")
 }
 
 func TestRoutePrewarmerSkipsEmptyProxyTarget(t *testing.T) {
 	prewarmer := routePrewarmer{}
-	if prewarmer.shouldAttempt(" ", time.Now()) {
+	if prewarmer.tryStart(" ") {
 		t.Fatal("expected empty proxy target to be skipped")
 	}
 }
 
-func TestPeerMatchesHost(t *testing.T) {
+func TestRoutePrewarmerCapsConcurrencyWithoutRetainingRejectedTarget(t *testing.T) {
+	prewarmer := routePrewarmer{}
+	for i := 0; i < routePrewarmConcurrency; i++ {
+		if !prewarmer.tryStart(fmt.Sprintf("agent-%d.tailnet:29443", i)) {
+			t.Fatalf("expected attempt %d to be admitted", i)
+		}
+	}
+
+	overflowTarget := "overflow-agent.tailnet:29443"
+	if prewarmer.tryStart(overflowTarget) {
+		t.Fatal("expected attempt above the concurrency cap to be rejected")
+	}
+	prewarmer.finish("agent-0.tailnet:29443")
+	if !prewarmer.tryStart(overflowTarget) {
+		t.Fatal("expected rejected target to be admitted immediately after capacity freed")
+	}
+
+	for i := 1; i < routePrewarmConcurrency; i++ {
+		prewarmer.finish(fmt.Sprintf("agent-%d.tailnet:29443", i))
+	}
+	prewarmer.finish(overflowTarget)
+}
+
+func TestRoutePrewarmerConcurrentStormNeverExceedsCap(t *testing.T) {
+	const attempts = 128
+	prewarmer := routePrewarmer{}
+	start := make(chan struct{})
+	release := make(chan struct{})
+	var attempted sync.WaitGroup
+	var finished sync.WaitGroup
+	var admitted atomic.Int32
+	var active atomic.Int32
+	var peak atomic.Int32
+
+	attempted.Add(attempts)
+	finished.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func(i int) {
+			defer finished.Done()
+			<-start
+			target := fmt.Sprintf("agent-%d.tailnet:29443", i)
+			if !prewarmer.tryStart(target) {
+				attempted.Done()
+				return
+			}
+			admitted.Add(1)
+			current := active.Add(1)
+			for {
+				previous := peak.Load()
+				if current <= previous || peak.CompareAndSwap(previous, current) {
+					break
+				}
+			}
+			attempted.Done()
+			<-release
+			active.Add(-1)
+			prewarmer.finish(target)
+		}(i)
+	}
+
+	close(start)
+	attempted.Wait()
+	if got := admitted.Load(); got != routePrewarmConcurrency {
+		t.Fatalf("admitted = %d, want %d", got, routePrewarmConcurrency)
+	}
+	if got := peak.Load(); got > routePrewarmConcurrency {
+		t.Fatalf("peak active = %d, want at most %d", got, routePrewarmConcurrency)
+	}
+	close(release)
+	finished.Wait()
+}
+
+func TestRouteEligibleForPrewarmRequiresReadyTSNetRoute(t *testing.T) {
 	tests := []struct {
-		name     string
-		hostName string
-		dnsName  string
-		target   string
-		want     bool
+		name  string
+		route types.BackendRoute
+		want  bool
 	}{
 		{
-			name:    "dns match",
-			dnsName: "beam-agent-machine.tailnet.ts.net.",
-			target:  "beam-agent-machine.tailnet.ts.net",
-			want:    true,
+			name: "ready tsnet route",
+			route: types.BackendRoute{
+				State:       types.BackendRouteStateReady,
+				Transport:   types.BackendRouteTransportTSNet,
+				ProxyTarget: "agent.tailnet:29443",
+			},
+			want: true,
 		},
 		{
-			name:    "short target matches dns prefix",
-			dnsName: "beam-agent-machine.tailnet.ts.net",
-			target:  "beam-agent-machine",
-			want:    true,
+			name: "opening route",
+			route: types.BackendRoute{
+				State:       types.BackendRouteStateOpening,
+				Transport:   types.BackendRouteTransportTSNet,
+				ProxyTarget: "agent.tailnet:29443",
+			},
 		},
 		{
-			name:     "host match",
-			hostName: "beam-agent-machine",
-			target:   "beam-agent-machine",
-			want:     true,
+			name: "degraded route",
+			route: types.BackendRoute{
+				State:       types.BackendRouteStateDegraded,
+				Transport:   types.BackendRouteTransportTSNet,
+				ProxyTarget: "agent.tailnet:29443",
+			},
 		},
 		{
-			name:    "no match",
-			dnsName: "beam-agent-other.tailnet.ts.net",
-			target:  "beam-agent-machine",
-			want:    false,
+			name: "direct route",
+			route: types.BackendRoute{
+				State:       types.BackendRouteStateReady,
+				Transport:   types.BackendRouteTransportDirect,
+				ProxyTarget: "agent.tailnet:29443",
+			},
+		},
+		{
+			name: "empty proxy target",
+			route: types.BackendRoute{
+				State:       types.BackendRouteStateReady,
+				Transport:   types.BackendRouteTransportTSNet,
+				ProxyTarget: " ",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := peerMatchesHost(tt.hostName, tt.dnsName, tt.target); got != tt.want {
-				t.Fatalf("peerMatchesHost() = %v, want %v", got, tt.want)
+			if got := routeEligibleForPrewarm(tt.route); got != tt.want {
+				t.Fatalf("routeEligibleForPrewarm() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/gateway/services/compute/service.go
+++ b/pkg/gateway/services/compute/service.go
@@ -76,7 +76,7 @@ func New(opts Options) *Service {
 		billing:              newRoutedManagedComputeBillingClient(opts.Config.ManagedCompute.Billing),
 		rentalUsage:          clients.NewMarketplaceUsageClient(opts.Config.ManagedCompute.Billing),
 		tailscale:            opts.Tailscale,
-		routePrewarm:         routePrewarmer{lastAttempt: map[string]time.Time{}},
+		routePrewarm:         routePrewarmer{activeTargets: map[string]struct{}{}},
 		managedPoolInstances: map[string]string{},
 	}
 	service.telemetryCredentials = newTelemetryCredentialIssuer(opts.Config.Database.S2)

--- a/pkg/network/backend_dialer.go
+++ b/pkg/network/backend_dialer.go
@@ -12,9 +12,15 @@ import (
 
 const BackendRoutePreface = "BEAMROUTE/1 "
 
-const backendRouteDialConcurrency = 64
+const (
+	backendRouteDialConcurrency           = 64
+	backendRouteBackgroundDialConcurrency = 4
+)
 
-var backendRouteDialSlots = make(chan struct{}, backendRouteDialConcurrency)
+var (
+	backendRouteDialSlots           = make(chan struct{}, backendRouteDialConcurrency)
+	backendRouteBackgroundDialSlots = make(chan struct{}, backendRouteBackgroundDialConcurrency)
+)
 
 var (
 	backendRouteReadyPollInterval = 50 * time.Millisecond
@@ -30,18 +36,36 @@ type BackendDialer struct {
 	tsConfig  types.TailscaleConfig
 	resolver  BackendRouteResolver
 	timeout   time.Duration
+	dialSlots chan struct{}
 
 	// tsnetDial overrides the tsnet dial in tests.
 	tsnetDial func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error)
 }
 
-func NewBackendDialer(tailscale *Tailscale, tsConfig types.TailscaleConfig, resolver BackendRouteResolver, timeout time.Duration) *BackendDialer {
-	return &BackendDialer{
+type BackendDialerOption func(*BackendDialer)
+
+// WithBackgroundDialSlots isolates best-effort background dials from
+// request-path backend route admission.
+func WithBackgroundDialSlots() BackendDialerOption {
+	return func(d *BackendDialer) {
+		d.dialSlots = backendRouteBackgroundDialSlots
+	}
+}
+
+func NewBackendDialer(tailscale *Tailscale, tsConfig types.TailscaleConfig, resolver BackendRouteResolver, timeout time.Duration, opts ...BackendDialerOption) *BackendDialer {
+	dialer := &BackendDialer{
 		tailscale: tailscale,
 		tsConfig:  tsConfig,
 		resolver:  resolver,
 		timeout:   timeout,
+		dialSlots: backendRouteDialSlots,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(dialer)
+		}
+	}
+	return dialer
 }
 
 func (d *BackendDialer) Dial(ctx context.Context, address string) (net.Conn, error) {
@@ -96,6 +120,10 @@ func (d *BackendDialer) Dial(ctx context.Context, address string) (net.Conn, err
 func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.BackendRoute, routeID string, deadline time.Time) (net.Conn, error) {
 	host := tailnetHostFromAddr(route.ProxyTarget)
 	var lastErr error
+	dialSlots := d.dialSlots
+	if dialSlots == nil {
+		dialSlots = backendRouteDialSlots
+	}
 
 	for remaining := time.Until(deadline); remaining > 0; remaining = time.Until(deadline) {
 		// A failed MagicDNS dial must still reach WaitForPeer so missing peers
@@ -108,16 +136,16 @@ func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.Backend
 		if dialBudget <= 0 {
 			break
 		}
-		if err := acquireBackendRouteDial(ctx, dialBudget); err != nil {
+		if err := acquireBackendRouteDial(ctx, dialBudget, dialSlots); err != nil {
 			return nil, err
 		}
 		dialTimeout := time.Until(deadline) - peerReserve
 		if dialTimeout <= 0 {
-			<-backendRouteDialSlots
+			<-dialSlots
 			return nil, context.DeadlineExceeded
 		}
 		conn, err := d.dialTSNetTarget(ctx, route.ProxyTarget, dialTimeout)
-		<-backendRouteDialSlots
+		<-dialSlots
 		if err == nil {
 			return writeBackendRoutePreface(conn, routeID)
 		}
@@ -163,11 +191,11 @@ func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.Backend
 	return nil, fmt.Errorf("backend route %s dial timed out", routeID)
 }
 
-func acquireBackendRouteDial(ctx context.Context, timeout time.Duration) error {
+func acquireBackendRouteDial(ctx context.Context, timeout time.Duration, dialSlots chan struct{}) error {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
-	case backendRouteDialSlots <- struct{}{}:
+	case dialSlots <- struct{}{}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/network/backend_dialer.go
+++ b/pkg/network/backend_dialer.go
@@ -92,13 +92,13 @@ func (d *BackendDialer) Dial(ctx context.Context, address string) (net.Conn, err
 // dialTSNetRoute connects to the agent's tsnet proxy target. A ready route is
 // dialed immediately: tsnet.Status can omit reachable peers, so checking the
 // netmap first only adds latency. After a failed dial, WaitForPeer enriches the
-// error and feeds the rate-limited stale-netmap detector before retrying.
+// error before retrying; it never mutates the shared tsnet server.
 func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.BackendRoute, routeID string, deadline time.Time) (net.Conn, error) {
 	host := tailnetHostFromAddr(route.ProxyTarget)
 	var lastErr error
 
 	for remaining := time.Until(deadline); remaining > 0; remaining = time.Until(deadline) {
-		// A failed MagicDNS dial must still reach WaitForPeer so stale netmaps
+		// A failed MagicDNS dial must still reach WaitForPeer so missing peers
 		// are observable. Keep a bounded part of each attempt for that check.
 		peerReserve := time.Duration(0)
 		if host != "" {
@@ -124,18 +124,36 @@ func (d *BackendDialer) dialTSNetRoute(ctx context.Context, route *types.Backend
 		lastErr = err
 
 		if host != "" {
-			peerWait := min(time.Until(deadline), tailnetPeerAdvisoryTimeout)
+			// Leave a small margin for error propagation so the advisory probe
+			// cannot consume the route deadline. If the dial wakes after its
+			// budget, retain an explicit netmap diagnostic without starting work
+			// that would extend the failed request.
+			peerWait := min(peerReserve, time.Until(deadline), tailnetPeerAdvisoryTimeout)
+			if peerWait > 0 {
+				peerWait -= min(peerWait/4, 10*time.Millisecond)
+			}
 			if peerWait > 0 {
 				if peerErr := d.tailscale.WaitForPeer(ctx, host, peerWait); peerErr != nil {
 					lastErr = fmt.Errorf("%w; tsnet dial failed: %w", peerErr, err)
 				}
+			} else {
+				lastErr = fmt.Errorf("tailnet netmap check skipped because the dial exhausted its route budget; tsnet dial failed: %w", err)
 			}
 		}
 
+		retryDelay := min(backendRouteDialRetryInterval, time.Until(deadline))
+		if retryDelay <= 0 {
+			break
+		}
+		retryTimer := time.NewTimer(retryDelay)
 		select {
 		case <-ctx.Done():
+			retryTimer.Stop()
+			if ctx.Err() == context.DeadlineExceeded && lastErr != nil {
+				return nil, fmt.Errorf("backend route %s dial timed out: %w", routeID, lastErr)
+			}
 			return nil, ctx.Err()
-		case <-time.After(backendRouteDialRetryInterval):
+		case <-retryTimer.C:
 		}
 	}
 

--- a/pkg/network/backend_dialer_test.go
+++ b/pkg/network/backend_dialer_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -282,8 +283,18 @@ func TestBackendDialerTSNetIncludesPeerMissWhenDialFails(t *testing.T) {
 	}
 }
 
-func TestBackendDialerTSNetChecksPeerAfterDialConsumesBudget(t *testing.T) {
+func TestBackendDialerTSNetPreservesNetmapDiagnosticAfterDialConsumesBudget(t *testing.T) {
 	ts, dialer := newMissingPeerBackendDialer(t, 100*time.Millisecond)
+	previousAdvisory := tailnetPeerAdvisoryTimeout
+	previousRetry := backendRouteDialRetryInterval
+	tailnetPeerAdvisoryTimeout = time.Second
+	backendRouteDialRetryInterval = 250 * time.Millisecond
+	t.Cleanup(func() {
+		tailnetPeerAdvisoryTimeout = previousAdvisory
+		backendRouteDialRetryInterval = previousRetry
+	})
+
+	originalServer := ts.currentServer()
 	dialer.tsnetDial = func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
 		timer := time.NewTimer(timeout)
 		defer timer.Stop()
@@ -295,18 +306,46 @@ func TestBackendDialerTSNetChecksPeerAfterDialConsumesBudget(t *testing.T) {
 		}
 	}
 
+	start := time.Now()
 	_, err := dialer.Dial(context.Background(), types.BackendRouteAddress("route-ts"))
+	elapsed := time.Since(start)
 	if err == nil || !strings.Contains(err.Error(), "netmap") {
 		t.Fatalf("dial error = %v, want netmap miss after exhausted dial", err)
 	}
-	if ts.staleNetmap.misses < 1 {
-		t.Fatalf("netmap misses = %d, want at least 1", ts.staleNetmap.misses)
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("dial took %s, want the 100ms route budget without a full retry delay", elapsed)
+	}
+	if ts.currentServer() != originalServer {
+		t.Fatal("peer lookup failure replaced the shared tsnet server")
+	}
+}
+
+func TestBackendDialerTSNetCallerCancellationWins(t *testing.T) {
+	_, dialer := newMissingPeerBackendDialer(t, 2*time.Second)
+	started := make(chan struct{})
+	dialer.tsnetDial = func(ctx context.Context, addr string, timeout time.Duration) (net.Conn, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := dialer.Dial(ctx, types.BackendRouteAddress("route-ts"))
+		done <- err
+	}()
+
+	<-started
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Dial() error = %v, want context.Canceled", err)
 	}
 }
 
 // A dead peer (offline seller machine) produces netmap miss + NXDOMAIN on
-// every dial. That must feed the rate-limited stale-netmap detector only —
-// recycling the shared tsnet server per dial would drop every other route.
+// every dial. That failure must remain local to the request; recycling the
+// shared tsnet server would drop every other route.
 func TestBackendDialerTSNetDeadPeerDoesNotRecycleServer(t *testing.T) {
 	ts, dialer := newMissingPeerBackendDialer(t, 250*time.Millisecond)
 	originalServer := ts.currentServer()

--- a/pkg/network/backend_dialer_test.go
+++ b/pkg/network/backend_dialer_test.go
@@ -414,3 +414,60 @@ func TestBackendDialerReadyRouteDialsImmediately(t *testing.T) {
 		t.Fatalf("resolver calls = %d, want 1", calls)
 	}
 }
+
+func TestBackendDialerBackgroundSlotsDoNotBlockDefaultRequestDial(t *testing.T) {
+	if got := len(backendRouteBackgroundDialSlots); got != 0 {
+		t.Fatalf("background dial slots already occupied: %d", got)
+	}
+	for i := 0; i < cap(backendRouteBackgroundDialSlots); i++ {
+		backendRouteBackgroundDialSlots <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < cap(backendRouteBackgroundDialSlots); i++ {
+			<-backendRouteBackgroundDialSlots
+		}
+	}()
+
+	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
+	resolver := &tsnetRouteResolver{proxyTarget: "beam-agent-machine.tailnet.ts.net:29443"}
+	backgroundDialer := NewBackendDialer(
+		ts,
+		types.TailscaleConfig{Enabled: true},
+		resolver,
+		100*time.Millisecond,
+		WithBackgroundDialSlots(),
+	)
+	var backgroundReachedDial atomic.Bool
+	backgroundDialer.tsnetDial = func(context.Context, string, time.Duration) (net.Conn, error) {
+		backgroundReachedDial.Store(true)
+		return nil, errors.New("unexpected background dial")
+	}
+	if _, err := backgroundDialer.Dial(context.Background(), types.BackendRouteAddress("route-background")); err == nil {
+		t.Fatal("background dial succeeded while all background slots were occupied")
+	}
+	if backgroundReachedDial.Load() {
+		t.Fatal("background dial reached tsnet while all background slots were occupied")
+	}
+
+	requestDialer := NewBackendDialer(
+		ts,
+		types.TailscaleConfig{Enabled: true},
+		resolver,
+		time.Second,
+	)
+	requestDialer.tsnetDial = func(context.Context, string, time.Duration) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer server.Close()
+			buf := make([]byte, 128)
+			_, _ = server.Read(buf)
+		}()
+		return client, nil
+	}
+
+	conn, err := requestDialer.Dial(context.Background(), types.BackendRouteAddress("route-request"))
+	if err != nil {
+		t.Fatalf("default request dial was blocked by saturated background slots: %v", err)
+	}
+	_ = conn.Close()
+}

--- a/pkg/network/tailscale.go
+++ b/pkg/network/tailscale.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -15,7 +14,6 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/rs/zerolog/log"
 	"tailscale.com/ipn/ipnstate"
-	"tailscale.com/tailcfg"
 	"tailscale.com/tsnet"
 )
 
@@ -53,7 +51,6 @@ type TailscaleConfig struct {
 var (
 	tailnetPeerPollInterval    = 500 * time.Millisecond
 	tailnetPeerAdvisoryTimeout = time.Second
-	tailnetPeerPingTimeout     = 10 * time.Second
 )
 
 type Tailscale struct {
@@ -65,9 +62,8 @@ type Tailscale struct {
 	debug         bool
 	tailscaleRepo repository.TailscaleRepository
 
-	// statusFunc, pingFunc, and dialFunc override tailnet operations in tests.
+	// statusFunc and dialFunc override tailnet operations in tests.
 	statusFunc func(ctx context.Context) (*ipnstate.Status, error)
-	pingFunc   func(ctx context.Context, ip netip.Addr) error
 	dialFunc   func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
@@ -121,83 +117,6 @@ func (t *Tailscale) ensureUp(ctx context.Context) error {
 
 func (t *Tailscale) Start(ctx context.Context) error {
 	return t.ensureUp(ctx)
-}
-
-// WarmPeers establishes paths to matching online peers before they carry traffic.
-func (t *Tailscale) WarmPeers(ctx context.Context, hostnamePrefix string) {
-	status, err := t.netmapStatus(ctx)
-	if err != nil || status == nil {
-		return
-	}
-	ping := t.pingFunc
-	if ping == nil {
-		client, err := t.currentServer().LocalClient()
-		if err != nil {
-			return
-		}
-		ping = func(ctx context.Context, ip netip.Addr) error {
-			result, err := client.Ping(ctx, ip, tailcfg.PingTSMP)
-			if err != nil {
-				return err
-			}
-			if result == nil {
-				return errors.New("tailnet ping returned no result")
-			}
-			if result.Err != "" {
-				return errors.New("tailnet ping failed: " + result.Err)
-			}
-			return nil
-		}
-	}
-
-	var peers sync.WaitGroup
-	for _, peer := range status.Peer {
-		if peer == nil || !peer.Online || !strings.HasPrefix(peer.HostName, hostnamePrefix) {
-			continue
-		}
-		ip, ok := tailnetPeerIP(peer)
-		if !ok {
-			continue
-		}
-
-		peers.Add(1)
-		go func(host string, ip netip.Addr) {
-			defer peers.Done()
-			pingCtx, cancel := context.WithTimeout(ctx, tailnetPeerPingTimeout)
-			defer cancel()
-			if err := ping(pingCtx, ip); err != nil {
-				log.Debug().Str("peer", host).Err(err).Msg("unable to warm tailnet peer")
-			}
-		}(peer.HostName, ip)
-	}
-	peers.Wait()
-}
-
-// KeepPeersAlive periodically refreshes paths when no application route is active.
-func (t *Tailscale) KeepPeersAlive(ctx context.Context, hostnamePrefix string, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			t.WarmPeers(ctx, hostnamePrefix)
-		}
-	}
-}
-
-func tailnetPeerIP(peer *ipnstate.PeerStatus) (netip.Addr, bool) {
-	for _, ip := range peer.TailscaleIPs {
-		if ip.Is4() {
-			return ip, true
-		}
-	}
-	if len(peer.TailscaleIPs) == 0 {
-		return netip.Addr{}, false
-	}
-	return peer.TailscaleIPs[0], true
 }
 
 // Serve connects to a tailnet and serves a local service

--- a/pkg/network/tailscale.go
+++ b/pkg/network/tailscale.go
@@ -50,72 +50,20 @@ type TailscaleConfig struct {
 	Debug      bool
 }
 
-// Stale-netmap self-healing: when peers the control plane says are connected
-// keep missing from this node's netmap, the tailnet control connection is
-// likely a zombie. After enough misses spread over a window, the tsnet server
-// is recycled (rate-limited) to force a fresh control connection and netmap.
 var (
-	staleNetmapMissThreshold   = 3
-	staleNetmapMissWindow      = time.Minute
-	staleNetmapRestartCooldown = 5 * time.Minute
 	tailnetPeerPollInterval    = 500 * time.Millisecond
 	tailnetPeerAdvisoryTimeout = time.Second
 	tailnetPeerPingTimeout     = 10 * time.Second
 )
 
-// staleNetmapDetector tracks terminal peer-lookup misses and decides when the
-// tsnet server should be recycled.
-type staleNetmapDetector struct {
-	mu          sync.Mutex
-	misses      int
-	firstMissAt time.Time
-	lastRestart time.Time
-}
-
-func (d *staleNetmapDetector) seen() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.misses = 0
-	d.firstMissAt = time.Time{}
-}
-
-// missed records a failed peer lookup and reports whether the caller should
-// recycle the tsnet server now.
-func (d *staleNetmapDetector) missed(now time.Time) bool {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	if d.firstMissAt.IsZero() {
-		d.firstMissAt = now
-	}
-	d.misses++
-
-	if d.misses < staleNetmapMissThreshold {
-		return false
-	}
-	if now.Sub(d.firstMissAt) < staleNetmapMissWindow {
-		return false
-	}
-	if !d.lastRestart.IsZero() && now.Sub(d.lastRestart) < staleNetmapRestartCooldown {
-		return false
-	}
-
-	d.lastRestart = now
-	d.misses = 0
-	d.firstMissAt = time.Time{}
-	return true
-}
-
 type Tailscale struct {
-	mu          sync.Mutex // guards server, initialized, served
+	mu          sync.Mutex // guards server and initialized
 	server      *tsnet.Server
 	initialized bool // server has been brought up
-	served      bool // server owns listeners; never recycle it
 
 	cfg           TailscaleConfig
 	debug         bool
 	tailscaleRepo repository.TailscaleRepository
-	staleNetmap   staleNetmapDetector
 
 	// statusFunc, pingFunc, and dialFunc override tailnet operations in tests.
 	statusFunc func(ctx context.Context) (*ipnstate.Status, error)
@@ -272,7 +220,6 @@ func (t *Tailscale) Serve(ctx context.Context, service types.InternalService) (n
 	}
 
 	t.mu.Lock()
-	t.served = true
 	t.initialized = true
 	t.mu.Unlock()
 
@@ -301,7 +248,9 @@ func (t *Tailscale) Dial(ctx context.Context, network, addr string) (net.Conn, e
 // the timeout elapses. Dialing a MagicDNS name for a peer that is missing from
 // the netmap silently falls back to the system resolver and surfaces as a
 // confusing NXDOMAIN ("no such host"); callers should use this to fail with a
-// clear error instead. Repeated misses feed the stale-netmap self-healing.
+// clear error instead. This lookup is deliberately advisory: request-path
+// failures must never close or replace the shared gateway tsnet server because
+// doing so tears down healthy traffic to every other peer.
 func (t *Tailscale) WaitForPeer(ctx context.Context, host string, timeout time.Duration) error {
 	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
 	if host == "" {
@@ -314,12 +263,23 @@ func (t *Tailscale) WaitForPeer(ctx context.Context, host string, timeout time.D
 	}
 
 	deadline := time.Now().Add(timeout)
+	probeCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		probeCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
 	var lastErr error
+
+poll:
 	for {
-		found, err := t.peerInNetmap(ctx, host)
+		found, err := t.peerInNetmap(probeCtx, host)
 		if err == nil && found {
-			t.staleNetmap.seen()
 			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		lastErr = err
 
@@ -329,17 +289,19 @@ func (t *Tailscale) WaitForPeer(ctx context.Context, host string, timeout time.D
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-probeCtx.Done():
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			break poll
 		case <-time.After(tailnetPeerPollInterval):
 		}
 	}
 
-	if t.staleNetmap.missed(time.Now()) {
-		t.recycleServer(host)
-	}
 	if lastErr != nil {
-		return fmt.Errorf("tailnet status unavailable while resolving peer %q: %w", host, lastErr)
+		return fmt.Errorf("tailnet netmap status unavailable while resolving peer %q: %w", host, lastErr)
 	}
-	return fmt.Errorf("tailnet peer %q is not visible in this node's netmap (peer is offline or the tailnet control connection is stale)", host)
+	return fmt.Errorf("tailnet peer %q is not visible in this node's netmap (peer is offline or has been removed)", host)
 }
 
 func (t *Tailscale) peerInNetmap(ctx context.Context, host string) (bool, error) {
@@ -385,34 +347,6 @@ func tailnetPeerMatchesHost(hostName, dnsName, target string) bool {
 	hostName = strings.TrimSuffix(hostName, ".")
 	dnsName = strings.TrimSuffix(dnsName, ".")
 	return target == hostName || target == dnsName || strings.HasPrefix(dnsName, target+".")
-}
-
-// recycleServer replaces the tsnet server to force a fresh control connection
-// and netmap. It is only safe for dial-only nodes; nodes serving listeners
-// would drop them.
-func (t *Tailscale) recycleServer(missingPeer string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.served {
-		log.Warn().
-			Str("missing_peer", missingPeer).
-			Msg("tailnet netmap appears stale but this node serves tsnet listeners; skipping tsnet restart")
-		return
-	}
-
-	log.Warn().
-		Str("missing_peer", missingPeer).
-		Msg("recycling tsnet server after repeated netmap misses; tailnet control connection may be stale")
-	closeTSNetServer(t.server)
-	t.server = t.buildServer()
-	t.initialized = false
-}
-
-// closeTSNetServer tolerates tsnet.Server.Close panicking on a server that
-// never finished coming up; recycling exists precisely for wedged servers.
-func closeTSNetServer(server *tsnet.Server) {
-	defer func() { _ = recover() }()
-	_ = server.Close()
 }
 
 // DialTimeout attempts to establish a TCP connection to a tailscale service with the specified timeout duration

--- a/pkg/network/tailscale_test.go
+++ b/pkg/network/tailscale_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"net/netip"
 	"strings"
 	"sync"
 	"testing"
@@ -76,48 +75,6 @@ func TestConnectToHostRetriesDialWhenPeerIsMissingFromNetmap(t *testing.T) {
 
 	if dialAttempts != 2 {
 		t.Fatalf("dial attempts = %d, want initial dial plus retry", dialAttempts)
-	}
-}
-
-func TestWarmPeersPingsOnlyMatchingOnlinePeers(t *testing.T) {
-	status := statusWithPeers()
-	addPeer := func(host, ip string, online bool) {
-		status.Peer[key.NewNode().Public()] = &ipnstate.PeerStatus{
-			HostName:     host,
-			Online:       online,
-			TailscaleIPs: []netip.Addr{netip.MustParseAddr(ip)},
-		}
-	}
-	addPeer("beam-agent-ready", "100.64.0.1", true)
-	addPeer("beam-agent-offline", "100.64.0.2", false)
-	addPeer("other-peer", "100.64.0.3", true)
-
-	ts := testTailscale(t, status)
-	var mu sync.Mutex
-	var pinged []netip.Addr
-	ts.pingFunc = func(_ context.Context, ip netip.Addr) error {
-		mu.Lock()
-		pinged = append(pinged, ip)
-		mu.Unlock()
-		return nil
-	}
-
-	ts.WarmPeers(context.Background(), "beam-agent-")
-
-	if len(pinged) != 1 || pinged[0] != netip.MustParseAddr("100.64.0.1") {
-		t.Fatalf("pinged = %v, want [100.64.0.1]", pinged)
-	}
-}
-
-func TestTailnetPeerIPPrefersIPv4(t *testing.T) {
-	peer := &ipnstate.PeerStatus{TailscaleIPs: []netip.Addr{
-		netip.MustParseAddr("fd7a:115c:a1e0::1"),
-		netip.MustParseAddr("100.64.0.1"),
-	}}
-
-	ip, ok := tailnetPeerIP(peer)
-	if !ok || ip != netip.MustParseAddr("100.64.0.1") {
-		t.Fatalf("tailnetPeerIP() = (%v, %v), want (100.64.0.1, true)", ip, ok)
 	}
 }
 

--- a/pkg/network/tailscale_test.go
+++ b/pkg/network/tailscale_test.go
@@ -128,9 +128,6 @@ func TestWaitForPeerFindsPeerByDNSName(t *testing.T) {
 	if err := ts.WaitForPeer(context.Background(), "beam-agent-machine.tailnet.ts.net", 100*time.Millisecond); err != nil {
 		t.Fatalf("WaitForPeer() error = %v, want nil", err)
 	}
-	if ts.staleNetmap.misses != 0 {
-		t.Fatalf("missCount = %d, want 0", ts.staleNetmap.misses)
-	}
 }
 
 func TestWaitForPeerSkipsIPLiterals(t *testing.T) {
@@ -142,9 +139,6 @@ func TestWaitForPeerSkipsIPLiterals(t *testing.T) {
 		if err := ts.WaitForPeer(context.Background(), host, 10*time.Millisecond); err != nil {
 			t.Fatalf("WaitForPeer(%q) error = %v, want nil for IP literal", host, err)
 		}
-	}
-	if ts.staleNetmap.misses != 0 {
-		t.Fatalf("missCount = %d, want 0 (IP literals must not count as misses)", ts.staleNetmap.misses)
 	}
 }
 
@@ -170,69 +164,110 @@ func TestWaitForPeerMissingPeerReturnsClearError(t *testing.T) {
 	if !strings.Contains(err.Error(), "netmap") {
 		t.Fatalf("WaitForPeer() error = %v, want mention of netmap", err)
 	}
-	if ts.staleNetmap.misses != 1 {
-		t.Fatalf("missCount = %d, want 1", ts.staleNetmap.misses)
-	}
 }
 
-func TestWaitForPeerSuccessResetsMissCount(t *testing.T) {
+func TestWaitForPeerReturnsCallerCancellationWithoutReplacingServer(t *testing.T) {
 	withFastPeerPolling(t)
-	ts := testTailscale(t, statusWithPeers("beam-agent-machine"))
-	ts.staleNetmap.misses = 2
-	ts.staleNetmap.firstMissAt = time.Now().Add(-time.Minute)
-
-	if err := ts.WaitForPeer(context.Background(), "beam-agent-machine", 50*time.Millisecond); err != nil {
-		t.Fatalf("WaitForPeer() error = %v, want nil", err)
-	}
-	if ts.staleNetmap.misses != 0 || !ts.staleNetmap.firstMissAt.IsZero() {
-		t.Fatalf("miss state = (%d, %v), want reset", ts.staleNetmap.misses, ts.staleNetmap.firstMissAt)
-	}
-}
-
-func TestRepeatedMissesRecycleServer(t *testing.T) {
-	withFastPeerPolling(t)
-	prevThreshold, prevWindow, prevCooldown := staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown
-	staleNetmapMissThreshold = 3
-	staleNetmapMissWindow = 0
-	staleNetmapRestartCooldown = 0
-	t.Cleanup(func() {
-		staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown = prevThreshold, prevWindow, prevCooldown
-	})
-
 	ts := testTailscale(t, statusWithPeers())
 	originalServer := ts.currentServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	for i := 0; i < 3; i++ {
+	err := ts.WaitForPeer(ctx, "beam-agent-missing", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForPeer() error = %v, want context.Canceled", err)
+	}
+	if ts.currentServer() != originalServer {
+		t.Fatal("caller cancellation replaced the shared tsnet server")
+	}
+}
+
+func TestWaitForPeerBoundsSlowStatusToAdvisoryTimeout(t *testing.T) {
+	ts := testTailscale(t, nil)
+	ts.statusFunc = func(ctx context.Context) (*ipnstate.Status, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+			return statusWithPeers(), nil
+		}
+	}
+
+	start := time.Now()
+	err := ts.WaitForPeer(context.Background(), "beam-agent-missing", 20*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "netmap status unavailable") {
+		t.Fatalf("WaitForPeer() error = %v, want bounded netmap status error", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("WaitForPeer() took %s, want less than 100ms", elapsed)
+	}
+}
+
+func TestRepeatedCleanPeerMissesPreserveHealthyPeerRouting(t *testing.T) {
+	withFastPeerPolling(t)
+	ts := testTailscale(t, statusWithPeers("beam-agent-healthy"))
+	originalServer := ts.currentServer()
+
+	for i := 0; i < 10; i++ {
 		_ = ts.WaitForPeer(context.Background(), "beam-agent-missing", time.Millisecond)
+		if err := ts.WaitForPeer(context.Background(), "beam-agent-healthy", 10*time.Millisecond); err != nil {
+			t.Fatalf("healthy peer lookup %d failed after missing peer: %v", i, err)
+		}
 	}
 
-	if ts.currentServer() == originalServer {
-		t.Fatal("server was not recycled after repeated netmap misses")
-	}
-	if ts.initialized {
-		t.Fatal("initialized = true after recycle, want false so the next dial re-ups")
+	if ts.currentServer() != originalServer {
+		t.Fatal("server was recycled for a peer absent from a healthy netmap")
 	}
 }
 
-func TestRepeatedMissesDoNotRecycleServingNode(t *testing.T) {
+func TestRepeatedStatusFailuresDoNotReplaceSharedServer(t *testing.T) {
 	withFastPeerPolling(t)
-	prevThreshold, prevWindow, prevCooldown := staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown
-	staleNetmapMissThreshold = 2
-	staleNetmapMissWindow = 0
-	staleNetmapRestartCooldown = 0
-	t.Cleanup(func() {
-		staleNetmapMissThreshold, staleNetmapMissWindow, staleNetmapRestartCooldown = prevThreshold, prevWindow, prevCooldown
-	})
-
-	ts := testTailscale(t, statusWithPeers())
-	ts.served = true
+	ts := testTailscale(t, nil)
+	ts.statusFunc = func(context.Context) (*ipnstate.Status, error) {
+		return nil, errors.New("tailnet status unavailable")
+	}
 	originalServer := ts.currentServer()
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 10; i++ {
 		_ = ts.WaitForPeer(context.Background(), "beam-agent-missing", time.Millisecond)
 	}
 
 	if ts.currentServer() != originalServer {
-		t.Fatal("serving node's tsnet server was recycled, want untouched")
+		t.Fatal("netmap status failures replaced the shared tsnet server")
+	}
+}
+
+func TestConcurrentPeerChecksDoNotMutateSharedServer(t *testing.T) {
+	withFastPeerPolling(t)
+	ts := testTailscale(t, statusWithPeers("beam-agent-healthy"))
+	originalServer := ts.currentServer()
+
+	const missingChecks = 32
+	const healthyChecks = 128
+	errs := make(chan error, healthyChecks)
+	var checks sync.WaitGroup
+	checks.Add(missingChecks + healthyChecks)
+	for range missingChecks {
+		go func() {
+			defer checks.Done()
+			_ = ts.WaitForPeer(context.Background(), "beam-agent-removed", time.Millisecond)
+		}()
+	}
+	for range healthyChecks {
+		go func() {
+			defer checks.Done()
+			if err := ts.WaitForPeer(context.Background(), "beam-agent-healthy", 10*time.Millisecond); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	checks.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("healthy peer lookup failed during missing-peer storm: %v", err)
+	}
+	if ts.currentServer() != originalServer {
+		t.Fatal("concurrent peer checks replaced the shared tsnet server")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents peer misses from recycling the gateway `tsnet` server and limits tailnet route prewarming so gateway startup and request handling scale independently of tailnet size.

- Gateway startup no longer enumerates and pings all tailnet peers; removed periodic keepalives. Ready agent routes are warmed by an end-to-end dial when they become ready.
- Route prewarming deduplicates by proxy target, caps concurrency at 4, and only runs for ready `TSNet` routes. Prewarm dials use isolated background dial slots.
- Backend dialer separates background and request-path dial slots, improves timeout handling, and ensures caller cancellation wins. `Tailscale.WaitForPeer` is advisory, bounded by its timeout, and never mutates the shared `tsnet` server.
- Removes stale-netmap “self-healing” and server recycling. Tightens dial retry timing and clarifies errors (netmap status and peer visibility).
- Drops peer status attributes from prewarm telemetry.

**Rollout**
- No config changes required. Expect fewer tailnet pings during startup and stable traffic even when a peer is missing or removed.
- If dashboards depended on prewarm peer status attributes, update them to use route prewarm results and dial latency instead.

<sup>Written for commit 159083647dafa2e09fc041628c29843da38941bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

