### PR TITLE
cache: budget protected content net of non-evictable disk usage

### DIFF
--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -226,7 +226,11 @@ func (cs *Server) refreshDisk(evict bool) (DiskUsage, error) {
 	if err != nil {
 		return DiskUsage{}, err
 	}
-	return diskUsageFromSnapshot(snapshot), nil
+	usage := diskUsageFromSnapshot(snapshot)
+	if indexed := cs.cas.index.bytes(); indexed > 0 {
+		usage.EvictableBytes = uint64(indexed)
+	}
+	return usage, nil
 }
 
 func (cs *Server) DiskPressureExceeded() bool {

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -1435,6 +1435,11 @@ type DiskUsage struct {
 	AvailableBytes uint64
 	UsedBytes      uint64
 	UsagePct       float64
+	// EvictableBytes is how much of UsedBytes is indexed cache content, the
+	// only part of the filesystem eviction can reclaim. The rest (OS, images,
+	// build and package caches on the same volume) has to be budgeted around.
+	// Zero when the store has not indexed anything yet.
+	EvictableBytes uint64
 }
 
 func diskUsageFromSnapshot(snapshot diskUsageSnapshot) DiskUsage {

--- a/pkg/cache/storage_eviction.go
+++ b/pkg/cache/storage_eviction.go
@@ -69,6 +69,9 @@ type contentEntry struct {
 type contentIndex struct {
 	mu      sync.RWMutex
 	entries map[string]contentEntry
+	// totalBytes is the running sum of entries' sizes, kept in step with
+	// every mutation so bytes() does not walk the map on each disk refresh.
+	totalBytes int64
 }
 
 func (idx *contentIndex) get(hash string) (contentEntry, bool) {
@@ -80,14 +83,26 @@ func (idx *contentIndex) get(hash string) (contentEntry, bool) {
 
 func (idx *contentIndex) put(hash string, entry contentEntry) {
 	idx.mu.Lock()
+	if previous, ok := idx.entries[hash]; ok {
+		idx.totalBytes -= previous.size
+	}
 	idx.entries[hash] = entry
+	idx.totalBytes += entry.size
 	idx.mu.Unlock()
 }
 
 func (idx *contentIndex) forget(hash string) {
 	idx.mu.Lock()
-	delete(idx.entries, hash)
+	idx.remove(hash)
 	idx.mu.Unlock()
+}
+
+// remove drops hash and its size from the running total; the caller holds mu.
+func (idx *contentIndex) remove(hash string) {
+	if entry, ok := idx.entries[hash]; ok {
+		idx.totalBytes -= entry.size
+		delete(idx.entries, hash)
+	}
 }
 
 // forgetIfUntouched drops the entry unless it has been accessed after since,
@@ -99,7 +114,7 @@ func (idx *contentIndex) forgetIfUntouched(hash string, since time.Time) bool {
 	if entry, ok := idx.entries[hash]; ok && entry.lastAccess.After(since) {
 		return false
 	}
-	delete(idx.entries, hash)
+	idx.remove(hash)
 	return true
 }
 
@@ -119,16 +134,12 @@ func (idx *contentIndex) touch(hash string, now time.Time, interval time.Duratio
 	return true, persist
 }
 
-// bytes sums the size of every indexed object: the content on this disk that
+// bytes is the size of every indexed object: the content on this disk that
 // eviction can act on, as opposed to whatever else shares the filesystem.
 func (idx *contentIndex) bytes() int64 {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	var total int64
-	for _, entry := range idx.entries {
-		total += entry.size
-	}
-	return total
+	return idx.totalBytes
 }
 
 // candidates snapshots the index as eviction candidates, skipping in-flight
@@ -167,6 +178,10 @@ func (idx *contentIndex) replace(scanned map[string]contentEntry, since time.Tim
 		}
 	}
 	idx.entries = scanned
+	idx.totalBytes = 0
+	for _, entry := range scanned {
+		idx.totalBytes += entry.size
+	}
 }
 
 // rebuildContentIndex walks the cache directory once and replaces the index

--- a/pkg/cache/storage_eviction.go
+++ b/pkg/cache/storage_eviction.go
@@ -119,6 +119,18 @@ func (idx *contentIndex) touch(hash string, now time.Time, interval time.Duratio
 	return true, persist
 }
 
+// bytes sums the size of every indexed object: the content on this disk that
+// eviction can act on, as opposed to whatever else shares the filesystem.
+func (idx *contentIndex) bytes() int64 {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	var total int64
+	for _, entry := range idx.entries {
+		total += entry.size
+	}
+	return total
+}
+
 // candidates snapshots the index as eviction candidates, skipping in-flight
 // writes that are still inside their grace period.
 func (idx *contentIndex) candidates(now time.Time) []evictionCandidate {

--- a/pkg/cache/storage_eviction_test.go
+++ b/pkg/cache/storage_eviction_test.go
@@ -266,6 +266,25 @@ func TestDiskUsageReportsIndexedBytesAsEvictable(t *testing.T) {
 
 	store.index.forget(a)
 	require.Equal(t, int64(len("second-object-longer")), store.index.bytes())
+	store.index.forget(a)
+	require.Equal(t, int64(len("second-object-longer")), store.index.bytes(), "forgetting twice must not double-subtract")
+
+	// Overwriting an entry replaces its contribution rather than adding to it.
+	b := addEvictionTestContent(t, store, "third", time.Now())
+	entryB, _ := store.index.get(b)
+	entryB.size = 100
+	store.index.put(b, entryB)
+	require.Equal(t, int64(len("second-object-longer")+100), store.index.bytes())
+
+	// A rebuild from disk resets the total to what the walk found, which still
+	// includes the object whose index entry was forgotten above.
+	store.index.replace(store.scanContent(), time.Now())
+	require.Equal(t, int64(len("first-object")+len("second-object-longer")+len("third")), store.index.bytes())
+	var walked int64
+	for _, entry := range store.scanContent() {
+		walked += entry.size
+	}
+	require.Equal(t, walked, store.index.bytes())
 }
 
 func TestRemoveContentFailureLeavesTheLeftoverIndexed(t *testing.T) {

--- a/pkg/cache/storage_eviction_test.go
+++ b/pkg/cache/storage_eviction_test.go
@@ -245,6 +245,29 @@ func TestContentIndexRebuildKeepsCompletionsRacingTheWalk(t *testing.T) {
 	require.False(t, store.Exists(drifted))
 }
 
+// TestDiskUsageReportsIndexedBytesAsEvictable: RefreshDiskUsage tells the
+// reconciler how much of the disk is content it can evict, so the protected
+// budget is net of everything else on the volume.
+func TestDiskUsageReportsIndexedBytesAsEvictable(t *testing.T) {
+	store := newTestStore(t, 5)
+	require.Equal(t, int64(0), store.index.bytes())
+
+	a := addEvictionTestContent(t, store, "first-object", time.Now())
+	addEvictionTestContent(t, store, "second-object-longer", time.Now())
+	sizeA, _ := store.index.get(a)
+	require.Greater(t, sizeA.size, int64(0))
+	require.Equal(t, int64(len("first-object")+len("second-object-longer")), store.index.bytes())
+
+	server := &Server{cas: store}
+	usage, err := server.RefreshDiskUsage()
+	require.NoError(t, err)
+	require.Equal(t, uint64(store.index.bytes()), usage.EvictableBytes)
+	require.Greater(t, usage.UsedBytes, usage.EvictableBytes, "the temp dir's filesystem holds more than the two objects")
+
+	store.index.forget(a)
+	require.Equal(t, int64(len("second-object-longer")), store.index.bytes())
+}
+
 func TestRemoveContentFailureLeavesTheLeftoverIndexed(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores directory permissions")

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -866,6 +866,13 @@ func pressureProtectedContentFromRecentStubs(stubs []recentStubContent, accelera
 	return protected
 }
 
+// pressureProtectionBudgetBytes is how much protected content may sit on the
+// disk for filesystem usage to come to rest at the resume watermark (and the
+// free-byte reserve). The watermark is measured on the whole filesystem but
+// eviction can only remove indexed cache content, so everything else on the
+// volume (OS, worker images, the uv and build caches) is taken off the top:
+// budgeting the cache as if it were alone parks the disk at watermark plus
+// that footprint, where every object is protected and nothing is evictable.
 func pressureProtectionBudgetBytes(usage cache.DiskUsage, softWatermark float64, minFreeBytes int64) int64 {
 	if usage.TotalBytes == 0 {
 		return 0
@@ -876,6 +883,9 @@ func pressureProtectionBudgetBytes(usage cache.DiskUsage, softWatermark float64,
 		if reserveBudget := int64(usage.TotalBytes) - minFreeBytes; reserveBudget < budget {
 			budget = reserveBudget
 		}
+	}
+	if usage.EvictableBytes > 0 && usage.UsedBytes > usage.EvictableBytes {
+		budget -= int64(usage.UsedBytes - usage.EvictableBytes)
 	}
 	return maxInt64(budget, 0)
 }

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -209,6 +209,49 @@ func TestPressureProtectedContentPrioritizesNewestStubWorkingSet(t *testing.T) {
 	require.NotContains(t, protected, "old-volume")
 }
 
+// TestPressureProtectionBudgetSubtractsNonEvictableUsage reproduces the staging
+// cache-server that parked at 81% with every object protected: 258.9 GB disk,
+// watermark 0.70 (resume 0.67), 40 GiB reserve, 168.6 GB of indexed content
+// and 41 GB of other usage (OS, uv/buildah caches) on the same volume.
+func TestPressureProtectionBudgetSubtractsNonEvictableUsage(t *testing.T) {
+	const gb = 1_000_000_000
+	total := uint64(258_906_374_144)
+	indexed := uint64(168_552_086_665)
+	other := uint64(41 * gb)
+	reserve := int64(42_949_672_960)
+	usage := cache.DiskUsage{
+		TotalBytes:     total,
+		UsedBytes:      indexed + other,
+		AvailableBytes: total - indexed - other,
+		EvictableBytes: indexed,
+	}
+	usage.UsagePct = float64(usage.UsedBytes) / float64(total)
+	require.InDelta(t, 0.81, usage.UsagePct, 0.005)
+
+	budget := pressureProtectionBudgetBytes(usage, 0.70, reserve)
+
+	// Protected content plus the other usage must land at the resume watermark.
+	resumeUsed := int64(0.67 * float64(total))
+	require.Equal(t, resumeUsed-int64(other), budget)
+	require.Less(t, budget, int64(indexed), "the budget must be below what is on disk, or nothing is ever evictable")
+	require.InDelta(t, 0.67, float64(budget+int64(other))/float64(total), 0.001)
+
+	// The reserve wins when it is the tighter bound, still net of other usage.
+	tight := pressureProtectionBudgetBytes(usage, 0.95, reserve)
+	require.Equal(t, int64(total)-reserve-int64(other), tight)
+
+	// Without an index reading the old whole-disk budget is used unchanged.
+	blind := usage
+	blind.EvictableBytes = 0
+	require.Equal(t, resumeUsed, pressureProtectionBudgetBytes(blind, 0.70, reserve))
+
+	// Other usage larger than the whole budget leaves nothing to protect.
+	swamped := usage
+	swamped.UsedBytes = total - 1*gb
+	swamped.EvictableBytes = 10 * gb
+	require.Equal(t, int64(0), pressureProtectionBudgetBytes(swamped, 0.70, reserve))
+}
+
 func TestPressureProtectedContentPrioritizesCheckpointWithinStub(t *testing.T) {
 	now := time.Now()
 	stubs := []recentStubContent{


### PR DESCRIPTION
## Problem

`cache.server.diskCacheEvictWatermarkPct` is enforced on the whole filesystem, but `pressureProtectionBudgetBytes` sized the pressure-mode protected set as `resumeWatermark × total` (capped by `minFreeBytes`) — as if the CAS were the only thing on the disk. Wherever the recent-stub required set is larger than that budget, the node parks at **watermark + everything else on the volume** (OS, worker images, uv and buildah caches). Every indexed object is protected, the store logs `disk cache eviction found nothing evictable ... protected=N eligible=0` every tick, and stores are accepted only while available space happens to stay above `minFreeBytes`.

Reproduced on staging today after lowering the watermark 0.80 → 0.70 to widen the disk margin for the rollout:

| | |
|---|---|
| disk | 258.9 GB |
| budget (0.67 × total) | 173.5 GB |
| CAS content after settling | 168.6 GB |
| uv + buildah + root usage | 41 GB |
| result | **81%**, `candidates=405 protected=405`, `want_free_bytes=28 GB` |

So the config knob cannot actually move the disk below ~81% on that node, and prod (190 GB / 191 GB / 121 GB cache dirs on 243 GB disks, currently 82–83% and refusing stores) has the same shape.

## Fix

- `Server.RefreshDiskUsage` / `ReclaimDisk` now report `DiskUsage.EvictableBytes` = bytes of indexed content (new `contentIndex.bytes()`).
- `pressureProtectionBudgetBytes` subtracts `UsedBytes − EvictableBytes` from the budget, so protected content **plus the rest of the disk** lands at the resume watermark (or the reserve, whichever is tighter).
- With no index reading (`EvictableBytes == 0`) the old whole-disk budget is used unchanged.

No config or proto changes. Eviction itself is untouched; only the size of the set the reconciler asks the store to protect changes.

## Tests

- `TestPressureProtectionBudgetSubtractsNonEvictableUsage` — the staging numbers above; asserts the budget lands at the resume watermark net of other usage, the reserve bound is also net of other usage, the no-index fallback, and the swamped case.
- `TestDiskUsageReportsIndexedBytesAsEvictable` — index byte total tracks adds/forgets and flows through `RefreshDiskUsage`.
- `go test ./pkg/cache/ ./pkg/worker/` green.

## Rollout

Cache-server (worker image) change; ships with the next worker tag, not 0.1.741.

Until then the 0.70 watermark already set in the stage/prod secrets helps only where non-CAS usage on the volume is small: the reconciler still fills to `0.67 × total` of CAS, so a node lands at `~67% + other usage`. On prod that is roughly:

| node | cache dir | other usage | lands at (0.70, before this PR) | after this PR |
|---|---|---|---|---|
| build node A | 190 GB | ~8 GB | ~70% (~70 GB free) | 67% |
| build node B | 191 GB | ~8 GB | ~70% (~70 GB free) | 67% |
| g5 GPU node | 121 GB | ~72 GB | reserve-gated (~43 GB free, refusing stores) — unchanged | 67% |

Lowering the watermark further does not rescue the GPU node (its other usage exceeds the headroom regardless) and only costs the build nodes cache, so 0.70 is the right config value and this PR is what fixes the remaining node.