### PR TITLE
cache: budget unsized CLIP v2 layers by on-disk size under pressure

### DIFF
--- a/pkg/cache/server.go
+++ b/pkg/cache/server.go
@@ -233,6 +233,19 @@ func (cs *Server) refreshDisk(evict bool) (DiskUsage, error) {
 	return usage, nil
 }
 
+// ContentSizeBytes is the on-disk size of hash as the local index knows it, or
+// 0 when the store does not hold it.
+func (cs *Server) ContentSizeBytes(hash string) int64 {
+	if cs == nil || cs.cas == nil {
+		return 0
+	}
+	entry, ok := cs.cas.index.get(hash)
+	if !ok {
+		return 0
+	}
+	return entry.size
+}
+
 func (cs *Server) DiskPressureExceeded() bool {
 	if cs == nil || cs.cas == nil {
 		return false

--- a/pkg/worker/cache_reconciler.go
+++ b/pkg/worker/cache_reconciler.go
@@ -834,7 +834,12 @@ func protectedContentFromRecentStubs(stubs []recentStubContent, accelerator stri
 	return protected, activeCheckpointIDs
 }
 
-func pressureProtectedContentFromRecentStubs(stubs []recentStubContent, accelerator string, usage cache.DiskUsage, softWatermark float64, minFreeBytes int64) map[string]struct{} {
+// pressureProtectedContentFromRecentStubs ranks recent stubs' content, newest
+// stub first, and protects it until the budget is spent. An item's size is what
+// its report carried or, failing that, what localSize says is on disk: CLIP v2
+// layer reports carry no size, and letting them through unbudgeted protects
+// every layer on the node, which is exactly the state eviction cannot leave.
+func pressureProtectedContentFromRecentStubs(stubs []recentStubContent, accelerator string, usage cache.DiskUsage, softWatermark float64, minFreeBytes int64, localSize func(hash string) int64) map[string]struct{} {
 	budget := pressureProtectionBudgetBytes(usage, softWatermark, minFreeBytes)
 	if budget <= 0 {
 		return map[string]struct{}{}
@@ -856,6 +861,9 @@ func pressureProtectedContentFromRecentStubs(stubs []recentStubContent, accelera
 				continue
 			}
 			sizeBytes := maxInt64(item.SizeBytes, 0)
+			if sizeBytes == 0 && localSize != nil {
+				sizeBytes = maxInt64(localSize(item.Hash), 0)
+			}
 			if sizeBytes > 0 && protectedBytes+sizeBytes > budget {
 				continue
 			}
@@ -961,7 +969,7 @@ func (m *WorkerCacheManager) pruneOwnerImageCache(stubs []recentStubContent, sof
 	bytesToFree := maxInt64(reconcilePressureBytesToFree(usage, softWatermark, minFreeBytes), 0)
 	var allowlist map[string]struct{}
 	if bytesToFree > 0 {
-		allowlist = pressureProtectedContentFromRecentStubs(stubs, m.accelerator, usage, softWatermark, minFreeBytes)
+		allowlist = pressureProtectedContentFromRecentStubs(stubs, m.accelerator, usage, softWatermark, minFreeBytes, nil)
 	}
 	mountRoot := filepath.Join(types.AgentImagesPath, "mnt")
 	mountSetComplete := m.pruneStaleImageMountPaths(mountRoot)
@@ -1395,7 +1403,7 @@ func (m *WorkerCacheManager) reconcileGatedByDiskUsage(server *cache.Server, loc
 
 	var reconcileAllowlist map[string]struct{}
 	if pressureMode && usage.TotalBytes > 0 {
-		reconcileAllowlist = pressureProtectedContentFromRecentStubs(stubContent, m.accelerator, usage, watermark, server.DiskMinFreeBytes())
+		reconcileAllowlist = pressureProtectedContentFromRecentStubs(stubContent, m.accelerator, usage, watermark, server.DiskMinFreeBytes(), server.ContentSizeBytes)
 		server.SetProtectedContent(reconcileAllowlist)
 	}
 

--- a/pkg/worker/cache_reconciler_test.go
+++ b/pkg/worker/cache_reconciler_test.go
@@ -201,7 +201,7 @@ func TestPressureProtectedContentPrioritizesNewestStubWorkingSet(t *testing.T) {
 		},
 	}
 
-	protected := pressureProtectedContentFromRecentStubs(stubs, "", cache.DiskUsage{TotalBytes: 100}, 0.75, 0)
+	protected := pressureProtectedContentFromRecentStubs(stubs, "", cache.DiskUsage{TotalBytes: 100}, 0.75, 0, nil)
 
 	require.Contains(t, protected, "new-checkpoint")
 	require.Contains(t, protected, "new-volume")
@@ -252,6 +252,46 @@ func TestPressureProtectionBudgetSubtractsNonEvictableUsage(t *testing.T) {
 	require.Equal(t, int64(0), pressureProtectionBudgetBytes(swamped, 0.70, reserve))
 }
 
+// TestPressureProtectedContentBudgetsUnsizedItemsByLocalSize reproduces the
+// staging cache-server that sat at 83% with "candidates=382 protected=382
+// eligible=0": CLIP v2 layer reports carry no SizeBytes, so every layer was
+// protected outside the budget. Sizes must come from the local index instead.
+func TestPressureProtectedContentBudgetsUnsizedItemsByLocalSize(t *testing.T) {
+	now := time.Now()
+	// Budget: resume watermark 0.67 of 1000 = 670, minus 100 of non-cache usage = 570.
+	usage := cache.DiskUsage{TotalBytes: 1000, UsedBytes: 900, EvictableBytes: 800}
+	stubs := []recentStubContent{
+		{
+			stub: cache.RecentStub{WorkspaceID: "ws", StubID: "new", LastSeen: now},
+			items: []types.CacheRequiredContentItem{
+				{Hash: "new-layer-a", Kind: types.CacheContentKindClipV2},
+				{Hash: "new-layer-b", Kind: types.CacheContentKindClipV2},
+			},
+		},
+		{
+			stub: cache.RecentStub{WorkspaceID: "ws", StubID: "old", LastSeen: now.Add(-time.Hour)},
+			items: []types.CacheRequiredContentItem{
+				{Hash: "old-layer", Kind: types.CacheContentKindClipV2},
+				{Hash: "old-absent-layer", Kind: types.CacheContentKindClipV2},
+			},
+		},
+	}
+	onDisk := map[string]int64{"new-layer-a": 300, "new-layer-b": 200, "old-layer": 300}
+	localSize := func(hash string) int64 { return onDisk[hash] }
+
+	// Without a size source every unsized item is protected and nothing is evictable.
+	all := pressureProtectedContentFromRecentStubs(stubs, "", usage, 0.70, 0, nil)
+	require.Len(t, all, 4)
+
+	protected := pressureProtectedContentFromRecentStubs(stubs, "", usage, 0.70, 0, localSize)
+	require.Contains(t, protected, "new-layer-a")
+	require.Contains(t, protected, "new-layer-b")
+	require.NotContains(t, protected, "old-layer", "300 more bytes would exceed the 570 budget")
+	// Content the store does not hold costs nothing to protect; it only
+	// bounds what may be materialized once pressure clears.
+	require.Contains(t, protected, "old-absent-layer")
+}
+
 func TestPressureProtectedContentPrioritizesCheckpointWithinStub(t *testing.T) {
 	now := time.Now()
 	stubs := []recentStubContent{
@@ -264,7 +304,7 @@ func TestPressureProtectedContentPrioritizesCheckpointWithinStub(t *testing.T) {
 		},
 	}
 
-	protected := pressureProtectedContentFromRecentStubs(stubs, "", cache.DiskUsage{TotalBytes: 90}, 0.75, 0)
+	protected := pressureProtectedContentFromRecentStubs(stubs, "", cache.DiskUsage{TotalBytes: 90}, 0.75, 0, nil)
 
 	require.Contains(t, protected, "checkpoint")
 	require.NotContains(t, protected, "volume")


### PR DESCRIPTION
pressureProtectedContentFromRecentStubs only charged an item against the
budget when its report carried SizeBytes. CLIP v2 layer reports never do,
so on a cache server whose content is mostly image layers every layer was
protected outside the budget: staging sat at 83% with the eviction loop
logging candidates=382 protected=382 eligible=0 every 30s, and the #1872
non-evictable accounting never got to bite.

Resolve a size-less item's size from the local content index (new
Server.ContentSizeBytes) so the budget is spent on what is actually on
disk. Content the store does not hold still costs nothing to protect; it
only bounds what may be materialized once pressure clears.

Co-authored-by: Cursor <cursoragent@cursor.com>

Observed on staging after the 0.1.742 rollout (node ip-10-100-30-24, 258 GB disk, 172 GB indexed CAS content, ~35 GB other usage, watermark 0.70):

```
disk cache eviction found nothing evictable: usage=0.83 watermark=0.70 ... candidates=382 protected=382 recent=0 eligible=0
```

With the budget applied to real sizes the protected set shrinks to ~130 GB and the remaining ~40 GB becomes evictable, letting the disk settle at the resume watermark instead of parking at 83% and only shedding content under the critical-pressure path.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pressure-protection budget so unsized CLIP v2 layers count against it, stopping image-heavy cache servers from parking at 83% usage with no evictable content.

Previously, `pressureProtectedContentFromRecentStubs` only charged an item to the budget when its report carried `SizeBytes`, and CLIP v2 layer reports never do — every layer was protected outside the budget. The function now falls back to the on-disk size from the local content index via the new `Server.ContentSizeBytes`. Content the store doesn't hold still costs nothing to protect; it only bounds what may be materialized once pressure clears.

<sup>Written for commit 134f544eb9a872991b07a7d7424cf3653d2f7303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

