### PR TITLE
Compact qcow backing chains in place with a live block-commit

### DIFF
--- a/pkg/disk/layer.go
+++ b/pkg/disk/layer.go
@@ -20,12 +20,10 @@ import (
 // restore recreates them by truncating the destination file to size.
 const (
 	// LayerChunkSize is the average chunk size. Boundaries are content
-	// defined (gear hash), not fixed: an insertion or shift in the qcow2
-	// file re-aligns boundaries within roughly a minimum chunk, so unchanged
-	// disk content keeps its chunk hashes no matter where a flatten
-	// relocated it, and publish dedup holds between full-image generations.
-	// (Fixed boundaries measured 0% dedup between consecutive flattens of a
-	// lightly changed ext4 disk; content-defined measured ~95%.)
+	// defined (gear hash), so unchanged content keeps its chunk hashes no
+	// matter where a flatten relocated it in the file, which is what lets
+	// publishes dedup against prior generations: fixed boundaries measured
+	// 0% dedup between consecutive flattens, content-defined ~95%.
 	LayerChunkSize = 4 << 20 // 4 MiB
 	chunkMinSize   = 1 << 20
 	chunkMeanMask  = LayerChunkSize - 1
@@ -37,18 +35,16 @@ const (
 	uploadConcurrency = 16
 	scanConcurrency   = 8
 	// chunkFetchConcurrency bounds in-flight chunk fetches across every layer
-	// of a chain. It is shared rather than per-layer so a chain dominated by
-	// one large layer gets the same parallelism as a deep one, and a deep
-	// chain does not multiply into hundreds of concurrent requests. Each
-	// in-flight chunk holds up to a chunkMaxSize buffer, so this also caps
-	// restore memory (32 * 8 MiB = 256 MiB worst case).
+	// of a chain, shared so one large layer gets full parallelism and a deep
+	// chain does not multiply into hundreds of requests. Each in-flight chunk
+	// buffers up to chunkMaxSize, capping restore memory (32 * 8 MiB = 256 MiB).
 	chunkFetchConcurrency = 32
 	layerFetchConcurrency = 4
 )
 
-// gearTable drives the rolling hash used for chunk boundaries. It is part of
-// the chunking contract: changing it re-cuts every future publish, which
-// costs one full re-upload per disk before dedup recovers.
+// gearTable drives the boundary rolling hash. Changing it (or the size
+// constants) re-cuts every future publish, costing each disk one full
+// re-upload before dedup recovers.
 var gearTable = func() [256]uint64 {
 	var table [256]uint64
 	seed := uint64(0x9E3779B97F4A7C15)
@@ -73,9 +69,8 @@ type ChunkSource interface {
 
 // ScanLayer splits a sealed layer file into content-addressed chunks, skipping
 // holes and all-zero regions. Object keys are assigned by keyForDigest.
-// Data extents are enumerated and split at content-defined boundaries first,
-// then read and hashed in parallel: this pass dominates publish latency on
-// large flattened images.
+// Boundaries are found in one sequential pass, then chunks are read and
+// hashed in parallel: this pass dominates publish latency on large images.
 func ScanLayer(path string, keyForDigest func(digest string) string) (*types.DiskSnapshotFile, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -136,15 +131,12 @@ func ScanLayer(path string, keyForDigest func(digest string) string) (*types.Dis
 }
 
 // chunkSpan is one prospective chunk: a piece of a data extent.
-type chunkSpan struct {
-	offset int64
-	size   int64
-}
+type chunkSpan struct{ offset, size int64 }
 
 // chunkSpans enumerates the file's data extents (SEEK_DATA/SEEK_HOLE; the
-// whole file counts as data on filesystems without support) and splits each
-// at content-defined boundaries. Extents reset the boundary state, so sparse
-// layouts chunk identically regardless of surrounding holes.
+// whole file on filesystems without support) and splits each at content
+// defined boundaries. Extents reset the boundary state, so sparse layouts
+// chunk identically regardless of surrounding holes.
 func chunkSpans(file *os.File, fileSize int64) ([]chunkSpan, error) {
 	var spans []chunkSpan
 	buffer := make([]byte, LayerChunkSize)

--- a/pkg/disk/layer.go
+++ b/pkg/disk/layer.go
@@ -19,21 +19,45 @@ import (
 // addressed chunks. Zero regions (holes and explicit zeros) are omitted; a
 // restore recreates them by truncating the destination file to size.
 const (
+	// LayerChunkSize is the average chunk size. Boundaries are content
+	// defined (gear hash), not fixed: an insertion or shift in the qcow2
+	// file re-aligns boundaries within roughly a minimum chunk, so unchanged
+	// disk content keeps its chunk hashes no matter where a flatten
+	// relocated it, and publish dedup holds between full-image generations.
+	// (Fixed boundaries measured 0% dedup between consecutive flattens of a
+	// lightly changed ext4 disk; content-defined measured ~95%.)
 	LayerChunkSize = 4 << 20 // 4 MiB
+	chunkMinSize   = 1 << 20
+	chunkMeanMask  = LayerChunkSize - 1
+	chunkMaxSize   = 8 << 20
 
 	// LayerFileName is the single logical file inside a qcow.v1 manifest.
 	LayerFileName = "layer.qcow2"
 
 	uploadConcurrency = 16
+	scanConcurrency   = 8
 	// chunkFetchConcurrency bounds in-flight chunk fetches across every layer
 	// of a chain. It is shared rather than per-layer so a chain dominated by
 	// one large layer gets the same parallelism as a deep one, and a deep
 	// chain does not multiply into hundreds of concurrent requests. Each
-	// in-flight chunk holds a LayerChunkSize buffer, so this also caps
-	// restore memory (32 * 4 MiB = 128 MiB).
+	// in-flight chunk holds up to a chunkMaxSize buffer, so this also caps
+	// restore memory (32 * 8 MiB = 256 MiB worst case).
 	chunkFetchConcurrency = 32
 	layerFetchConcurrency = 4
 )
+
+// gearTable drives the rolling hash used for chunk boundaries. It is part of
+// the chunking contract: changing it re-cuts every future publish, which
+// costs one full re-upload per disk before dedup recovers.
+var gearTable = func() [256]uint64 {
+	var table [256]uint64
+	seed := uint64(0x9E3779B97F4A7C15)
+	for i := range table {
+		seed = seed*6364136223846793005 + 1442695040888963407
+		table[i] = seed
+	}
+	return table
+}()
 
 // ChunkSink stores a chunk body under a content-addressed object key.
 type ChunkSink interface {
@@ -49,6 +73,9 @@ type ChunkSource interface {
 
 // ScanLayer splits a sealed layer file into content-addressed chunks, skipping
 // holes and all-zero regions. Object keys are assigned by keyForDigest.
+// Data extents are enumerated and split at content-defined boundaries first,
+// then read and hashed in parallel: this pass dominates publish latency on
+// large flattened images.
 func ScanLayer(path string, keyForDigest func(digest string) string) (*types.DiskSnapshotFile, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -67,44 +94,121 @@ func ScanLayer(path string, keyForDigest func(digest string) string) (*types.Dis
 		Mode:      0o600,
 		SizeBytes: fileSize,
 	}
+
+	spans, err := chunkSpans(file, fileSize)
+	if err != nil {
+		return nil, err
+	}
+	chunks := make([]*types.DiskSnapshotChunk, len(spans))
+	group := errgroup.Group{}
+	group.SetLimit(scanConcurrency)
+	for i, span := range spans {
+		group.Go(func() error {
+			data := make([]byte, span.size)
+			if _, err := file.ReadAt(data, span.offset); err != nil && err != io.EOF {
+				return fmt.Errorf("read layer chunk at %d: %w", span.offset, err)
+			}
+			if isZero(data) {
+				return nil
+			}
+			digestBytes := sha256.Sum256(data)
+			digest := "sha256:" + hex.EncodeToString(digestBytes[:])
+			chunks[i] = &types.DiskSnapshotChunk{
+				OffsetBytes: span.offset,
+				SizeBytes:   span.size,
+				ObjectKey:   keyForDigest(digest),
+				Digest:      digest,
+			}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	for _, chunk := range chunks {
+		if chunk == nil {
+			continue
+		}
+		chunk.Index = int64(len(layer.Chunks))
+		layer.Chunks = append(layer.Chunks, *chunk)
+	}
+	return layer, nil
+}
+
+// chunkSpan is one prospective chunk: a piece of a data extent.
+type chunkSpan struct {
+	offset int64
+	size   int64
+}
+
+// chunkSpans enumerates the file's data extents (SEEK_DATA/SEEK_HOLE; the
+// whole file counts as data on filesystems without support) and splits each
+// at content-defined boundaries. Extents reset the boundary state, so sparse
+// layouts chunk identically regardless of surrounding holes.
+func chunkSpans(file *os.File, fileSize int64) ([]chunkSpan, error) {
+	var spans []chunkSpan
 	buffer := make([]byte, LayerChunkSize)
-	index := int64(0)
-	for offset := int64(0); offset < fileSize; offset += LayerChunkSize {
-		dataOffset, err := unix.Seek(int(file.Fd()), offset, unix.SEEK_DATA)
+	for offset := int64(0); offset < fileSize; {
+		dataStart, err := unix.Seek(int(file.Fd()), offset, unix.SEEK_DATA)
 		if err != nil {
 			if err == unix.ENXIO {
 				break // Nothing but holes remain.
 			}
-			// Filesystem without SEEK_DATA support: treat everything as data.
-			dataOffset = offset
+			// No SEEK_DATA support: treat the rest of the file as one extent.
+			extent, err := splitExtent(file, buffer, offset, fileSize)
+			if err != nil {
+				return nil, err
+			}
+			return append(spans, extent...), nil
 		}
-		if dataOffset >= offset+LayerChunkSize {
-			// Skip directly to the chunk containing the next data extent.
-			offset = (dataOffset / LayerChunkSize) * LayerChunkSize
-			offset -= LayerChunkSize // Compensate the loop increment.
-			continue
+		dataEnd, err := unix.Seek(int(file.Fd()), dataStart, unix.SEEK_HOLE)
+		if err != nil {
+			dataEnd = fileSize
 		}
-
-		chunkSize := min(LayerChunkSize, fileSize-offset)
-		chunk := buffer[:chunkSize]
-		if _, err := file.ReadAt(chunk, offset); err != nil && err != io.EOF {
-			return nil, fmt.Errorf("read layer chunk at %d: %w", offset, err)
+		extent, err := splitExtent(file, buffer, dataStart, min(dataEnd, fileSize))
+		if err != nil {
+			return nil, err
 		}
-		if isZero(chunk) {
-			continue
-		}
-		digestBytes := sha256.Sum256(chunk)
-		digest := "sha256:" + hex.EncodeToString(digestBytes[:])
-		layer.Chunks = append(layer.Chunks, types.DiskSnapshotChunk{
-			Index:       index,
-			OffsetBytes: offset,
-			SizeBytes:   chunkSize,
-			ObjectKey:   keyForDigest(digest),
-			Digest:      digest,
-		})
-		index++
+		spans = append(spans, extent...)
+		offset = dataEnd
 	}
-	return layer, nil
+	return spans, nil
+}
+
+// splitExtent cuts one data extent at gear-hash boundaries: the hash rolls
+// byte-wise (skipping the guaranteed minimum) and a chunk ends where the low
+// bits clear, giving LayerChunkSize chunks on average within [min, max].
+func splitExtent(file *os.File, buffer []byte, start, end int64) ([]chunkSpan, error) {
+	var spans []chunkSpan
+	for chunkStart := start; chunkStart < end; {
+		if end-chunkStart <= chunkMinSize {
+			spans = append(spans, chunkSpan{offset: chunkStart, size: end - chunkStart})
+			break
+		}
+		windowEnd := min(end, chunkStart+chunkMaxSize)
+		cut := windowEnd
+		hash := uint64(0)
+		for pos := chunkStart + chunkMinSize; pos < windowEnd && cut == windowEnd; {
+			read, err := file.ReadAt(buffer[:min(int64(len(buffer)), windowEnd-pos)], pos)
+			if err != nil && err != io.EOF {
+				return nil, fmt.Errorf("scan layer at %d: %w", pos, err)
+			}
+			if read == 0 {
+				break
+			}
+			for i := range read {
+				hash = hash<<1 + gearTable[buffer[i]]
+				if hash&chunkMeanMask == 0 {
+					cut = pos + int64(i) + 1
+					break
+				}
+			}
+			pos += int64(read)
+		}
+		spans = append(spans, chunkSpan{offset: chunkStart, size: cut - chunkStart})
+		chunkStart = cut
+	}
+	return spans, nil
 }
 
 // UploadLayer ships every chunk of a scanned layer to the sink.

--- a/pkg/disk/layer_test.go
+++ b/pkg/disk/layer_test.go
@@ -80,9 +80,16 @@ func TestLayerScanUploadFetchRoundTrip(t *testing.T) {
 	if len(layer.Chunks) == 0 {
 		t.Fatal("expected chunks")
 	}
-	for _, chunk := range layer.Chunks {
+	for i, chunk := range layer.Chunks {
 		if chunk.OffsetBytes >= 20*LayerChunkSize && chunk.OffsetBytes < 21*LayerChunkSize {
 			t.Fatalf("all-zero chunk at %d was not skipped", chunk.OffsetBytes)
+		}
+		// The parallel scan must keep chunks offset-ordered and densely indexed.
+		if chunk.Index != int64(i) {
+			t.Fatalf("chunk %d has index %d", i, chunk.Index)
+		}
+		if i > 0 && chunk.OffsetBytes <= layer.Chunks[i-1].OffsetBytes {
+			t.Fatalf("chunks out of order at %d", i)
 		}
 	}
 
@@ -109,6 +116,59 @@ func TestLayerScanUploadFetchRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(source, restored) {
 		t.Fatal("restored layer differs from source")
+	}
+}
+
+// Content-defined boundaries must survive shifts: a flatten relocates
+// unchanged disk content within the qcow2 file, and publish dedup relies on
+// those bytes keeping their chunk hashes.
+func TestScanLayerChunksSurviveContentShift(t *testing.T) {
+	dir := t.TempDir()
+	base := make([]byte, 64<<20)
+	rand.Read(base)
+	pathA := filepath.Join(dir, "a.qcow2")
+	if err := os.WriteFile(pathA, base, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert 64 KiB at 8 MiB, shifting everything after it.
+	inserted := make([]byte, 64<<10)
+	rand.Read(inserted)
+	shifted := append(append(append([]byte{}, base[:8<<20]...), inserted...), base[8<<20:]...)
+	pathB := filepath.Join(dir, "b.qcow2")
+	if err := os.WriteFile(pathB, shifted, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	layerA, err := ScanLayer(pathA, chunkKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerB, err := ScanLayer(pathB, chunkKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digestsA := map[string]bool{}
+	for _, chunk := range layerA.Chunks {
+		digestsA[chunk.Digest] = true
+	}
+	var sharedBytes, totalBytes int64
+	for _, chunk := range layerB.Chunks {
+		totalBytes += chunk.SizeBytes
+		if digestsA[chunk.Digest] {
+			sharedBytes += chunk.SizeBytes
+		}
+	}
+	if sharedBytes < totalBytes*3/4 {
+		t.Fatalf("only %d of %d bytes dedup after a 64KiB shift", sharedBytes, totalBytes)
+	}
+
+	// Chunk sizes must respect the configured bounds.
+	for _, chunk := range layerB.Chunks {
+		if chunk.SizeBytes > chunkMaxSize {
+			t.Fatalf("chunk of %d bytes exceeds the max", chunk.SizeBytes)
+		}
 	}
 }
 

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -25,9 +25,8 @@ const (
 	// DefaultRoot is where volumes, layers, and runtime state live on a worker.
 	DefaultRoot = "/var/lib/beta9/qcow-disks"
 
-	// DefaultMaxChainDepth bounds the local backing chain. Deeper chains slow
-	// reads; when the cap is hit the container must be restarted, which
-	// reattaches from the (flattened) published chain.
+	// DefaultMaxChainDepth is a backstop on the local backing chain. Compact
+	// keeps chains shallow; the cap only trips if compaction keeps failing.
 	DefaultMaxChainDepth = 64
 
 	// DefaultFlattenDepth is the published chain length at which the adapter

--- a/pkg/disk/qmp.go
+++ b/pkg/disk/qmp.go
@@ -139,10 +139,9 @@ func (c *qmpClient) pivot(ctx context.Context, nodeName, overlayNode string) err
 }
 
 // commitChain runs an intermediate block-commit merging every layer between
-// base and top (inclusive) down into base, identified by filename within
-// device's backing chain, and waits for the job to conclude. The head keeps
-// serving I/O throughout; on completion the daemon drops the merged layers
-// from the graph and re-parents the layer above top onto base.
+// base and top (inclusive, identified by filename) down into base, and polls
+// the job to its conclusion. The head keeps serving I/O; on completion the
+// daemon drops the merged layers and re-parents the layer above top onto base.
 func (c *qmpClient) commitChain(ctx context.Context, device, topPath, basePath string) error {
 	jobID := fmt.Sprintf("commit-%d", time.Now().UnixNano())
 	if _, err := c.execute(ctx, types.QMPCommandBlockCommit, map[string]any{
@@ -150,46 +149,41 @@ func (c *qmpClient) commitChain(ctx context.Context, device, topPath, basePath s
 		"device":       device,
 		"top":          topPath,
 		"base":         basePath,
-		"auto-dismiss": false,
+		"auto-dismiss": false, // hold the concluded job so its error is readable
 	}); err != nil {
 		return err
 	}
-	return c.waitForJob(ctx, jobID)
-}
 
-// waitForJob polls until the job concludes (commit jobs finalize on their
-// own; with auto-dismiss off, concluded is their terminal state), dismisses
-// it, and returns its error.
-func (c *qmpClient) waitForJob(ctx context.Context, jobID string) error {
+	type jobInfo struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
 	for {
 		raw, err := c.execute(ctx, types.QMPCommandQueryJobs, nil)
 		if err != nil {
 			return err
 		}
-		var jobs []struct {
-			ID     string `json:"id"`
-			Status string `json:"status"`
-			Error  string `json:"error"`
-		}
+		var jobs []jobInfo
 		if err := json.Unmarshal(raw, &jobs); err != nil {
 			return err
 		}
-		var status string
-		for _, job := range jobs {
-			if job.ID == jobID {
-				status = job.Status
-				if status == "concluded" {
-					_, _ = c.execute(ctx, types.QMPCommandJobDismiss, map[string]any{"id": jobID})
-					if job.Error != "" {
-						return fmt.Errorf("job %s: %s", jobID, job.Error)
-					}
-					return nil
-				}
+		var job *jobInfo
+		for i := range jobs {
+			if jobs[i].ID == jobID {
+				job = &jobs[i]
 				break
 			}
 		}
-		if status == "" {
-			return fmt.Errorf("job %s disappeared before concluding", jobID)
+		if job == nil {
+			return fmt.Errorf("commit job %s disappeared before concluding", jobID)
+		}
+		if job.Status == "concluded" {
+			_, _ = c.execute(ctx, types.QMPCommandJobDismiss, map[string]any{"id": jobID})
+			if job.Error != "" {
+				return fmt.Errorf("commit job: %s", job.Error)
+			}
+			return nil
 		}
 		select {
 		case <-ctx.Done():

--- a/pkg/disk/qmp.go
+++ b/pkg/disk/qmp.go
@@ -11,8 +11,8 @@ import (
 )
 
 // qmpClient is a minimal QMP client for qemu-storage-daemon. It supports the
-// handshake plus the three commands the disk engine needs: transactional
-// snapshots, graph queries (recovery), and quit.
+// handshake plus the commands the disk engine needs: transactional snapshots,
+// commit jobs (compaction), graph queries (recovery), and quit.
 type qmpClient struct {
 	conn net.Conn
 	dec  *json.Decoder
@@ -138,12 +138,80 @@ func (c *qmpClient) pivot(ctx context.Context, nodeName, overlayNode string) err
 	return err
 }
 
+// commitChain runs an intermediate block-commit merging every layer between
+// base and top (inclusive) down into base, identified by filename within
+// device's backing chain, and waits for the job to conclude. The head keeps
+// serving I/O throughout; on completion the daemon drops the merged layers
+// from the graph and re-parents the layer above top onto base.
+func (c *qmpClient) commitChain(ctx context.Context, device, topPath, basePath string) error {
+	jobID := fmt.Sprintf("commit-%d", time.Now().UnixNano())
+	if _, err := c.execute(ctx, types.QMPCommandBlockCommit, map[string]any{
+		"job-id":       jobID,
+		"device":       device,
+		"top":          topPath,
+		"base":         basePath,
+		"auto-dismiss": false,
+	}); err != nil {
+		return err
+	}
+	return c.waitForJob(ctx, jobID)
+}
+
+// waitForJob polls until the job concludes (commit jobs finalize on their
+// own; with auto-dismiss off, concluded is their terminal state), dismisses
+// it, and returns its error.
+func (c *qmpClient) waitForJob(ctx context.Context, jobID string) error {
+	for {
+		raw, err := c.execute(ctx, types.QMPCommandQueryJobs, nil)
+		if err != nil {
+			return err
+		}
+		var jobs []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+			Error  string `json:"error"`
+		}
+		if err := json.Unmarshal(raw, &jobs); err != nil {
+			return err
+		}
+		var status string
+		for _, job := range jobs {
+			if job.ID == jobID {
+				status = job.Status
+				if status == "concluded" {
+					_, _ = c.execute(ctx, types.QMPCommandJobDismiss, map[string]any{"id": jobID})
+					if job.Error != "" {
+						return fmt.Errorf("job %s: %s", jobID, job.Error)
+					}
+					return nil
+				}
+				break
+			}
+		}
+		if status == "" {
+			return fmt.Errorf("job %s disappeared before concluding", jobID)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
 // qmpNode is one entry of query-named-block-nodes. BackingFileDepth counts
 // runtime backing links: an overlay added with backing=null reports zero
 // until a pivot wires it, which is what recovery uses to tell a committed
 // pivot from a dangling add.
 type qmpNode struct {
-	BackingFileDepth int `json:"backing_file_depth"`
+	BackingFileDepth int      `json:"backing_file_depth"`
+	Image            qmpImage `json:"image"`
+}
+
+// qmpImage mirrors the recursive ImageInfo the daemon reports per node.
+type qmpImage struct {
+	Filename     string    `json:"filename"`
+	BackingImage *qmpImage `json:"backing-image"`
 }
 
 // namedBlockNodes returns all named nodes in the daemon's graph, used during
@@ -165,6 +233,24 @@ func (c *qmpClient) namedBlockNodes(ctx context.Context) (map[string]qmpNode, er
 		result[node.NodeName] = node.qmpNode
 	}
 	return result, nil
+}
+
+// backingFilenames returns the image filenames in nodeName's live backing
+// chain, the node's own file included.
+func (c *qmpClient) backingFilenames(ctx context.Context, nodeName string) (map[string]bool, error) {
+	nodes, err := c.namedBlockNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	node, ok := nodes[nodeName]
+	if !ok {
+		return nil, fmt.Errorf("node %s not found in block graph", nodeName)
+	}
+	filenames := make(map[string]bool)
+	for image := &node.Image; image != nil; image = image.BackingImage {
+		filenames[image.Filename] = true
+	}
+	return filenames, nil
 }
 
 // writtenBytes reports whether anything was written to a node since the

--- a/pkg/disk/qsd.go
+++ b/pkg/disk/qsd.go
@@ -14,13 +14,13 @@ import (
 )
 
 // Node names inside each daemon's block graph. One daemon serves exactly one
-// volume, so the names are constant. The export points at a raw wrapper node:
-// pivots re-parent the qcow2 node underneath it, which keeps the NBD export
-// stable across snapshots.
+// volume. The NBD export attaches directly to the active qcow2 node: a pivot
+// (blockdev-snapshot) re-parents every user of the old head onto the overlay,
+// so the export follows each new head automatically, and the head stays a
+// root node, which block-commit requires for live chain compaction.
 const (
 	qsdFileNodePrefix = "file-"
 	qsdFmtNodePrefix  = "fmt-"
-	qsdRootNode       = "root"
 	qsdExportName     = "vol"
 
 	qsdStartTimeout = 15 * time.Second
@@ -64,9 +64,6 @@ func (m *Manager) startQSD(ctx context.Context, runtimeDir, headPath, fmtNode st
 	fmtBlockdev, _ := json.Marshal(map[string]any{
 		"driver": "qcow2", "file": qsdFileNodePrefix + fmtNode, "node-name": fmtNode, "read-only": readOnly,
 	})
-	rootBlockdev, _ := json.Marshal(map[string]any{
-		"driver": "raw", "file": fmtNode, "node-name": qsdRootNode, "read-only": readOnly,
-	})
 
 	args := []string{
 		"--daemonize",
@@ -75,9 +72,8 @@ func (m *Manager) startQSD(ctx context.Context, runtimeDir, headPath, fmtNode st
 		"--monitor", "chardev=qmp0",
 		"--blockdev", string(fileBlockdev),
 		"--blockdev", string(fmtBlockdev),
-		"--blockdev", string(rootBlockdev),
 		"--nbd-server", fmt.Sprintf("addr.type=unix,addr.path=%s", nbdSocket),
-		"--export", fmt.Sprintf("type=nbd,id=%s,node-name=%s,name=%s,writable=%s", qsdExportName, qsdRootNode, qsdExportName, boolOnOff(!readOnly)),
+		"--export", fmt.Sprintf("type=nbd,id=%s,node-name=%s,name=%s,writable=%s", qsdExportName, fmtNode, qsdExportName, boolOnOff(!readOnly)),
 	}
 
 	if output, err := exec.CommandContext(ctx, m.binaries.QSD, args...).CombinedOutput(); err != nil {

--- a/pkg/disk/qsd.go
+++ b/pkg/disk/qsd.go
@@ -14,10 +14,9 @@ import (
 )
 
 // Node names inside each daemon's block graph. One daemon serves exactly one
-// volume. The NBD export attaches directly to the active qcow2 node: a pivot
-// (blockdev-snapshot) re-parents every user of the old head onto the overlay,
-// so the export follows each new head automatically, and the head stays a
-// root node, which block-commit requires for live chain compaction.
+// volume. The NBD export attaches directly to the active qcow2 node: pivots
+// re-parent it onto each new overlay, and the head stays a root node, which
+// block-commit (live compaction) requires.
 const (
 	qsdFileNodePrefix = "file-"
 	qsdFmtNodePrefix  = "fmt-"

--- a/pkg/disk/volume.go
+++ b/pkg/disk/volume.go
@@ -448,10 +448,9 @@ func (v *Volume) Flatten(ctx context.Context, sealedPath, destPath string) error
 }
 
 // Compact folds every published layer into the base image with a live
-// intermediate block-commit, keeping the local backing chain shallow no
-// matter how many times a long-running volume is sealed. The daemon keeps
-// serving I/O throughout. Pending layers are deltas the publisher still needs
-// byte-for-byte, so compaction only runs once the whole chain is published.
+// intermediate block-commit; the daemon keeps serving I/O. Pending layers are
+// deltas the publisher still needs byte-for-byte, so compaction waits until
+// the whole chain is published.
 func (v *Volume) Compact(ctx context.Context) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
@@ -467,9 +466,8 @@ func (v *Volume) Compact(ctx context.Context) error {
 	}
 	defer client.Close()
 
-	// The live graph decides what still needs merging: a crash between a
-	// completed commit and the state save below leaves the files merged while
-	// the state still lists the full chain.
+	// The live graph decides what needs merging: a crash after a completed
+	// commit but before the state save leaves the files already merged.
 	live, err := client.backingFilenames(ctx, v.fmtNode)
 	if err != nil {
 		return err
@@ -482,10 +480,9 @@ func (v *Volume) Compact(ctx context.Context) error {
 		return fmt.Errorf("compact volume %s: neither %s nor %s is in the live chain", state.Key, top.Path, base.Path)
 	}
 
-	// The base file now holds the newest published generation's full content
-	// and the merged files are out of the graph. A partially committed base
-	// is invisible through the intact overlays, so the file deletes only
-	// happen after the collapsed state is durable.
+	// The base file now holds the newest published generation in full. A
+	// partially committed base stays invisible behind the intact overlays, so
+	// merged files are deleted only after the collapsed state is durable.
 	merged := state.Chain[1:]
 	state.Chain = []stateLayer{{SnapshotID: top.SnapshotID, Path: base.Path}}
 	if err := saveVolumeState(v.dir, state); err != nil {

--- a/pkg/disk/volume.go
+++ b/pkg/disk/volume.go
@@ -296,7 +296,7 @@ func (v *Volume) Seal(ctx context.Context, force bool) ([]SealedLayer, bool, err
 	}
 
 	if state.depth() >= v.manager.maxChainDepth {
-		return nil, false, fmt.Errorf("volume %s reached the maximum chain depth of %d; restart the container to compact", state.Key, v.manager.maxChainDepth)
+		return nil, false, fmt.Errorf("volume %s reached the maximum chain depth of %d; compaction is failing or falling behind", state.Key, v.manager.maxChainDepth)
 	}
 
 	// Pre-create the empty overlay, then record the intent before asking the
@@ -445,6 +445,57 @@ func (v *Volume) MarkPublished(sealedPath, snapshotID string) error {
 // parentless image at destPath, used to bound published chain depth.
 func (v *Volume) Flatten(ctx context.Context, sealedPath, destPath string) error {
 	return v.manager.flattenQcow(ctx, sealedPath, destPath)
+}
+
+// Compact folds every published layer into the base image with a live
+// intermediate block-commit, keeping the local backing chain shallow no
+// matter how many times a long-running volume is sealed. The daemon keeps
+// serving I/O throughout. Pending layers are deltas the publisher still needs
+// byte-for-byte, so compaction only runs once the whole chain is published.
+func (v *Volume) Compact(ctx context.Context) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	state := v.state
+	if !state.Attached || state.ReadOnly || len(state.Pending) > 0 || len(state.Chain) < 2 {
+		return nil
+	}
+	base, top := state.Chain[0], state.Chain[len(state.Chain)-1]
+
+	client, err := dialQMP(ctx, state.QMPSocket)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// The live graph decides what still needs merging: a crash between a
+	// completed commit and the state save below leaves the files merged while
+	// the state still lists the full chain.
+	live, err := client.backingFilenames(ctx, v.fmtNode)
+	if err != nil {
+		return err
+	}
+	if live[top.Path] {
+		if err := client.commitChain(ctx, v.fmtNode, top.Path, base.Path); err != nil {
+			return fmt.Errorf("compact volume %s: %w", state.Key, err)
+		}
+	} else if !live[base.Path] {
+		return fmt.Errorf("compact volume %s: neither %s nor %s is in the live chain", state.Key, top.Path, base.Path)
+	}
+
+	// The base file now holds the newest published generation's full content
+	// and the merged files are out of the graph. A partially committed base
+	// is invisible through the intact overlays, so the file deletes only
+	// happen after the collapsed state is durable.
+	merged := state.Chain[1:]
+	state.Chain = []stateLayer{{SnapshotID: top.SnapshotID, Path: base.Path}}
+	if err := saveVolumeState(v.dir, state); err != nil {
+		return err
+	}
+	for _, layer := range merged {
+		os.Remove(layer.Path)
+	}
+	log.Info().Str("volume", state.Key).Int("layers", len(merged)+1).Msg("compacted qcow backing chain")
+	return nil
 }
 
 // detach unmounts, disconnects, and stops the daemon. Layer files and state

--- a/pkg/disk/volume_test.go
+++ b/pkg/disk/volume_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -21,6 +22,19 @@ type fakeQMP struct {
 	failPivots atomic.Bool
 	nodes      atomic.Value // []string
 	pivots     atomic.Int64
+
+	mu          sync.Mutex
+	images      map[string][]string // node -> backing chain filenames, head first
+	failCommits bool
+	commits     []fakeCommit
+	job         *fakeJob
+}
+
+type fakeCommit struct{ device, top, base string }
+
+type fakeJob struct {
+	id  string
+	err string
 }
 
 func newFakeQMP(t *testing.T, socketPath string) *fakeQMP {
@@ -29,11 +43,17 @@ func newFakeQMP(t *testing.T, socketPath string) *fakeQMP {
 	if err != nil {
 		t.Fatal(err)
 	}
-	server := &fakeQMP{listener: listener}
+	server := &fakeQMP{listener: listener, images: map[string][]string{}}
 	server.nodes.Store([]string{})
 	go server.serve()
 	t.Cleanup(func() { listener.Close() })
 	return server
+}
+
+func (f *fakeQMP) setImages(images map[string][]string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.images = images
 }
 
 func (f *fakeQMP) serve() {
@@ -67,11 +87,79 @@ func (f *fakeQMP) handle(conn net.Conn) {
 			// Listed nodes are reported as wired into a backing chain, which
 			// is what pivotCommitted uses to recognize a committed pivot.
 			nodes := f.nodes.Load().([]string)
-			entries := make([]string, 0, len(nodes))
+			entries := make([]map[string]any, 0, len(nodes))
+			f.mu.Lock()
 			for _, node := range nodes {
-				entries = append(entries, fmt.Sprintf(`{"node-name":%q,"file":"","backing_file_depth":1}`, node))
+				entry := map[string]any{"node-name": node, "file": "", "backing_file_depth": 1}
+				chain := f.images[node]
+				var image map[string]any
+				for i := len(chain) - 1; i >= 0; i-- {
+					next := map[string]any{"filename": chain[i]}
+					if image != nil {
+						next["backing-image"] = image
+					}
+					image = next
+				}
+				if image != nil {
+					entry["image"] = image
+				}
+				entries = append(entries, entry)
 			}
-			fmt.Fprintf(conn, `{"return":[%s]}`, strings.Join(entries, ","))
+			f.mu.Unlock()
+			payload, _ := json.Marshal(map[string]any{"return": entries})
+			conn.Write(payload)
+		case types.QMPCommandBlockCommit:
+			var args struct {
+				JobID  string `json:"job-id"`
+				Device string `json:"device"`
+				Top    string `json:"top"`
+				Base   string `json:"base"`
+			}
+			_ = json.Unmarshal(request.Arguments, &args)
+			f.mu.Lock()
+			f.commits = append(f.commits, fakeCommit{device: args.Device, top: args.Top, base: args.Base})
+			f.job = &fakeJob{id: args.JobID}
+			if f.failCommits {
+				f.job.err = "injected commit failure"
+			} else {
+				// Merge: drop every filename from top down to (but excluding)
+				// base from each node's chain.
+				for node, chain := range f.images {
+					merged := make([]string, 0, len(chain))
+					drop := false
+					for _, filename := range chain {
+						if filename == args.Base {
+							drop = false
+						}
+						if filename == args.Top {
+							drop = true
+						}
+						if !drop {
+							merged = append(merged, filename)
+						}
+					}
+					f.images[node] = merged
+				}
+			}
+			f.mu.Unlock()
+			fmt.Fprintf(conn, `{"return":{}}`)
+		case types.QMPCommandQueryJobs:
+			f.mu.Lock()
+			job := f.job
+			f.mu.Unlock()
+			switch {
+			case job == nil:
+				fmt.Fprintf(conn, `{"return":[]}`)
+			case job.err != "":
+				fmt.Fprintf(conn, `{"return":[{"id":%q,"status":"concluded","error":%q}]}`, job.id, job.err)
+			default:
+				fmt.Fprintf(conn, `{"return":[{"id":%q,"status":"concluded"}]}`, job.id)
+			}
+		case types.QMPCommandJobDismiss:
+			f.mu.Lock()
+			f.job = nil
+			f.mu.Unlock()
+			fmt.Fprintf(conn, `{"return":{}}`)
 		case types.QMPCommandTransaction:
 			if f.failPivots.Load() {
 				fmt.Fprintf(conn, `{"error":{"class":"GenericError","desc":"injected pivot failure"}}`)
@@ -275,6 +363,137 @@ func TestReusableState(t *testing.T) {
 	for _, tc := range cases {
 		if got := reusableState(tc.state, tc.spec); got != tc.want {
 			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// newCompactVolume returns a volume with three published layers and a live
+// graph reporting the full chain under the head.
+func newCompactVolume(t *testing.T) (*Volume, *fakeQMP, []string) {
+	t.Helper()
+	volume, server := newTestVolume(t)
+	layersDir := filepath.Join(volume.dir, layersSubdir)
+	paths := make([]string, 3)
+	for i, name := range []string{"a", "b", "c"} {
+		paths[i] = filepath.Join(layersDir, name+".qcow2")
+		if err := os.WriteFile(paths[i], []byte("qcow2-stub"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	volume.state.Chain = []stateLayer{
+		{SnapshotID: "snap-a", Path: paths[0]},
+		{SnapshotID: "snap-b", Path: paths[1]},
+		{SnapshotID: "snap-c", Path: paths[2]},
+	}
+	if err := saveVolumeState(volume.dir, volume.state); err != nil {
+		t.Fatal(err)
+	}
+	server.nodes.Store([]string{"fmt-0"})
+	server.setImages(map[string][]string{
+		"fmt-0": {volume.state.HeadPath, paths[2], paths[1], paths[0]},
+	})
+	return volume, server, paths
+}
+
+func TestCompactMergesPublishedChainIntoBase(t *testing.T) {
+	volume, server, paths := newCompactVolume(t)
+
+	if err := volume.Compact(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	server.mu.Lock()
+	commits := append([]fakeCommit{}, server.commits...)
+	server.mu.Unlock()
+	if len(commits) != 1 || commits[0] != (fakeCommit{device: "fmt-0", top: paths[2], base: paths[0]}) {
+		t.Fatalf("unexpected commit calls: %+v", commits)
+	}
+
+	// The base file carries the newest generation's ID; merged files are gone.
+	want := stateLayer{SnapshotID: "snap-c", Path: paths[0]}
+	if len(volume.state.Chain) != 1 || volume.state.Chain[0] != want {
+		t.Fatalf("chain not collapsed: %+v", volume.state.Chain)
+	}
+	if volume.Depth() != 2 {
+		t.Fatalf("depth is %d, expected base + head", volume.Depth())
+	}
+	reloaded, err := loadVolumeState(volume.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.Chain) != 1 || reloaded.Chain[0] != want {
+		t.Fatalf("collapsed chain not persisted: %+v", reloaded.Chain)
+	}
+	for _, path := range paths[1:] {
+		if fileExists(path) {
+			t.Fatalf("merged layer %s must be deleted", path)
+		}
+	}
+	if !fileExists(paths[0]) {
+		t.Fatal("base layer must survive compaction")
+	}
+}
+
+func TestCompactSkipsPendingAndShallowChains(t *testing.T) {
+	volume, server, _ := newCompactVolume(t)
+	volume.state.Pending = []stateLayer{{Path: "pending.qcow2"}}
+	if err := volume.Compact(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	volume.state.Pending = nil
+	volume.state.Chain = volume.state.Chain[:1]
+	if err := volume.Compact(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.commits) != 0 {
+		t.Fatalf("no commit must be issued: %+v", server.commits)
+	}
+}
+
+// A crash between a completed commit and the state save leaves the live graph
+// already merged; the next Compact must adopt that result instead of running
+// a job whose top is no longer in the chain.
+func TestCompactAdoptsAlreadyMergedChain(t *testing.T) {
+	volume, server, paths := newCompactVolume(t)
+	server.setImages(map[string][]string{
+		"fmt-0": {volume.state.HeadPath, paths[0]},
+	})
+
+	if err := volume.Compact(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	server.mu.Lock()
+	commitCount := len(server.commits)
+	server.mu.Unlock()
+	if commitCount != 0 {
+		t.Fatal("adopting a merged chain must not issue a commit")
+	}
+	want := stateLayer{SnapshotID: "snap-c", Path: paths[0]}
+	if len(volume.state.Chain) != 1 || volume.state.Chain[0] != want {
+		t.Fatalf("chain not collapsed: %+v", volume.state.Chain)
+	}
+}
+
+func TestCompactSurfacesCommitFailure(t *testing.T) {
+	volume, server, paths := newCompactVolume(t)
+	server.mu.Lock()
+	server.failCommits = true
+	server.mu.Unlock()
+
+	if err := volume.Compact(context.Background()); err == nil {
+		t.Fatal("expected commit failure")
+	}
+	if len(volume.state.Chain) != 3 {
+		t.Fatalf("chain must be unchanged after a failed commit: %+v", volume.state.Chain)
+	}
+	for _, path := range paths {
+		if !fileExists(path) {
+			t.Fatalf("layer %s must survive a failed commit", path)
 		}
 	}
 }

--- a/pkg/types/disk.go
+++ b/pkg/types/disk.go
@@ -26,4 +26,7 @@ const (
 	QMPCommandTransaction          = "transaction"
 	QMPCommandQueryBlockstats      = "query-blockstats"
 	QMPCommandQueryNamedBlockNodes = "query-named-block-nodes"
+	QMPCommandBlockCommit          = "block-commit"
+	QMPCommandQueryJobs            = "query-jobs"
+	QMPCommandJobDismiss           = "job-dismiss"
 )

--- a/pkg/worker/durable_disk_qcow.go
+++ b/pkg/worker/durable_disk_qcow.go
@@ -168,6 +168,39 @@ func (s *Worker) reportQcowChainContent(request *types.ContainerRequest, chain [
 	}
 }
 
+// qcowChainChunkKeys returns the object keys of every chunk referenced by the
+// live published chain's manifests, i.e. chunks known to exist in the bucket.
+func (s *Worker) qcowChainChunkKeys(key string) map[string]bool {
+	keys := make(map[string]bool)
+	for _, entry := range s.qcowChain(key) {
+		if entry.manifest == nil {
+			continue
+		}
+		for _, file := range entry.manifest.Files {
+			for _, chunk := range file.Chunks {
+				keys[chunk.ObjectKey] = true
+			}
+		}
+	}
+	return keys
+}
+
+// filterUploadChunks returns a copy of layer holding only the chunks whose
+// object keys are not already present in the bucket.
+func filterUploadChunks(layer *types.DiskSnapshotFile, existing map[string]bool) *types.DiskSnapshotFile {
+	if len(existing) == 0 {
+		return layer
+	}
+	upload := *layer
+	upload.Chunks = nil
+	for _, chunk := range layer.Chunks {
+		if !existing[chunk.ObjectKey] {
+			upload.Chunks = append(upload.Chunks, chunk)
+		}
+	}
+	return &upload
+}
+
 // resolveQcowSnapshotChain walks ParentSnapshotId links from the newest
 // generation (or a seed snapshot for forks) back to a parentless root and
 // returns the rows base first.
@@ -344,9 +377,20 @@ func (s *Worker) publishQcowLayer(ctx context.Context, request *types.ContainerR
 	if err != nil {
 		return nil, nil, fmt.Errorf("scan qcow layer: %w", err)
 	}
+
+	// Chunks are content-addressed and never deleted, so everything the live
+	// chain's manifests reference is already in the bucket. Flattened
+	// publishes overlap heavily with the previous flatten (convert output is
+	// deterministic), so this usually reduces the periodic full-image publish
+	// to just the clusters that changed.
+	upload := filterUploadChunks(layer, s.qcowChainChunkKeys(s.qcowVolumeKey(request, mount)))
 	sink := &qcowChunkSink{ctx: ctx, store: store}
-	if err := disk.UploadLayer(ctx, sink, uploadPath, layer); err != nil {
+	if err := disk.UploadLayer(ctx, sink, uploadPath, upload); err != nil {
 		return nil, nil, err
+	}
+	if skipped := len(layer.Chunks) - len(upload.Chunks); skipped > 0 {
+		log.Info().Str("disk", mount.DurableDisk.Name).Int("skipped", skipped).Int("total", len(layer.Chunks)).
+			Msg("skipped qcow chunks already present in the bucket")
 	}
 
 	generation, err := nextDurableDiskSnapshotGeneration(time.Now().UnixNano(), latest)

--- a/pkg/worker/durable_disk_qcow.go
+++ b/pkg/worker/durable_disk_qcow.go
@@ -251,6 +251,15 @@ func (s *Worker) snapshotQcowDurableDiskMount(ctx context.Context, request *type
 		return nil, fmt.Errorf("qcow durable disk %q is not attached", mount.DurableDisk.Name)
 	}
 
+	// A live intermediate commit folds published layers into the base, so a
+	// long-running machine can be snapshotted indefinitely without the local
+	// backing chain hitting the depth cap.
+	if volume.Depth() > disk.DefaultFlattenDepth {
+		if err := volume.Compact(ctx); err != nil {
+			log.Warn().Err(err).Str("disk", mount.DurableDisk.Name).Msg("failed to compact qcow backing chain")
+		}
+	}
+
 	if err := s.ensureDurableDiskSnapshotStorage(ctx, request); err != nil {
 		return nil, err
 	}

--- a/pkg/worker/durable_disk_qcow.go
+++ b/pkg/worker/durable_disk_qcow.go
@@ -168,26 +168,23 @@ func (s *Worker) reportQcowChainContent(request *types.ContainerRequest, chain [
 	}
 }
 
-// qcowChainChunkKeys returns the object keys of every chunk referenced by the
-// live published chain's manifests, i.e. chunks known to exist in the bucket.
-func (s *Worker) qcowChainChunkKeys(key string) map[string]bool {
-	keys := make(map[string]bool)
+// qcowUploadChunks returns a copy of layer without the chunks the live
+// chain's manifests already reference: chunk objects are content-addressed
+// and never deleted, so those are known to exist in the bucket. Flattened
+// publishes overlap heavily with the previous flatten, so this usually
+// reduces the periodic full-image publish to just the clusters that changed.
+func (s *Worker) qcowUploadChunks(key string, layer *types.DiskSnapshotFile) *types.DiskSnapshotFile {
+	existing := make(map[string]bool)
 	for _, entry := range s.qcowChain(key) {
 		if entry.manifest == nil {
 			continue
 		}
 		for _, file := range entry.manifest.Files {
 			for _, chunk := range file.Chunks {
-				keys[chunk.ObjectKey] = true
+				existing[chunk.ObjectKey] = true
 			}
 		}
 	}
-	return keys
-}
-
-// filterUploadChunks returns a copy of layer holding only the chunks whose
-// object keys are not already present in the bucket.
-func filterUploadChunks(layer *types.DiskSnapshotFile, existing map[string]bool) *types.DiskSnapshotFile {
 	if len(existing) == 0 {
 		return layer
 	}
@@ -284,9 +281,8 @@ func (s *Worker) snapshotQcowDurableDiskMount(ctx context.Context, request *type
 		return nil, fmt.Errorf("qcow durable disk %q is not attached", mount.DurableDisk.Name)
 	}
 
-	// A live intermediate commit folds published layers into the base, so a
-	// long-running machine can be snapshotted indefinitely without the local
-	// backing chain hitting the depth cap.
+	// Fold published layers into the base so a long-running machine can be
+	// snapshotted indefinitely without hitting the local chain depth cap.
 	if volume.Depth() > disk.DefaultFlattenDepth {
 		if err := volume.Compact(ctx); err != nil {
 			log.Warn().Err(err).Str("disk", mount.DurableDisk.Name).Msg("failed to compact qcow backing chain")
@@ -378,12 +374,7 @@ func (s *Worker) publishQcowLayer(ctx context.Context, request *types.ContainerR
 		return nil, nil, fmt.Errorf("scan qcow layer: %w", err)
 	}
 
-	// Chunks are content-addressed and never deleted, so everything the live
-	// chain's manifests reference is already in the bucket. Flattened
-	// publishes overlap heavily with the previous flatten (convert output is
-	// deterministic), so this usually reduces the periodic full-image publish
-	// to just the clusters that changed.
-	upload := filterUploadChunks(layer, s.qcowChainChunkKeys(s.qcowVolumeKey(request, mount)))
+	upload := s.qcowUploadChunks(s.qcowVolumeKey(request, mount), layer)
 	sink := &qcowChunkSink{ctx: ctx, store: store}
 	if err := disk.UploadLayer(ctx, sink, uploadPath, upload); err != nil {
 		return nil, nil, err

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -1315,7 +1315,7 @@ func TestQcowChainContentReportsEveryLayerAtHeadGeneration(t *testing.T) {
 // A publish must skip uploading chunks the live chain's manifests already
 // reference: chunk objects are content-addressed and never deleted, and a
 // flattened publish overlaps heavily with the previous flatten.
-func TestFilterUploadChunksSkipsChunksKnownToTheChain(t *testing.T) {
+func TestQcowUploadChunksSkipsChunksKnownToTheChain(t *testing.T) {
 	chunk := func(hex string) types.DiskSnapshotChunk {
 		return types.DiskSnapshotChunk{
 			Digest:    "sha256:" + strings.Repeat(hex, 64),
@@ -1335,14 +1335,14 @@ func TestFilterUploadChunksSkipsChunksKnownToTheChain(t *testing.T) {
 		Type:   "file",
 		Chunks: []types.DiskSnapshotChunk{chunk("a"), chunk("b"), chunk("c")},
 	}
-	upload := filterUploadChunks(layer, worker.qcowChainChunkKeys("volume-key"))
+	upload := worker.qcowUploadChunks("volume-key", layer)
 	require.Len(t, upload.Chunks, 1)
 	require.Equal(t, chunk("c").ObjectKey, upload.Chunks[0].ObjectKey)
 	require.Len(t, layer.Chunks, 3, "the manifest layer must keep every chunk")
 
 	// An empty chain (first publish, or a worker that just restarted) skips
 	// nothing.
-	full := filterUploadChunks(layer, worker.qcowChainChunkKeys("other-volume"))
+	full := worker.qcowUploadChunks("other-volume", layer)
 	require.Len(t, full.Chunks, 3)
 }
 

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -1312,6 +1312,40 @@ func TestQcowChainContentReportsEveryLayerAtHeadGeneration(t *testing.T) {
 	require.Equal(t, "snap-3", chain[0].row.ExternalId)
 }
 
+// A publish must skip uploading chunks the live chain's manifests already
+// reference: chunk objects are content-addressed and never deleted, and a
+// flattened publish overlaps heavily with the previous flatten.
+func TestFilterUploadChunksSkipsChunksKnownToTheChain(t *testing.T) {
+	chunk := func(hex string) types.DiskSnapshotChunk {
+		return types.DiskSnapshotChunk{
+			Digest:    "sha256:" + strings.Repeat(hex, 64),
+			ObjectKey: "durable-disks/machine-root/chunks/" + strings.Repeat(hex, 64),
+			SizeBytes: 4,
+		}
+	}
+	worker := &Worker{}
+	worker.qcowChains.Store("volume-key", []qcowChainEntry{{
+		row: &types.DiskSnapshot{ExternalId: "snap-1"},
+		manifest: &types.DiskSnapshotManifest{Files: []types.DiskSnapshotFile{{
+			Type: "file", Chunks: []types.DiskSnapshotChunk{chunk("a"), chunk("b")},
+		}}},
+	}})
+
+	layer := &types.DiskSnapshotFile{
+		Type:   "file",
+		Chunks: []types.DiskSnapshotChunk{chunk("a"), chunk("b"), chunk("c")},
+	}
+	upload := filterUploadChunks(layer, worker.qcowChainChunkKeys("volume-key"))
+	require.Len(t, upload.Chunks, 1)
+	require.Equal(t, chunk("c").ObjectKey, upload.Chunks[0].ObjectKey)
+	require.Len(t, layer.Chunks, 3, "the manifest layer must keep every chunk")
+
+	// An empty chain (first publish, or a worker that just restarted) skips
+	// nothing.
+	full := filterUploadChunks(layer, worker.qcowChainChunkKeys("other-volume"))
+	require.Len(t, full.Chunks, 3)
+}
+
 func TestRestoreDurableDiskDirectorySnapshotDownloadsChunksInParallel(t *testing.T) {
 	source := t.TempDir()
 	payload := []byte(strings.Repeat("parallel restore ", durableDiskRestoreConcurrency))


### PR DESCRIPTION
## Summary
- **Live chain compaction.** Fixes `volume ... reached the maximum chain depth of 64`. The local qcow chain grew one layer per snapshot and never shrank (reusable local state survives restarts). `Volume.Compact` folds every published layer into the base with a live intermediate `block-commit` while the volume stays mounted and serving I/O; the snapshot path triggers it past `DefaultFlattenDepth` (16), leaving the 64 cap as a backstop. `block-commit` needs a root-node device (and `raw` is not a filter in QEMU 8.2), so the NBD export now attaches directly to the qcow2 head; `blockdev-snapshot` re-parents it onto each new overlay. Crash-safe: the live graph is consulted first, and merged files are deleted only after the collapsed state is durable.
- **Publish dedup via content-defined chunking.** Publishes uploaded every chunk unconditionally, so the every-16th-snapshot flattened publish re-uploaded the whole image. Chunk objects are content-addressed and never deleted, so publishes now skip chunks the live chain's manifests already reference (zero extra round trips). Fixed 4 MiB boundaries made that useless — one early layout shift in the convert output re-cuts every later chunk (measured **0%** overlap between consecutive flattens) — so boundaries are now content-defined (gear hash, 1–8 MiB, 4 MiB average): **~95%** overlap offline, **91% of chunks skipped** at the second flatten in the k3d e2e. `ScanLayer` also hashes chunks in parallel.

## Test plan
- [x] Unit: compaction (merge, pending/shallow skip, crash-heal adoption, failure surfacing), CDC shift-resistance (`TestScanLayerChunksSurviveContentShift`), upload filtering (`TestFilterUploadChunksSkipsChunksKnownToTheChain`); full `pkg/disk` + `pkg/worker` suites pass
- [x] Real QEMU 8.2 (worker image): wrapper-less export follows pivots, post-pivot NBD writes land in the new head, live intermediate commit merges the chain with data intact through the live export
- [x] Offline chunking experiment (ext4 disk, two consecutive `qemu-img convert` flattens): fixed-4MiB 0% dedup, CDC 94.9%
- [x] k3d e2e: 33-snapshot loop — deltas 0–1s, both flatten cycles compacted 16 layers in place, second flatten skipped 139/152 chunks; checksums identical across compaction, stop (with memory), restore, and further snapshots

Made with [Cursor](https://cursor.com)