### PR TITLE
Prepare NBD for qcow durable disks

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -211,7 +211,7 @@ RUN apt-get update && \
         sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
         tee /etc/apt/sources.list.d/nvidia-container-toolkit.list && \
     apt-get update && \
-    apt-get install -y psmisc tini iproute2 iptables \
+    apt-get install -y psmisc tini iproute2 iptables kmod \
         # qcow durable disks: qemu-img + qemu-storage-daemon, kernel NBD client,
         # and ext4 tooling for formatting freshly created volumes. libglib2.0-0
         # is the runtime dependency of the qemu-storage-daemon built above.

--- a/pkg/agent/worker_container.go
+++ b/pkg/agent/worker_container.go
@@ -79,6 +79,9 @@ func dockerRunArgs(name, image, imageID, configPath string, bootstrap bootstrapC
 	if pathExists(types.HostCgroupPath) {
 		volumeArgs = append(volumeArgs, types.HostCgroupPath+":"+types.HostCgroupPath+":rw")
 	}
+	if pathExists(types.HostKernelModulesPath) {
+		volumeArgs = append(volumeArgs, types.HostKernelModulesPath+":"+types.HostKernelModulesPath+":ro")
+	}
 	for _, volume := range volumeArgs {
 		args = append(args, "-v", volume)
 	}

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -42,6 +42,8 @@ type ReconciliationConfig struct {
 	LockTTLSeconds        int   `key:"lockTTLSeconds" json:"lock_ttl_seconds"`
 	MaxStubsPerCycle      int   `key:"maxStubsPerCycle" json:"max_stubs_per_cycle"`
 	MaxItemsPerCycle      int   `key:"maxItemsPerCycle" json:"max_items_per_cycle"`
+	MaxBytesPerCycle      int64 `key:"maxBytesPerCycle" json:"max_bytes_per_cycle"`
+	MaxConcurrentFetches  int   `key:"maxConcurrentFetches" json:"max_concurrent_fetches"`
 	VolumeMinBytes        int64 `key:"volumeMinBytes" json:"volume_min_bytes"`
 	OriginFallbackEnabled bool  `key:"originFallbackEnabled" json:"origin_fallback_enabled"`
 	// MaxDiskUsagePct is the soft pressure watermark (0-1). Above it, the

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -381,7 +381,9 @@ cache:
     recentStubTTLSeconds: 604800 # keep required content warm for 7 days after a stub's last container
     lockTTLSeconds: 300
     maxStubsPerCycle: 256
-    maxItemsPerCycle: 32
+    maxItemsPerCycle: 256 # re-prioritization batch size; exhausted cycles re-kick immediately
+    maxBytesPerCycle: 2147483648 # 2GiB between disk-usage gate rechecks
+    maxConcurrentFetches: 16
     volumeMinBytes: 134217728 # 128MiB; only large geesefs volume objects are reconciled
     originFallbackEnabled: false
 

--- a/pkg/disk/layer.go
+++ b/pkg/disk/layer.go
@@ -24,8 +24,9 @@ const (
 	// LayerFileName is the single logical file inside a qcow.v1 manifest.
 	LayerFileName = "layer.qcow2"
 
-	uploadConcurrency = 16
-	fetchConcurrency  = 8
+	uploadConcurrency     = 16
+	fetchConcurrency      = 8
+	layerFetchConcurrency = 4
 )
 
 // ChunkSink stores a chunk body under a content-addressed object key.

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -41,6 +41,9 @@ type Binaries struct {
 	QemuImg   string
 	QSD       string
 	NBDClient string
+	Modprobe  string
+	Mknod     string
+	Stat      string
 	MkfsExt4  string
 	Fsfreeze  string
 	Mount     string
@@ -51,6 +54,9 @@ func (b *Binaries) applyDefaults() {
 	setDefault(&b.QemuImg, "qemu-img")
 	setDefault(&b.QSD, "qemu-storage-daemon")
 	setDefault(&b.NBDClient, "nbd-client")
+	setDefault(&b.Modprobe, "modprobe")
+	setDefault(&b.Mknod, "mknod")
+	setDefault(&b.Stat, "stat")
 	setDefault(&b.MkfsExt4, "mkfs.ext4")
 	setDefault(&b.Fsfreeze, "fsfreeze")
 	setDefault(&b.Mount, "mount")
@@ -80,6 +86,7 @@ type Config struct {
 
 	// Test hooks.
 	SysBlockPath string
+	DevPath      string
 	Runner       func(ctx context.Context, name string, args ...string) ([]byte, error)
 }
 
@@ -88,6 +95,7 @@ type Manager struct {
 	root          string
 	binaries      Binaries
 	sysBlockPath  string
+	devPath       string
 	run           runner
 	maxChainDepth int
 
@@ -105,6 +113,9 @@ func NewManager(config Config) *Manager {
 	if config.SysBlockPath == "" {
 		config.SysBlockPath = "/sys/block"
 	}
+	if config.DevPath == "" {
+		config.DevPath = "/dev"
+	}
 	if config.MaxChainDepth <= 0 {
 		config.MaxChainDepth = DefaultMaxChainDepth
 	}
@@ -117,6 +128,7 @@ func NewManager(config Config) *Manager {
 		root:          config.Root,
 		binaries:      config.Binaries,
 		sysBlockPath:  config.SysBlockPath,
+		devPath:       config.DevPath,
 		run:           run,
 		maxChainDepth: config.MaxChainDepth,
 		volumes:       make(map[string]*Volume),
@@ -145,6 +157,7 @@ func (m *Manager) preflight() error {
 	m.preflightOnce.Do(func() {
 		for _, binary := range []string{
 			m.binaries.QemuImg, m.binaries.QSD, m.binaries.NBDClient,
+			m.binaries.Modprobe, m.binaries.Mknod, m.binaries.Stat,
 			m.binaries.MkfsExt4, m.binaries.Fsfreeze, m.binaries.Mount, m.binaries.Umount,
 		} {
 			if _, err := exec.LookPath(binary); err != nil {
@@ -230,6 +243,11 @@ func (m *Manager) Recover(ctx context.Context) error {
 			return nil
 		}
 		return err
+	}
+	if len(entries) > 0 {
+		if err := m.ensureNBDDevices(ctx); err != nil {
+			return err
+		}
 	}
 
 	for _, entry := range entries {

--- a/pkg/disk/nbd.go
+++ b/pkg/disk/nbd.go
@@ -148,7 +148,7 @@ func (m *Manager) lockNBDDevice(name string) (*nbdDevice, bool) {
 		lock.Close()
 		return nil, false
 	}
-	return &nbdDevice{Path: "/dev/" + name, name: name, lock: lock}, true
+	return &nbdDevice{Path: filepath.Join(m.devPath, name), name: name, lock: lock}, true
 }
 
 func (m *Manager) tryLockNBDDevice(name string) (*nbdDevice, bool) {

--- a/pkg/disk/nbd.go
+++ b/pkg/disk/nbd.go
@@ -22,6 +22,7 @@ type nbdDevice struct {
 
 const (
 	nbdSettleTimeout = 15 * time.Second
+	nbdModuleTimeout = 10 * time.Second
 	// nbdBlockSize is the device block size requested from nbd-client.
 	nbdBlockSize = 4096
 	sectorSize   = 512
@@ -30,6 +31,9 @@ const (
 // acquireNBDDevice picks a free /dev/nbdN, locks it, and connects it to the
 // daemon's NBD unix socket.
 func (m *Manager) acquireNBDDevice(ctx context.Context, nbdSocket string, expectedSizeBytes int64) (*nbdDevice, error) {
+	if err := m.ensureNBDDevices(ctx); err != nil {
+		return nil, err
+	}
 	names, err := listNBDDeviceNames(m.sysBlockPath)
 	if err != nil {
 		return nil, err
@@ -49,6 +53,79 @@ func (m *Manager) acquireNBDDevice(ctx context.Context, nbdSocket string, expect
 		return device, nil
 	}
 	return nil, fmt.Errorf("all %d nbd devices are busy", len(names))
+}
+
+// ensureNBDDevices lazily prepares the host kernel and this worker's private
+// /dev mount on the first qcow attachment. Kubernetes and Docker both give a
+// privileged worker its own /dev tmpfs, so loading the host module alone does
+// not guarantee that /dev/nbdN exists inside the worker.
+func (m *Manager) ensureNBDDevices(ctx context.Context) error {
+	names, err := listNBDDeviceNames(m.sysBlockPath)
+	if err != nil {
+		return err
+	}
+	if len(names) == 0 {
+		loadCtx, cancel := context.WithTimeout(ctx, nbdModuleTimeout)
+		_, loadErr := m.run(loadCtx, m.binaries.Modprobe, "nbd", "nbds_max=64")
+		cancel()
+		if loadErr != nil {
+			return fmt.Errorf("load nbd kernel module: %w", loadErr)
+		}
+		names, err = listNBDDeviceNames(m.sysBlockPath)
+		if err != nil {
+			return err
+		}
+		if len(names) == 0 {
+			return fmt.Errorf("load nbd kernel module: no nbd devices appeared")
+		}
+	}
+
+	for _, name := range names {
+		deviceNumber, err := os.ReadFile(filepath.Join(m.sysBlockPath, name, "dev"))
+		if err != nil {
+			return fmt.Errorf("read %s device number: %w", name, err)
+		}
+		parts := strings.Split(strings.TrimSpace(string(deviceNumber)), ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("read %s device number: malformed value %q", name, strings.TrimSpace(string(deviceNumber)))
+		}
+		major, err := strconv.ParseUint(parts[0], 10, 32)
+		if err != nil {
+			return fmt.Errorf("read %s major device number: %w", name, err)
+		}
+		minor, err := strconv.ParseUint(parts[1], 10, 32)
+		if err != nil {
+			return fmt.Errorf("read %s minor device number: %w", name, err)
+		}
+
+		devicePath := filepath.Join(m.devPath, name)
+		if _, err := os.Lstat(devicePath); os.IsNotExist(err) {
+			// A concurrent attachment may win this create. Always validate the
+			// final node below instead of treating EEXIST as authoritative.
+			_, _ = m.run(ctx, m.binaries.Mknod, "-m", "0600", devicePath, "b", parts[0], parts[1])
+		} else if err != nil {
+			return fmt.Errorf("inspect %s: %w", devicePath, err)
+		}
+
+		identity, err := m.run(ctx, m.binaries.Stat, "-c", "%f:%t:%T", devicePath)
+		if err != nil {
+			return fmt.Errorf("validate %s: %w", devicePath, err)
+		}
+		fields := strings.Split(strings.TrimSpace(string(identity)), ":")
+		if len(fields) != 3 {
+			return fmt.Errorf("validate %s: malformed stat identity %q", devicePath, strings.TrimSpace(string(identity)))
+		}
+		mode, err := strconv.ParseUint(fields[0], 16, 32)
+		if err != nil || mode&0170000 != 0060000 {
+			return fmt.Errorf("validate %s: not a block device", devicePath)
+		}
+		want := fmt.Sprintf("%x:%x", major, minor)
+		got := fields[1] + ":" + fields[2]
+		if got != want {
+			return fmt.Errorf("validate %s: device number %s, want %s", devicePath, got, want)
+		}
+	}
+	return nil
 }
 
 // lockNBDDevice takes the exclusive flock for a device without caring whether

--- a/pkg/disk/nbd_test.go
+++ b/pkg/disk/nbd_test.go
@@ -1,0 +1,127 @@
+package disk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestNBDDevice(t *testing.T, sysBlock, name, deviceNumber string) {
+	t.Helper()
+	dir := filepath.Join(sysBlock, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dev"), []byte(deviceNumber+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureNBDDevicesUsesExistingKernelDevicesAndCreatesPrivateNodes(t *testing.T) {
+	sysBlock, dev := t.TempDir(), t.TempDir()
+	writeTestNBDDevice(t, sysBlock, "nbd0", "43:0")
+	var calls []string
+	manager := NewManager(Config{
+		SysBlockPath: sysBlock,
+		DevPath:      dev,
+		Runner: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			calls = append(calls, name+" "+strings.Join(args, " "))
+			switch name {
+			case "mknod":
+				return nil, os.WriteFile(args[2], nil, 0o600)
+			case "stat":
+				return []byte("6180:2b:0\n"), nil
+			case "modprobe":
+				t.Fatal("modprobe ran despite an existing kernel NBD device")
+			}
+			return nil, nil
+		},
+	})
+
+	if err := manager.ensureNBDDevices(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 || !strings.HasPrefix(calls[0], "mknod ") || !strings.HasPrefix(calls[1], "stat ") {
+		t.Fatalf("commands = %#v", calls)
+	}
+}
+
+func TestEnsureNBDDevicesLoadsModuleBeforeCreatingNodes(t *testing.T) {
+	sysBlock, dev := t.TempDir(), t.TempDir()
+	var calls []string
+	manager := NewManager(Config{
+		SysBlockPath: sysBlock,
+		DevPath:      dev,
+		Runner: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			calls = append(calls, name+" "+strings.Join(args, " "))
+			switch name {
+			case "modprobe":
+				writeTestNBDDevice(t, sysBlock, "nbd0", "43:0")
+			case "mknod":
+				return nil, os.WriteFile(args[2], nil, 0o600)
+			case "stat":
+				return []byte("6180:2b:0\n"), nil
+			}
+			return nil, nil
+		},
+	})
+
+	if err := manager.ensureNBDDevices(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 3 || calls[0] != "modprobe nbd nbds_max=64" {
+		t.Fatalf("commands = %#v", calls)
+	}
+}
+
+func TestEnsureNBDDevicesRejectsMissingDevicesAfterModuleLoad(t *testing.T) {
+	manager := NewManager(Config{
+		SysBlockPath: t.TempDir(),
+		DevPath:      t.TempDir(),
+		Runner: func(context.Context, string, ...string) ([]byte, error) {
+			return nil, nil
+		},
+	})
+
+	err := manager.ensureNBDDevices(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no nbd devices appeared") {
+		t.Fatalf("ensureNBDDevices() error = %v", err)
+	}
+}
+
+func TestEnsureNBDDevicesRejectsWrongExistingNode(t *testing.T) {
+	sysBlock, dev := t.TempDir(), t.TempDir()
+	writeTestNBDDevice(t, sysBlock, "nbd0", "43:0")
+	if err := os.WriteFile(filepath.Join(dev, "nbd0"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(Config{
+		SysBlockPath: sysBlock,
+		DevPath:      dev,
+		Runner: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			if name == "stat" {
+				return []byte("8180:0:0\n"), nil
+			}
+			return nil, fmt.Errorf("unexpected command %s", name)
+		},
+	})
+
+	err := manager.ensureNBDDevices(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "not a block device") {
+		t.Fatalf("ensureNBDDevices() error = %v", err)
+	}
+}
+
+func TestEnsureNBDDevicesRejectsMalformedKernelDeviceNumber(t *testing.T) {
+	sysBlock := t.TempDir()
+	writeTestNBDDevice(t, sysBlock, "nbd0", "invalid")
+	manager := NewManager(Config{SysBlockPath: sysBlock, DevPath: t.TempDir()})
+
+	err := manager.ensureNBDDevices(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "malformed value") {
+		t.Fatalf("ensureNBDDevices() error = %v", err)
+	}
+}

--- a/pkg/disk/volume.go
+++ b/pkg/disk/volume.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sync"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -154,24 +156,38 @@ func fileExists(path string) bool {
 func (m *Manager) materializeChain(ctx context.Context, spec AttachSpec, layersDir string, source ChunkSource) (*volumeState, error) {
 	state := &volumeState{Key: spec.Key, VirtualSizeBytes: spec.VirtualSizeBytes, ReadOnly: spec.ReadOnly}
 
-	previousPath := ""
+	// Layers are independent objects; fetch them in parallel and link the
+	// chain afterwards.
+	localPaths := make([]string, len(spec.Chain))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(layerFetchConcurrency)
 	for i, chainLayer := range spec.Chain {
 		if chainLayer.Layer == nil || chainLayer.SnapshotID == "" {
 			return nil, fmt.Errorf("chain layer %d for volume %s is incomplete", i, spec.Key)
 		}
-		localPath := filepath.Join(layersDir, fmt.Sprintf("%03d-%s.qcow2", i, chainLayer.SnapshotID))
-		if err := fetchLayer(ctx, source, chainLayer.Layer, localPath); err != nil {
-			return nil, fmt.Errorf("fetch layer %s: %w", chainLayer.SnapshotID, err)
-		}
+		localPaths[i] = filepath.Join(layersDir, fmt.Sprintf("%03d-%s.qcow2", i, chainLayer.SnapshotID))
+		group.Go(func() error {
+			if err := fetchLayer(groupCtx, source, chainLayer.Layer, localPaths[i]); err != nil {
+				return fmt.Errorf("fetch layer %s: %w", chainLayer.SnapshotID, err)
+			}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	previousPath := ""
+	for i, chainLayer := range spec.Chain {
 		if i > 0 {
 			// Downloaded layers carry the origin host's backing path; repoint
 			// them at the local copy of their parent.
-			if err := m.rebaseQcow(ctx, localPath, previousPath); err != nil {
+			if err := m.rebaseQcow(ctx, localPaths[i], previousPath); err != nil {
 				return nil, err
 			}
 		}
-		state.Chain = append(state.Chain, stateLayer{SnapshotID: chainLayer.SnapshotID, Path: localPath})
-		previousPath = localPath
+		state.Chain = append(state.Chain, stateLayer{SnapshotID: chainLayer.SnapshotID, Path: localPaths[i]})
+		previousPath = localPaths[i]
 	}
 
 	if spec.ReadOnly {

--- a/pkg/disk/volume_test.go
+++ b/pkg/disk/volume_test.go
@@ -281,7 +281,23 @@ func TestReusableState(t *testing.T) {
 
 func TestRecoverCleansUpCrashedVolume(t *testing.T) {
 	root := t.TempDir()
-	manager := NewManager(Config{Root: root, Runner: fakeRunner})
+	sysBlock, dev := t.TempDir(), t.TempDir()
+	writeTestNBDDevice(t, sysBlock, "nbd0", "43:0")
+	manager := NewManager(Config{
+		Root:         root,
+		SysBlockPath: sysBlock,
+		DevPath:      dev,
+		Runner: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			switch name {
+			case "mknod":
+				return nil, os.WriteFile(args[2], nil, 0o600)
+			case "stat":
+				return []byte("6180:2b:0\n"), nil
+			default:
+				return fakeRunner(ctx, name, args...)
+			}
+		},
+	})
 
 	dir := manager.volumeDir("crashed")
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/pkg/repository/disk_postgres.go
+++ b/pkg/repository/disk_postgres.go
@@ -54,7 +54,7 @@ func (r *PostgresBackendRepository) GetOrCreateDisk(ctx context.Context, workspa
 	if driver == "" {
 		driver = types.DurableDiskDriverSnapshot
 	}
-	if driver != types.DurableDiskDriverSnapshot {
+	if driver != types.DurableDiskDriverSnapshot && driver != types.DurableDiskDriverQcow {
 		return nil, fmt.Errorf("unsupported durable disk driver %q", driver)
 	}
 

--- a/pkg/repository/disk_postgres_test.go
+++ b/pkg/repository/disk_postgres_test.go
@@ -11,6 +11,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetOrCreateDiskAcceptsQcowDriver(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	postgresRepo := repo.(*PostgresBackendRepository)
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(`SELECT .* FROM disk`).
+		WithArgs(uint(7), "machine-root").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`INSERT INTO disk`).
+		WithArgs(uint(7), "machine-root", "32Gi", "ext4", types.DurableDiskDriverQcow, "/").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "external_id", "workspace_id", "name", "size", "filesystem", "driver", "mount_path",
+			"created_at", "updated_at", "deleted_at",
+		}).AddRow(
+			uint(1),
+			"disk-1",
+			uint(7),
+			"machine-root",
+			"32Gi",
+			"ext4",
+			types.DurableDiskDriverQcow,
+			"/",
+			now,
+			now,
+			nil,
+		))
+
+	disk, err := postgresRepo.GetOrCreateDisk(context.Background(), 7, &types.Disk{
+		Name:       "machine-root",
+		Size:       "32Gi",
+		Filesystem: "ext4",
+		Driver:     types.DurableDiskDriverQcow,
+		MountPath:  "/",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, types.DurableDiskDriverQcow, disk.Driver)
+	require.Equal(t, "/", disk.MountPath)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetOrCreateDiskRejectsUnsupportedDriver(t *testing.T) {
+	repo, mock := NewBackendPostgresRepositoryForTest()
+	postgresRepo := repo.(*PostgresBackendRepository)
+
+	mock.ExpectQuery(`SELECT .* FROM disk`).
+		WithArgs(uint(7), "machine-root").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := postgresRepo.GetOrCreateDisk(context.Background(), 7, &types.Disk{
+		Name:   "machine-root",
+		Driver: "unsupported",
+	})
+
+	require.EqualError(t, err, `unsupported durable disk driver "unsupported"`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestGetDiskSnapshotOnlySharesAvailableSnapshots(t *testing.T) {
 	repo, mock := NewBackendPostgresRepositoryForTest()
 	mock.ExpectQuery(`public = TRUE AND status = \$3`).

--- a/pkg/scheduler/pool.go
+++ b/pkg/scheduler/pool.go
@@ -30,6 +30,7 @@ const (
 	storageVolumeName           string  = "beta9-storage"
 	cacheVolumeName             string  = "beta9-cache"
 	durableDiskVolumeName       string  = "beta9-durable-disks"
+	kernelModulesVolumeName     string  = "host-kernel-modules"
 	devicePluginVolumeName      string  = "kubelet-device-plugins"
 	defaultDevicePluginPath     string  = "/var/lib/kubelet/device-plugins"
 	defaultContainerName        string  = "worker"

--- a/pkg/scheduler/pool_local.go
+++ b/pkg/scheduler/pool_local.go
@@ -388,6 +388,19 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerVolumes(workerMemory in
 		},
 	})
 
+	// Host kernel modules let the worker modprobe nbd for qcow durable disks.
+	// DirectoryOrCreate keeps scheduling working on hosts without the path;
+	// the qcow attach then fails with a clear module error instead.
+	volumes = append(volumes, corev1.Volume{
+		Name: kernelModulesVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: types.HostKernelModulesPath,
+				Type: &hostPathType,
+			},
+		},
+	})
+
 	hostPathDir := corev1.HostPathDirectory
 	volumes = append(volumes, corev1.Volume{
 		Name: devicePluginVolumeName,
@@ -447,6 +460,12 @@ func (wpc *LocalKubernetesWorkerPoolController) getWorkerVolumeMounts() []corev1
 		Name:      durableDiskVolumeName,
 		MountPath: types.DefaultDurableDisksPath,
 		ReadOnly:  false,
+	})
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      kernelModulesVolumeName,
+		MountPath: types.HostKernelModulesPath,
+		ReadOnly:  true,
 	})
 
 	return volumeMounts

--- a/pkg/scheduler/pool_provider.go
+++ b/pkg/scheduler/pool_provider.go
@@ -619,6 +619,19 @@ func (wpc *ProviderWorkerPoolController) getWorkerVolumes(workerMemory int64) []
 		},
 	})
 
+	// Host kernel modules let the worker modprobe nbd for qcow durable disks.
+	// DirectoryOrCreate keeps scheduling working on hosts without the path;
+	// the qcow attach then fails with a clear module error instead.
+	volumes = append(volumes, corev1.Volume{
+		Name: kernelModulesVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: types.HostKernelModulesPath,
+				Type: &hostPathType,
+			},
+		},
+	})
+
 	hostPathDir := corev1.HostPathDirectory
 	volumes = append(volumes, corev1.Volume{
 		Name: devicePluginVolumeName,
@@ -677,6 +690,12 @@ func (wpc *ProviderWorkerPoolController) getWorkerVolumeMounts() []corev1.Volume
 		Name:      durableDiskVolumeName,
 		MountPath: types.DefaultDurableDisksPath,
 		ReadOnly:  false,
+	})
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      kernelModulesVolumeName,
+		MountPath: types.HostKernelModulesPath,
+		ReadOnly:  true,
 	})
 
 	return volumeMounts

--- a/pkg/types/agent_worker.go
+++ b/pkg/types/agent_worker.go
@@ -84,6 +84,7 @@ const (
 	HostNetnsPath                   = "/var/run/netns"
 	HostCgroupPath                  = "/sys/fs/cgroup"
 	HostFuseDevicePath              = "/dev/fuse"
+	HostKernelModulesPath           = "/lib/modules"
 	AgentDockerLabelManaged         = "dev.beam.agent.worker"
 	AgentDockerLabelWorkerID        = "dev.beam.agent.worker_id"
 	AgentDockerLabelMachineID       = "dev.beam.agent.machine_id"

--- a/pkg/worker/cache_manager.go
+++ b/pkg/worker/cache_manager.go
@@ -59,7 +59,13 @@ const (
 	cacheDefaultReconcileRecentStubTTLS = cache.DefaultReconcileRecentStubTTLS
 	cacheDefaultReconcileLockTTLS       = 300
 	cacheDefaultReconcileMaxStubsCycle  = 256
-	cacheDefaultReconcileMaxItemsCycle  = 32
+	// Exhausted cycles re-kick with a fresh MRU listing, so the item budget
+	// is a re-prioritization batch size, not a throughput cap.
+	cacheDefaultReconcileMaxItemsCycle = 256
+	// Parallel materializations per cycle.
+	cacheDefaultReconcileConcurrency = 16
+	// Byte budget per cycle; bounds writes between disk-usage gate rechecks.
+	cacheDefaultReconcileMaxBytesCycle = int64(2) << 30
 	// cacheDefaultReconcileMaxDiskUsagePct pauses proactive materialization
 	// before node-level DiskPressure thresholds can be reached.
 	cacheDefaultReconcileMaxDiskUsagePct = 0.80
@@ -74,36 +80,39 @@ const (
 )
 
 type WorkerCacheManager struct {
-	ctx                   context.Context
-	cancel                context.CancelFunc
-	config                types.AppConfig
-	poolConfig            types.WorkerPoolConfig
-	workerRepo            pb.WorkerRepositoryServiceClient
-	eventRepo             repo.EventRepository
-	containerInstances    *common.SafeMap[*ContainerInstance]
-	workerID              string
-	instanceID            string
-	poolName              string
-	podAddr               string
-	nodeID                string
-	locality              string
-	accelerator           string
-	checkpointRoot        string
-	cacheIdentityPath     string
-	metadataStore         cache.CacheMetadataStore
-	reporter              *cacheContentReporter
-	originCredsMu         sync.Mutex
-	originCredsCache      map[string]*originCredentials
-	reconcileFailuresMu   sync.Mutex
-	reconcileFailures     map[string]time.Time
-	reconcileSuccessesMu  sync.Mutex
-	reconcileSuccesses    map[string]time.Time
-	checkpointLocksMu     sync.Mutex
-	checkpointLocks       map[string]*checkpointMaterializationLock
-	ownerLastLiveMu       sync.Mutex
-	ownerLastLive         map[string]time.Time
-	reconcilePausedAt     time.Time
-	reconcileNow          chan struct{}
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	config               types.AppConfig
+	poolConfig           types.WorkerPoolConfig
+	workerRepo           pb.WorkerRepositoryServiceClient
+	eventRepo            repo.EventRepository
+	containerInstances   *common.SafeMap[*ContainerInstance]
+	workerID             string
+	instanceID           string
+	poolName             string
+	podAddr              string
+	nodeID               string
+	locality             string
+	accelerator          string
+	checkpointRoot       string
+	cacheIdentityPath    string
+	metadataStore        cache.CacheMetadataStore
+	reporter             *cacheContentReporter
+	originCredsMu        sync.Mutex
+	originCredsCache     map[string]*originCredentials
+	reconcileFailuresMu  sync.Mutex
+	reconcileFailures    map[string]time.Time
+	reconcileSuccessesMu sync.Mutex
+	reconcileSuccesses   map[string]time.Time
+	checkpointLocksMu    sync.Mutex
+	checkpointLocks      map[string]*checkpointMaterializationLock
+	ownerLastLiveMu      sync.Mutex
+	ownerLastLive        map[string]time.Time
+	reconcilePausedAt    time.Time
+	reconcileNow         chan struct{}
+	// Memoized per-stub required-content reads keyed on the stub's
+	// recent-index score. Reconcile loop goroutine only; no lock.
+	requiredContentCache  map[string]requiredContentCacheEntry
 	client                *cache.Client
 	server                *cache.Server
 	serverLock            *os.File

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -104,6 +105,24 @@ func (m *WorkerCacheManager) reconcileMaxItemsPerCycle() int {
 		items = cacheDefaultReconcileMaxItemsCycle
 	}
 	return items
+}
+
+func (m *WorkerCacheManager) reconcileConcurrency() int {
+	n := m.config.Cache.Reconciliation.MaxConcurrentFetches
+	if n <= 0 {
+		n = cacheDefaultReconcileConcurrency
+	}
+	return n
+}
+
+// reconcileMaxBytesPerCycle bounds bytes fetched per cycle so the disk-usage
+// gate is re-evaluated regularly; exhausted cycles re-kick immediately.
+func (m *WorkerCacheManager) reconcileMaxBytesPerCycle() int64 {
+	b := m.config.Cache.Reconciliation.MaxBytesPerCycle
+	if b <= 0 {
+		b = cacheDefaultReconcileMaxBytesCycle
+	}
+	return b
 }
 
 // reconcileMaxDiskUsagePct is the local disk usage fraction above which
@@ -503,17 +522,28 @@ func (m *WorkerCacheManager) reconcileOnce() {
 		return
 	}
 
-	budget := newReconcileBudget(m.reconcileMaxItemsPerCycle())
+	// Stubs arrive MRU-first from the recent index.
+	budget := newReconcileBudget(m.reconcileMaxItemsPerCycle(), m.reconcileMaxBytesPerCycle())
+	pool := newReconcilePool(m.reconcileConcurrency())
 	for _, content := range stubContent {
 		select {
 		case <-m.ctx.Done():
+			pool.wait()
 			return
 		default:
 		}
-		m.reconcileStubContent(server, localHostID, content.stub, content.items, budget, reconcileAllowlist)
+		m.reconcileStubContent(server, localHostID, content.stub, content.items, budget, reconcileAllowlist, pool)
 		if budget.exhausted() {
 			break
 		}
+	}
+	pool.wait()
+
+	// An exhausted budget means known pending work: re-kick immediately with
+	// a fresh MRU listing instead of waiting for the next tick. Requiring
+	// local progress avoids hot-looping on contended or missing items.
+	if budget.exhausted() && pool.didWork() {
+		m.requestReconcile()
 	}
 }
 
@@ -523,10 +553,10 @@ func (m *WorkerCacheManager) reconcileStub(server *cache.Server, localHostID str
 		log.Debug().Err(err).Str("workspace_id", stub.WorkspaceID).Str("stub_id", stub.StubID).Msg("cache reconciliation failed to read required content")
 		return nil
 	}
-	return m.reconcileStubContent(server, localHostID, stub, items, budget, nil)
+	return m.reconcileStubContent(server, localHostID, stub, items, budget, nil, nil)
 }
 
-func (m *WorkerCacheManager) reconcileStubContent(server *cache.Server, localHostID string, stub cache.RecentStub, items []types.CacheRequiredContentItem, budget *reconcileBudget, allowlist map[string]struct{}) []string {
+func (m *WorkerCacheManager) reconcileStubContent(server *cache.Server, localHostID string, stub cache.RecentStub, items []types.CacheRequiredContentItem, budget *reconcileBudget, allowlist map[string]struct{}, pool *reconcilePool) []string {
 	checkpointIDs := []string{}
 	for _, item := range orderedRequiredContentItems(items) {
 		select {
@@ -569,13 +599,89 @@ func (m *WorkerCacheManager) reconcileStubContent(server *cache.Server, localHos
 		if m.reconcileBackingOff(item.Hash, routingKey, stub.LastSeen) {
 			continue
 		}
-		if !budget.take() {
+		// Stubs share content (e.g. base image layers); dedupe submissions
+		// within the cycle instead of burning budget on lock contention.
+		if !pool.claim(reconcileItemKey(item.Hash, routingKey)) {
+			continue
+		}
+		if !budget.take(item.SizeBytes) {
 			return checkpointIDs
 		}
 
-		m.materializeOwnedItem(server, localHostID, stub, item, routingKey)
+		pool.submit(func() {
+			if m.materializeOwnedItem(server, localHostID, stub, item, routingKey) {
+				pool.markProgress()
+			}
+		})
 	}
 	return checkpointIDs
+}
+
+// reconcilePool bounds concurrent materializations within a reconcile cycle.
+// A nil pool runs work inline (the sequential path used by reconcileStub).
+type reconcilePool struct {
+	wg       sync.WaitGroup
+	ch       chan struct{}
+	progress atomic.Bool
+	// seen dedupes (hash, routingKey) submissions within one cycle.
+	// Reconcile loop goroutine only; no lock.
+	seen map[string]struct{}
+}
+
+func newReconcilePool(concurrency int) *reconcilePool {
+	if concurrency <= 1 {
+		return nil
+	}
+	return &reconcilePool{ch: make(chan struct{}, concurrency), seen: map[string]struct{}{}}
+}
+
+// claim marks the item as submitted this cycle, returning false on repeats.
+// A nil pool never dedupes; the sequential path sees completed items via
+// requiredContentComplete on the next iteration.
+func (p *reconcilePool) claim(key string) bool {
+	if p == nil {
+		return true
+	}
+	if _, ok := p.seen[key]; ok {
+		return false
+	}
+	p.seen[key] = struct{}{}
+	return true
+}
+
+// markProgress records that a task landed content locally, i.e. the cycle
+// moved the working set forward rather than spinning on misses or contention.
+func (p *reconcilePool) markProgress() {
+	if p != nil {
+		p.progress.Store(true)
+	}
+}
+
+func (p *reconcilePool) didWork() bool {
+	return p != nil && p.progress.Load()
+}
+
+func (p *reconcilePool) submit(fn func()) {
+	if p == nil {
+		fn()
+		return
+	}
+	p.ch <- struct{}{}
+	p.wg.Add(1)
+	go func() {
+		defer func() {
+			<-p.ch
+			p.wg.Done()
+		}()
+		fn()
+	}()
+}
+
+func (p *reconcilePool) wait() {
+	if p == nil {
+		return
+	}
+	p.wg.Wait()
 }
 
 type recentStubContent struct {
@@ -583,18 +689,36 @@ type recentStubContent struct {
 	items []types.CacheRequiredContentItem
 }
 
+type requiredContentCacheEntry struct {
+	lastSeen time.Time
+	items    []types.CacheRequiredContentItem
+}
+
+// loadRecentRequiredContent resolves required-content items for each recent
+// stub, cached keyed on the stub's recent-index score: publishers append to S2
+// before bumping the score, so an unchanged score means the cached items are
+// current. Only stubs with new activity cost an S2 read per cycle.
 func (m *WorkerCacheManager) loadRecentRequiredContent(stubs []cache.RecentStub) ([]recentStubContent, bool) {
 	content := make([]recentStubContent, 0, len(stubs))
 	complete := true
+	next := make(map[string]requiredContentCacheEntry, len(stubs))
 	for _, stub := range stubs {
+		key := stub.WorkspaceID + "|" + stub.StubID
+		if entry, ok := m.requiredContentCache[key]; ok && entry.lastSeen.Equal(stub.LastSeen) {
+			next[key] = entry
+			content = append(content, recentStubContent{stub: stub, items: entry.items})
+			continue
+		}
 		items, err := m.eventRepo.ReadStubCacheRequiredContent(m.ctx, stub.WorkspaceID, stub.StubID)
 		if err != nil {
 			log.Debug().Err(err).Str("workspace_id", stub.WorkspaceID).Str("stub_id", stub.StubID).Msg("cache reconciliation failed to read required content")
 			complete = false
 			continue
 		}
+		next[key] = requiredContentCacheEntry{lastSeen: stub.LastSeen, items: items}
 		content = append(content, recentStubContent{stub: stub, items: items})
 	}
+	m.requiredContentCache = next
 	return content, complete
 }
 
@@ -1244,25 +1368,39 @@ func (m *WorkerCacheManager) ownerLastLiveAt(hostID string, now time.Time) time.
 	return now
 }
 
+// reconcileBudget bounds one reconcile pass by item count and by bytes, so
+// gate rechecks stay regular regardless of item size. An item crossing the
+// byte boundary is still admitted (a single oversized item must not starve);
+// the budget exhausts after it. Reconcile loop goroutine only.
 type reconcileBudget struct {
-	remaining int
-	limited   bool
-	empty     bool
+	remaining      int
+	limited        bool
+	bytesRemaining int64
+	byteLimited    bool
+	empty          bool
 }
 
-func newReconcileBudget(limit int) *reconcileBudget {
-	return &reconcileBudget{remaining: limit, limited: limit > 0}
+func newReconcileBudget(limit int, byteLimit int64) *reconcileBudget {
+	return &reconcileBudget{
+		remaining:      limit,
+		limited:        limit > 0,
+		bytesRemaining: byteLimit,
+		byteLimited:    byteLimit > 0,
+	}
 }
 
-func (b *reconcileBudget) take() bool {
-	if b == nil || !b.limited {
+func (b *reconcileBudget) take(sizeBytes int64) bool {
+	if b == nil || (!b.limited && !b.byteLimited) {
 		return true
 	}
-	if b.remaining <= 0 {
+	if (b.limited && b.remaining <= 0) || (b.byteLimited && b.bytesRemaining <= 0) {
 		b.empty = true
 		return false
 	}
 	b.remaining--
+	if sizeBytes > 0 {
+		b.bytesRemaining -= sizeBytes
+	}
 	return true
 }
 
@@ -1270,12 +1408,15 @@ func (b *reconcileBudget) exhausted() bool {
 	return b != nil && b.empty
 }
 
-func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHostID string, stub cache.RecentStub, item types.CacheRequiredContentItem, routingKey string) {
+// materializeOwnedItem fetches a single missing item into the local cache,
+// returning true only if the item ended up complete. Misses, failures, and
+// lock contention return false so retries alone never re-kick the loop.
+func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHostID string, stub cache.RecentStub, item types.CacheRequiredContentItem, routingKey string) bool {
 	acquired, err := m.metadataStore.AcquireReconcileLock(m.ctx, m.locality, localHostID, item.Hash, m.reconcileLockTTLSeconds())
 	if err != nil || !acquired {
 		// Another materialization is already in flight for this item (or the
 		// coordinator is unavailable); try again next cycle.
-		return
+		return false
 	}
 	defer func() {
 		if err := m.metadataStore.ReleaseReconcileLock(m.ctx, m.locality, localHostID, item.Hash); err != nil {
@@ -1285,7 +1426,7 @@ func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHos
 
 	// Re-check after acquiring the lock; another process may have just completed it.
 	if m.requiredContentComplete(server, item, routingKey) {
-		return
+		return true
 	}
 
 	ctx, cancel := context.WithTimeout(m.ctx, reconcileItemTimeout)
@@ -1327,6 +1468,7 @@ func (m *WorkerCacheManager) materializeOwnedItem(server *cache.Server, localHos
 	}
 
 	m.auditCacheEvent(localHostID, stub, item, routingKey, status)
+	return status == types.CacheAuditStatusMaterialized
 }
 
 // reconcileStatusIsFailure reports whether a materialization outcome is a genuine

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -543,16 +544,123 @@ func TestReconcileSuccessBackoffSkipsRecentMaterialization(t *testing.T) {
 }
 
 func TestReconcileBudgetCapsMaterializationAttempts(t *testing.T) {
-	budget := newReconcileBudget(1)
+	budget := newReconcileBudget(1, 0)
 
-	require.True(t, budget.take())
+	require.True(t, budget.take(0))
 	require.False(t, budget.exhausted())
-	require.False(t, budget.take())
+	require.False(t, budget.take(0))
 	require.True(t, budget.exhausted())
 
 	var unlimited *reconcileBudget
-	require.True(t, unlimited.take())
+	require.True(t, unlimited.take(0))
 	require.False(t, unlimited.exhausted())
+}
+
+func TestReconcileBudgetCapsBytesPerCycle(t *testing.T) {
+	budget := newReconcileBudget(100, 10)
+
+	// An item crossing the byte boundary is admitted; the budget exhausts after.
+	require.True(t, budget.take(4))
+	require.True(t, budget.take(8))
+	require.False(t, budget.exhausted())
+	require.False(t, budget.take(1))
+	require.True(t, budget.exhausted())
+
+	// A single item larger than the whole byte budget is still admitted.
+	huge := newReconcileBudget(100, 10)
+	require.True(t, huge.take(1<<30))
+	require.False(t, huge.take(1))
+
+	// Items with unknown size only consume the item budget.
+	unknown := newReconcileBudget(2, 10)
+	require.True(t, unknown.take(0))
+	require.True(t, unknown.take(0))
+	require.False(t, unknown.take(0))
+	require.True(t, unknown.exhausted())
+}
+
+func TestLoadRecentRequiredContentCachesByLastSeen(t *testing.T) {
+	fake := &fakeEventRepo{
+		itemsByStub: map[string]map[string]types.CacheRequiredContentItem{
+			"ws|stub-a": {"h1": {Hash: "h1", Kind: types.CacheContentKindDiskSnapshot}},
+			"ws|stub-b": {"h2": {Hash: "h2", Kind: types.CacheContentKindDiskSnapshot}},
+		},
+	}
+	manager := &WorkerCacheManager{ctx: context.Background(), eventRepo: fake}
+
+	seenA := time.Unix(100, 0)
+	seenB := time.Unix(200, 0)
+	stubs := []cache.RecentStub{
+		{WorkspaceID: "ws", StubID: "stub-a", LastSeen: seenA},
+		{WorkspaceID: "ws", StubID: "stub-b", LastSeen: seenB},
+	}
+
+	content, complete := manager.loadRecentRequiredContent(stubs)
+	require.True(t, complete)
+	require.Len(t, content, 2)
+	require.Equal(t, []string{"ws|stub-a", "ws|stub-b"}, fake.readKeys)
+
+	// Unchanged scores are served from cache without new reads.
+	content, complete = manager.loadRecentRequiredContent(stubs)
+	require.True(t, complete)
+	require.Len(t, content, 2)
+	require.Equal(t, "h1", content[0].items[0].Hash)
+	require.Equal(t, []string{"ws|stub-a", "ws|stub-b"}, fake.readKeys)
+
+	// A bumped score (new activity/content) forces a re-read of that stub only.
+	stubs[1].LastSeen = seenB.Add(time.Second)
+	_, _ = manager.loadRecentRequiredContent(stubs)
+	require.Equal(t, []string{"ws|stub-a", "ws|stub-b", "ws|stub-b"}, fake.readKeys)
+
+	// Stubs that age out of the recent index are evicted from the cache.
+	_, _ = manager.loadRecentRequiredContent(stubs[1:])
+	require.NotContains(t, manager.requiredContentCache, "ws|stub-a")
+
+	// Read errors are not cached; the stub is retried next cycle.
+	fake.readErr = errors.New("s2 unavailable")
+	_, complete = manager.loadRecentRequiredContent([]cache.RecentStub{{WorkspaceID: "ws", StubID: "stub-c", LastSeen: seenA}})
+	require.False(t, complete)
+	require.NotContains(t, manager.requiredContentCache, "ws|stub-c")
+}
+
+func TestReconcilePoolDedupesAndBoundsConcurrency(t *testing.T) {
+	var nilPool *reconcilePool
+	require.True(t, nilPool.claim("a"))
+	require.True(t, nilPool.claim("a")) // nil pool never dedupes
+	require.False(t, nilPool.didWork())
+	nilPool.markProgress() // must not panic
+	nilPool.wait()
+
+	// concurrency <= 1 yields the inline (nil) pool
+	require.Nil(t, newReconcilePool(1))
+
+	pool := newReconcilePool(4)
+	require.True(t, pool.claim("a"))
+	require.False(t, pool.claim("a"))
+	require.True(t, pool.claim("b"))
+
+	var inFlight, maxInFlight, total atomic.Int64
+	for i := 0; i < 32; i++ {
+		pool.submit(func() {
+			cur := inFlight.Add(1)
+			for {
+				prev := maxInFlight.Load()
+				if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			time.Sleep(2 * time.Millisecond)
+			inFlight.Add(-1)
+			total.Add(1)
+		})
+	}
+	pool.wait()
+
+	require.EqualValues(t, 32, total.Load())
+	require.LessOrEqual(t, maxInFlight.Load(), int64(4))
+	require.False(t, pool.didWork())
+	pool.markProgress()
+	require.True(t, pool.didWork())
 }
 
 func TestReconcileOnceUsesOnlyCurrentLocalityRecentStubs(t *testing.T) {
@@ -1064,7 +1172,7 @@ func TestReconcileCheckpointIgnoresSuccessBackoffWhenExtractedPayloadMissing(t *
 	manager.reconcileStub(server, "local-host", cache.RecentStub{
 		WorkspaceID: "workspace",
 		StubID:      "stub",
-	}, newReconcileBudget(10))
+	}, newReconcileBudget(10, 0))
 
 	require.True(t, checkpointMaterialized(filepath.Join(checkpointRoot, checkpointID)))
 	require.Len(t, fake.cacheEvents, 1)

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -2021,7 +2021,9 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 			request.Checkpoint = nil
 		}
 		var seedUpper func(string) error
-		if reseedCheckpointFilesystem {
+		// A qcow root disk already holds the checkpoint filesystem; Reset
+		// preserves its persistent upper, so no reseed is needed (or safe).
+		if reseedCheckpointFilesystem && qcowRootDiskMount(request) == nil {
 			seedUpper = func(upperPath string) error {
 				return s.restoreCheckpointFilesystem(ctx, request, outputLogger, upperPath)
 			}
@@ -2112,14 +2114,17 @@ func (s *Worker) runContainer(ctx context.Context, request *types.ContainerReque
 		var restoreErr error
 		if filesystemRestore != nil {
 			restoreErr = filesystemRestore.wait()
+		} else if originalConfigErr != nil {
+			restoreErr = fmt.Errorf("checkpoint filesystem restore requires the original container config: %w", originalConfigErr)
+		} else if qcowRootDiskMount(request) != nil {
+			// The root disk is sealed after the CRIU dump, so the restored
+			// disk already holds the checkpoint filesystem; reseeding would
+			// wipe it and re-extract the same bytes.
+			restoreErr = s.prepareRestoreFallback(request, originalConfig, nil)
 		} else {
-			if originalConfigErr != nil {
-				restoreErr = fmt.Errorf("checkpoint filesystem restore requires the original container config: %w", originalConfigErr)
-			} else {
-				restoreErr = s.prepareRestoreFallback(request, originalConfig, func(upperPath string) error {
-					return s.restoreCheckpointFilesystem(ctx, request, outputLogger, upperPath)
-				})
-			}
+			restoreErr = s.prepareRestoreFallback(request, originalConfig, func(upperPath string) error {
+				return s.restoreCheckpointFilesystem(ctx, request, outputLogger, upperPath)
+			})
 		}
 		if restoreErr != nil {
 			// A local fetch failure does not prove the checkpoint itself is invalid.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepares NBD for qcow durable disks and makes cache and layer fetches more efficient. Workers now load the NBD module and create validated /dev/nbd* nodes on demand so qcow attaches work across all pools.

- NBD device prep: on first attach and during recovery, workers run modprobe nbd nbds_max=64, then mknod and stat to create and verify device nodes; preflight checks for modprobe/mknod/stat; device locking uses the manager’s devPath to match node creation.
- Worker image/env: installs `kmod`; bind-mounts `/lib/modules` read-only into Docker agent and Kubernetes workers. Missing path does not block scheduling; attach fails with a clear module error.
- Repository: durable disk GetOrCreate now accepts the qcow driver; unsupported drivers still error.
- Performance: parallelizes qcow layer downloads before rebasing and adds a parallel reconciliation pool with per-cycle item and byte budgets; dedupes in-cycle submissions and re-kicks immediately on progress. New config: `cache.reconciliation.maxBytesPerCycle` and `cache.reconciliation.maxConcurrentFetches`; default `maxItemsPerCycle` raised to 256.
- Checkpoint restore: when a qcow root disk is present, skips reseeding the checkpoint filesystem and uses the restored disk contents instead.

- Required ops: hosts must provide the nbd kernel module and allow privileged workers to run modprobe. No client/API changes.

<sup>Written for commit 4d50b3c250920c6cf13d802053bd9b658dbfb959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

