### PR TITLE
worker: bounded lifetime for busy workers (worker.maxAge, drain then exit)

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -333,18 +333,13 @@ worker:
   cleanupWorkerInterval: 1m
   cleanupPendingWorkerAgeLimit: 10m
   # An idle worker holding a pool's minimum free capacity (poolSizing.minFree*)
-  # never idles out on its own. Past this age it exits anyway and the sizer
-  # replaces it (the pool is cold for one worker boot, ~4s, once per period).
-  # Each worker adds up to 1/8 of this as id-derived jitter so two headroom
-  # workers in a pool do not leave together. 0 disables the bound.
+  # stays up; past this age it exits anyway and the sizer replaces it.
   headroomWorkerMaxAge: 6h
-  # Upper bound on any non-persistent worker's lifetime, busy or idle. Past it
-  # the worker stops accepting containers (the scheduler skips it and the pool
-  # sizer stops counting it, so a replacement starts right away), lets the
-  # containers it is running finish, and exits. Without this a worker with
-  # steady traffic never idles out and keeps running the image it booted with
-  # across releases. Same 1/8 id-derived jitter as headroomWorkerMaxAge.
-  # 0 disables the bound.
+  # Lifetime bound for any non-persistent worker, busy or idle: past it the
+  # worker stops accepting containers, lets running ones finish and exits, so
+  # steady traffic cannot keep a worker on an old image forever.
+  # Both ages get up to 1/8 worker-id jitter so workers do not leave together;
+  # 0 disables either bound.
   maxAge: 24h
   cacheEnabled: true
   containerLogLinesPerHour: 6000

--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -338,6 +338,14 @@ worker:
   # Each worker adds up to 1/8 of this as id-derived jitter so two headroom
   # workers in a pool do not leave together. 0 disables the bound.
   headroomWorkerMaxAge: 6h
