### PR TITLE
Replicate disk snapshot chunks locality-wide and share chunk fetch budget

### DIFF
--- a/pkg/disk/layer.go
+++ b/pkg/disk/layer.go
@@ -24,8 +24,14 @@ const (
 	// LayerFileName is the single logical file inside a qcow.v1 manifest.
 	LayerFileName = "layer.qcow2"
 
-	uploadConcurrency     = 16
-	fetchConcurrency      = 8
+	uploadConcurrency = 16
+	// chunkFetchConcurrency bounds in-flight chunk fetches across every layer
+	// of a chain. It is shared rather than per-layer so a chain dominated by
+	// one large layer gets the same parallelism as a deep one, and a deep
+	// chain does not multiply into hundreds of concurrent requests. Each
+	// in-flight chunk holds a LayerChunkSize buffer, so this also caps
+	// restore memory (32 * 4 MiB = 128 MiB).
+	chunkFetchConcurrency = 32
 	layerFetchConcurrency = 4
 )
 
@@ -126,10 +132,39 @@ func UploadLayer(ctx context.Context, sink ChunkSink, path string, layer *types.
 	return group.Wait()
 }
 
+// chunkGate bounds concurrent chunk fetches. A nil gate is unbounded.
+type chunkGate chan struct{}
+
+func newChunkGate(limit int) chunkGate {
+	if limit <= 0 {
+		return nil
+	}
+	return make(chunkGate, limit)
+}
+
+func (g chunkGate) acquire(ctx context.Context) error {
+	if g == nil {
+		return nil
+	}
+	select {
+	case g <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (g chunkGate) release() {
+	if g != nil {
+		<-g
+	}
+}
+
 // fetchLayer reassembles a layer file from its chunks. The result is written
 // to a temporary file and atomically renamed, so a crashed fetch never leaves
-// a truncated layer behind.
-func fetchLayer(ctx context.Context, source ChunkSource, layer *types.DiskSnapshotFile, destPath string) error {
+// a truncated layer behind. Chunk parallelism is bounded by gate, which the
+// caller shares across all layers of a chain.
+func fetchLayer(ctx context.Context, source ChunkSource, layer *types.DiskSnapshotFile, destPath string, gate chunkGate) error {
 	tmpPath := destPath + ".tmp"
 	file, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
@@ -143,10 +178,17 @@ func fetchLayer(ctx context.Context, source ChunkSource, layer *types.DiskSnapsh
 		return err
 	}
 
+	if gate == nil {
+		gate = newChunkGate(chunkFetchConcurrency)
+	}
 	group, groupCtx := errgroup.WithContext(ctx)
-	group.SetLimit(fetchConcurrency)
 	for _, chunk := range layer.Chunks {
 		group.Go(func() error {
+			if err := gate.acquire(groupCtx); err != nil {
+				return err
+			}
+			defer gate.release()
+
 			data := make([]byte, chunk.SizeBytes)
 			if err := source.ReadChunk(groupCtx, chunk, data); err != nil {
 				return fmt.Errorf("fetch chunk %s: %w", chunk.Digest, err)

--- a/pkg/disk/layer_test.go
+++ b/pkg/disk/layer_test.go
@@ -95,7 +95,7 @@ func TestLayerScanUploadFetchRoundTrip(t *testing.T) {
 	}
 
 	destPath := filepath.Join(dir, "restored.qcow2")
-	if err := fetchLayer(context.Background(), store, layer, destPath); err != nil {
+	if err := fetchLayer(context.Background(), store, layer, destPath, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -109,6 +109,81 @@ func TestLayerScanUploadFetchRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(source, restored) {
 		t.Fatal("restored layer differs from source")
+	}
+}
+
+// blockingChunkStore records peak concurrent ReadChunk calls.
+type blockingChunkStore struct {
+	*memoryChunkStore
+	mu       sync.Mutex
+	inflight int
+	peak     int
+}
+
+func (s *blockingChunkStore) ReadChunk(ctx context.Context, chunk types.DiskSnapshotChunk, dest []byte) error {
+	s.mu.Lock()
+	s.inflight++
+	if s.inflight > s.peak {
+		s.peak = s.inflight
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inflight--
+		s.mu.Unlock()
+	}()
+	return s.memoryChunkStore.ReadChunk(ctx, chunk, dest)
+}
+
+func TestFetchLayerSharesChunkGateAcrossLayers(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "layer.qcow2")
+	data := make([]byte, 40*LayerChunkSize)
+	rand.Read(data)
+	if err := os.WriteFile(sourcePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	layer, err := ScanLayer(sourcePath, chunkKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layer.Chunks) < 20 {
+		t.Fatalf("expected a multi-chunk layer, got %d", len(layer.Chunks))
+	}
+
+	store := &blockingChunkStore{memoryChunkStore: newMemoryChunkStore()}
+	if err := UploadLayer(context.Background(), store, sourcePath, layer); err != nil {
+		t.Fatal(err)
+	}
+
+	// A single layer must saturate the whole shared budget, not a per-layer slice.
+	gate := newChunkGate(chunkFetchConcurrency)
+	if err := fetchLayer(context.Background(), store, layer, filepath.Join(dir, "a.qcow2"), gate); err != nil {
+		t.Fatal(err)
+	}
+	if store.peak > chunkFetchConcurrency {
+		t.Fatalf("peak concurrency %d exceeded budget %d", store.peak, chunkFetchConcurrency)
+	}
+
+	// Two layers sharing one gate stay within the same budget.
+	store.peak = 0
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = fetchLayer(context.Background(), store, layer, filepath.Join(dir, fmt.Sprintf("b%d.qcow2", i)), gate)
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if store.peak > chunkFetchConcurrency {
+		t.Fatalf("shared gate exceeded budget: peak %d", store.peak)
 	}
 }
 
@@ -134,7 +209,7 @@ func TestFetchLayerRejectsCorruptChunks(t *testing.T) {
 	}
 
 	destPath := filepath.Join(dir, "restored.qcow2")
-	if err := fetchLayer(context.Background(), store, layer, destPath); err == nil {
+	if err := fetchLayer(context.Background(), store, layer, destPath, nil); err == nil {
 		t.Fatal("expected digest mismatch error")
 	}
 	if _, err := os.Stat(destPath); !os.IsNotExist(err) {

--- a/pkg/disk/volume.go
+++ b/pkg/disk/volume.go
@@ -157,8 +157,10 @@ func (m *Manager) materializeChain(ctx context.Context, spec AttachSpec, layersD
 	state := &volumeState{Key: spec.Key, VirtualSizeBytes: spec.VirtualSizeBytes, ReadOnly: spec.ReadOnly}
 
 	// Layers are independent objects; fetch them in parallel and link the
-	// chain afterwards.
+	// chain afterwards. Chunk parallelism is a single budget shared by every
+	// layer, so restore speed does not depend on how the data is split.
 	localPaths := make([]string, len(spec.Chain))
+	gate := newChunkGate(chunkFetchConcurrency)
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(layerFetchConcurrency)
 	for i, chainLayer := range spec.Chain {
@@ -167,7 +169,7 @@ func (m *Manager) materializeChain(ctx context.Context, spec AttachSpec, layersD
 		}
 		localPaths[i] = filepath.Join(layersDir, fmt.Sprintf("%03d-%s.qcow2", i, chainLayer.SnapshotID))
 		group.Go(func() error {
-			if err := fetchLayer(groupCtx, source, chainLayer.Layer, localPaths[i]); err != nil {
+			if err := fetchLayer(groupCtx, source, chainLayer.Layer, localPaths[i], gate); err != nil {
 				return fmt.Errorf("fetch layer %s: %w", chainLayer.SnapshotID, err)
 			}
 			return nil

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -582,7 +582,7 @@ func (m *WorkerCacheManager) reconcileStubContent(server *cache.Server, localHos
 			if item.CheckpointID != "" {
 				checkpointIDs = append(checkpointIDs, item.CheckpointID)
 			}
-		} else if !m.localHostOwnsForReconcile(localHostID, routingKey) {
+		} else if !reconcileOnEveryHost(item.Kind) && !m.localHostOwnsForReconcile(localHostID, routingKey) {
 			continue
 		}
 
@@ -615,6 +615,16 @@ func (m *WorkerCacheManager) reconcileStubContent(server *cache.Server, localHos
 		})
 	}
 	return checkpointIDs
+}
+
+// reconcileOnEveryHost reports whether a content kind replicates to every host
+// in the locality instead of sharding by ring owner. Checkpoints and disk
+// snapshot chunks are what a machine restore reads, and the client prefers
+// local stores, so full replication makes a post-reconcile start run at local
+// disk speed on any host. Everything else stays owner-sharded and is served
+// to peers over the network.
+func reconcileOnEveryHost(kind types.CacheContentKind) bool {
+	return kind == types.CacheContentKindCheckpoint || kind == types.CacheContentKindDiskSnapshot
 }
 
 // reconcilePool bounds concurrent materializations within a reconcile cycle.

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -619,10 +619,9 @@ func (m *WorkerCacheManager) reconcileStubContent(server *cache.Server, localHos
 
 // reconcileOnEveryHost reports whether a content kind replicates to every host
 // in the locality instead of sharding by ring owner. Checkpoints and disk
-// snapshot chunks are what a machine restore reads, and the client prefers
-// local stores, so full replication makes a post-reconcile start run at local
-// disk speed on any host. Everything else stays owner-sharded and is served
-// to peers over the network.
+// snapshot chunks are what a machine restore reads, so full replication lets a
+// post-reconcile start run at local disk speed on any host; everything else
+// stays owner-sharded and is served to peers over the network.
 func reconcileOnEveryHost(kind types.CacheContentKind) bool {
 	return kind == types.CacheContentKindCheckpoint || kind == types.CacheContentKindDiskSnapshot
 }

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -1303,6 +1303,111 @@ func TestRequiredContentReportedByOneWorkerReconcilesCheckpointOnPeerInLocality(
 	require.Equal(t, types.CacheAuditStatusMaterialized, cacheEvents[0].Status)
 }
 
+// Disk snapshot chunks replicate to every host in the locality (like
+// checkpoints) so a restore reads them locally, while other kinds stay
+// sharded by ring owner.
+func TestReconcileDiskSnapshotChunksMaterializeOnNonOwnerHost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := testCacheManagerConfig(t.TempDir()).Cache
+	cfg.Client.NTopHosts = 2
+
+	newServer := func(hostID string) (*cache.Server, *cache.Host) {
+		t.Helper()
+		serverCfg := cfg
+		serverCfg.Server.DiskCacheDir = t.TempDir()
+		server, err := cache.NewServerWithOptions(ctx, serverCfg, "locality-a", cache.WithServerMetadataStore(cache.NewMockCacheMetadataStore()), cache.WithServerHostID(hostID))
+		require.NoError(t, err)
+		addr, err := server.Serve("127.0.0.1:0", "")
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+		host := server.Host()
+		require.NotNil(t, host)
+		host.Addr = addr
+		host.PrivateAddr = addr
+		return server, host
+	}
+	sourceServer, sourceHost := newServer("source-host")
+	destinationServer, destinationHost := newServer("destination-host")
+
+	clientCfg := cfg
+	clientCfg.Server.DiskCacheDir = t.TempDir()
+	destinationClient, err := cache.NewClientWithHostDirectory(ctx, clientCfg, cache.NewMockCacheMetadataStore(), testHostDirectoryFunc(func(context.Context, string) ([]*cache.Host, error) {
+		return []*cache.Host{sourceHost, destinationHost}, nil
+	}), "locality-a")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, destinationClient.Cleanup()) })
+	destinationClient.AttachLocalServer(destinationServer)
+	require.Eventually(t, func() bool {
+		return len(destinationClient.RankedReadHosts("probe")) == 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	// Two source-host-owned blobs: one disk snapshot chunk (must replicate
+	// to the non-owner destination) and one owner-sharded volume blob
+	// (must stay gated).
+	sourceOwnedContent := func(seed string) (string, []byte) {
+		t.Helper()
+		for i := 0; i < 256; i++ {
+			data := []byte(fmt.Sprintf("%s-%d-content", seed, i))
+			digest := sha256.Sum256(data)
+			hash := hex.EncodeToString(digest[:])
+			ranked := destinationClient.RankedReadHosts(hash)
+			require.Len(t, ranked, 2)
+			if ranked[0].HostId == sourceHost.HostId {
+				return hash, data
+			}
+		}
+		t.Fatal("expected content owned by the source host")
+		return "", nil
+	}
+	chunkHash, chunkData := sourceOwnedContent("chunk")
+	volumeHash, volumeData := sourceOwnedContent("volume")
+	for hash, data := range map[string][]byte{chunkHash: chunkData, volumeHash: volumeData} {
+		_, _, err = sourceServer.StoreReader(ctx, strings.NewReader(string(data)), hash)
+		require.NoError(t, err)
+		require.True(t, sourceServer.HasCompleteContent(hash, int64(len(data))))
+		require.False(t, destinationServer.HasCompleteContent(hash, int64(len(data))))
+	}
+
+	events := &fakeEventRepo{items: []types.CacheRequiredContentItem{
+		{
+			Kind:       types.CacheContentKindDiskSnapshot,
+			Hash:       chunkHash,
+			RoutingKey: chunkHash,
+			SizeBytes:  int64(len(chunkData)),
+			DiskName:   "machine-root",
+		},
+		{
+			Kind:       types.CacheContentKindVolume,
+			Hash:       volumeHash,
+			RoutingKey: volumeHash,
+			SizeBytes:  int64(len(volumeData)),
+		},
+	}}
+	manager := &WorkerCacheManager{
+		ctx:               ctx,
+		config:            types.AppConfig{Cache: cfg},
+		locality:          "locality-a",
+		metadataStore:     cache.NewMockCacheMetadataStore(),
+		eventRepo:         events,
+		client:            destinationClient,
+		server:            destinationServer,
+		reconcileFailures: make(map[string]time.Time),
+	}
+
+	manager.reconcileStub(destinationServer, destinationHost.HostId, cache.RecentStub{
+		WorkspaceID: "workspace",
+		StubID:      "stub",
+	}, newReconcileBudget(10, 0))
+
+	require.True(t, destinationServer.HasCompleteContent(chunkHash, int64(len(chunkData))),
+		"disk snapshot chunk must materialize on the non-owner host")
+	require.False(t, destinationServer.HasCompleteContent(volumeHash, int64(len(volumeData))),
+		"owner-sharded content must not materialize on the non-owner host")
+}
+
 func TestReconcileStubFansOutCheckpointsAcrossMatchingHosts(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/worker/durable_disk.go
+++ b/pkg/worker/durable_disk.go
@@ -381,7 +381,7 @@ func (s *Worker) snapshotDurableDiskMount(ctx context.Context, request *types.Co
 
 	recordPublishedDurableDiskMarker(mount, snapshot)
 
-	s.reportDurableDiskSnapshotContent(request, snapshot, manifest)
+	s.reportDurableDiskSnapshotContent(request, snapshot, manifest, 0)
 	return snapshot, nil
 }
 
@@ -520,7 +520,7 @@ func (s *Worker) restoreDurableDiskSnapshot(request *types.ContainerRequest, mou
 		_ = os.RemoveAll(mount.LocalPath)
 		return fmt.Errorf("restore durable disk snapshot %s produced an invalid payload", snapshot.ExternalId)
 	}
-	s.reportDurableDiskSnapshotContent(request, snapshot, manifest)
+	s.reportDurableDiskSnapshotContent(request, snapshot, manifest, 0)
 	log.Info().
 		Str("disk", mount.DurableDisk.Name).
 		Int64("bytes", snapshot.LogicalSizeBytes).
@@ -667,16 +667,10 @@ func durableDiskChunkPrefix(mount *types.Mount) string {
 	return path.Join(durableDiskObjectRoot, types.SafeDurableDiskName(mount.DurableDisk.Name), "chunks")
 }
 
-func (s *Worker) reportDurableDiskSnapshotContent(request *types.ContainerRequest, snapshot *types.DiskSnapshot, manifest *types.DiskSnapshotManifest) {
-	s.reportDurableDiskSnapshotContentTagged(request, snapshot, manifest, 0)
-}
-
-// reportDurableDiskSnapshotContentTagged reports a snapshot's content tagged
-// with chainGeneration instead of the snapshot's own generation. The recency
-// index keeps only a disk's newest generation; qcow layers are deltas, so
-// every layer of the live chain is tagged with the chain head's generation to
-// stay protected and replicated until the whole chain is superseded.
-func (s *Worker) reportDurableDiskSnapshotContentTagged(request *types.ContainerRequest, snapshot *types.DiskSnapshot, manifest *types.DiskSnapshotManifest, chainGeneration int64) {
+// reportDurableDiskSnapshotContent registers a snapshot's manifest and chunks
+// as required content. A non-zero chainGeneration overrides the generation the
+// items are tagged with (see reportQcowChainContent).
+func (s *Worker) reportDurableDiskSnapshotContent(request *types.ContainerRequest, snapshot *types.DiskSnapshot, manifest *types.DiskSnapshotManifest, chainGeneration int64) {
 	if s == nil || s.cacheManager == nil || request == nil || snapshot == nil || manifest == nil {
 		return
 	}

--- a/pkg/worker/durable_disk.go
+++ b/pkg/worker/durable_disk.go
@@ -668,6 +668,15 @@ func durableDiskChunkPrefix(mount *types.Mount) string {
 }
 
 func (s *Worker) reportDurableDiskSnapshotContent(request *types.ContainerRequest, snapshot *types.DiskSnapshot, manifest *types.DiskSnapshotManifest) {
+	s.reportDurableDiskSnapshotContentTagged(request, snapshot, manifest, 0)
+}
+
+// reportDurableDiskSnapshotContentTagged reports a snapshot's content tagged
+// with chainGeneration instead of the snapshot's own generation. The recency
+// index keeps only a disk's newest generation; qcow layers are deltas, so
+// every layer of the live chain is tagged with the chain head's generation to
+// stay protected and replicated until the whole chain is superseded.
+func (s *Worker) reportDurableDiskSnapshotContentTagged(request *types.ContainerRequest, snapshot *types.DiskSnapshot, manifest *types.DiskSnapshotManifest, chainGeneration int64) {
 	if s == nil || s.cacheManager == nil || request == nil || snapshot == nil || manifest == nil {
 		return
 	}
@@ -678,6 +687,11 @@ func (s *Worker) reportDurableDiskSnapshotContent(request *types.ContainerReques
 	items := durableDiskSnapshotRequiredContentItems(snapshot, manifest)
 	if len(items) == 0 {
 		return
+	}
+	if chainGeneration > 0 {
+		for i := range items {
+			items[i].SnapshotGeneration = chainGeneration
+		}
 	}
 	reporter.reportItems(cacheRequestWorkspaceID(request), cacheRequestStubID(request), types.CacheContentKindDiskSnapshot, items)
 }

--- a/pkg/worker/durable_disk_qcow.go
+++ b/pkg/worker/durable_disk_qcow.go
@@ -115,11 +115,57 @@ func (s *Worker) prepareQcowDurableDiskMount(request *types.ContainerRequest, mo
 	// The chain is rooted at its last parentless row, so its length is the
 	// generation count since the last flatten, which drives the periodic
 	// flattened publish that bounds restore chains.
-	s.qcowChainDepths.Store(s.qcowVolumeKey(request, mount), len(rows))
-	for i, row := range rows {
-		s.reportDurableDiskSnapshotContent(request, row, manifests[i])
+	entries := make([]qcowChainEntry, len(rows))
+	for i := range rows {
+		entries[i] = qcowChainEntry{row: rows[i], manifest: manifests[i]}
+	}
+	s.qcowChains.Store(s.qcowVolumeKey(request, mount), entries)
+	s.reportQcowChainContent(request, entries)
+	return nil
+}
+
+// qcowChainEntry is one published generation of a volume's live chain.
+type qcowChainEntry struct {
+	row      *types.DiskSnapshot
+	manifest *types.DiskSnapshotManifest
+}
+
+func (s *Worker) qcowChain(key string) []qcowChainEntry {
+	if value, ok := s.qcowChains.Load(key); ok {
+		chain, _ := value.([]qcowChainEntry)
+		return chain
 	}
 	return nil
+}
+
+// appendQcowChain records a newly published generation. A parentless row
+// (first generation or a flattened publish) is self-contained and supersedes
+// the whole previous chain.
+func (s *Worker) appendQcowChain(key string, entry qcowChainEntry) []qcowChainEntry {
+	chain := s.qcowChain(key)
+	if entry.row.ParentSnapshotId == "" {
+		chain = []qcowChainEntry{entry}
+	} else {
+		chain = append(chain, entry)
+	}
+	s.qcowChains.Store(key, chain)
+	return chain
+}
+
+// reportQcowChainContent reports every layer of the live chain tagged with
+// the head generation. Restores need the whole chain, and the recency index
+// keeps only a disk's newest generation, so tagging parents with the head
+// generation keeps them protected and locality-replicated until a flatten
+// (or newer chain) supersedes them; superseded and idle content then ages
+// out of the cache through the normal recency prune.
+func (s *Worker) reportQcowChainContent(request *types.ContainerRequest, chain []qcowChainEntry) {
+	if len(chain) == 0 {
+		return
+	}
+	head := chain[len(chain)-1].row.Generation
+	for _, entry := range chain {
+		s.reportDurableDiskSnapshotContentTagged(request, entry.row, entry.manifest, head)
+	}
 }
 
 // resolveQcowSnapshotChain walks ParentSnapshotId links from the newest
@@ -240,7 +286,7 @@ func (s *Worker) snapshotQcowDurableDiskMount(ctx context.Context, request *type
 		if err := volume.MarkPublished(layer.Path, row.ExternalId); err != nil {
 			return published, err
 		}
-		s.reportDurableDiskSnapshotContent(request, row, manifest)
+		s.reportQcowChainContent(request, s.appendQcowChain(key, qcowChainEntry{row: row, manifest: manifest}))
 		published, latest, parentID = row, row, row.ExternalId
 	}
 	return published, nil
@@ -267,11 +313,7 @@ func (s *Worker) latestQcowSnapshotRow(ctx context.Context, request *types.Conta
 // published chain is deep) plus its manifest, then creates the repository row.
 // The manifest upload is the durability boundary, mirroring the dir.v1 driver.
 func (s *Worker) publishQcowLayer(ctx context.Context, request *types.ContainerRequest, mount *types.Mount, volume *disk.Volume, store *durableDiskSnapshotBucketStore, sealedPath, parentID string, latest *types.DiskSnapshot) (*types.DiskSnapshot, *types.DiskSnapshotManifest, error) {
-	key := s.qcowVolumeKey(request, mount)
-	depth := 0
-	if value, ok := s.qcowChainDepths.Load(key); ok {
-		depth, _ = value.(int)
-	}
+	depth := len(s.qcowChain(s.qcowVolumeKey(request, mount)))
 
 	uploadPath := sealedPath
 	if parentID != "" && depth+1 >= disk.DefaultFlattenDepth {
@@ -359,12 +401,6 @@ func (s *Worker) publishQcowLayer(ctx context.Context, request *types.ContainerR
 		snapshot = created
 	}
 	reportDurableDiskProgress(ctx, durableDiskProgressEvent{})
-
-	if parentID == "" {
-		s.qcowChainDepths.Store(key, 1)
-	} else {
-		s.qcowChainDepths.Store(key, depth+1)
-	}
 	return snapshot, manifest, nil
 }
 

--- a/pkg/worker/durable_disk_qcow.go
+++ b/pkg/worker/durable_disk_qcow.go
@@ -153,18 +153,18 @@ func (s *Worker) appendQcowChain(key string, entry qcowChainEntry) []qcowChainEn
 }
 
 // reportQcowChainContent reports every layer of the live chain tagged with
-// the head generation. Restores need the whole chain, and the recency index
-// keeps only a disk's newest generation, so tagging parents with the head
-// generation keeps them protected and locality-replicated until a flatten
-// (or newer chain) supersedes them; superseded and idle content then ages
-// out of the cache through the normal recency prune.
+// the head generation. The recency index keeps only a disk's newest
+// generation, and qcow layers are deltas: tagging parents with the head
+// generation keeps the whole restore chain protected and locality-replicated
+// until a flatten or newer chain supersedes it, at which point the old chain
+// ages out through the normal recency prune.
 func (s *Worker) reportQcowChainContent(request *types.ContainerRequest, chain []qcowChainEntry) {
 	if len(chain) == 0 {
 		return
 	}
 	head := chain[len(chain)-1].row.Generation
 	for _, entry := range chain {
-		s.reportDurableDiskSnapshotContentTagged(request, entry.row, entry.manifest, head)
+		s.reportDurableDiskSnapshotContent(request, entry.row, entry.manifest, head)
 	}
 }
 

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -1251,6 +1251,68 @@ func TestDurableDiskSnapshotRequiredContentItems(t *testing.T) {
 	require.Equal(t, int64(7), items[1].SnapshotGeneration)
 }
 
+// Every layer of a live qcow chain must be reported at the chain head's
+// generation: the recency index keeps only a disk's newest generation, and
+// qcow layers are deltas, so tagging parents with their own generation would
+// evict content the chain still needs while stale chains age out.
+func TestQcowChainContentReportsEveryLayerAtHeadGeneration(t *testing.T) {
+	events := &fakeEventRepo{}
+	reporter := newTestReporter(events)
+	worker := &Worker{cacheManager: &WorkerCacheManager{reporter: reporter}}
+	request := &types.ContainerRequest{WorkspaceId: "workspace", StubId: "stub"}
+
+	entry := func(id string, generation int64, parentID, manifestHex, chunkHex string) qcowChainEntry {
+		return qcowChainEntry{
+			row: &types.DiskSnapshot{
+				ExternalId:        id,
+				BucketName:        "bucket",
+				DiskName:          "machine-root",
+				Generation:        generation,
+				ParentSnapshotId:  parentID,
+				ManifestKey:       fmt.Sprintf("durable-disks/machine-root/snapshots/%d/manifest.json", generation),
+				ManifestDigest:    "sha256:" + strings.Repeat(manifestHex, 64),
+				ManifestSizeBytes: 64,
+			},
+			manifest: &types.DiskSnapshotManifest{Files: []types.DiskSnapshotFile{{
+				Type: "file",
+				Chunks: []types.DiskSnapshotChunk{{
+					Digest:    "sha256:" + strings.Repeat(chunkHex, 64),
+					ObjectKey: "durable-disks/machine-root/chunks/" + strings.Repeat(chunkHex, 64),
+					SizeBytes: 4,
+				}},
+			}}},
+		}
+	}
+
+	worker.qcowChains.Store("volume-key", []qcowChainEntry{
+		entry("snap-1", 100, "", "1", "2"),
+		entry("snap-2", 200, "snap-1", "3", "4"),
+	})
+	worker.reportQcowChainContent(request, worker.qcowChain("volume-key"))
+	reporter.flush()
+
+	events.mu.Lock()
+	hashes := map[string]int64{}
+	for _, schema := range events.pushed {
+		for _, item := range schema.Items {
+			hashes[item.Hash] = item.SnapshotGeneration
+		}
+	}
+	events.mu.Unlock()
+	require.Len(t, hashes, 4, "manifest and chunk items of both layers must be reported")
+	for hash, generation := range hashes {
+		require.Equal(t, int64(200), generation, "item %s must carry the chain head generation", hash)
+	}
+
+	// A parentless publish (first generation or a flatten) is self-contained
+	// and supersedes the whole previous chain; deltas append to it.
+	chain := worker.appendQcowChain("volume-key", entry("snap-3", 300, "", "5", "6"))
+	require.Len(t, chain, 1)
+	chain = worker.appendQcowChain("volume-key", entry("snap-4", 400, "snap-3", "7", "8"))
+	require.Len(t, chain, 2)
+	require.Equal(t, "snap-3", chain[0].row.ExternalId)
+}
+
 func TestRestoreDurableDiskDirectorySnapshotDownloadsChunksInParallel(t *testing.T) {
 	source := t.TempDir()
 	payload := []byte(strings.Repeat("parallel restore ", durableDiskRestoreConcurrency))

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -478,7 +478,7 @@ func TestDurabilityReportingNeverBlocksCheckpointOrDiskPublication(t *testing.T)
 			BucketName: "bucket", ManifestKey: "disk/manifest.json", ManifestDigest: "sha256:manifest", ManifestSizeBytes: 10,
 		}, &types.DiskSnapshotManifest{Files: []types.DiskSnapshotFile{{
 			Type: "file", Chunks: []types.DiskSnapshotChunk{{Digest: "sha256:chunk", ObjectKey: "disk/chunks/chunk", SizeBytes: 4}},
-		}}})
+		}}}, 0)
 		close(done)
 	}()
 
@@ -1252,9 +1252,8 @@ func TestDurableDiskSnapshotRequiredContentItems(t *testing.T) {
 }
 
 // Every layer of a live qcow chain must be reported at the chain head's
-// generation: the recency index keeps only a disk's newest generation, and
-// qcow layers are deltas, so tagging parents with their own generation would
-// evict content the chain still needs while stale chains age out.
+// generation; tagging parents with their own generation would let the recency
+// index evict deltas the chain still needs.
 func TestQcowChainContentReportsEveryLayerAtHeadGeneration(t *testing.T) {
 	events := &fakeEventRepo{}
 	reporter := newTestReporter(events)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -114,7 +114,7 @@ type Worker struct {
 	eventRepo               repo.EventRepository
 	storageManager          *WorkspaceStorageManager
 	diskManager             *disk.Manager
-	qcowChainDepths         sync.Map
+	qcowChains              sync.Map // live published qcow chain (rows + manifests) per volume key
 	userDataStorage         storage.Storage
 	persistent              bool
 	routeTransport          string


### PR DESCRIPTION
## Summary
- Disk snapshot chunks now reconcile onto **every host in the locality** (like checkpoints) instead of sharding by ring owner. Workers read chunks local-first (`PreferLocalCacheHost`), so a post-reconcile start reassembles the chain from local disk on any host instead of pulling GBs over LAN (~30s → ~5-10s for a 4.6GB root, host-independent).
- Chunk fetch parallelism during restore is now a single budget (32) shared across all layers of a chain, so a chain dominated by one large layer gets full throughput and a deep chain doesn't multiply concurrency.

Eviction is unchanged: recent-stub protection is already ownership-agnostic, and MRU generation pruning plus the recent-stub TTL bound how much replicates per host (same policy checkpoints already have).

## Test plan
- [x] New `TestReconcileDiskSnapshotChunksMaterializeOnNonOwnerHost`: chunk owned by a peer materializes locally; owner-sharded `volume` content stays gated
- [x] New `TestFetchLayerSharesChunkGateAcrossLayers`
- [x] `pkg/worker` reconciler suite and `pkg/disk` suite pass
- [ ] Prod: snapshot a large machine, wait for reconcile, force a cross-host start and confirm local-disk-speed restore

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replicates disk snapshot chunks to every host in a locality and shares a single chunk-fetch budget across a restore chain; also reports every layer of a live qcow chain at the chain head generation so parents stay protected and replicated. Previously chunks reconciled only to the ring owner, layers fetched with per-layer concurrency, and qcow parents used their own generation; now chunks reconcile to all hosts, fetches share one budget (32), and all layers re-report at the head generation until superseded.

- `pkg/worker`: `reconcileOnEveryHost` replicates `CacheContentKindDiskSnapshot` on every host; owner-sharded kinds (e.g., `CacheContentKindVolume`) remain gated. Qcow reporting now uses `reportQcowChainContent` with `qcowChains` (rows + manifests) to tag all layers at the head generation; parentless publishes reset the chain, deltas append. Folded the chain-generation override into `reportDurableDiskSnapshotContent`.
- `pkg/disk`: introduce a shared `chunkGate`; `fetchLayer` takes the gate and `materializeChain` shares one gate across all layers. Replace per-layer fetch concurrency with `chunkFetchConcurrency = 32`; keep `layerFetchConcurrency = 4`, capping restore memory to ~128 MiB.
- Tests: added coverage for non-owner chunk materialization, shared chunk gate across layers, and qcow chain items reported at head generation; existing suites pass.

<sup>Written for commit 1f9fb0f9a68d088f8a75608f5e5307b17a074d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

