### PR TITLE
Harden worker runtime edge cases and node stability

### DIFF
--- a/pkg/abstractions/pod/proxy.go
+++ b/pkg/abstractions/pod/proxy.go
@@ -1019,19 +1019,6 @@ func (pb *PodProxyBuffer) pruneBackendTransports(containers []container) {
 func (pb *PodProxyBuffer) proxyWebSocket(conn *connection, container container, addr string, path string) error {
 	subprotocols := websocket.Subprotocols(conn.ctx.Request())
 
-	upgrader := websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true // Allow all origins
-		},
-		Subprotocols: subprotocols,
-	}
-
-	clientConn, err := upgrader.Upgrade(conn.ctx.Response().Writer, conn.ctx.Request(), nil)
-	if err != nil {
-		return err
-	}
-	defer clientConn.Close()
-
 	wsURL, err := url.Parse(podBackendURL("ws", addr, path, conn.ctx.Request().URL.RawQuery))
 	if err != nil {
 		return err
@@ -1047,11 +1034,38 @@ func (pb *PodProxyBuffer) proxyWebSocket(conn *connection, container container, 
 		Subprotocols: subprotocols,
 	}
 
-	serverConn, _, err := dstDialer.Dial(wsURL.String(), forwardedWebSocketHeaders(conn.ctx.Request()))
+	// The backend is dialed before the client is upgraded: once the upgrade
+	// has happened this handler can only answer a dead backend by slamming the
+	// fresh socket shut, which the browser reports as a connection that never
+	// worked. Before the upgrade a failure is still an ordinary HTTP error,
+	// and a cold route gets the same single redial the HTTP path has.
+	var serverConn *websocket.Conn
+	for attempt := 0; ; attempt++ {
+		var err error
+		serverConn, _, err = dstDialer.Dial(wsURL.String(), forwardedWebSocketHeaders(conn.ctx.Request()))
+		if err == nil {
+			break
+		}
+		if attempt < backendDialRetryLimit && conn.ctx.Request().Context().Err() == nil {
+			log.Warn().Err(err).Str("container_id", container.id).Str("stub_id", pb.stubId).Msg("websocket backend dial failed; dialing again")
+			continue
+		}
+		return conn.ctx.String(http.StatusBadGateway, "Backend route unavailable")
+	}
+	defer serverConn.Close()
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true // Allow all origins
+		},
+		Subprotocols: subprotocols,
+	}
+
+	clientConn, err := upgrader.Upgrade(conn.ctx.Response().Writer, conn.ctx.Request(), nil)
 	if err != nil {
 		return err
 	}
-	defer serverConn.Close()
+	defer clientConn.Close()
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)

--- a/pkg/abstractions/pod/proxy_test.go
+++ b/pkg/abstractions/pod/proxy_test.go
@@ -309,6 +309,51 @@ func TestForwardRequestProxiesReadyBackendWithoutQueueing(t *testing.T) {
 	}
 }
 
