### PR TITLE
Fix flaky runc restore output assertion

### DIFF
--- a/pkg/runtime/runc_test.go
+++ b/pkg/runtime/runc_test.go
@@ -233,7 +233,12 @@ esac
 	case <-time.After(3 * time.Second):
 		t.Fatal("restore did not return after detached restore completed")
 	}
-	require.Contains(t, output.String(), "restore-output-done\n")
+	// Restore returns once runc exits and the PID is known; the output copier
+	// keeps running so the restored container stays connected, so the final
+	// line of restore output may land a moment after Restore returns.
+	require.Eventually(t, func() bool {
+		return bytes.Contains([]byte(output.String()), []byte("restore-output-done\n"))
+	}, time.Second, 10*time.Millisecond, "restore output was not fully forwarded")
 	require.NotContains(t, output.String(), "container-output\n")
 	require.Eventually(t, func() bool {
 		return bytes.Contains([]byte(output.String()), []byte("container-output\n"))


### PR DESCRIPTION
The `gateway-0.1.765` tag build failed on `TestRuncRestoreSignalsStartedAfterRestoreCompletes` while the identical commit passed on the `main` push seconds earlier.

`Restore` deliberately returns once `runc restore` exits and the restored PID is known, while the output copier keeps forwarding so the restored container's stdout stays connected. The fake runc writes `restore-output-done` as its last line before exiting, so that line can land a moment after `Restore` returns. The test asserted on it immediately; poll for it instead, like the assertion right below it.

Test-only change; no runtime behavior affected.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `TestRuncRestoreSignalsStartedAfterRestoreCompletes` assertion by polling for `restore-output-done` instead of checking immediately. `Restore` returns once `runc restore` exits while the output copier keeps forwarding, so the last line of restore output can land a moment later. Test-only change; no runtime behavior affected.

<sup>Written for commit f97cf44233c8486e08950bc036aa9f684a570f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

