### PR TITLE
Sort image build secrets deterministically

### DIFF
--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 
 	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
 	"github.com/beam-cloud/beta9/pkg/auth"
@@ -239,6 +240,12 @@ func (is *ContainerImageService) retrieveBuildSecrets(ctx context.Context, secre
 		if err != nil {
 			return nil, err
 		}
+
+		// The repository query does not guarantee row order. Canonicalize it so
+		// repeated builds render the same Dockerfile and resolve to the same image.
+		sort.Slice(secrets, func(i, j int) bool {
+			return secrets[i].Name < secrets[j].Name
+		})
 
 		for _, secret := range secrets {
 			buildSecrets = append(buildSecrets, fmt.Sprintf("%s=%s", secret.Name, secret.Value))

--- a/pkg/abstractions/image/image_test.go
+++ b/pkg/abstractions/image/image_test.go
@@ -5,9 +5,50 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
+
+type unorderedBuildSecretsRepository struct {
+	repository.BackendRepository
+	secrets []types.Secret
+}
+
+func (r *unorderedBuildSecretsRepository) GetSecretsByNameDecrypted(
+	context.Context,
+	*types.Workspace,
+	[]string,
+) ([]types.Secret, error) {
+	return r.secrets, nil
+}
+
+func TestRetrieveBuildSecretsSortsByName(t *testing.T) {
+	is := &ContainerImageService{
+		backendRepo: &unorderedBuildSecretsRepository{
+			secrets: []types.Secret{
+				{Name: "ZEBRA_TOKEN", Value: "zebra"},
+				{Name: "API_KEY", Value: "api"},
+				{Name: "DB_PASSWORD", Value: "db"},
+			},
+		},
+	}
+
+	buildSecrets, err := is.retrieveBuildSecrets(
+		context.Background(),
+		[]string{"DB_PASSWORD", "ZEBRA_TOKEN", "API_KEY"},
+		&auth.AuthInfo{Workspace: &types.Workspace{}},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{
+		"API_KEY=api",
+		"DB_PASSWORD=db",
+		"ZEBRA_TOKEN=zebra",
+	}, buildSecrets)
+}
 
 func TestStreamImageBuildOutputSendsTerminalFailureWhenBuildReturnsWithoutOutput(t *testing.T) {
 	outputChan := make(chan common.OutputMsg)


### PR DESCRIPTION
Image build secrets were loaded from PostgreSQL without a guaranteed order. This could generate different Dockerfiles for the same configuration, causing cache misses and unnecessary image rebuilds.

Build secrets are now sorted by name before Dockerfile generation, ensuring stable image IDs and reliable cache reuse.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts build secrets by name before Dockerfile generation, so the same configuration always produces the same Dockerfile and image ID. Previously PostgreSQL returned secrets in arbitrary order, causing cache misses and redundant rebuilds.

- Adds a regression test with unsorted secrets to verify they are emitted alphabetically.

<sup>Written for commit 80ae5c9e5945da9d754dbdff4cb34a4364a0fa1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