+// Prevents this: the websocket path upgraded the browser before dialing the
+// machine, so a cold or racing dial could only slam the fresh socket shut —
+// which VNC clients report as a first connect that never works.
+func TestForwardRequestAnswersWebSocketDialFailureBeforeUpgrade(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadAddress := listener.Addr().String()
+	listener.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/websockify", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-Websocket-Version", "13")
+	req.Header.Set("Sec-Websocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("port", "subPath")
+	ctx.SetParamValues("8000", "websockify")
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pb := &PodProxyBuffer{
+		ctx:        parentCtx,
+		workspace:  &types.Workspace{Name: "workspace"},
+		stubId:     "stub",
+		stubConfig: &types.StubConfigV1{},
+		buffer:     abstractions.NewRingBuffer[*connection](1),
+		availableContainers: []container{{
+			id:              "container-1",
+			addressMap:      map[int32]string{8000: deadAddress},
+			readyAddressMap: map[int32]string{8000: deadAddress},
+		}},
+	}
+
+	if err := pb.ForwardRequest(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%q", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+}
+
 func TestForwardRequestRequeuesClosingRouteAndPreservesBody(t *testing.T) {
 	staleRouteID := "stale-route"
 	receivedBody := make(chan string, 1)

--- a/pkg/clients/container_cost.go
+++ b/pkg/clients/container_cost.go
@@ -261,9 +261,14 @@ func (c *ContainerCostClient) lastGood(key ContainerCostRequest) ContainerCostQu
 	return c.quotes[key].quote
 }
 
+// cacheKey must cover every field of the request: it deduplicates in-flight
+// refreshes, and two requests that differ anywhere (workspace, sandbox flag)
+// can be quoted differently. A narrower key hands one workspace's quote to
+// another workspace's concurrent lookup.
 func (r ContainerCostRequest) cacheKey() string {
-	return strconv.FormatInt(r.Cpu, 10) + "\x00" + strconv.FormatInt(r.Memory, 10) +
-		"\x00" + r.Gpu + "\x00" + strconv.FormatUint(uint64(r.GpuCount), 10)
+	return r.WorkspaceId + "\x00" + strconv.FormatInt(r.Cpu, 10) + "\x00" + strconv.FormatInt(r.Memory, 10) +
+		"\x00" + r.Gpu + "\x00" + strconv.FormatUint(uint64(r.GpuCount), 10) +
+		"\x00" + strconv.FormatBool(r.Sandbox)
 }
 
 func optionalTime(value, name string) (time.Time, error) {

--- a/pkg/clients/container_cost_test.go
+++ b/pkg/clients/container_cost_test.go
@@ -175,6 +175,62 @@ func TestContainerCostClientSeparatesWorkspaceAndSandboxQuotes(t *testing.T) {
 	}
 }
 
+// Prevents this: concurrent refreshes were deduplicated by resources alone, so
+// two workspaces asking at the same moment shared one flight and one of them
+// was handed the other's price.
+func TestContainerCostClientDoesNotCoalesceAcrossWorkspaces(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var request ContainerCostRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Error(err)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+		cost := "0.1"
+		if request.WorkspaceId == "workspace-b" {
+			cost = "0.2"
+		}
+		_, _ = fmt.Fprintf(w, `{"cost_per_ms":%q}`, cost)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewContainerCostClient(types.ContainerCostHookConfig{Endpoint: server.URL, Token: "test-token"})
+	requests := map[string]*types.ContainerRequest{
+		"workspace-a": {WorkspaceId: "workspace-a", Cpu: 1_000, Memory: 1_024},
+		"workspace-b": {WorkspaceId: "workspace-b", Cpu: 1_000, Memory: 1_024},
+	}
+	want := map[string]float64{"workspace-a": 0.1, "workspace-b": 0.2}
+
+	start := make(chan struct{})
+	errs := make(chan error, len(requests))
+	var wg sync.WaitGroup
+	for workspace, request := range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			quote, err := client.GetContainerCostQuote(context.Background(), request)
+			if err == nil && (!quote.Valid || quote.CostPerMs != want[workspace]) {
+				err = fmt.Errorf("%s quote = %+v, want cost %v", workspace, quote, want[workspace])
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("quote calls = %d, want one refresh per workspace", got)
+	}
+}
+
 func TestContainerCostClientRetriesWhenNoQuoteWasCached(t *testing.T) {
 	clock := newAtomicTestClock(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC))
 	var calls atomic.Int32

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -229,6 +230,27 @@ func (m *Manager) Detach(ctx context.Context, key string) error {
 	delete(m.volumes, key)
 	m.mu.Unlock()
 	return nil
+}
+
+// DetachAll tears down every volume still owned by this worker. It is safe to
+// call after the last container exits and during worker shutdown.
+func (m *Manager) DetachAll(ctx context.Context) error {
+	m.mu.Lock()
+	keys := make([]string, 0, len(m.volumes))
+	for key, volume := range m.volumes {
+		if volume != nil {
+			keys = append(keys, key)
+		}
+	}
+	m.mu.Unlock()
+
+	var errs error
+	for _, key := range keys {
+		if err := m.Detach(ctx, key); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("detach volume %s: %w", key, err))
+		}
+	}
+	return errs
 }
 
 // Recover sweeps volume state left behind by a previous worker process. Live

