### PR TITLE
fix usage client

### DIFF
--- a/pkg/clients/managed_compute_container_usage.go
+++ b/pkg/clients/managed_compute_container_usage.go
@@ -106,18 +106,25 @@ func managedComputeContainerUsageBody(
 	if request.WorkspaceId == "" || request.ContainerId == "" || !end.After(start) {
 		return nil, fmt.Errorf("managed compute usage is missing attribution or duration")
 	}
-	if costCents == nil || *costCents <= 0 || math.IsNaN(*costCents) || math.IsInf(*costCents, 0) {
-		return nil, fmt.Errorf("managed compute usage is missing a positive cost")
-	}
-	costMicros := math.Ceil(*costCents * 10_000)
-	if math.IsInf(costMicros, 0) || costMicros >= float64(1<<63) {
-		return nil, fmt.Errorf("managed compute usage cost is too large")
+
+	// The quote is optional: the cost hook cannot price every deployment, and
+	// the ledger stops machines whose usage goes silent. An unquoted window is
+	// sent with its resources and duration, and the ledger prices it from its
+	// own rate card.
+	var costMicros *int64
+	if costCents != nil && *costCents > 0 && !math.IsNaN(*costCents) && !math.IsInf(*costCents, 0) {
+		micros := math.Ceil(*costCents * 10_000)
+		if math.IsInf(micros, 0) || micros >= float64(1<<63) {
+			return nil, fmt.Errorf("managed compute usage cost is too large")
+		}
+		quoted := int64(micros)
+		costMicros = &quoted
 	}
 
 	payload := struct {
 		WorkspaceID   string    `json:"workspace_id"`
 		ReservationID string    `json:"reservation_id"`
-		CostMicros    int64     `json:"cost_micros"`
+		CostMicros    *int64    `json:"cost_micros,omitempty"`
 		StartAt       time.Time `json:"start_at"`
 		EndAt         time.Time `json:"end_at"`
 		GPU           string    `json:"gpu"`
@@ -127,7 +134,7 @@ func managedComputeContainerUsageBody(
 	}{
 		WorkspaceID:   request.WorkspaceId,
 		ReservationID: request.ContainerId,
-		CostMicros:    int64(costMicros),
+		CostMicros:    costMicros,
 		StartAt:       start.UTC(),
 		EndAt:         end.UTC(),
 		GPU:           request.Gpu,

--- a/pkg/clients/managed_compute_container_usage_test.go
+++ b/pkg/clients/managed_compute_container_usage_test.go
@@ -195,3 +195,47 @@ func TestManagedComputeContainerUsageRejectsInt64Overflow(t *testing.T) {
 		t.Fatalf("error = %v, want cost overflow", err)
 	}
 }
+
+// A cost-hook outage (or a workspace it cannot quote) leaves intervals without
+// a cost. Routed usage must still be sent — with resources and duration, no
+// cost fields — so the ledger can price it from its own rate card. Dropping it
+// instead bricks every machine the route covers: the ledger stops machines
+// whose usage goes silent.
+func TestManagedComputeContainerUsageSendsUnquotedWindowsWithoutACost(t *testing.T) {
+	requests := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		requests <- payload
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	recorder := managedComputeUsageTestRecorder(server.URL)
+	start := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	request := managedComputeUsageTestRequest("tama-machine-1")
+	request.Cpu = 4_000
+	request.Memory = 8_192
+	if err := recorder.RecordContainerUsage(context.Background(), request, start, start.Add(time.Minute), nil); err != nil {
+		t.Fatal(err)
+	}
+	payload := <-requests
+	if _, quoted := payload["cost_micros"]; quoted {
+		t.Fatalf("payload = %+v, want no cost on an unquoted window", payload)
+	}
+	if payload["cpu_millicores"] != float64(4_000) || payload["memory_mb"] != float64(8_192) {
+		t.Fatalf("payload = %+v, want resources for the ledger's rate card", payload)
+	}
+
+	// A quoted interval keeps sending the quote.
+	cost := 0.012345
+	if err := recorder.RecordContainerUsage(context.Background(), request, start, start.Add(time.Minute), &cost); err != nil {
+		t.Fatal(err)
+	}
+	payload = <-requests
+	if payload["cost_micros"] != float64(124) {
+		t.Fatalf("cost_micros = %v, want 124", payload["cost_micros"])
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the usage client so unquoted usage intervals are still reported. Previously, any usage without a positive cost was rejected; now the cost is optional and omitted from the payload, letting the ledger price unquoted windows from its own rate card. Adds a test covering unquoted and quoted intervals.

<sup>Written for commit ceebbf2b9c7c4399c737deeca675b1b578dc0783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

