### PR TITLE
fix(worker): restored sandbox exec failed instantly when its process manager blipped (IPv6 fallback masked retryable error)

### DIFF
--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -530,7 +530,7 @@ func newProcessManagerClient(ctx context.Context, instance *ContainerInstance) (
 
 	var lastErr error
 	for _, endpoint := range endpoints {
-		client, err := goproc.NewGoProcClient(ctx, endpoint.host, uint(endpoint.port))
+		client, err := goproc.NewGoProcClient(ctx, endpoint.dialHost(), uint(endpoint.port))
 		if err != nil {
 			lastErr = err
 			continue
@@ -552,6 +552,18 @@ func newProcessManagerClient(ctx context.Context, instance *ContainerInstance) (
 type processManagerEndpoint struct {
 	host string
 	port int
+}
+
+// dialHost returns the host in the form goproc's client can join with a port
+// ("%s:%d" into grpc.NewClient). An IPv6 literal has to be bracketed there,
+// otherwise the dns resolver rejects the target ("too many colons") and the
+// host-mapped fallback endpoint is dead on every dual-stack node.
+func (e processManagerEndpoint) dialHost() string {
+	host := strings.TrimSuffix(strings.TrimPrefix(e.host, "["), "]")
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		return "[" + host + "]"
+	}
+	return host
 }
 
 func sandboxProcessManagerEndpoints(instance *ContainerInstance) []processManagerEndpoint {

--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -538,23 +538,32 @@ func newProcessManagerClient(ctx context.Context, instance *ContainerInstance) (
 // later hard failure must not turn the transient refusal into a fatal exec.
 func newProcessManagerClientFromEndpoints(ctx context.Context, endpoints []processManagerEndpoint) (*goproc.GoProcClient, error) {
 	var lastErr, retryableErr error
-	for _, endpoint := range endpoints {
-		client, err := goproc.NewGoProcClient(ctx, endpoint.dialHost(), uint(endpoint.port))
-		if err == nil {
-			probeCtx, cancel := context.WithTimeout(ctx, goprocReadyProbeTimeout)
-			err = client.ReadyContext(probeCtx)
-			cancel()
-			if err == nil {
-				return client, nil
-			}
-			_ = client.Cleanup()
-		}
-
+	recordErr := func(err error) {
 		lastErr = err
 		if retryableErr == nil && isProcessManagerDialFailure(err) {
 			retryableErr = err
 		}
 	}
+
+	for _, endpoint := range endpoints {
+		client, err := goproc.NewGoProcClient(ctx, endpoint.dialHost(), uint(endpoint.port))
+		if err != nil {
+			recordErr(err)
+			continue
+		}
+
+		probeCtx, cancel := context.WithTimeout(ctx, goprocReadyProbeTimeout)
+		err = client.ReadyContext(probeCtx)
+		cancel()
+		if err != nil {
+			_ = client.Cleanup()
+			recordErr(err)
+			continue
+		}
+
+		return client, nil
+	}
+
 	if retryableErr != nil {
 		return nil, retryableErr
 	}

--- a/pkg/worker/sandbox.go
+++ b/pkg/worker/sandbox.go
@@ -527,24 +527,36 @@ func newProcessManagerClient(ctx context.Context, instance *ContainerInstance) (
 	if len(endpoints) == 0 {
 		return nil, fmt.Errorf("sandbox process manager address unavailable")
 	}
+	return newProcessManagerClientFromEndpoints(ctx, endpoints)
+}
 
-	var lastErr error
+// newProcessManagerClientFromEndpoints tries each endpoint in order and returns
+// the first that answers Ready. When none does, a retryable (dial) failure from
+// any endpoint takes precedence over a non-retryable one: a restored sandbox
+// briefly refuses on its container IP while its published host-mapped address
+// fails hard (the worker itself cannot reach a PREROUTING-only DNAT), and the
+// later hard failure must not turn the transient refusal into a fatal exec.
+func newProcessManagerClientFromEndpoints(ctx context.Context, endpoints []processManagerEndpoint) (*goproc.GoProcClient, error) {
+	var lastErr, retryableErr error
 	for _, endpoint := range endpoints {
 		client, err := goproc.NewGoProcClient(ctx, endpoint.dialHost(), uint(endpoint.port))
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		probeCtx, cancel := context.WithTimeout(ctx, goprocReadyProbeTimeout)
-		err = client.ReadyContext(probeCtx)
-		cancel()
 		if err == nil {
-			return client, nil
+			probeCtx, cancel := context.WithTimeout(ctx, goprocReadyProbeTimeout)
+			err = client.ReadyContext(probeCtx)
+			cancel()
+			if err == nil {
+				return client, nil
+			}
+			_ = client.Cleanup()
 		}
 
-		_ = client.Cleanup()
 		lastErr = err
+		if retryableErr == nil && isProcessManagerDialFailure(err) {
+			retryableErr = err
+		}
+	}
+	if retryableErr != nil {
+		return nil, retryableErr
 	}
 	return nil, lastErr
 }

--- a/pkg/worker/sandbox_test.go
+++ b/pkg/worker/sandbox_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/beam-cloud/beta9/pkg/common"
 	"github.com/beam-cloud/beta9/pkg/types"
+	goproc "github.com/beam-cloud/goproc/pkg"
 	goprocpb "github.com/beam-cloud/goproc/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -234,6 +235,33 @@ func TestSandboxProcessManagerEndpointsBracketIPv6ForDialing(t *testing.T) {
 	require.Equal(t, "[fd00::5]", processManagerEndpoint{host: "[fd00::5]", port: 7111}.dialHost())
 	require.Equal(t, "10.42.0.163", processManagerEndpoint{host: "10.42.0.163", port: 7111}.dialHost())
 	require.Equal(t, "sandbox.local", processManagerEndpoint{host: "sandbox.local", port: 7111}.dialHost())
+}
+
+// End-to-end version of the above: a real goproc server on an IPv6 address,
+// reachable only through the host-mapped fallback endpoint. Before dialHost()
+// this failed with "invalid target address ::1:<port> ... too many colons".
+func TestNewProcessManagerClientReachesIPv6FallbackEndpoint(t *testing.T) {
+	lis, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("no IPv6 loopback: %v", err)
+	}
+	srv := grpc.NewServer()
+	goprocpb.RegisterGoProcServer(srv, &goproc.GoProcServer{})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	instance := &ContainerInstance{
+		ContainerAddressMap: map[int32]string{
+			types.WorkerSandboxProcessManagerPort: lis.Addr().String(),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := newProcessManagerClient(ctx, instance)
+	require.NoError(t, err)
+	defer client.Cleanup()
+	require.NoError(t, client.ReadyContext(ctx))
 }
 
 func TestDockerSandboxStartupCleanupRemovesStalePidFiles(t *testing.T) {

--- a/pkg/worker/sandbox_test.go
+++ b/pkg/worker/sandbox_test.go
@@ -212,6 +212,30 @@ func TestSandboxProcessManagerEndpointsIgnoreInvalidPublishedAddress(t *testing.
 	require.Equal(t, int(types.WorkerSandboxProcessManagerPort), endpoints[0].port)
 }
 
+// On dual-stack nodes the worker publishes the process manager port on the
+// node's IPv6 address. goproc joins host and port with "%s:%d", so the host
+// must arrive bracketed or grpc rejects the target with "too many colons" and
+// the fallback endpoint is useless exactly when it is needed.
+func TestSandboxProcessManagerEndpointsBracketIPv6ForDialing(t *testing.T) {
+	endpoints := sandboxProcessManagerEndpoints(&ContainerInstance{
+		ContainerIp: "192.168.0.81",
+		ContainerAddressMap: map[int32]string{
+			types.WorkerSandboxProcessManagerPort: "[2600:1f18:37a4:c02::1a9b]:44209",
+		},
+	})
+
+	require.Len(t, endpoints, 2)
+	require.Equal(t, "192.168.0.81", endpoints[0].dialHost())
+	require.Equal(t, "2600:1f18:37a4:c02::1a9b", endpoints[1].host)
+	require.Equal(t, "[2600:1f18:37a4:c02::1a9b]", endpoints[1].dialHost())
+	require.Equal(t, 44209, endpoints[1].port)
+
+	require.Equal(t, "[fd00::5]", processManagerEndpoint{host: "fd00::5", port: 7111}.dialHost())
+	require.Equal(t, "[fd00::5]", processManagerEndpoint{host: "[fd00::5]", port: 7111}.dialHost())
+	require.Equal(t, "10.42.0.163", processManagerEndpoint{host: "10.42.0.163", port: 7111}.dialHost())
+	require.Equal(t, "sandbox.local", processManagerEndpoint{host: "sandbox.local", port: 7111}.dialHost())
+}
+
 func TestDockerSandboxStartupCleanupRemovesStalePidFiles(t *testing.T) {
 	require.Equal(t, "rm -f /var/run/docker.pid /var/run/docker/containerd/containerd.pid", dockerSandboxStartupCleanupScript())
 }

--- a/pkg/worker/sandbox_test.go
+++ b/pkg/worker/sandbox_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -262,6 +263,47 @@ func TestNewProcessManagerClientReachesIPv6FallbackEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Cleanup()
 	require.NoError(t, client.ReadyContext(ctx))
+}
+
+// A restored sandbox has both endpoints. Right after restore the container-IP
+// endpoint can refuse for a moment (retryable), while the published address is
+// a host-mapped port the worker itself cannot reach (PREROUTING-only DNAT) and
+// fails in a non-retryable way. The retryable error has to win, otherwise the
+// exec fails immediately instead of riding out the blip.
+func TestNewProcessManagerClientKeepsRetryableErrorWhenFallbackFailsHard(t *testing.T) {
+	refused, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	primaryHost, primaryPort, _ := net.SplitHostPort(refused.Addr().String())
+	require.NoError(t, refused.Close()) // primary: nothing listening -> connection refused
+
+	// fallback: accepts and immediately hangs up -> "error reading server preface: EOF"
+	hangup, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer hangup.Close()
+	go func() {
+		for {
+			conn, err := hangup.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	port, err := strconv.Atoi(primaryPort)
+	require.NoError(t, err)
+	instance := &ContainerInstance{ContainerIp: primaryHost}
+	instance.setContainerAddressMap(map[int32]string{types.WorkerSandboxProcessManagerPort: hangup.Addr().String()})
+	endpoints := sandboxProcessManagerEndpoints(instance)
+	require.Len(t, endpoints, 2)
+	endpoints[0].port = port // the real primary is fixed at 7111, which a test cannot bind
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := newProcessManagerClientFromEndpoints(ctx, endpoints)
+	require.Nil(t, client)
+	require.Error(t, err)
+	require.True(t, isProcessManagerDialFailure(err), "expected the primary's retryable error, got: %v", err)
 }
 
 func TestDockerSandboxStartupCleanupRemovesStalePidFiles(t *testing.T) {

--- a/sdk/src/beta9/cli/run.py
+++ b/sdk/src/beta9/cli/run.py
@@ -91,7 +91,10 @@ def run(
     result: PodInstance = pod_spec.create(machine_id=machine_id)
     if not result.ok:
         if result.error_msg == RUNTIME_PREPARE_FAILED_MSG:
-            return  # prepare_runtime already reported the specific failure
+            # prepare_runtime already reported the specific failure. Preserve
+            # that message without printing the generic error again, but make
+            # sure scripts and CI still receive a failing exit status.
+            raise click.exceptions.Exit(1)
         terminal.error(result.error_msg or "Failed to create container.")
         return
 

--- a/sdk/src/beta9/config.py
+++ b/sdk/src/beta9/config.py
@@ -54,8 +54,9 @@ class SDKSettings:
     app_url_template: str = os.getenv("BETA9_APP_URL_TEMPLATE", "")
 
     def __post_init__(self, **kwargs):
-        if p := os.getenv("CONFIG_PATH"):
-            self.config_path = Path(p).expanduser()
+        config_path = os.getenv("CONFIG_PATH")
+        if config_path:
+            self.config_path = Path(config_path).expanduser()
 
         # Handle Beam-specific environment variables if beam module is loaded
         if "beam" in sys.modules:
@@ -64,7 +65,8 @@ class SDKSettings:
             self.api_port = int(os.getenv("API_PORT", 443))
             self.gateway_host = os.getenv("GATEWAY_HOST", "gateway.beam.cloud")
             self.gateway_port = int(os.getenv("GATEWAY_PORT", 443))
-            self.config_path = Path("~/.beam/config.ini").expanduser()
+            if not config_path:
+                self.config_path = Path("~/.beam/config.ini").expanduser()
             self.use_defaults_in_prompt = True
             self.api_token = os.getenv("BEAM_TOKEN")
 

--- a/sdk/tests/test_cli.py
+++ b/sdk/tests/test_cli.py
@@ -1,12 +1,19 @@
 import datetime
+import sys
+from pathlib import Path
 from types import SimpleNamespace
+from types import ModuleType
 
 import click
 import pytest
+from click.testing import CliRunner
 
 from beta9.cli import database as database_cli
 from beta9.cli import container as container_cli
+from beta9.cli import extraclick
+from beta9.cli import run as run_cli
 from beta9.cli.main import load_cli
+from beta9.config import SDKSettings
 
 
 def test_disk_management_commands_registered():
@@ -70,6 +77,43 @@ def test_reserved_hardware_dx_commands_are_registered():
 
     container = cli.management_group.get_command(None, "container")
     assert "machine_id" in {param.name for param in container.commands["list"].params}
+
+
+def test_beam_settings_honor_config_path(monkeypatch, tmp_path):
+    config_path = tmp_path / "beam-config.ini"
+    monkeypatch.setenv("CONFIG_PATH", str(config_path))
+    monkeypatch.setitem(sys.modules, "beam", ModuleType("beam"))
+
+    settings = SDKSettings()
+
+    assert settings.config_path == Path(config_path)
+
+
+def test_run_runtime_prepare_failure_exits_nonzero(monkeypatch):
+    class FakeServiceClient:
+        def __init__(self, _config):
+            self.channel = object()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    class FakePod:
+        def __init__(self, entrypoint=None):
+            self.entrypoint = entrypoint
+
+        def create(self, machine_id=""):
+            return SimpleNamespace(ok=False, error_msg="Failed to prepare runtime")
+
+    monkeypatch.setattr(extraclick, "ServiceClient", FakeServiceClient)
+    monkeypatch.setattr(extraclick, "get_config_context", lambda _context: SimpleNamespace())
+    monkeypatch.setattr(run_cli, "Pod", FakePod)
+
+    result = CliRunner().invoke(run_cli.common, ["run", "--entrypoint", "echo hi"])
+
+    assert result.exit_code == 1
 
 
 def test_database_exists_error_uses_active_cli_name(monkeypatch):


### PR DESCRIPTION
## Problem

On dual-stack clusters (staging and prod both give pods IPv6 addresses) the worker publishes the sandbox process-manager port as `[2600:...]:44209`. `sandboxProcessManagerEndpoints` splits that with `net.SplitHostPort` and hands the bare `2600:...` host to `goproc.NewGoProcClient`, which does `grpc.NewClient(fmt.Sprintf("%s:%d", host, port))`. grpc's dns resolver then fails with:

```
rpc error: code = Unavailable desc = invalid target address 2600:1f18:37a4:c02::1a9b:44209, error info: address 2600:1f18:37a4:c02::1a9b:44209:443: too many colons in address
```

Because that error is not a dial failure, `newSandboxProcessManagerClient` returns it immediately rather than retrying. So whenever the primary container-IP endpoint hiccups (reproduced on staging right after a memory-snapshot restore: the process manager rebinds its listener), the sandbox exec/status call fails and the SDK raises `SandboxProcessError` instead of the fallback endpoint saving the request.

Pre-dates #1868 (the endpoint list was added in #1699); found during the release QA of 0.1.766.

## Fix

`processManagerEndpoint.dialHost()` brackets IPv6 literals before they reach goproc. Hostnames and IPv4 are unchanged. Unit test covers the published-IPv6, already-bracketed, IPv4 and hostname cases.

## Verification

- `go test ./pkg/worker -run TestSandboxProcessManagerEndpoints`
- Reproduced the failure on staging (2/2 snapshot restore iterations → 1 failure) before the change; will re-run the probe once this is on staging.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox process manager endpoints on dual-stack clusters: IPv6 literals are now bracketed before reaching goproc, and the primary endpoint's retryable error wins over a fallback endpoint's hard failure. Also fixes two SDK behaviors.

- Brackets IPv6 hosts so grpc no longer rejects targets with "too many colons".
- Returns the primary's retryable error when it briefly refuses (e.g. right after a snapshot restore) and the fallback fails hard, so the exec rides out the blip instead of failing instantly.
- Adds an end-to-end test using a real goproc server on IPv6 loopback and a test covering the retryable-error precedence.
- `beta9 run` now exits nonzero when runtime preparation fails, and `CONFIG_PATH` is honored even when the `beam` module is loaded.

<sup>Written for commit ef01ec0985554235d8c0feb72eec4533062fa78a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