--- a/pkg/disk/nbd.go
+++ b/pkg/disk/nbd.go
@@ -193,6 +193,11 @@ func (m *Manager) connectNBDDevice(ctx context.Context, device *nbdDevice, nbdSo
 func (m *Manager) disconnectNBDDevice(ctx context.Context, device *nbdDevice) error {
 	defer device.release()
 	if _, err := m.run(ctx, m.binaries.NBDClient, "-d", device.Path); err != nil {
+		// The server may have exited between the disconnect attempt and this
+		// check. Treat an already-cleared kernel device as success.
+		if !m.nbdDeviceBusy(device.name) {
+			return nil
+		}
 		return fmt.Errorf("disconnect %s: %w", device.Path, err)
 	}
 	deadline := time.Now().Add(nbdSettleTimeout)

--- a/pkg/disk/nbd_test.go
+++ b/pkg/disk/nbd_test.go
@@ -125,3 +125,17 @@ func TestEnsureNBDDevicesRejectsMalformedKernelDeviceNumber(t *testing.T) {
 		t.Fatalf("ensureNBDDevices() error = %v", err)
 	}
 }
+
+func TestDisconnectTreatsAlreadyClearedDeviceAsSuccess(t *testing.T) {
+	manager := NewManager(Config{
+		SysBlockPath: t.TempDir(),
+		DevPath:      t.TempDir(),
+		Runner: func(context.Context, string, ...string) ([]byte, error) {
+			return nil, fmt.Errorf("not connected")
+		},
+	})
+
+	if err := manager.disconnectNBDDevice(context.Background(), &nbdDevice{name: "nbd0", Path: "/dev/nbd0"}); err != nil {
+		t.Fatalf("disconnect already-cleared device: %v", err)
+	}
+}

--- a/pkg/disk/volume.go
+++ b/pkg/disk/volume.go
@@ -2,6 +2,7 @@ package disk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -507,16 +508,27 @@ func (v *Volume) detach(ctx context.Context) error {
 	if err := v.manager.unmount(ctx, v.state.Mountpoint); err != nil {
 		return err
 	}
+	var disconnectErr error
 	if v.nbd != nil {
 		if err := v.manager.disconnectNBDDevice(ctx, v.nbd); err != nil {
-			return err
+			disconnectErr = err
+		} else {
+			v.nbd = nil
 		}
-		v.nbd = nil
 	}
-	if err := v.manager.stopQSD(ctx, v.qsd); err != nil {
+	stopErr := v.manager.stopQSD(ctx, v.qsd)
+	if stopErr == nil {
+		v.qsd = nil
+	}
+	// A dead daemon closes its NBD socket. If that cleared a failed
+	// disconnect, allow the state to be finalized instead of leaking it.
+	if v.nbd != nil && !v.manager.nbdDeviceBusy(v.nbd.name) {
+		v.nbd = nil
+		disconnectErr = nil
+	}
+	if err := errors.Join(disconnectErr, stopErr); err != nil {
 		return err
 	}
-	v.qsd = nil
 
 	v.state.Attached = false
 	v.state.QSDPid = 0

--- a/pkg/disk/volume_test.go
+++ b/pkg/disk/volume_test.go
@@ -546,3 +546,25 @@ func TestRecoverCleansUpCrashedVolume(t *testing.T) {
 		t.Fatal("crashed volume must not be adopted")
 	}
 }
+
+func TestDetachAllCleansEveryOwnedVolume(t *testing.T) {
+	manager := NewManager(Config{Root: t.TempDir(), Runner: fakeRunner})
+	for _, key := range []string{"disk-a", "disk-b"} {
+		dir := manager.volumeDir(key)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		state := &volumeState{Key: key, Attached: true}
+		if err := saveVolumeState(dir, state); err != nil {
+			t.Fatal(err)
+		}
+		manager.volumes[key] = &Volume{manager: manager, dir: dir, state: state}
+	}
+
+	if err := manager.DetachAll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(manager.volumes) != 0 {
+		t.Fatalf("owned volumes after detach = %d, want 0", len(manager.volumes))
+	}
+}

--- a/pkg/scheduler/pool_provider.go
+++ b/pkg/scheduler/pool_provider.go
@@ -349,15 +349,7 @@ func (wpc *ProviderWorkerPoolController) createWorkerJob(workerId, machineId str
 		wpc.config.Worker.ImageTag,
 	)
 
-	resources := corev1.ResourceRequirements{}
-	if workerGpuType != "" {
-		resources.Requests = corev1.ResourceList{
-			"nvidia.com/gpu": *resource.NewQuantity(int64(gpuCount), resource.DecimalSI),
-		}
-		resources.Limits = corev1.ResourceList{
-			"nvidia.com/gpu": *resource.NewQuantity(int64(gpuCount), resource.DecimalSI),
-		}
-	}
+	resources := providerWorkerResources(wpc.config.Worker.DefaultWorkerCPURequest, workerCpu, workerGpuType, gpuCount)
 
 	env, err := wpc.getWorkerEnvironment(workerId, machineId, workerCpu, workerMemory, workerGpuType, workerGpuCount, token)
 	if err != nil {
@@ -433,6 +425,33 @@ func (wpc *ProviderWorkerPoolController) createWorkerJob(workerId, machineId str
 		BuildVersion:  wpc.config.Worker.ImageTag,
 		Preemptable:   wpc.workerPoolConfig.Preemptable,
 	}, nil
+}
+
+func providerWorkerResources(defaultCPURequest, workerCPU int64, workerGPUType string, gpuCount uint32) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{}
+	if workerCPU > 0 {
+		// Provider clusters contain one physical node. Request only the normal
+		// scheduling footprint, but cap the worker pod at its advertised CPU so
+		// nested user cgroups cannot oversubscribe the machine in aggregate.
+		cpuRequest := min(workerCPU, max(defaultCPURequest, 0))
+		resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewMilliQuantity(cpuRequest, resource.DecimalSI),
+		}
+		resources.Limits = corev1.ResourceList{
+			corev1.ResourceCPU: *resource.NewMilliQuantity(workerCPU, resource.DecimalSI),
+		}
+	}
+	if workerGPUType != "" {
+		if resources.Requests == nil {
+			resources.Requests = corev1.ResourceList{}
+		}
+		if resources.Limits == nil {
+			resources.Limits = corev1.ResourceList{}
+		}
+		resources.Requests["nvidia.com/gpu"] = *resource.NewQuantity(int64(gpuCount), resource.DecimalSI)
+		resources.Limits["nvidia.com/gpu"] = *resource.NewQuantity(int64(gpuCount), resource.DecimalSI)
+	}
+	return resources
 }
 
 func (wpc *ProviderWorkerPoolController) getWorkerEnvironment(workerId, machineId string, cpu int64, memory int64, gpuType string, gpuCount uint32, token string) ([]corev1.EnvVar, error) {

--- a/pkg/scheduler/pool_provider_test.go
+++ b/pkg/scheduler/pool_provider_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/providers"
 	"github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type failingProviderRepo struct {
@@ -49,6 +50,37 @@ func TestProviderMachineGPUCompatible(t *testing.T) {
 				t.Fatalf("providerMachineGPUCompatible() = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestProviderWorkerCapsAdvertisedCPUWithoutReservingItAll(t *testing.T) {
+	resources := providerWorkerResources(2000, 16000, "", 0)
+	if got := resources.Limits.Cpu(); got == nil || got.Cmp(resource.MustParse("16")) != 0 {
+		t.Fatalf("CPU limit = %v, want 16", got)
+	}
+	if got := resources.Requests.Cpu(); got == nil || got.Cmp(resource.MustParse("2")) != 0 {
+		t.Fatalf("CPU request = %v, want 2", got)
+	}
+}
+
+func TestProviderWorkerCPURequestNeverExceedsItsLimit(t *testing.T) {
+	resources := providerWorkerResources(2000, 500, "", 0)
+	if got := resources.Limits.Cpu(); got == nil || got.Cmp(resource.MustParse("500m")) != 0 {
+		t.Fatalf("CPU limit = %v, want 500m", got)
+	}
+	if got := resources.Requests.Cpu(); got == nil || got.Cmp(resource.MustParse("500m")) != 0 {
+		t.Fatalf("CPU request = %v, want 500m", got)
+	}
+}
+
+func TestProviderWorkerCPUCapPreservesGPUResources(t *testing.T) {
+	resources := providerWorkerResources(2000, 16000, "RTX4090", 2)
+	wantGPU := resource.MustParse("2")
+	if got := resources.Requests["nvidia.com/gpu"]; got.Cmp(wantGPU) != 0 {
+		t.Fatalf("GPU request = %v, want 2", got)
+	}
+	if got := resources.Limits["nvidia.com/gpu"]; got.Cmp(wantGPU) != 0 {
+		t.Fatalf("GPU limit = %v, want 2", got)
 	}
 }
 

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -855,7 +855,7 @@ type imageCacheEntry struct {
 	modified time.Time
 }
 
-func (m *WorkerCacheManager) pruneOwnerImageCache(stubs []recentStubContent, softWatermark float64, minFreeBytes int64) int64 {
+func (m *WorkerCacheManager) pruneOwnerImageCache(stubs []recentStubContent, softWatermark float64, minFreeBytes int64, protectedSetComplete bool) int64 {
 	root := getImageCachePath()
 	usage, err := fastDiskUsage(root)
 	if err != nil {
@@ -866,8 +866,15 @@ func (m *WorkerCacheManager) pruneOwnerImageCache(stubs []recentStubContent, sof
 	if bytesToFree > 0 {
 		allowlist = pressureProtectedContentFromRecentStubs(stubs, m.accelerator, usage, softWatermark, minFreeBytes)
 	}
-	protected := protectedImageCache(stubs, allowlist, root, filepath.Join(types.AgentImagesPath, "mnt"))
-	evicted, freed := evictImageCache(root, protected, time.Now().Add(-m.recentStubTTL()), bytesToFree)
+	mountRoot := filepath.Join(types.AgentImagesPath, "mnt")
+	mountSetComplete := m.pruneStaleImageMountPaths(mountRoot)
+	protected := protectedImageCache(stubs, allowlist, root, mountRoot)
+	protected.complete = protected.complete && mountSetComplete
+	cutoff := time.Time{}
+	if protectedSetComplete {
+		cutoff = time.Now().Add(-m.recentStubTTL())
+	}
+	evicted, freed := evictImageCache(root, protected, cutoff, bytesToFree)
 	if evicted > 0 {
 		event := log.Info()
 		message := "pruned stale image cache content"
@@ -884,6 +891,59 @@ func (m *WorkerCacheManager) pruneOwnerImageCache(stubs []recentStubContent, sof
 			Msg(message)
 	}
 	return freed
+}
+
+func (m *WorkerCacheManager) pruneStaleImageMountPaths(mountRoot string) bool {
+	if m.workerRepo == nil {
+		return false
+	}
+
+	rpcCtx, cancel := context.WithTimeout(m.ctx, cacheCoordinatorRPCTimeout)
+	defer cancel()
+	pruned, complete := pruneStaleImageMountPathsWithLookup(mountRoot, func(workerID string) (bool, error) {
+		_, err := handleGRPCResponse(m.workerRepo.GetWorkerById(rpcCtx, &pb.GetWorkerByIdRequest{WorkerId: workerID}))
+		if err == nil {
+			return true, nil
+		}
+		notFoundErr := &types.ErrWorkerNotFound{}
+		if notFoundErr.From(err) {
+			return false, nil
+		}
+		return false, err
+	})
+	if pruned > 0 {
+		log.Info().Int("pruned", pruned).Str("mount_root", mountRoot).Msg("pruned stale worker image mount paths")
+	}
+	return complete
+}
+
+func pruneStaleImageMountPathsWithLookup(mountRoot string, workerExists func(string) (bool, error)) (int, bool) {
+	workers, err := os.ReadDir(mountRoot)
+	if err != nil {
+		return 0, false
+	}
+
+	pruned := 0
+	complete := true
+	for _, worker := range workers {
+		if !worker.IsDir() || worker.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		exists, err := workerExists(worker.Name())
+		if err != nil {
+			complete = false
+			continue
+		}
+		if exists {
+			continue
+		}
+		if err := cleanupImageMountPath(filepath.Join(mountRoot, worker.Name())); err != nil {
+			complete = false
+			continue
+		}
+		pruned++
+	}
+	return pruned, complete
 }
 
 func protectedImageCache(stubs []recentStubContent, allowlist map[string]struct{}, cacheRoot, mountRoot string) imageCacheProtection {
@@ -970,7 +1030,7 @@ func activeImageLayers(cacheRoot, imageID string) ([]string, bool) {
 }
 
 func evictImageCache(root string, protected imageCacheProtection, cutoff time.Time, bytesToFree int64) (int, int64) {
-	if !protected.complete || cutoff.IsZero() && bytesToFree <= 0 {
+	if cutoff.IsZero() && bytesToFree <= 0 {
 		return 0, 0
 	}
 	scanStarted := time.Now()
@@ -988,6 +1048,12 @@ func evictImageCache(root string, protected imageCacheProtection, cutoff time.Ti
 			continue
 		}
 		if _, ok := protected.names[entry.name]; ok {
+			continue
+		}
+		// Without complete mount metadata, raw layers cannot be attributed to
+		// active images safely. Archive names are still protected directly by
+		// their mount directory, so unrelated archives remain evictable.
+		if !protected.complete && isSHA256HexDigest(entry.name) {
 			continue
 		}
 
@@ -1212,7 +1278,7 @@ func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, loc
 
 	softWatermark := m.reconcileMaxDiskUsagePct()
 	resumeWatermark := reconcileResumeDiskUsagePct(softWatermark)
-	if protectedSetComplete && m.pruneOwnerImageCache(stubContent, softWatermark, server.DiskMinFreeBytes()) > 0 {
+	if m.pruneOwnerImageCache(stubContent, softWatermark, server.DiskMinFreeBytes(), protectedSetComplete) > 0 {
 		if refreshed, refreshErr := server.RefreshDiskUsage(); refreshErr == nil {
 			usage = refreshed
 		}
@@ -1244,20 +1310,6 @@ func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, loc
 	}
 
 	bytesToFree := reconcilePressureBytesToFree(usage, softWatermark, server.DiskMinFreeBytes())
-	if bytesToFree > 0 && !protectedSetComplete {
-		server.SetProtectedContent(protected)
-		if m.reconcilePausedAt.IsZero() {
-			m.reconcilePausedAt = time.Now()
-			log.Warn().
-				Str("locality", m.locality).
-				Str("logical_host", localHostID).
-				Int64("target_free_bytes", bytesToFree).
-				Float64("disk_usage_pct", usage.UsagePct).
-				Float64("soft_watermark_pct", softWatermark).
-				Msg("cache reconciliation paused: required content set incomplete under disk pressure")
-		}
-		return true, nil
-	}
 	if bytesToFree > 0 {
 		evicted, freed := server.PressureEvictContent(protectedForPressure, bytesToFree)
 		if evicted > 0 {

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -1912,7 +1912,7 @@ func TestEvictImageCacheProtectsRecentAndMountedImages(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(cacheRoot, "stale.rclip"))
 }
 
-func TestEvictImageCacheFailsClosedForLayersWithoutMountedMetadata(t *testing.T) {
+func TestEvictImageCacheProtectsLayersWithoutMountedMetadata(t *testing.T) {
 	cacheRoot := t.TempDir()
 	mountRoot := filepath.Join(t.TempDir(), "mnt")
 	layerHash := strings.Repeat("d", 64)
@@ -1928,9 +1928,38 @@ func TestEvictImageCacheFailsClosedForLayersWithoutMountedMetadata(t *testing.T)
 	evicted, _ := evictImageCache(cacheRoot, protected, time.Now().Add(-time.Hour), 0)
 
 	require.False(t, protected.complete)
-	require.Zero(t, evicted)
+	require.Equal(t, 1, evicted)
 	require.FileExists(t, filepath.Join(cacheRoot, layerHash))
-	require.FileExists(t, filepath.Join(cacheRoot, "stale.clip"))
+	require.NoFileExists(t, filepath.Join(cacheRoot, "stale.clip"))
+}
+
+func TestPruneStaleImageMountPaths(t *testing.T) {
+	mountRoot := t.TempDir()
+	for _, workerID := range []string{"live", "stale"} {
+		require.NoError(t, os.Mkdir(filepath.Join(mountRoot, workerID), 0o755))
+	}
+
+	pruned, complete := pruneStaleImageMountPathsWithLookup(mountRoot, func(workerID string) (bool, error) {
+		return workerID == "live", nil
+	})
+
+	require.True(t, complete)
+	require.Equal(t, 1, pruned)
+	require.DirExists(t, filepath.Join(mountRoot, "live"))
+	require.NoDirExists(t, filepath.Join(mountRoot, "stale"))
+}
+
+func TestPruneStaleImageMountPathsPreservesWorkersWithUnknownLiveness(t *testing.T) {
+	mountRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(mountRoot, "unknown"), 0o755))
+
+	pruned, complete := pruneStaleImageMountPathsWithLookup(mountRoot, func(string) (bool, error) {
+		return false, errors.New("gateway unavailable")
+	})
+
+	require.False(t, complete)
+	require.Zero(t, pruned)
+	require.DirExists(t, filepath.Join(mountRoot, "unknown"))
 }
 
 func writeStubCodeCacheEntry(t *testing.T, root, name string, readyTime time.Time) string {

--- a/pkg/worker/durable_disk.go
+++ b/pkg/worker/durable_disk.go
@@ -25,6 +25,7 @@ const (
 	durableDiskLockWait   = 10 * time.Minute
 
 	durableDiskSnapshotInactivityTimeout = 3 * time.Minute
+	durableDiskPhaseHeartbeatInterval    = 45 * time.Second
 
 	durableDiskStateClean = "clean"
 	durableDiskStateDirty = "dirty"

--- a/pkg/worker/durable_disk_lifecycle.go
+++ b/pkg/worker/durable_disk_lifecycle.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -64,8 +65,12 @@ func (s *Worker) finalizeDurableDiskMountsWithContext(ctx context.Context, conta
 	)
 	defer stopProgress()
 
-	if _, syncErr := s.syncDurableDiskMounts(progressCtx, request, durableDiskSyncFinal); syncErr != nil {
-		log.Error().Str("container_id", containerID).Err(syncErr).Msg("failed to sync durable disks during container cleanup")
+	_, syncErr := s.syncDurableDiskMounts(progressCtx, request, durableDiskSyncFinal)
+	// Final sync can consume or cancel its transfer budget. Detach gets a fresh
+	// cleanup context so the NBD is still released after the container exits.
+	detachErr := s.detachFinalQcowDurableDisks(request)
+	if finalErr := errors.Join(syncErr, detachErr); finalErr != nil {
+		log.Error().Str("container_id", containerID).Err(finalErr).Msg("failed to finalize durable disks during container cleanup")
 		finalExitCode = durableDiskSyncFailureExitCode(exitCode)
 		if finalExitCode != exitCode {
 			s.setLocalContainerExitCode(containerID, finalExitCode)
@@ -73,6 +78,39 @@ func (s *Worker) finalizeDurableDiskMountsWithContext(ctx context.Context, conta
 		}
 	}
 	return finalExitCode, finalExitReported
+}
+
+func (s *Worker) detachFinalQcowDurableDisks(request *types.ContainerRequest) error {
+	if request == nil || s.diskManager == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(s.durableDiskCleanupContext(), durableDiskCleanupGrace)
+	defer cancel()
+
+	var errs error
+	for i := range request.Mounts {
+		mount := &request.Mounts[i]
+		if isQcowDurableDiskMount(mount) {
+			errs = errors.Join(errs, s.detachQcowDurableDiskMount(ctx, request, mount))
+		}
+	}
+	return errs
+}
+
+func (s *Worker) cleanupIdleQcowVolumes() {
+	if s.diskManager == nil || s.containerInstances == nil {
+		return
+	}
+	s.containerLock.Lock()
+	defer s.containerLock.Unlock()
+	if s.containerInstances.Len() != 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(s.durableDiskCleanupContext(), durableDiskCleanupGrace)
+	defer cancel()
+	if err := s.diskManager.DetachAll(ctx); err != nil {
+		log.Warn().Err(err).Msg("failed to detach idle qcow volumes")
+	}
 }
 
 func durableDiskSyncFailureExitCode(exitCode int) int {

--- a/pkg/worker/durable_disk_qcow.go
+++ b/pkg/worker/durable_disk_qcow.go
@@ -284,7 +284,10 @@ func (s *Worker) snapshotQcowDurableDiskMount(ctx context.Context, request *type
 	// Fold published layers into the base so a long-running machine can be
 	// snapshotted indefinitely without hitting the local chain depth cap.
 	if volume.Depth() > disk.DefaultFlattenDepth {
-		if err := volume.Compact(ctx); err != nil {
+		stopHeartbeat := durableDiskPhaseHeartbeat(ctx, durableDiskPhaseHeartbeatInterval)
+		err := volume.Compact(ctx)
+		stopHeartbeat()
+		if err != nil {
 			log.Warn().Err(err).Str("disk", mount.DurableDisk.Name).Msg("failed to compact qcow backing chain")
 		}
 	}
@@ -358,7 +361,10 @@ func (s *Worker) publishQcowLayer(ctx context.Context, request *types.ContainerR
 		// Publish a parentless flattened generation so restore chains stay
 		// short. The local chain is untouched; only the artifact differs.
 		flatPath := sealedPath + ".flat"
-		if err := volume.Flatten(ctx, sealedPath, flatPath); err != nil {
+		stopHeartbeat := durableDiskPhaseHeartbeat(ctx, durableDiskPhaseHeartbeatInterval)
+		err := volume.Flatten(ctx, sealedPath, flatPath)
+		stopHeartbeat()
+		if err != nil {
 			return nil, nil, fmt.Errorf("flatten qcow chain: %w", err)
 		}
 		defer os.Remove(flatPath)
@@ -367,9 +373,11 @@ func (s *Worker) publishQcowLayer(ctx context.Context, request *types.ContainerR
 	}
 
 	chunkPrefix := durableDiskChunkPrefix(mount)
+	stopHeartbeat := durableDiskPhaseHeartbeat(ctx, durableDiskPhaseHeartbeatInterval)
 	layer, err := disk.ScanLayer(uploadPath, func(digest string) string {
 		return path.Join(chunkPrefix, strings.TrimPrefix(digest, "sha256:"))
 	})
+	stopHeartbeat()
 	if err != nil {
 		return nil, nil, fmt.Errorf("scan qcow layer: %w", err)
 	}

--- a/pkg/worker/durable_disk_snapshot.go
+++ b/pkg/worker/durable_disk_snapshot.go
@@ -105,6 +105,34 @@ func withDurableDiskInactivityWatchdog(ctx context.Context, timeout time.Duratio
 	}
 }
 
+// durableDiskPhaseHeartbeat reports snapshot progress on an interval until the
+// returned stop function is called. Long single operations — a block-commit or
+// qemu-img convert of a many-gigabyte chain, hashing a sealed layer — do real
+// work for minutes with nothing uploaded to report, and without a heartbeat
+// the inactivity watchdog reads that silence as a stall and fails healthy
+// snapshots of exactly the disks that take longest to capture. The phases fed
+// this way run supervised subprocesses or QMP jobs bounded by the caller's
+// context, so a genuine hang still has an owner.
+func durableDiskPhaseHeartbeat(ctx context.Context, interval time.Duration) func() {
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reportDurableDiskProgress(ctx, durableDiskProgressEvent{})
+			}
+		}
+	}()
+	var once sync.Once
+	return func() { once.Do(func() { close(done) }) }
+}
+
 type durableDiskSnapshotStore interface {
 	Upload(ctx context.Context, key string, data []byte) error
 	UploadWithReader(ctx context.Context, key string, data io.Reader) error

--- a/pkg/worker/durable_disk_test.go
+++ b/pkg/worker/durable_disk_test.go
@@ -351,6 +351,32 @@ func TestDurableDiskInactivityWatchdogResetsOnlyOnProgress(t *testing.T) {
 	}
 }
 
+// Prevents this: flattening or committing a many-gigabyte qcow chain uploads
+// nothing for minutes, the watchdog read the silence as a stall, and snapshots
+// of exactly the heaviest disks always failed around the inactivity deadline.
+func TestDurableDiskPhaseHeartbeatKeepsTheWatchdogFed(t *testing.T) {
+	ctx, stop := withDurableDiskInactivityWatchdog(context.Background(), 80*time.Millisecond)
+	defer stop()
+
+	stopHeartbeat := durableDiskPhaseHeartbeat(ctx, 20*time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case <-ctx.Done():
+		t.Fatal("watchdog expired during a heartbeat-covered phase")
+	default:
+	}
+
+	// Once the phase ends the watchdog is armed again: silence after the
+	// heartbeat stops must still catch a genuinely stalled snapshot.
+	stopHeartbeat()
+	select {
+	case <-ctx.Done():
+		require.ErrorIs(t, context.Cause(ctx), errDurableDiskSnapshotInactive)
+	case <-time.After(400 * time.Millisecond):
+		t.Fatal("watchdog did not cancel after the heartbeat stopped")
+	}
+}
+
 func TestDurableDiskLockContentionKeepsInactivityWatchdogAlive(t *testing.T) {
 	diskPath := filepath.Join(t.TempDir(), "disk")
 	mount := &types.Mount{

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -462,6 +462,7 @@ func (s *Worker) finishContainerShutdown(containerId string, request *types.Cont
 	}
 
 	s.deleteContainer(containerId)
+	s.cleanupIdleQcowVolumes()
 	if request != nil && s.completedRequests != nil {
 		var workerDone <-chan struct{}
 		if s.ctx != nil {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -1423,6 +1423,13 @@ func (s *Worker) shutdown() error {
 
 	s.waitForActiveContainersBeforeShutdown()
 	s.stopActiveContainersForShutdown()
+	if s.diskManager != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), durableDiskCleanupGrace)
+		if err := s.diskManager.DetachAll(ctx); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to detach qcow volumes: %w", err))
+		}
+		cancel()
+	}
 
 	if s.containerNetworkManager != nil {
 		if err := s.containerNetworkManager.Close(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes websocket proxying, cost quoting, and snapshotting of heavy durable disks, and hardens worker disk cleanup and resource limits.

**Bug Fixes**
- Websocket proxy dials the backend before upgrading the client, so cold or raced dials return a 502 HTTP error instead of slamming a fresh socket shut; it also retries once on dial failure.
- Container cost cache keys now include `WorkspaceId` and `Sandbox`, so concurrent refreshes for different requests no longer share a single quote.
- Durable disk snapshot phases (compact, flatten, scan) emit a heartbeat at 45s intervals so the inactivity watchdog doesn't cancel snapshots of large disks that legitimately take minutes to process.
- Disk detach treats an NBD device the kernel already cleared as success, and `DetachAll` tears down remaining volumes on cleanup, shutdown, and after the last container exits.
- Worker pods on provider clusters now cap CPU at their advertised amount while requesting only the default scheduling footprint, so nested user cgroups can't oversubscribe the machine.
- Image cache reconciliation prunes mount paths for dead workers and, when mount metadata is incomplete, protects raw layers while still evicting unrelated archives instead of failing closed.

<sup>Written for commit a9d1ad3cc8c979856ee3043ae58a03d1b590b161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

