### PR TITLE
feat: add OrcaRouter as a named LLM provider for bots

### DIFF
--- a/pkg/abstractions/experimental/bot/interface.go
+++ b/pkg/abstractions/experimental/bot/interface.go
@@ -5,11 +5,24 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/beam-cloud/beta9/pkg/types"
 	openai "github.com/sashabaranov/go-openai"
 	"github.com/sashabaranov/go-openai/jsonschema"
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	botProviderOpenAI     = "openai"
+	botProviderOrcaRouter = "orcarouter"
+
+	httpRefererHeader = "HTTP-Referer"
+	xTitleHeader      = "X-Title"
+)
+
+var (
+	orcarouterBaseURL = "https://api.orcarouter.ai/v1"
 )
 
 type BotInterface struct {
@@ -55,7 +68,7 @@ func NewBotInterface(opts botInterfaceOpts) (*BotInterface, error) {
 	}
 
 	bi := &BotInterface{
-		client:       openai.NewClient(opts.BotConfig.ApiKey),
+		client:       newBotLLMClient(opts.BotConfig),
 		botConfig:    opts.BotConfig,
 		model:        opts.BotConfig.Model,
 		systemPrompt: systemPrompt,
@@ -87,6 +100,38 @@ func NewBotInterface(opts botInterfaceOpts) (*BotInterface, error) {
 	bi.memorySchema = schema
 
 	return bi, nil
+}
+
+// newBotLLMClient builds the OpenAI-compatible chat client used by the bot.
+// It selects the base URL and attribution headers based on the configured
+// LLM provider. For provider "orcarouter", requests are sent to the OrcaRouter
+// gateway, which exposes an OpenAI-compatible API across many models.
+func newBotLLMClient(botConfig BotConfig) *openai.Client {
+	config := openai.DefaultConfig(botConfig.ApiKey)
+
+	switch botConfig.Provider {
+	case botProviderOrcaRouter:
+		config.BaseURL = orcarouterBaseURL
+		config.HTTPClient = &http.Client{
+			Transport: &attributionTransport{},
+		}
+	}
+
+	return openai.NewClientWithConfig(config)
+}
+
+// attributionTransport sets gateway attribution headers on each request so the
+// upstream gateway can attribute traffic to the Beta9 SDK.
+type attributionTransport struct{}
+
+func (t *attributionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get(httpRefererHeader) == "" {
+		req.Header.Set(httpRefererHeader, "https://github.com/beam-cloud/beta9")
+	}
+	if req.Header.Get(xTitleHeader) == "" {
+		req.Header.Set(xTitleHeader, "beta9")
+	}
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func (bi *BotInterface) initSession(sessionId string) error {

--- a/pkg/abstractions/experimental/bot/interface_test.go
+++ b/pkg/abstractions/experimental/bot/interface_test.go
@@ -1,0 +1,108 @@
+package bot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func TestNewBotLLMClientOpenAIProvider(t *testing.T) {
+	client := newBotLLMClient(BotConfig{
+		Provider: "openai",
+		ApiKey:   "sk-test",
+		Model:    "gpt-4o",
+	})
+
+	if client == nil {
+		t.Fatal("expected non-nil client for openai provider")
+	}
+}
+
+func TestNewBotLLMClientOrcaRouterProvider(t *testing.T) {
+	var gotPath, gotAuth, gotReferer, gotTitle string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotReferer = r.Header.Get(httpRefererHeader)
+		gotTitle = r.Header.Get(xTitleHeader)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion","created":0,"model":"openai/gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := orcarouterBaseURL
+	orcarouterBaseURL = server.URL
+	defer func() { orcarouterBaseURL = oldBaseURL }()
+
+	client := newBotLLMClient(BotConfig{
+		Provider: "orcarouter",
+		ApiKey:   "sk-orca-test",
+		Model:    "openai/gpt-4o-mini",
+	})
+
+	resp, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: "openai/gpt-4o-mini",
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPath != "/chat/completions" {
+		t.Errorf("expected path /chat/completions, got %s", gotPath)
+	}
+	if gotAuth != "Bearer sk-orca-test" {
+		t.Errorf("expected Bearer sk-orca-test, got %s", gotAuth)
+	}
+	if gotReferer == "" {
+		t.Errorf("expected HTTP-Referer header to be set")
+	}
+	if gotTitle == "" {
+		t.Errorf("expected X-Title header to be set")
+	}
+	if resp.Choices[0].Message.Content != "hello" {
+		t.Errorf("expected response content hello, got %s", resp.Choices[0].Message.Content)
+	}
+}
+
+func TestBotConfigProviderJSONRoundTrip(t *testing.T) {
+	cfg := BotConfig{
+		Provider:       "orcarouter",
+		Model:          "orcarouter/auto",
+		ApiKey:         "sk-orca-test",
+		Authorized:     false,
+		WelcomeMessage: "hi",
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded BotConfig
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Provider != "orcarouter" {
+		t.Errorf("expected provider orcarouter, got %s", decoded.Provider)
+	}
+	if decoded.Model != "orcarouter/auto" {
+		t.Errorf("expected model orcarouter/auto, got %s", decoded.Model)
+	}
+	if decoded.ApiKey != "sk-orca-test" {
+		t.Errorf("expected api key to round trip")
+	}
+	if !strings.Contains(string(data), "\"provider\"") {
+		t.Errorf("expected serialized JSON to contain provider field")
+	}
+}

--- a/pkg/abstractions/experimental/bot/types.go
+++ b/pkg/abstractions/experimental/bot/types.go
@@ -153,6 +153,7 @@ type MarkerField struct {
 
 // BotConfig holds the overall config for the bot
 type BotConfig struct {
+	Provider       string                         `json:"provider" redis:"provider"`
 	Model          string                         `json:"model" redis:"model"`
 	Locations      map[string]BotLocationConfig   `json:"locations" redis:"locations"`
 	Transitions    map[string]BotTransitionConfig `json:"transitions" redis:"transitions"`

--- a/sdk/src/beta9/abstractions/experimental/bot/bot.py
+++ b/sdk/src/beta9/abstractions/experimental/bot/bot.py
@@ -222,10 +222,18 @@ class BotTransition:
 class Bot(RunnerAbstraction, DeployableMixin):
     """
     Parameters:
+        provider (str):
+            LLM provider to use for the bot. Default is "openai". Set to
+            "orcarouter" to route requests through an OrcaRouter API key,
+            which exposes an OpenAI-compatible gateway across many models.
         model (Optional[str]):
-            Which model to use for the bot. Default is "gpt-4o".
+            Which model to use for the bot. Default is "gpt-4o". When provider
+            is "orcarouter", this is a namespaced model id such as
+            "openai/gpt-4o-mini" or "orcarouter/auto".
         api_key (str):
-            OpenAI API key to use for the bot. In the future this will support other LLM providers.
+            API key to use for the bot. For provider="openai", this is an
+            OpenAI API key. For provider="orcarouter", this is an OrcaRouter
+            API key.
         locations (Optional[List[BotLocation]]):
             A list of locations where the bot can store markers. Default is [].
         description (Optional[str]):
@@ -241,6 +249,9 @@ class Bot(RunnerAbstraction, DeployableMixin):
 
     deployment_stub_type = BOT_DEPLOYMENT_STUB_TYPE
     base_stub_type = BOT_STUB_TYPE
+
+    OPENAI_PROVIDER = "openai"
+    ORCAROUTER_PROVIDER = "orcarouter"
 
     VALID_MODELS = [
         "gpt-4o",
@@ -263,16 +274,29 @@ class Bot(RunnerAbstraction, DeployableMixin):
         disks: Optional[List[DurableDisk]] = None,
         authorized: bool = True,
         welcome_message: Optional[str] = None,
+        provider: str = OPENAI_PROVIDER,
     ) -> None:
         super().__init__(volumes=volumes, disks=disks)
 
         if not api_key or api_key == "":
             raise ValueError("API key is required")
 
-        if model not in self.VALID_MODELS:
+        if provider not in (self.OPENAI_PROVIDER, self.ORCAROUTER_PROVIDER):
             raise ValueError(
-                f"Invalid model name: {model}. We currently only support: {', '.join(self.VALID_MODELS)}"
+                f"Invalid provider: {provider}. We currently only support: {self.OPENAI_PROVIDER}, {self.ORCAROUTER_PROVIDER}"
             )
+
+        if provider == self.OPENAI_PROVIDER:
+            if model not in self.VALID_MODELS:
+                raise ValueError(
+                    f"Invalid model name: {model}. We currently only support: {', '.join(self.VALID_MODELS)}"
+                )
+        else:
+            # OrcaRouter uses a namespaced model id (e.g. "openai/gpt-4o-mini",
+            # "orcarouter/auto"), so we accept any model string and pass it
+            # through to the gateway.
+            if not model or model == "":
+                raise ValueError("A model name is required")
 
         self.is_websocket = True
         self._bot_stub: Optional[BotServiceStub] = None
@@ -281,6 +305,7 @@ class Bot(RunnerAbstraction, DeployableMixin):
         self.parent: "Bot" = self
 
         self.extra: Dict[str, Dict[str, dict]] = {}
+        self.extra["provider"] = provider
         self.extra["model"] = model
         self.extra["locations"] = {}
         self.extra["description"] = description

--- a/sdk/tests/test_bot.py
+++ b/sdk/tests/test_bot.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from beta9.abstractions.experimental.bot.bot import Bot
+
+
+class TestBotProvider(unittest.TestCase):
+    def _make_bot(self, **kwargs):
+        params = dict(api_key="sk-orca-test")
+        params.update(kwargs)
+        with (
+            patch(
+                "beta9.abstractions.base.runner.RunnerAbstraction.__init__",
+                return_value=None,
+            ),
+            patch(
+                "beta9.abstractions.experimental.bot.bot.Bot.gateway_stub",
+                new_callable=PropertyMock,
+                return_value=MagicMock(),
+            ),
+            patch("beta9.abstractions.experimental.bot.bot.FileSyncer"),
+        ):
+            return Bot(**params)
+
+    def test_default_provider_is_openai(self):
+        bot = self._make_bot(model="gpt-4o")
+        self.assertEqual(bot.extra["provider"], Bot.OPENAI_PROVIDER)
+
+    def test_orcarouter_provider_accepts_namespaced_model(self):
+        bot = self._make_bot(
+            provider=Bot.ORCAROUTER_PROVIDER, model="openai/gpt-4o-mini"
+        )
+        self.assertEqual(bot.extra["provider"], Bot.ORCAROUTER_PROVIDER)
+        self.assertEqual(bot.extra["model"], "openai/gpt-4o-mini")
+
+    def test_orcarouter_provider_accepts_auto_router(self):
+        bot = self._make_bot(provider=Bot.ORCAROUTER_PROVIDER, model="orcarouter/auto")
+        self.assertEqual(bot.extra["provider"], Bot.ORCAROUTER_PROVIDER)
+        self.assertEqual(bot.extra["model"], "orcarouter/auto")
+
+    def test_invalid_provider_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_bot(provider="unknown", model="gpt-4o")
+
+    def test_openai_provider_rejects_unknown_model(self):
+        with self.assertRaises(ValueError):
+            self._make_bot(model="not-a-real-model")
+
+    def test_missing_api_key_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_bot(api_key="")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Beta9's `Bot` abstraction is the one place the runtime talks to an external LLM provider, and today it is hardwired to OpenAI: the SDK validates against a fixed OpenAI model list and the gateway always dials `api.openai.com`. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means Beta9 bot users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

## Changes

- **SDK (`sdk/src/beta9/abstractions/experimental/bot/bot.py`)**: added an optional `provider` argument to `Bot`, defaulting to `openai` (existing behavior unchanged). When `provider="orcarouter"`, the SDK accepts namespaced model ids such as `openai/gpt-4o-mini` or `orcarouter/auto` and stores the provider in the bot stub config.
- **Gateway (`pkg/abstractions/experimental/bot/interface.go`)**: the bot's OpenAI-compatible client is now built from the configured provider. For `orcarouter`, requests go to `https://api.orcarouter.ai/v1` and include `HTTP-Referer` / `X-Title` attribution headers so the gateway can attribute traffic to the Beta9 SDK.
- **Gateway (`pkg/abstractions/experimental/bot/types.go`)**: `BotConfig` now carries the `provider` field through JSON serialization to Redis.

## Verification

- Python SDK: `ruff check .` clean; full suite 245 passed, 2 skipped (pre-existing), including 6 new tests covering provider validation and namespaced model handling.
- Go: `go build ./...` succeeds; 3 new tests in the bot package pass, including an `httptest` round trip that exercises the `orcarouter` client wiring (base URL, Bearer auth, attribution headers).
- Live: drove the real `orcarouter` provider client against `https://api.orcarouter.ai/v1` with a live key: `POST /chat/completions` returned 200 for `openai/gpt-4o-mini` (response content confirmed).

Using it looks like this:

```python
from beta9 import Bot

bot = Bot(
    provider="orcarouter",
    model="openai/gpt-4o-mini",  # or "orcarouter/auto"
    api_key="sk-orca-...",
)
```

The `provider` argument is additive and fully backward compatible. It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `orcarouter` as a named LLM provider for the `Bot` abstraction. Previously `Bot` was hardwired to OpenAI: the SDK validated against a fixed model list and the gateway always dialed `api.openai.com`. Now `Bot` accepts an optional `provider` argument (defaults to `openai`, existing behavior unchanged) that routes requests to OrcaRouter's OpenAI-compatible gateway, supporting namespaced model IDs like `openai/gpt-4o-mini` or `orcarouter/auto`.

**New Features**
- `provider="orcarouter"` accepts any non-empty model string instead of the fixed OpenAI model list.
- The gateway sends `HTTP-Referer` and `X-Title` attribution headers for OrcaRouter traffic so upstream usage is attributed to Beta9.
- `provider` is serialized into bot stub config so the gateway builds the right client per deployment.

<sup>Written for commit 3317d9d1453de25ba7422c4914fefdd507d17781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

