### PR TITLE
disk: deterministic chunk-shift dedup test (fixes ~8% CI flake)

### DIFF
--- a/pkg/disk/layer_test.go
+++ b/pkg/disk/layer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	mathrand "math/rand/v2"
 	"os"
 	"path/filepath"
 	"sync"
@@ -122,19 +123,31 @@ func TestLayerScanUploadFetchRoundTrip(t *testing.T) {
 // Content-defined boundaries must survive shifts: a flatten relocates
 // unchanged disk content within the qcow2 file, and publish dedup relies on
 // those bytes keeping their chunk hashes.
+//
+// The gear hash's low chunkMeanMask bits depend on the last 22 bytes only,
+// so a shifted stream re-finds its boundaries as soon as one boundary
+// re-aligns. What delays that is the max-size clamp: with a 4 MiB mean and
+// 8 MiB max, ~17% of chunks are cut at chunkMaxSize (exp(-7/4)), and a
+// clamped cut is relative to the chunk start, not the content, so it
+// carries a misalignment into the next chunk. Only the run of chunks from
+// the insertion point to the first re-aligned boundary may differ; with
+// unseeded data that run is geometric and ~8% of the time long enough to
+// drop dedup below 3/4, so the input is seeded to keep the test stable.
 func TestScanLayerChunksSurviveContentShift(t *testing.T) {
 	dir := t.TempDir()
+	rng := mathrand.NewChaCha8([32]byte{'l', 'a', 'y', 'e', 'r', '-', 's', 'h', 'i', 'f', 't'})
 	base := make([]byte, 64<<20)
-	rand.Read(base)
+	rng.Read(base)
 	pathA := filepath.Join(dir, "a.qcow2")
 	if err := os.WriteFile(pathA, base, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	// Insert 64 KiB at 8 MiB, shifting everything after it.
+	const insertAt = 8 << 20
 	inserted := make([]byte, 64<<10)
-	rand.Read(inserted)
-	shifted := append(append(append([]byte{}, base[:8<<20]...), inserted...), base[8<<20:]...)
+	rng.Read(inserted)
+	shifted := append(append(append([]byte{}, base[:insertAt]...), inserted...), base[insertAt:]...)
 	pathB := filepath.Join(dir, "b.qcow2")
 	if err := os.WriteFile(pathB, shifted, 0o600); err != nil {
 		t.Fatal(err)
@@ -153,13 +166,33 @@ func TestScanLayerChunksSurviveContentShift(t *testing.T) {
 	for _, chunk := range layerA.Chunks {
 		digestsA[chunk.Digest] = true
 	}
+	// The chunks that miss must be one contiguous run starting at the chunk
+	// holding the insertion: everything before it is untouched, and once a
+	// boundary re-aligns every later boundary is content-defined from it.
 	var sharedBytes, totalBytes int64
-	for _, chunk := range layerB.Chunks {
+	firstMiss, lastMiss := -1, -1
+	for i, chunk := range layerB.Chunks {
 		totalBytes += chunk.SizeBytes
 		if digestsA[chunk.Digest] {
 			sharedBytes += chunk.SizeBytes
+			continue
 		}
+		if firstMiss == -1 {
+			firstMiss = i
+		} else if i != lastMiss+1 {
+			t.Fatalf("chunk %d at %d lost dedup after boundaries re-aligned at chunk %d", i, chunk.OffsetBytes, lastMiss+1)
+		}
+		lastMiss = i
 	}
+	if firstMiss == -1 {
+		t.Fatal("the chunk holding the inserted bytes cannot dedup")
+	}
+	if first := layerB.Chunks[firstMiss]; first.OffsetBytes > insertAt || first.OffsetBytes+first.SizeBytes <= insertAt {
+		t.Fatalf("chunk %d at %d lost dedup before the insertion at %d", firstMiss, first.OffsetBytes, insertAt)
+	}
+	// Each max-size clamp carries the shift one chunk further; with the seed
+	// above the missing run is short (logged for reference).
+	t.Logf("%d of %d bytes dedup after a 64KiB shift; %d chunks re-cut", sharedBytes, totalBytes, lastMiss-firstMiss+1)
 	if sharedBytes < totalBytes*3/4 {
 		t.Fatalf("only %d of %d bytes dedup after a 64KiB shift", sharedBytes, totalBytes)
 	}


### PR DESCRIPTION
## Summary

`TestScanLayerChunksSurviveContentShift` failed on CI for #1869 with `only 42565034 of 67174400 bytes dedup after a 64KiB shift`. Investigated whether this pointed at a chunker defect. It does not.

**Chunker (`pkg/disk/layer.go`) is correct:** gear hash with `hash<<1 + gear[b]`, so the low 22 mask bits depend only on the last 22 bytes; hash state carried across `ReadAt` buffers; cuts are absolute offsets. Boundaries are content-defined and resynchronise permanently once one boundary re-aligns.

**Why the test flaked:** with a 4 MiB mean and 8 MiB max, `exp(-7/4) ≈ 17%` of chunks are cut by the max-size clamp, and a clamped cut is relative to the chunk start, not the content. Each clamped chunk therefore carries the 64 KiB shift one chunk further with p ≈ 0.18. The 3/4 threshold allows ≤ 16 MiB of non-dedup bytes; two consecutive clamped chunks plus the re-aligning chunk exceeds it. The CI failure was exactly 8 + 8 + 7.47 MiB.

Empirically over 300 seeded inputs: 8% failure rate against 3/4 (median 5.5 MiB missing, p90 14.3 MiB, max 35.8 MiB); in every seed the non-dedup chunks formed one contiguous run starting at the insertion.

## Change (test only)

- Seed the input (`math/rand/v2` ChaCha8) so the test is deterministic (85% dedup, 2 chunks re-cut with this seed).
- Assert the actual guarantee: non-dedup chunks form exactly one contiguous run, and its first chunk contains the insertion offset. A real resynchronisation bug now fails every run instead of hiding inside a ratio.
- Keep the 3/4 and max-size checks.

`go test ./pkg/disk/ -count=50` passes.

Follow-up (not in this PR, changes published chunk boundaries): FastCDC-style normalised chunking would cut the clamp rate from ~17% to ~1% and improve real-world dedup after shifts.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Test-only change that fixes the flaky `TestScanLayerChunksSurviveContentShift` by seeding the random input and asserting the actual dedup guarantee.

- Previously the test used unseeded random data, causing ~8% of runs to fail even though the chunker is correct.
- Now the test checks that non-dedup chunks form one contiguous run starting at the insertion, so a real resynchronisation bug always fails.

<sup>Written for commit 4182f4c1a7760edbb6fd58fe89c14aafafcec8da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