+  # Upper bound on any non-persistent worker's lifetime, busy or idle. Past it
+  # the worker stops accepting containers (the scheduler skips it and the pool
+  # sizer stops counting it, so a replacement starts right away), lets the
+  # containers it is running finish, and exits. Without this a worker with
+  # steady traffic never idles out and keeps running the image it booted with
+  # across releases. Same 1/8 id-derived jitter as headroomWorkerMaxAge.
+  # 0 disables the bound.
+  maxAge: 24h
   cacheEnabled: true
   containerLogLinesPerHour: 6000
   criu:

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -548,14 +548,12 @@ type WorkerConfig struct {
 	TmpSizeLimit                 string                        `key:"tmpSizeLimit" json:"tmp_size_limit"`
 	ContainerLogLinesPerHour     int                           `key:"containerLogLinesPerHour" json:"container_log_lines_per_hour"`
 	ContainerRuntime             string                        `key:"containerRuntime" json:"container_runtime"`
-	// HeadroomWorkerMaxAge bounds how long an idle worker that holds its pool's
-	// minimum free capacity (poolSizing.minFree*) stays up before it exits and
-	// lets the pool sizer boot a fresh one. Zero disables the bound.
+	// HeadroomWorkerMaxAge bounds how long pool headroom alone keeps an idle
+	// worker up. Zero disables the bound.
 	HeadroomWorkerMaxAge time.Duration `key:"headroomWorkerMaxAge" json:"headroom_worker_max_age"`
-	// MaxAge bounds a worker's whole lifetime, busy or idle. Past it the worker
-	// disables scheduling for itself, lets running containers finish and exits,
-	// so a worker with steady traffic still cycles onto the current image and
-	// off its node. Persistent workers are exempt. Zero disables the bound.
+	// MaxAge bounds any non-persistent worker's lifetime, busy or idle: past it
+	// the worker disables scheduling, lets running containers finish and exits.
+	// Zero disables the bound.
 	MaxAge time.Duration `key:"maxAge" json:"max_age"`
 }
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -552,6 +552,11 @@ type WorkerConfig struct {
 	// minimum free capacity (poolSizing.minFree*) stays up before it exits and
 	// lets the pool sizer boot a fresh one. Zero disables the bound.
 	HeadroomWorkerMaxAge time.Duration `key:"headroomWorkerMaxAge" json:"headroom_worker_max_age"`
+	// MaxAge bounds a worker's whole lifetime, busy or idle. Past it the worker
+	// disables scheduling for itself, lets running containers finish and exits,
+	// so a worker with steady traffic still cycles onto the current image and
+	// off its node. Persistent workers are exempt. Zero disables the bound.
+	MaxAge time.Duration `key:"maxAge" json:"max_age"`
 }
 
 type ContainerResourceLimitsConfig struct {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -55,6 +55,13 @@ const (
 	containerStartupTimeout        time.Duration = 15 * time.Minute
 	stuckContainerAbortDelay       time.Duration = 2 * time.Minute
 	gvisorShmemTHPPath                           = "/sys/kernel/mm/transparent_hugepage/shmem_enabled"
+
+	// workerDrainGrace is how long a draining worker must have been both
+	// disabled and without a new request before it treats an empty container
+	// set as fully drained: a request the scheduler placed here just before
+	// the disable landed is delivered within the stream poll interval, so
+	// this covers that window with a wide margin.
+	workerDrainGrace time.Duration = 10 * time.Second
 )
 
 func ensureGVisorShmemTHP(path string) (bool, error) {
@@ -129,6 +136,13 @@ type Worker struct {
 	// idle worker up (see shouldExitIdle); a zero headroomMaxAge is no bound.
 	startedAt      time.Time
 	headroomMaxAge time.Duration
+	// maxAge bounds the worker's whole lifetime, busy or not: past it the
+	// worker drains (see maybeStartDraining) and exits once its containers are
+	// gone. Zero is no bound. draining and drainStartedAt are only touched from
+	// the request-stream loop that calls shouldShutDown.
+	maxAge         time.Duration
+	draining       bool
+	drainStartedAt time.Time
 	routeTransport string
 	ctx            context.Context
 	cancel         func()
@@ -666,7 +680,8 @@ func NewWorker() (_ *Worker, err error) {
 		userDataStorage:     userDataStorage,
 		persistent:          persistent,
 		startedAt:           time.Now(),
-		headroomMaxAge:      headroomWorkerMaxAge(config.Worker.HeadroomWorkerMaxAge, workerId),
+		headroomMaxAge:      jitteredWorkerAge(config.Worker.HeadroomWorkerMaxAge, workerId),
+		maxAge:              jitteredWorkerAge(config.Worker.MaxAge, workerId),
 		routeTransport:      routeTransport,
 	}
 
@@ -1037,34 +1052,104 @@ func (s *Worker) listenForShutdown() {
 }
 
 func (s *Worker) disableSchedulingForShutdown() {
-	ctx, cancel := context.WithTimeout(context.Background(), workerShutdownRPCTimeout)
-	defer cancel()
-
-	if _, err := handleGRPCResponse(s.workerRepoClient.DisableWorker(ctx, &pb.DisableWorkerRequest{
-		WorkerId: s.workerId,
-	})); err != nil {
+	if err := s.disableScheduling(); err != nil {
 		log.Warn().Err(err).Msg("failed to disable worker scheduling during shutdown")
 	}
 }
 
+// disableScheduling marks the worker disabled at the gateway: the scheduler
+// stops placing containers on it and the pool sizer stops counting its free
+// capacity, so a replacement is provisioned while this one is still running.
+func (s *Worker) disableScheduling() error {
+	ctx, cancel := context.WithTimeout(context.Background(), workerShutdownRPCTimeout)
+	defer cancel()
+
+	_, err := handleGRPCResponse(s.workerRepoClient.DisableWorker(ctx, &pb.DisableWorkerRequest{
+		WorkerId: s.workerId,
+	}))
+	return err
+}
+
 // Exit if there are no containers running and no containers have recently been spun up on this
-// worker, or if a shutdown signal has been received.
+// worker, if the worker has drained past its max age, or if a shutdown signal has been received.
 func (s *Worker) shouldShutDown(lastContainerRequest time.Time) bool {
 	select {
 	case <-s.ctx.Done():
 		return true
 	default:
 	}
-	if !s.shouldExitIdle(lastContainerRequest, time.Now()) {
+	now := time.Now()
+	s.maybeStartDraining(now)
+	if !s.shouldExit(lastContainerRequest, now) {
 		return false
 	}
 
-	s.disableSchedulingForShutdown()
+	if !s.draining {
+		s.disableSchedulingForShutdown()
+	}
 	if err := s.storageManager.Cleanup(); err != nil {
 		log.Error().Err(err).Msg("failed to cleanup workspace storage")
 	}
 
 	s.cancel() // Stops goroutines
+	return true
+}
+
+// shouldExit is the exit decision behind shouldShutDown: a draining worker
+// leaves as soon as it is drained, any other worker follows the idle rules.
+func (s *Worker) shouldExit(lastContainerRequest, now time.Time) bool {
+	if s.draining {
+		return s.drained(lastContainerRequest, now)
+	}
+	return s.shouldExitIdle(lastContainerRequest, now)
+}
+
+// maybeStartDraining begins the end of life of a worker past maxAge. Busy
+// workers are otherwise never aged out (see shouldExitIdle), so a worker with
+// steady traffic, a cron every minute for instance, would run forever on the
+// image it booted with. Draining disables scheduling first, so the next
+// container goes to another worker (or the one the sizer boots to replace the
+// capacity this one no longer counts for), and lets the running containers
+// finish on their own. Persistent workers are external machines and are left
+// alone. A failed disable is retried on the next call rather than treated as
+// draining, since exiting while still schedulable is what strands requests.
+func (s *Worker) maybeStartDraining(now time.Time) {
+	if s.draining || s.persistent || s.maxAge <= 0 {
+		return
+	}
+	age := now.Sub(s.startedAt)
+	if age < s.maxAge {
+		return
+	}
+	if err := s.disableScheduling(); err != nil {
+		log.Warn().Err(err).Str("worker_id", s.workerId).Msg("worker reached its max age but could not disable scheduling, retrying")
+		return
+	}
+	s.draining = true
+	s.drainStartedAt = now
+	log.Info().
+		Str("worker_id", s.workerId).
+		Dur("age", age).
+		Dur("max_age", s.maxAge).
+		Int("containers", s.containerInstances.Len()).
+		Msg("worker reached its max age, draining: scheduling disabled, exiting once running containers finish")
+}
+
+// drained reports whether a draining worker can leave: no containers, and
+// long enough since both the disable and the last delivered request that
+// nothing placed here before the disable is still on its way.
+func (s *Worker) drained(lastContainerRequest, now time.Time) bool {
+	if s.containerInstances.Len() != 0 {
+		return false
+	}
+	if now.Sub(s.drainStartedAt) < workerDrainGrace || now.Sub(lastContainerRequest) < workerDrainGrace {
+		return false
+	}
+	log.Info().
+		Str("worker_id", s.workerId).
+		Dur("age", now.Sub(s.startedAt)).
+		Dur("drain_took", now.Sub(s.drainStartedAt)).
+		Msg("worker drained after reaching its max age, exiting")
 	return true
 }
 
@@ -1108,11 +1193,11 @@ func (s *Worker) shouldExitIdle(lastContainerRequest, now time.Time) bool {
 	return true
 }
 
-// headroomWorkerMaxAge is the configured bound plus up to 1/8 of it as jitter
-// derived from the worker id, so two headroom workers the sizer started
-// together do not reach the bound in the same instant and leave the pool with
-// no ready worker at all. Zero (or negative) base means no bound.
-func headroomWorkerMaxAge(base time.Duration, workerId string) time.Duration {
+// jitteredWorkerAge is a configured age bound plus up to 1/8 of it as jitter
+// derived from the worker id, so workers the sizer started together do not
+// reach the bound in the same instant and leave the pool with no ready worker
+// at all. Zero (or negative) base means no bound.
+func jitteredWorkerAge(base time.Duration, workerId string) time.Duration {
 	if base <= 0 {
 		return 0
 	}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -56,16 +56,11 @@ const (
 	stuckContainerAbortDelay       time.Duration = 2 * time.Minute
 	gvisorShmemTHPPath                           = "/sys/kernel/mm/transparent_hugepage/shmem_enabled"
 
-	// workerDrainGrace is how long a draining worker must have been both
-	// disabled and without a new request before it treats an empty container
-	// set as fully drained: a request the scheduler placed here just before
-	// the disable landed is delivered within the stream poll interval, so
-	// this covers that window with a wide margin.
+	// A draining worker is drained once it has no containers and this long
+	// has passed since both its disable and its last request, so a container
+	// placed just before the disable landed is not orphaned.
 	workerDrainGrace time.Duration = 10 * time.Second
-	// workerDrainRetryInterval spaces out DisableWorker attempts once a worker
-	// is past its max age and the RPC fails, so a gateway that answers the
-	// request stream but not this call costs the stream loop at most one
-	// 5s RPC per interval rather than one per tick.
+	// Minimum spacing between DisableWorker retries for a worker past maxAge.
 	workerDrainRetryInterval time.Duration = 30 * time.Second
 )
 
@@ -134,17 +129,13 @@ type Worker struct {
 	userDataStorage         storage.Storage
 	persistent              bool
 	// poolHeadroom is the gateway's answer on the last keepalive: this worker
-	// is what keeps the pool's free capacity at its minimum, so it must not
-	// idle out (see shouldShutDown).
+	// holds the pool's minimum free capacity and must not idle out.
 	poolHeadroom atomic.Bool
-	// startedAt and headroomMaxAge bound how long holding headroom keeps an
-	// idle worker up (see shouldExitIdle); a zero headroomMaxAge is no bound.
-	startedAt      time.Time
-	headroomMaxAge time.Duration
-	// maxAge bounds the worker's whole lifetime, busy or not: past it the
-	// worker drains (see maybeStartDraining) and exits once its containers are
-	// gone. Zero is no bound. draining, drainStartedAt and nextDrainAttempt are
-	// only touched from the request-stream loop that calls shouldShutDown.
+	startedAt    time.Time
+	// headroomMaxAge bounds how long headroom alone keeps an idle worker up;
+	// maxAge bounds the whole lifetime, busy or not. Zero is no bound. The
+	// drain fields are only touched from the request-stream loop.
+	headroomMaxAge   time.Duration
 	maxAge           time.Duration
 	draining         bool
 	drainStartedAt   time.Time
@@ -1076,8 +1067,8 @@ func (s *Worker) disableScheduling() error {
 	return err
 }
 
-// Exit if there are no containers running and no containers have recently been spun up on this
-// worker, if the worker has drained past its max age, or if a shutdown signal has been received.
+// shouldShutDown is the request-stream loop's exit check: the context is done,
+// a worker past maxAge has drained, or an idle worker may leave.
 func (s *Worker) shouldShutDown(lastContainerRequest time.Time) bool {
 	select {
 	case <-s.ctx.Done():
@@ -1101,51 +1092,49 @@ func (s *Worker) shouldShutDown(lastContainerRequest time.Time) bool {
 	return true
 }
 
-// shouldExit is the exit decision behind shouldShutDown: a draining worker
-// leaves as soon as it is drained, any other worker follows the idle rules.
+// shouldExit: a worker past maxAge leaves only once drained, so the exit never
+// races a DisableWorker that has not landed; any other worker follows the
+// idle rules.
 func (s *Worker) shouldExit(lastContainerRequest, now time.Time) bool {
 	if s.draining {
 		return s.drained(lastContainerRequest, now)
 	}
+	if s.pastMaxAge(now) {
+		return false
+	}
 	return s.shouldExitIdle(lastContainerRequest, now)
 }
 
-// maybeStartDraining begins the end of life of a worker past maxAge. Busy
-// workers are otherwise never aged out (see shouldExitIdle), so a worker with
-// steady traffic, a cron every minute for instance, would run forever on the
-// image it booted with. Draining disables scheduling first, so the next
-// container goes to another worker (or the one the sizer boots to replace the
-// capacity this one no longer counts for), and lets the running containers
-// finish on their own. Persistent workers are external machines and are left
-// alone. A failed disable is retried (no sooner than workerDrainRetryInterval
-// later) rather than treated as draining, since exiting while still
-// schedulable is what strands requests.
+func (s *Worker) pastMaxAge(now time.Time) bool {
+	return !s.persistent && s.maxAge > 0 && now.Sub(s.startedAt) >= s.maxAge
+}
+
+// maybeStartDraining disables scheduling for a worker past maxAge: the
+// scheduler skips it, the sizer stops counting it and boots a replacement, and
+// this one exits once its containers are gone. Without it a worker with steady
+// traffic never idles out and runs the image it booted with forever. A failed
+// disable is retried every workerDrainRetryInterval.
 func (s *Worker) maybeStartDraining(now time.Time) {
-	if s.draining || s.persistent || s.maxAge <= 0 {
-		return
-	}
-	age := now.Sub(s.startedAt)
-	if age < s.maxAge || now.Before(s.nextDrainAttempt) {
+	if s.draining || !s.pastMaxAge(now) || now.Before(s.nextDrainAttempt) {
 		return
 	}
 	if err := s.disableScheduling(); err != nil {
 		s.nextDrainAttempt = now.Add(workerDrainRetryInterval)
-		log.Warn().Err(err).Str("worker_id", s.workerId).Dur("retry_in", workerDrainRetryInterval).Msg("worker reached its max age but could not disable scheduling, retrying")
+		log.Warn().Err(err).Str("worker_id", s.workerId).Dur("retry_in", workerDrainRetryInterval).Msg("worker past its max age could not disable scheduling, retrying")
 		return
 	}
 	s.draining = true
 	s.drainStartedAt = now
 	log.Info().
 		Str("worker_id", s.workerId).
-		Dur("age", age).
+		Dur("age", now.Sub(s.startedAt)).
 		Dur("max_age", s.maxAge).
 		Int("containers", s.containerInstances.Len()).
-		Msg("worker reached its max age, draining: scheduling disabled, exiting once running containers finish")
+		Msg("worker past its max age, draining: scheduling disabled, exiting once running containers finish")
 }
 
-// drained reports whether a draining worker can leave: no containers, and
-// long enough since both the disable and the last delivered request that
-// nothing placed here before the disable is still on its way.
+// drained: no containers, and workerDrainGrace since both the disable and the
+// last request, so nothing placed here before the disable is still on its way.
 func (s *Worker) drained(lastContainerRequest, now time.Time) bool {
 	if s.containerInstances.Len() != 0 {
 		return false
@@ -1162,20 +1151,12 @@ func (s *Worker) drained(lastContainerRequest, now time.Time) bool {
 }
 
 // shouldExitIdle decides whether a worker with no containers and no request
-// for the spindown timeout leaves now. Persistent workers never do.
-//
-// An idle worker that is part of the pool's minimum free capacity stays:
-// exiting would only make the sizer start a replacement and leave the pool
-// cold while it boots. The gateway is asked right now rather than trusting a
-// flag up to a keepalive old, and the worker stays when the answer cannot be
-// had, since leaving on a stale or missing answer is what empties the pool.
-//
-// Holding headroom alone must not keep a worker up forever, though: an idle
-// pool would pin the same pod indefinitely, past image rollouts and node
-// drains. Past headroomMaxAge (id-jittered, see jitteredWorkerAge) an idle
-// headroom worker exits anyway; the sizer replaces it and the pool is cold for
-// one boot per period. Busy workers are never aged out: the bound applies only
-// when headroom is the sole reason the worker is still here.
+// for the spindown timeout leaves. Persistent workers never do. A worker the
+// gateway says holds the pool's minimum free capacity stays, since exiting
+// would only make the sizer boot a replacement and leave the pool cold; the
+// gateway is asked now rather than trusting the last keepalive, and no answer
+// keeps the worker. Past headroomMaxAge headroom no longer holds it, so an
+// idle pool does not pin one pod across image rollouts and node drains.
 func (s *Worker) shouldExitIdle(lastContainerRequest, now time.Time) bool {
 	if s.persistent {
 		return false
@@ -1201,10 +1182,8 @@ func (s *Worker) shouldExitIdle(lastContainerRequest, now time.Time) bool {
 	return true
 }
 
-// jitteredWorkerAge is a configured age bound plus up to 1/8 of it as jitter
-// derived from the worker id, so workers the sizer started together do not
-// reach the bound in the same instant and leave the pool with no ready worker
-// at all. Zero (or negative) base means no bound.
+// jitteredWorkerAge adds up to 1/8 of base as worker-id-derived jitter, so
+// workers started together do not leave together. Non-positive base: no bound.
 func jitteredWorkerAge(base time.Duration, workerId string) time.Duration {
 	if base <= 0 {
 		return 0

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -62,6 +62,11 @@ const (
 	// the disable landed is delivered within the stream poll interval, so
 	// this covers that window with a wide margin.
 	workerDrainGrace time.Duration = 10 * time.Second
+	// workerDrainRetryInterval spaces out DisableWorker attempts once a worker
+	// is past its max age and the RPC fails, so a gateway that answers the
+	// request stream but not this call costs the stream loop at most one
+	// 5s RPC per interval rather than one per tick.
+	workerDrainRetryInterval time.Duration = 30 * time.Second
 )
 
 func ensureGVisorShmemTHP(path string) (bool, error) {
@@ -138,15 +143,16 @@ type Worker struct {
 	headroomMaxAge time.Duration
 	// maxAge bounds the worker's whole lifetime, busy or not: past it the
 	// worker drains (see maybeStartDraining) and exits once its containers are
-	// gone. Zero is no bound. draining and drainStartedAt are only touched from
-	// the request-stream loop that calls shouldShutDown.
-	maxAge         time.Duration
-	draining       bool
-	drainStartedAt time.Time
-	routeTransport string
-	ctx            context.Context
-	cancel         func()
-	config         types.AppConfig
+	// gone. Zero is no bound. draining, drainStartedAt and nextDrainAttempt are
+	// only touched from the request-stream loop that calls shouldShutDown.
+	maxAge           time.Duration
+	draining         bool
+	drainStartedAt   time.Time
+	nextDrainAttempt time.Time
+	routeTransport   string
+	ctx              context.Context
+	cancel           func()
+	config           types.AppConfig
 }
 
 func (w *Worker) gpuVirtualizedForRequest(request *types.ContainerRequest) bool {
@@ -1111,18 +1117,20 @@ func (s *Worker) shouldExit(lastContainerRequest, now time.Time) bool {
 // container goes to another worker (or the one the sizer boots to replace the
 // capacity this one no longer counts for), and lets the running containers
 // finish on their own. Persistent workers are external machines and are left
-// alone. A failed disable is retried on the next call rather than treated as
-// draining, since exiting while still schedulable is what strands requests.
+// alone. A failed disable is retried (no sooner than workerDrainRetryInterval
+// later) rather than treated as draining, since exiting while still
+// schedulable is what strands requests.
 func (s *Worker) maybeStartDraining(now time.Time) {
 	if s.draining || s.persistent || s.maxAge <= 0 {
 		return
 	}
 	age := now.Sub(s.startedAt)
-	if age < s.maxAge {
+	if age < s.maxAge || now.Before(s.nextDrainAttempt) {
 		return
 	}
 	if err := s.disableScheduling(); err != nil {
-		log.Warn().Err(err).Str("worker_id", s.workerId).Msg("worker reached its max age but could not disable scheduling, retrying")
+		s.nextDrainAttempt = now.Add(workerDrainRetryInterval)
+		log.Warn().Err(err).Str("worker_id", s.workerId).Dur("retry_in", workerDrainRetryInterval).Msg("worker reached its max age but could not disable scheduling, retrying")
 		return
 	}
 	s.draining = true
@@ -1164,7 +1172,7 @@ func (s *Worker) drained(lastContainerRequest, now time.Time) bool {
 //
 // Holding headroom alone must not keep a worker up forever, though: an idle
 // pool would pin the same pod indefinitely, past image rollouts and node
-// drains. Past headroomMaxAge (id-jittered, see headroomWorkerMaxAge) an idle
+// drains. Past headroomMaxAge (id-jittered, see jitteredWorkerAge) an idle
 // headroom worker exits anyway; the sizer replaces it and the pool is cold for
 // one boot per period. Busy workers are never aged out: the bound applies only
 // when headroom is the sole reason the worker is still here.

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -116,55 +116,53 @@ type fakeWorkerRepoClient struct {
 	claimStarted chan struct{}
 	claimRelease <-chan struct{}
 
-	// keepAliveHeadroom is the pool_headroom answer to SetWorkerKeepAlive;
-	// keepAliveErr fails the call instead. keepAlives counts calls and
-	// lastKeepAlive keeps the most recent request.
+	// SetWorkerKeepAlive answers keepAliveHeadroom as pool_headroom, or fails
+	// with keepAliveErr; DisableWorker fails with disableErr. Each counts its
+	// calls, and lastKeepAlive keeps the most recent keepalive request.
 	keepAliveHeadroom bool
 	keepAliveErr      error
 	keepAlives        int
 	lastKeepAlive     *pb.SetWorkerKeepAliveRequest
+	disableErr        error
+	disables          int
+}
 
-	// disableErr fails DisableWorker; disables counts calls.
-	disableErr error
-	disables   int
+// call records one fake RPC under the lock and returns its configured error.
+func (f *fakeWorkerRepoClient) call(calls *int, err *error, record func()) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	*calls++
+	if record != nil {
+		record()
+	}
+	return *err
+}
+
+func (f *fakeWorkerRepoClient) count(calls *int) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return *calls
 }
 
 func (f *fakeWorkerRepoClient) DisableWorker(ctx context.Context, req *pb.DisableWorkerRequest, _ ...grpc.CallOption) (*pb.DisableWorkerResponse, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.disables++
-	if f.disableErr != nil {
-		return nil, f.disableErr
+	if err := f.call(&f.disables, &f.disableErr, nil); err != nil {
+		return nil, err
 	}
 	return &pb.DisableWorkerResponse{Ok: true}, nil
 }
 
-func (f *fakeWorkerRepoClient) disableCalls() int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.disables
-}
-
 func (f *fakeWorkerRepoClient) SetWorkerKeepAlive(ctx context.Context, req *pb.SetWorkerKeepAliveRequest, _ ...grpc.CallOption) (*pb.SetWorkerKeepAliveResponse, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.keepAlives++
-	f.lastKeepAlive = req
-	if f.keepAliveErr != nil {
-		return nil, f.keepAliveErr
+	if err := f.call(&f.keepAlives, &f.keepAliveErr, func() { f.lastKeepAlive = req }); err != nil {
+		return nil, err
 	}
 	return &pb.SetWorkerKeepAliveResponse{Ok: true, PoolHeadroom: f.keepAliveHeadroom}, nil
 }
 
-func (f *fakeWorkerRepoClient) keepAliveCalls() int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.keepAlives
-}
+func (f *fakeWorkerRepoClient) disableCalls() int   { return f.count(&f.disables) }
+func (f *fakeWorkerRepoClient) keepAliveCalls() int { return f.count(&f.keepAlives) }
 
 // idleTestWorker is a worker with no containers that asks repo for headroom
-// before an idle exit. Its max age is set directly so the id jitter of
-// jitteredWorkerAge stays out of the arithmetic.
+// before an idle exit. Ages are set directly, without jitteredWorkerAge.
 func idleTestWorker(repo *fakeWorkerRepoClient, startedAt time.Time, maxAge time.Duration) *Worker {
 	return &Worker{
 		workerId:           "w-test",
@@ -248,9 +246,8 @@ func TestShouldExitIdle(t *testing.T) {
 	})
 }
 
-// TestMaxAgeDrain covers the whole-lifetime bound: a busy worker past maxAge
-// disables scheduling once, keeps running until its containers are gone, and
-// then leaves without consulting the idle rules.
+// TestMaxAgeDrain: a worker past maxAge disables scheduling once, keeps running
+// until its containers are gone, and leaves without consulting the idle rules.
 func TestMaxAgeDrain(t *testing.T) {
 	now := time.Now()
 	maxAge := 24 * time.Hour
@@ -329,6 +326,29 @@ func TestMaxAgeDrain(t *testing.T) {
 		repo.mu.Unlock()
 		w.maybeStartDraining(now.Add(workerDrainRetryInterval))
 		require.True(t, w.draining)
+		require.Equal(t, 2, repo.disableCalls())
+	})
+
+	t.Run("idle worker past max age exits only by draining, not while still schedulable", func(t *testing.T) {
+		// DisableWorker fails but keepalive works and reports no headroom: the
+		// idle rules would let it go while the scheduler can still place here.
+		repo := &fakeWorkerRepoClient{disableErr: status.Error(codes.Unavailable, "gateway restarting")}
+		w := busyWorker(repo, old)
+		w.containerInstances.Delete("c1")
+
+		w.maybeStartDraining(now)
+		require.False(t, w.draining)
+		require.False(t, w.shouldExit(quiet, now))
+		require.Equal(t, 0, repo.keepAliveCalls(), "idle rules must not be consulted past max age")
+
+		repo.mu.Lock()
+		repo.disableErr = nil
+		repo.mu.Unlock()
+		later := now.Add(workerDrainRetryInterval)
+		w.maybeStartDraining(later)
+		require.True(t, w.draining)
+		require.False(t, w.shouldExit(quiet, later))
+		require.True(t, w.shouldExit(quiet, later.Add(workerDrainGrace)))
 		require.Equal(t, 2, repo.disableCalls())
 	})
 

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -123,6 +123,26 @@ type fakeWorkerRepoClient struct {
 	keepAliveErr      error
 	keepAlives        int
 	lastKeepAlive     *pb.SetWorkerKeepAliveRequest
+
+	// disableErr fails DisableWorker; disables counts calls.
+	disableErr error
+	disables   int
+}
+
+func (f *fakeWorkerRepoClient) DisableWorker(ctx context.Context, req *pb.DisableWorkerRequest, _ ...grpc.CallOption) (*pb.DisableWorkerResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.disables++
+	if f.disableErr != nil {
+		return nil, f.disableErr
+	}
+	return &pb.DisableWorkerResponse{Ok: true}, nil
+}
+
+func (f *fakeWorkerRepoClient) disableCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.disables
 }
 
 func (f *fakeWorkerRepoClient) SetWorkerKeepAlive(ctx context.Context, req *pb.SetWorkerKeepAliveRequest, _ ...grpc.CallOption) (*pb.SetWorkerKeepAliveResponse, error) {
@@ -228,18 +248,116 @@ func TestShouldExitIdle(t *testing.T) {
 	})
 }
 
-func TestHeadroomWorkerMaxAge(t *testing.T) {
-	require.Equal(t, time.Duration(0), headroomWorkerMaxAge(0, "1713919c"))
-	require.Equal(t, time.Duration(0), headroomWorkerMaxAge(-time.Hour, "1713919c"))
+// TestMaxAgeDrain covers the whole-lifetime bound: a busy worker past maxAge
+// disables scheduling once, keeps running until its containers are gone, and
+// then leaves without consulting the idle rules.
+func TestMaxAgeDrain(t *testing.T) {
+	now := time.Now()
+	maxAge := 24 * time.Hour
+	old := now.Add(-maxAge - time.Minute)
+	recent := now.Add(-time.Second) // a request just arrived
+	quiet := now.Add(-time.Hour)    // no request in a while
+
+	busyWorker := func(repo *fakeWorkerRepoClient, startedAt time.Time) *Worker {
+		w := idleTestWorker(repo, startedAt, 6*time.Hour)
+		w.maxAge = maxAge
+		w.containerInstances.Set("c1", &ContainerInstance{})
+		return w
+	}
+
+	t.Run("young busy worker is untouched", func(t *testing.T) {
+		repo := &fakeWorkerRepoClient{}
+		w := busyWorker(repo, now.Add(-time.Hour))
+		w.maybeStartDraining(now)
+		require.False(t, w.draining)
+		require.Equal(t, 0, repo.disableCalls())
+		require.False(t, w.shouldExit(recent, now))
+	})
+
+	t.Run("no bound when maxAge is zero", func(t *testing.T) {
+		repo := &fakeWorkerRepoClient{}
+		w := busyWorker(repo, now.Add(-100*24*time.Hour))
+		w.maxAge = 0
+		w.maybeStartDraining(now)
+		require.False(t, w.draining)
+		require.Equal(t, 0, repo.disableCalls())
+	})
+
+	t.Run("persistent workers are never drained", func(t *testing.T) {
+		repo := &fakeWorkerRepoClient{}
+		w := busyWorker(repo, old)
+		w.persistent = true
+		w.maybeStartDraining(now)
+		require.False(t, w.draining)
+		require.Equal(t, 0, repo.disableCalls())
+	})
+
+	t.Run("old busy worker disables scheduling once and keeps its containers", func(t *testing.T) {
+		repo := &fakeWorkerRepoClient{}
+		w := busyWorker(repo, old)
+
+		w.maybeStartDraining(now)
+		require.True(t, w.draining)
+		require.Equal(t, now, w.drainStartedAt)
+		require.Equal(t, 1, repo.disableCalls())
+
+		// Still running a container: stays, and the idle rules are not consulted.
+		require.False(t, w.shouldExit(recent, now))
+		require.Equal(t, 0, repo.keepAliveCalls())
+
+		// Later ticks do not disable again.
+		w.maybeStartDraining(now.Add(time.Minute))
+		require.Equal(t, 1, repo.disableCalls())
+	})
+
+	t.Run("failed disable is retried and does not count as draining", func(t *testing.T) {
+		repo := &fakeWorkerRepoClient{disableErr: status.Error(codes.Unavailable, "gateway restarting")}
+		w := busyWorker(repo, old)
+
+		w.maybeStartDraining(now)
+		require.False(t, w.draining)
+		require.Equal(t, 1, repo.disableCalls())
+
+		repo.mu.Lock()
+		repo.disableErr = nil
+		repo.mu.Unlock()
+		w.maybeStartDraining(now.Add(30 * time.Second))
+		require.True(t, w.draining)
+		require.Equal(t, 2, repo.disableCalls())
+	})
+
+	t.Run("drained worker exits after the grace, without the idle spindown wait", func(t *testing.T) {
+		repo := &fakeWorkerRepoClient{keepAliveHeadroom: true}
+		w := busyWorker(repo, old)
+		w.maybeStartDraining(now)
+		w.containerInstances.Delete("c1")
+
+		// Right after the disable: a request placed before it may still be in flight.
+		require.False(t, w.shouldExit(quiet, now))
+		require.False(t, w.shouldExit(quiet, now.Add(workerDrainGrace-time.Second)))
+		// A request delivered during the drain restarts the clock.
+		require.False(t, w.shouldExit(now.Add(2*workerDrainGrace-time.Second), now.Add(2*workerDrainGrace)))
+
+		// Past the grace on both counts it leaves; headroom would have kept an
+		// idle worker, and the 5-minute spindown has not elapsed, neither applies.
+		later := now.Add(workerDrainGrace)
+		require.True(t, w.shouldExit(now, later))
+		require.Equal(t, 0, repo.keepAliveCalls())
+	})
+}
+
+func TestJitteredWorkerAge(t *testing.T) {
+	require.Equal(t, time.Duration(0), jitteredWorkerAge(0, "1713919c"))
+	require.Equal(t, time.Duration(0), jitteredWorkerAge(-time.Hour, "1713919c"))
 
 	base := 6 * time.Hour
 	ids := []string{"1713919c", "cca87061", "3c51ead2", "df3dc97d", "00000000", "ffffffff", ""}
 	seen := map[time.Duration]bool{}
 	for _, id := range ids {
-		got := headroomWorkerMaxAge(base, id)
+		got := jitteredWorkerAge(base, id)
 		require.GreaterOrEqual(t, got, base, id)
 		require.LessOrEqual(t, got, base+base/8, id)
-		require.Equal(t, got, headroomWorkerMaxAge(base, id), "jitter must be stable for %q", id)
+		require.Equal(t, got, jitteredWorkerAge(base, id), "jitter must be stable for %q", id)
 		seen[got] = true
 	}
 	// Different ids spread out rather than all landing on the same instant.

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -164,7 +164,7 @@ func (f *fakeWorkerRepoClient) keepAliveCalls() int {
 
 // idleTestWorker is a worker with no containers that asks repo for headroom
 // before an idle exit. Its max age is set directly so the id jitter of
-// headroomWorkerMaxAge stays out of the arithmetic.
+// jitteredWorkerAge stays out of the arithmetic.
 func idleTestWorker(repo *fakeWorkerRepoClient, startedAt time.Time, maxAge time.Duration) *Worker {
 	return &Worker{
 		workerId:           "w-test",
@@ -310,7 +310,7 @@ func TestMaxAgeDrain(t *testing.T) {
 		require.Equal(t, 1, repo.disableCalls())
 	})
 
-	t.Run("failed disable is retried and does not count as draining", func(t *testing.T) {
+	t.Run("failed disable is retried on an interval and does not count as draining", func(t *testing.T) {
 		repo := &fakeWorkerRepoClient{disableErr: status.Error(codes.Unavailable, "gateway restarting")}
 		w := busyWorker(repo, old)
 
@@ -318,10 +318,16 @@ func TestMaxAgeDrain(t *testing.T) {
 		require.False(t, w.draining)
 		require.Equal(t, 1, repo.disableCalls())
 
+		// Ticks inside the retry interval do not hit the gateway again.
+		w.maybeStartDraining(now.Add(time.Second))
+		w.maybeStartDraining(now.Add(workerDrainRetryInterval - time.Second))
+		require.Equal(t, 1, repo.disableCalls())
+		require.False(t, w.draining)
+
 		repo.mu.Lock()
 		repo.disableErr = nil
 		repo.mu.Unlock()
-		w.maybeStartDraining(now.Add(30 * time.Second))
+		w.maybeStartDraining(now.Add(workerDrainRetryInterval))
 		require.True(t, w.draining)
 		require.Equal(t, 2, repo.disableCalls())
 	})


### PR DESCRIPTION
## Why

A worker only ever exited when idle: no containers and no request for the 5-minute spindown, plus the 6h `headroomWorkerMaxAge` for idle headroom holders (#1868). A worker with steady traffic never met that. On staging, two `default` workers serving a once-a-minute schedule stub have been up 20h and 16h on the image they booted with (0.1.740), straight through a release; prod's A10G failover worker is 2d+ on 0.1.739 for the same reason. Nothing recycled them short of `kubectl delete job`.

## What

Past `worker.maxAge` (default **24h**, plus the same 1/8 id-derived jitter as `headroomWorkerMaxAge`), a non-persistent worker **drains** instead of running on:

1. It calls `DisableWorker` once. The scheduler already skips disabled workers (`scheduler.go` `selectWorker`), `freePoolCapacity` stops counting them (so the sizer starts a replacement while this one is still running), and `WorkerHoldsPoolHeadroom` ignores them. No new gateway code.
2. Containers it is running finish on their own; nothing is stopped.
3. Once it has no containers and 10 s have passed since both the disable and the last delivered request (covers a placement that raced the disable; delivery is 100 ms), it exits through the normal shutdown path. The idle rules (spindown wait, headroom) do not apply while draining.
4. A failed `DisableWorker` is retried on the next stream tick and does **not** count as draining: exiting while still schedulable is what strands requests.

Persistent workers are exempt. `maxAge: 0` disables the bound. `headroomWorkerMaxAge` keeps its own key and its 6h default. The jitter helper is renamed `jitteredWorkerAge` since it now serves both bounds.

Cost: once per ~24-27h per worker, the next container that would have landed on it goes to another worker or waits one worker boot (~4 s) if the pool has no spare capacity.

## Tests

`TestMaxAgeDrain`: young / zero-maxAge / persistent untouched; old busy worker disables exactly once and keeps its containers; failed disable retried and not treated as draining; drained exit waits the grace on both clocks and does not consult the idle rules (no keepalive call, no 5-minute wait). `TestJitteredWorkerAge` is the renamed jitter test.

Not in today's release tags (0.1.766 / 0.1.741); follow-up for the next worker release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `worker.maxAge` bound so non-persistent workers recycle onto current images even under steady traffic.

Previously a worker only exited when idle; one serving a once-a-minute cron never did, leaving staging and prod workers running 20h+ on stale images. Now past `maxAge` (default 24h, plus the same id-derived jitter as `headroomWorkerMaxAge`) a worker disables scheduling once, lets running containers finish, and exits after 10s with no containers and no new requests. Persistent workers are exempt; `maxAge: 0` disables the bound; `headroomWorkerMaxAge` keeps its 6h default.

- A failed `DisableWorker` is retried at most every 30s and does not count as draining, so the worker never exits while still schedulable.
- Draining skips the idle spindown wait and headroom keepalive; the only cost is the next container possibly waiting one worker boot (~4s) if the pool has no spare capacity.
- Replaces the `headroomWorkerMaxAge` jitter helper with `jitteredWorkerAge`, shared by both bounds.

<sup>Written for commit e5a77acb687bc3e95a92441d4ac6374b0b759a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

