### PR TITLE
worker: bound the persistent buildah layer store (imageService.buildLayerCacheMaxPct)

### DIFF
--- a/pkg/common/config.default.yaml
+++ b/pkg/common/config.default.yaml
@@ -141,6 +141,10 @@ imageService:
     proxy: ""
     timeoutS: 20
     retries: 3
+  # The buildah layer store under the build cache keeps every layer a build on
+  # the node produced. Cap it at this fraction of its filesystem; after each
+  # build the oldest images go until it fits. 0 disables the cap.
+  buildLayerCacheMaxPct: 0.20
   registryStore: local
   registryCredentialProvider: docker
   buildRegistry: registry.localhost:5000

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -310,6 +310,10 @@ type ImageServiceConfig struct {
 	// BuildApt tunes apt inside the RUN steps of a layered build. The settings
 	// are bind-mounted into each step and never land in the image.
 	BuildApt BuildAptConfig `key:"buildApt" json:"build_apt"`
+	// BuildLayerCacheMaxPct bounds the persistent buildah layer store to this
+	// fraction of the filesystem it sits on; after a build, the oldest images
+	// are removed until it fits. Zero disables the bound.
+	BuildLayerCacheMaxPct float64 `key:"buildLayerCacheMaxPct" json:"build_layer_cache_max_pct"`
 }
 
 // BuildAptConfig is applied to apt during image builds whose base image has

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -2504,8 +2504,15 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 		}
 	}()
 	if !cleanupGraphroot {
-		// The persistent store outlives this build; keep it within bounds.
+		// The persistent store outlives this build; keep it within bounds
+		// once this build is done, and keep concurrent trims off this
+		// build's own images meanwhile.
+		sourceImage := ""
+		if request.BuildOptions.SourceImage != nil {
+			sourceImage = *request.BuildOptions.SourceImage
+		}
 		defer c.trimBuildLayerCacheInBackground(graphroot, storageDriver)
+		defer buildLayerCacheTrims.protectBuildImages(request.ImageId, request.ImageId, sourceImage)()
 	}
 
 	buildCtxPath, err := c.getBuildContext(ctx, buildPath, request)

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -2512,7 +2512,7 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 		// once this build is done, and keep concurrent trims off this
 		// build's own images meanwhile.
 		defer c.trimBuildLayerCacheInBackground(graphroot, storageDriver)
-		defer buildLayerCacheTrims.protectBuildImages(request.ImageId, request.ImageId, sourceImage)()
+		defer buildLayerCacheTrims.protectBuildImages(request.ImageId, sourceImage)()
 	}
 
 	buildCtxPath, err := c.getBuildContext(ctx, buildPath, request)

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -2503,14 +2503,14 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 			os.Remove(storageConf)
 		}
 	}()
+	sourceImage := ""
+	if request.BuildOptions.SourceImage != nil {
+		sourceImage = *request.BuildOptions.SourceImage
+	}
 	if !cleanupGraphroot {
 		// The persistent store outlives this build; keep it within bounds
 		// once this build is done, and keep concurrent trims off this
 		// build's own images meanwhile.
-		sourceImage := ""
-		if request.BuildOptions.SourceImage != nil {
-			sourceImage = *request.BuildOptions.SourceImage
-		}
 		defer c.trimBuildLayerCacheInBackground(graphroot, storageDriver)
 		defer buildLayerCacheTrims.protectBuildImages(request.ImageId, request.ImageId, sourceImage)()
 	}
@@ -2530,10 +2530,6 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 
 	// Pre-pull base image with insecure option if necessary
 	insecure := false
-	sourceImage := ""
-	if request.BuildOptions.SourceImage != nil {
-		sourceImage = *request.BuildOptions.SourceImage
-	}
 	dockerfile := *request.BuildOptions.Dockerfile
 	if sourceImage != "" {
 		insecure = c.config.ImageService.BuildRegistryInsecure

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -2503,6 +2503,10 @@ func (c *ImageClient) BuildAndArchiveImage(ctx context.Context, outputLogger *sl
 			os.Remove(storageConf)
 		}
 	}()
+	if !cleanupGraphroot {
+		// The persistent store outlives this build; keep it within bounds.
+		defer c.trimBuildLayerCacheInBackground(graphroot, storageDriver)
+	}
 
 	buildCtxPath, err := c.getBuildContext(ctx, buildPath, request)
 	if err != nil {

--- a/pkg/worker/image_build_cache.go
+++ b/pkg/worker/image_build_cache.go
@@ -1,0 +1,273 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// The buildah graphroot under the persistent build cache keeps every layer a
+// build on the node ever produced or pulled; buildah itself expires nothing.
+// Left alone it grows until the node's disk is full (prod build nodes reached
+// 160-210 GB), starving the content cache on the same volume. After each build
+// the store is trimmed to its share of the filesystem, oldest images first.
+// buildah refuses to remove an image whose layers a working container or a
+// newer image still builds on, so a build running alongside the trim is never
+// pulled from under; those images are simply skipped.
+
+// buildLayerCacheTrimHysteresis is the fraction of the cap the trim aims for,
+// so a store just over the cap is not trimmed again after every build.
+const buildLayerCacheTrimHysteresis = 0.9
+
+// buildLayerCacheTrimBatch is how many images one buildah rmi removes before
+// the store is re-measured.
+const buildLayerCacheTrimBatch = 16
+
+const buildLayerCacheTrimTimeout = 30 * time.Minute
+
+// buildLayerCacheTrimMu serializes trims: a second build finishing while one
+// trim runs does not start another.
+var buildLayerCacheTrimMu sync.Mutex
+
+// buildahStoredLayer is a containers/storage layer record as written to
+// overlay-layers/layers.json (vfs-layers for the vfs driver).
+type buildahStoredLayer struct {
+	ID       string    `json:"id"`
+	Parent   string    `json:"parent"`
+	Created  time.Time `json:"created"`
+	DiffSize int64     `json:"diff-size"`
+}
+
+// buildahStoredImage is an image record from overlay-images/images.json.
+type buildahStoredImage struct {
+	ID      string    `json:"id"`
+	Layer   string    `json:"layer"`
+	Names   []string  `json:"names"`
+	Created time.Time `json:"created"`
+}
+
+// buildahStoredContainer is a working-container record from
+// overlay-containers/containers.json.
+type buildahStoredContainer struct {
+	ID      string `json:"id"`
+	ImageID string `json:"image"`
+}
+
+// buildLayerCacheMaxBytes is the store's cap on the filesystem holding
+// graphroot, or 0 when the cap is disabled or the filesystem cannot be sized.
+func (c *ImageClient) buildLayerCacheMaxBytes(graphroot string) int64 {
+	pct := c.config.ImageService.BuildLayerCacheMaxPct
+	if pct <= 0 || pct >= 1 {
+		return 0
+	}
+	usage, err := fastDiskUsage(graphroot)
+	if err != nil || usage.TotalBytes == 0 {
+		return 0
+	}
+	return int64(pct * float64(usage.TotalBytes))
+}
+
+// trimBuildLayerCacheInBackground trims the persistent store once the build
+// that used it has returned. At most one trim runs at a time.
+func (c *ImageClient) trimBuildLayerCacheInBackground(graphroot, driver string) {
+	if !buildLayerCacheTrimMu.TryLock() {
+		return
+	}
+	go func() {
+		defer buildLayerCacheTrimMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), buildLayerCacheTrimTimeout)
+		defer cancel()
+		c.trimBuildLayerCache(ctx, graphroot, driver)
+	}()
+}
+
+func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver string) {
+	maxBytes := c.buildLayerCacheMaxBytes(graphroot)
+	if maxBytes <= 0 {
+		return
+	}
+	size, err := buildLayerStoreBytes(graphroot, driver)
+	if err != nil {
+		log.Warn().Err(err).Str("graphroot", graphroot).Msg("build layer cache trim skipped: cannot size the store")
+		return
+	}
+	if size <= maxBytes {
+		return
+	}
+	target := int64(float64(maxBytes) * buildLayerCacheTrimHysteresis)
+
+	runroot := mustMkdirTempBuildahDir("buildah-trim-run-")
+	defer os.RemoveAll(runroot)
+	tmpdir := mustMkdirTempBuildahDir("buildah-trim-tmp-")
+	defer os.RemoveAll(tmpdir)
+	storageConf, err := c.writeStorageConf(graphroot, runroot, driver)
+	if err != nil {
+		log.Warn().Err(err).Msg("build layer cache trim skipped: cannot write storage config")
+		return
+	}
+	defer os.Remove(storageConf)
+	store := &buildahStore{graphroot: graphroot, runroot: runroot, tmpdir: tmpdir, driver: driver, conf: storageConf}
+	env := c.buildahEnv(runroot, tmpdir, storageConf)
+
+	started := time.Now()
+	startBytes := size
+	removed, failed := 0, 0
+	// Every pass re-reads the store so removals that failed or freed less than
+	// expected (shared layers) do not end the trim early; an image that failed
+	// once is not retried within this trim.
+	skip := map[string]struct{}{}
+	for size > target {
+		if ctx.Err() != nil {
+			break
+		}
+		batch, err := oldestRemovableBuildahImages(graphroot, driver, skip, buildLayerCacheTrimBatch)
+		if err != nil {
+			log.Warn().Err(err).Msg("build layer cache trim stopped: cannot list images")
+			break
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, id := range batch {
+			skip[id] = struct{}{}
+		}
+		var out strings.Builder
+		args := append(store.args("rmi"), batch...)
+		if err := newBuildahCommand(ctx, args, env, &out, &out).Run(); err != nil {
+			// rmi keeps going past images it cannot remove and exits non-zero;
+			// the re-measure below shows what it did remove.
+			failed++
+			log.Debug().Err(err).Str("output", strings.TrimSpace(out.String())).Msg("build layer cache trim: some images not removed")
+		}
+		removed += len(batch)
+		if size, err = buildLayerStoreBytes(graphroot, driver); err != nil {
+			log.Warn().Err(err).Msg("build layer cache trim stopped: cannot re-size the store")
+			break
+		}
+	}
+
+	event := log.Info()
+	if size > target {
+		event = log.Warn()
+	}
+	event.
+		Int64("start_bytes", startBytes).
+		Int64("end_bytes", size).
+		Int64("max_bytes", maxBytes).
+		Int64("target_bytes", target).
+		Int("images_attempted", removed).
+		Int("batches_with_failures", failed).
+		Dur("duration", time.Since(started)).
+		Msg("trimmed build layer cache")
+}
+
+// buildLayerStoreBytes sums the recorded diff size of every layer in the
+// store. It is read from the store's own layer index, not a walk of the
+// overlay tree, which on a store this size would take minutes of IOPS.
+func buildLayerStoreBytes(graphroot, driver string) (int64, error) {
+	layers, err := readBuildahStoredLayers(graphroot, driver)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, layer := range layers {
+		if layer.DiffSize > 0 {
+			total += layer.DiffSize
+		}
+	}
+	return total, nil
+}
+
+// oldestRemovableBuildahImages returns up to limit image ids, oldest first by
+// when their top layer was added to this store (a pulled image's upstream
+// creation date says nothing about when this node fetched it). Images a
+// working container is built from, and ids in skip, are left out.
+func oldestRemovableBuildahImages(graphroot, driver string, skip map[string]struct{}, limit int) ([]string, error) {
+	layers, err := readBuildahStoredLayers(graphroot, driver)
+	if err != nil {
+		return nil, err
+	}
+	layerCreated := make(map[string]time.Time, len(layers))
+	for _, layer := range layers {
+		layerCreated[layer.ID] = layer.Created
+	}
+
+	var images []buildahStoredImage
+	if err := readBuildahStoreJSON(graphroot, driver, "images", "images.json", &images); err != nil {
+		return nil, err
+	}
+	inUse := map[string]struct{}{}
+	var containers []buildahStoredContainer
+	if err := readBuildahStoreJSON(graphroot, driver, "containers", "containers.json", &containers); err == nil {
+		for _, container := range containers {
+			inUse[container.ImageID] = struct{}{}
+		}
+	}
+
+	type aged struct {
+		id    string
+		added time.Time
+	}
+	candidates := make([]aged, 0, len(images))
+	for _, image := range images {
+		if _, ok := skip[image.ID]; ok {
+			continue
+		}
+		if _, ok := inUse[image.ID]; ok {
+			continue
+		}
+		added, ok := layerCreated[image.Layer]
+		if !ok || added.IsZero() {
+			added = image.Created
+		}
+		candidates = append(candidates, aged{id: image.ID, added: added})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].added.Equal(candidates[j].added) {
+			return candidates[i].added.Before(candidates[j].added)
+		}
+		return candidates[i].id < candidates[j].id
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		ids = append(ids, candidate.id)
+	}
+	return ids, nil
+}
+
+func readBuildahStoredLayers(graphroot, driver string) ([]buildahStoredLayer, error) {
+	var layers []buildahStoredLayer
+	if err := readBuildahStoreJSON(graphroot, driver, "layers", "layers.json", &layers); err != nil {
+		return nil, err
+	}
+	return layers, nil
+}
+
+// readBuildahStoreJSON decodes graphroot/<driver>-<kind>/<name>. A store that
+// has not written the file yet is empty, not an error.
+func readBuildahStoreJSON(graphroot, driver, kind, name string, out any) error {
+	path := filepath.Join(graphroot, driver+"-"+kind, name)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/worker/image_build_cache.go
+++ b/pkg/worker/image_build_cache.go
@@ -53,13 +53,19 @@ type buildLayerCacheTrimmer struct {
 	running bool
 	pending bool
 
-	// inFlight holds references (image ids, base image refs) of builds this
-	// worker is running, keyed by build; a trim never removes an image named
-	// for one of them.
-	inFlight map[string][]string
+	// inFlight holds the builds this worker is running, keyed by build; a
+	// trim never removes an image named for one of them.
+	inFlight map[string]inFlightBuild
 }
 
-var buildLayerCacheTrims = &buildLayerCacheTrimmer{inFlight: map[string][]string{}}
+// inFlightBuild is what a running build names in the store: the image it
+// commits under its id, and the base image it starts from.
+type inFlightBuild struct {
+	imageID   string
+	baseImage string
+}
+
+var buildLayerCacheTrims = &buildLayerCacheTrimmer{inFlight: map[string]inFlightBuild{}}
 
 // buildahStoredLayer is a containers/storage layer record as written to
 // overlay-layers/layers.json (vfs-layers for the vfs driver).
@@ -99,27 +105,27 @@ func (c *ImageClient) buildLayerCacheMaxBytes(graphroot string) int64 {
 	return int64(pct * float64(usage.TotalBytes))
 }
 
-// protectBuildImages records a build's image references as in flight until
-// the returned func runs.
-func (t *buildLayerCacheTrimmer) protectBuildImages(buildKey string, refs ...string) func() {
+// protectBuildImages records a build as in flight until the returned func
+// runs.
+func (t *buildLayerCacheTrimmer) protectBuildImages(imageID, baseImage string) func() {
 	t.mu.Lock()
-	t.inFlight[buildKey] = refs
+	t.inFlight[imageID] = inFlightBuild{imageID: imageID, baseImage: baseImage}
 	t.mu.Unlock()
 	return func() {
 		t.mu.Lock()
-		delete(t.inFlight, buildKey)
+		delete(t.inFlight, imageID)
 		t.mu.Unlock()
 	}
 }
 
-func (t *buildLayerCacheTrimmer) protectedRefs() []string {
+func (t *buildLayerCacheTrimmer) inFlightBuilds() []inFlightBuild {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	var refs []string
-	for _, r := range t.inFlight {
-		refs = append(refs, r...)
+	builds := make([]inFlightBuild, 0, len(t.inFlight))
+	for _, b := range t.inFlight {
+		builds = append(builds, b)
 	}
-	return refs
+	return builds
 }
 
 // trimBuildLayerCacheInBackground trims the persistent store once the build
@@ -194,9 +200,9 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 	skip := map[string]struct{}{}
 	for size > target && ctx.Err() == nil {
 		batch, err := oldestRemovableBuildahImages(graphroot, driver, trimExclusions{
-			skip:          skip,
-			protectedRefs: buildLayerCacheTrims.protectedRefs(),
-			minAdded:      time.Now().Add(-buildLayerCacheMinAge),
+			skip:     skip,
+			inFlight: buildLayerCacheTrims.inFlightBuilds(),
+			minAdded: time.Now().Add(-buildLayerCacheMinAge),
 		}, buildLayerCacheTrimBatch)
 		if err != nil {
 			log.Warn().Err(err).Msg("build layer cache trim stopped: cannot list images")
@@ -273,9 +279,9 @@ func buildLayerStoreBytes(graphroot, driver string) (int64, error) {
 
 // trimExclusions is what a trim pass must leave in the store.
 type trimExclusions struct {
-	skip          map[string]struct{} // image ids set aside this trim
-	protectedRefs []string            // refs of builds in flight on this worker
-	minAdded      time.Time           // images added at or after this stay
+	skip     map[string]struct{} // image ids set aside this trim
+	inFlight []inFlightBuild     // builds running on this worker
+	minAdded time.Time           // images added at or after this stay
 }
 
 // oldestRemovableBuildahImages returns up to limit image ids, oldest first by
@@ -320,7 +326,7 @@ func oldestRemovableBuildahImages(graphroot, driver string, excl trimExclusions,
 		if _, ok := inUse[image.ID]; ok {
 			continue
 		}
-		if imageNamedForRefs(image, excl.protectedRefs) {
+		if imageNamedForBuilds(image, excl.inFlight) {
 			continue
 		}
 		added, ok := layerCreated[image.Layer]
@@ -348,26 +354,28 @@ func oldestRemovableBuildahImages(graphroot, driver string, excl trimExclusions,
 	return ids, nil
 }
 
-// imageNamedForRefs reports whether any of the image's names refers to one
-// of refs. A base image ref matches a name with the same final repo:tag (or
-// repo@digest), so python:3.12 covers docker.io/library/python:3.12 but
-// python alone covers only python:latest. A build id matches the name a build
-// gives its image: as the tag (registry/beta9-users:<id>) or as the repo
-// (<id>:latest).
-func imageNamedForRefs(image buildahStoredImage, refs []string) bool {
-	for _, ref := range refs {
-		if ref == "" {
-			continue
+// imageNamedForBuilds reports whether the image is named for a build in
+// flight: it is the image the build commits under its id (the id as the tag,
+// registry/beta9-users:<id>, or as the repo, <id>:latest), or it is the
+// build's base image, compared by final repo:tag or repo@digest with an
+// implicit :latest made explicit, so python and docker.io/library/python
+// both cover docker.io/library/python:latest and nothing else.
+func imageNamedForBuilds(image buildahStoredImage, builds []inFlightBuild) bool {
+	for _, build := range builds {
+		var baseTail string
+		if build.baseImage != "" {
+			baseTail = imageRefTail(build.baseImage)
 		}
-		refTail := imageRefTail(ref)
 		for _, name := range image.Names {
 			tail := imageRefTail(name)
-			if tail == refTail {
+			if baseTail != "" && tail == baseTail {
 				return true
 			}
-			repo, tag := splitImageRefTail(tail)
-			if ref == tag || (ref == repo && tag == "latest") {
-				return true
+			if build.imageID != "" {
+				repo, tag := splitImageRefTail(tail)
+				if tag == build.imageID || (repo == build.imageID && tag == "latest") {
+					return true
+				}
 			}
 		}
 	}
@@ -375,10 +383,13 @@ func imageNamedForRefs(image buildahStoredImage, refs []string) bool {
 }
 
 // imageRefTail is the last path element of an image reference with its tag or
-// digest: repo:tag, or repo@sha256:... .
+// digest, repo:tag or repo@sha256:..., with an implicit :latest made explicit.
 func imageRefTail(ref string) string {
 	if i := strings.LastIndex(ref, "/"); i >= 0 {
 		ref = ref[i+1:]
+	}
+	if !strings.ContainsAny(ref, ":@") {
+		ref += ":latest"
 	}
 	return ref
 }

--- a/pkg/worker/image_build_cache.go
+++ b/pkg/worker/image_build_cache.go
@@ -349,16 +349,24 @@ func oldestRemovableBuildahImages(graphroot, driver string, excl trimExclusions,
 }
 
 // imageNamedForRefs reports whether any of the image's names refers to one
-// of refs. A ref matches a name that contains it (a build id inside
-// registry/repo:build-id) or whose repo:tag or digest equals the ref's, so
-// python:3.12 covers docker.io/library/python:3.12.
+// of refs. A base image ref matches a name with the same final repo:tag (or
+// repo@digest), so python:3.12 covers docker.io/library/python:3.12 but
+// python alone covers only python:latest. A build id matches the name a build
+// gives its image: as the tag (registry/beta9-users:<id>) or as the repo
+// (<id>:latest).
 func imageNamedForRefs(image buildahStoredImage, refs []string) bool {
 	for _, ref := range refs {
 		if ref == "" {
 			continue
 		}
+		refTail := imageRefTail(ref)
 		for _, name := range image.Names {
-			if strings.Contains(name, ref) || imageRefTail(name) == imageRefTail(ref) {
+			tail := imageRefTail(name)
+			if tail == refTail {
+				return true
+			}
+			repo, tag := splitImageRefTail(tail)
+			if ref == tag || (ref == repo && tag == "latest") {
 				return true
 			}
 		}
@@ -373,6 +381,17 @@ func imageRefTail(ref string) string {
 		ref = ref[i+1:]
 	}
 	return ref
+}
+
+// splitImageRefTail splits repo:tag or repo@digest into its two parts.
+func splitImageRefTail(tail string) (repo, tagOrDigest string) {
+	if i := strings.Index(tail, "@"); i >= 0 {
+		return tail[:i], tail[i+1:]
+	}
+	if i := strings.Index(tail, ":"); i >= 0 {
+		return tail[:i], tail[i+1:]
+	}
+	return tail, ""
 }
 
 func buildahStoredImageIDs(graphroot, driver string) (map[string]struct{}, error) {

--- a/pkg/worker/image_build_cache.go
+++ b/pkg/worker/image_build_cache.go
@@ -20,13 +20,25 @@ import (
 // Left alone it grows until the node's disk is full (prod build nodes reached
 // 160-210 GB), starving the content cache on the same volume. After each build
 // the store is trimmed to its share of the filesystem, oldest images first.
-// buildah refuses to remove an image whose layers a working container or a
-// newer image still builds on, so a build running alongside the trim is never
-// pulled from under; those images are simply skipped.
+//
+// A trim runs alongside other builds, so it must not remove what they need:
+//   - anything added to the store within buildLayerCacheMinAge is left alone,
+//     which covers a base image a starting build has just pulled and an image
+//     a finishing build has committed but not yet pushed;
+//   - images named for a build in flight on this worker (its id, its base
+//     image) are left alone whatever their age;
+//   - images a working container is built from are left alone;
+//   - buildah itself refuses to remove a layer another image or container
+//     still builds on, so a stale view of the store fails safe.
 
 // buildLayerCacheTrimHysteresis is the fraction of the cap the trim aims for,
 // so a store just over the cap is not trimmed again after every build.
 const buildLayerCacheTrimHysteresis = 0.9
+
+// buildLayerCacheMinAge: images added to the store more recently than this
+// are never removed, so a build in progress cannot lose what it just pulled
+// or committed.
+const buildLayerCacheMinAge = time.Hour
 
 // buildLayerCacheTrimBatch is how many images one buildah rmi removes before
 // the store is re-measured.
@@ -34,9 +46,20 @@ const buildLayerCacheTrimBatch = 16
 
 const buildLayerCacheTrimTimeout = 30 * time.Minute
 
-// buildLayerCacheTrimMu serializes trims: a second build finishing while one
-// trim runs does not start another.
-var buildLayerCacheTrimMu sync.Mutex
+// buildLayerCacheTrimmer runs one trim at a time. A build finishing while a
+// trim is underway marks it pending, and the running trim goes again.
+type buildLayerCacheTrimmer struct {
+	mu      sync.Mutex
+	running bool
+	pending bool
+
+	// inFlight holds references (image ids, base image refs) of builds this
+	// worker is running, keyed by build; a trim never removes an image named
+	// for one of them.
+	inFlight map[string][]string
+}
+
+var buildLayerCacheTrims = &buildLayerCacheTrimmer{inFlight: map[string][]string{}}
 
 // buildahStoredLayer is a containers/storage layer record as written to
 // overlay-layers/layers.json (vfs-layers for the vfs driver).
@@ -76,17 +99,58 @@ func (c *ImageClient) buildLayerCacheMaxBytes(graphroot string) int64 {
 	return int64(pct * float64(usage.TotalBytes))
 }
 
+// protectBuildImages records a build's image references as in flight until
+// the returned func runs.
+func (t *buildLayerCacheTrimmer) protectBuildImages(buildKey string, refs ...string) func() {
+	t.mu.Lock()
+	t.inFlight[buildKey] = refs
+	t.mu.Unlock()
+	return func() {
+		t.mu.Lock()
+		delete(t.inFlight, buildKey)
+		t.mu.Unlock()
+	}
+}
+
+func (t *buildLayerCacheTrimmer) protectedRefs() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var refs []string
+	for _, r := range t.inFlight {
+		refs = append(refs, r...)
+	}
+	return refs
+}
+
 // trimBuildLayerCacheInBackground trims the persistent store once the build
-// that used it has returned. At most one trim runs at a time.
+// that used it has returned. One trim runs at a time; a request during a trim
+// makes it run once more when done.
 func (c *ImageClient) trimBuildLayerCacheInBackground(graphroot, driver string) {
-	if !buildLayerCacheTrimMu.TryLock() {
+	t := buildLayerCacheTrims
+	t.mu.Lock()
+	if t.running {
+		t.pending = true
+		t.mu.Unlock()
 		return
 	}
+	t.running = true
+	t.mu.Unlock()
+
 	go func() {
-		defer buildLayerCacheTrimMu.Unlock()
-		ctx, cancel := context.WithTimeout(context.Background(), buildLayerCacheTrimTimeout)
-		defer cancel()
-		c.trimBuildLayerCache(ctx, graphroot, driver)
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), buildLayerCacheTrimTimeout)
+			c.trimBuildLayerCache(ctx, graphroot, driver)
+			cancel()
+
+			t.mu.Lock()
+			if !t.pending {
+				t.running = false
+				t.mu.Unlock()
+				return
+			}
+			t.pending = false
+			t.mu.Unlock()
+		}
 	}()
 }
 
@@ -120,16 +184,20 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 
 	started := time.Now()
 	startBytes := size
-	removed, failed := 0, 0
-	// Every pass re-reads the store so removals that failed or freed less than
-	// expected (shared layers) do not end the trim early; an image that failed
-	// once is not retried within this trim.
+	attempted, removed, stuck := 0, 0, 0
+	// Each pass lists the oldest removable images afresh and re-measures the
+	// store afterwards, so removals that freed less than expected (shared
+	// layers) do not end the trim early. An image buildah refused (a newer
+	// image builds on it) is retried while passes still make progress, since
+	// removing that newer image may have freed it; it is set aside only once a
+	// whole pass removes nothing.
 	skip := map[string]struct{}{}
-	for size > target {
-		if ctx.Err() != nil {
-			break
-		}
-		batch, err := oldestRemovableBuildahImages(graphroot, driver, skip, buildLayerCacheTrimBatch)
+	for size > target && ctx.Err() == nil {
+		batch, err := oldestRemovableBuildahImages(graphroot, driver, trimExclusions{
+			skip:          skip,
+			protectedRefs: buildLayerCacheTrims.protectedRefs(),
+			minAdded:      time.Now().Add(-buildLayerCacheMinAge),
+		}, buildLayerCacheTrimBatch)
 		if err != nil {
 			log.Warn().Err(err).Msg("build layer cache trim stopped: cannot list images")
 			break
@@ -137,18 +205,33 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 		if len(batch) == 0 {
 			break
 		}
-		for _, id := range batch {
-			skip[id] = struct{}{}
-		}
+		attempted += len(batch)
 		var out strings.Builder
 		args := append(store.args("rmi"), batch...)
 		if err := newBuildahCommand(ctx, args, env, &out, &out).Run(); err != nil {
-			// rmi keeps going past images it cannot remove and exits non-zero;
-			// the re-measure below shows what it did remove.
-			failed++
+			// rmi keeps going past images it cannot remove and exits
+			// non-zero; the re-read below shows which ones went.
 			log.Debug().Err(err).Str("output", strings.TrimSpace(out.String())).Msg("build layer cache trim: some images not removed")
 		}
-		removed += len(batch)
+
+		remaining, err := buildahStoredImageIDs(graphroot, driver)
+		if err != nil {
+			log.Warn().Err(err).Msg("build layer cache trim stopped: cannot re-read images")
+			break
+		}
+		progress := 0
+		for _, id := range batch {
+			if _, still := remaining[id]; !still {
+				progress++
+			}
+		}
+		removed += progress
+		if progress == 0 {
+			for _, id := range batch {
+				skip[id] = struct{}{}
+			}
+			stuck += len(batch)
+		}
 		if size, err = buildLayerStoreBytes(graphroot, driver); err != nil {
 			log.Warn().Err(err).Msg("build layer cache trim stopped: cannot re-size the store")
 			break
@@ -164,8 +247,9 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 		Int64("end_bytes", size).
 		Int64("max_bytes", maxBytes).
 		Int64("target_bytes", target).
-		Int("images_attempted", removed).
-		Int("batches_with_failures", failed).
+		Int("images_attempted", attempted).
+		Int("images_removed", removed).
+		Int("images_stuck", stuck).
 		Dur("duration", time.Since(started)).
 		Msg("trimmed build layer cache")
 }
@@ -187,11 +271,19 @@ func buildLayerStoreBytes(graphroot, driver string) (int64, error) {
 	return total, nil
 }
 
+// trimExclusions is what a trim pass must leave in the store.
+type trimExclusions struct {
+	skip          map[string]struct{} // image ids set aside this trim
+	protectedRefs []string            // refs of builds in flight on this worker
+	minAdded      time.Time           // images added at or after this stay
+}
+
 // oldestRemovableBuildahImages returns up to limit image ids, oldest first by
 // when their top layer was added to this store (a pulled image's upstream
-// creation date says nothing about when this node fetched it). Images a
-// working container is built from, and ids in skip, are left out.
-func oldestRemovableBuildahImages(graphroot, driver string, skip map[string]struct{}, limit int) ([]string, error) {
+// creation date says nothing about when this node fetched it). Left out:
+// images a working container is built from, images named for a build in
+// flight, images added since minAdded, and ids in skip.
+func oldestRemovableBuildahImages(graphroot, driver string, excl trimExclusions, limit int) ([]string, error) {
 	layers, err := readBuildahStoredLayers(graphroot, driver)
 	if err != nil {
 		return nil, err
@@ -205,12 +297,15 @@ func oldestRemovableBuildahImages(graphroot, driver string, skip map[string]stru
 	if err := readBuildahStoreJSON(graphroot, driver, "images", "images.json", &images); err != nil {
 		return nil, err
 	}
-	inUse := map[string]struct{}{}
+	// An unreadable container index means unknown liveness: nothing is
+	// removable rather than everything.
 	var containers []buildahStoredContainer
-	if err := readBuildahStoreJSON(graphroot, driver, "containers", "containers.json", &containers); err == nil {
-		for _, container := range containers {
-			inUse[container.ImageID] = struct{}{}
-		}
+	if err := readBuildahStoreJSON(graphroot, driver, "containers", "containers.json", &containers); err != nil {
+		return nil, err
+	}
+	inUse := map[string]struct{}{}
+	for _, container := range containers {
+		inUse[container.ImageID] = struct{}{}
 	}
 
 	type aged struct {
@@ -219,15 +314,21 @@ func oldestRemovableBuildahImages(graphroot, driver string, skip map[string]stru
 	}
 	candidates := make([]aged, 0, len(images))
 	for _, image := range images {
-		if _, ok := skip[image.ID]; ok {
+		if _, ok := excl.skip[image.ID]; ok {
 			continue
 		}
 		if _, ok := inUse[image.ID]; ok {
 			continue
 		}
+		if imageNamedForRefs(image, excl.protectedRefs) {
+			continue
+		}
 		added, ok := layerCreated[image.Layer]
 		if !ok || added.IsZero() {
 			added = image.Created
+		}
+		if !added.Before(excl.minAdded) {
+			continue
 		}
 		candidates = append(candidates, aged{id: image.ID, added: added})
 	}
@@ -243,6 +344,45 @@ func oldestRemovableBuildahImages(graphroot, driver string, skip map[string]stru
 	ids := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {
 		ids = append(ids, candidate.id)
+	}
+	return ids, nil
+}
+
+// imageNamedForRefs reports whether any of the image's names refers to one
+// of refs. A ref matches a name that contains it (a build id inside
+// registry/repo:build-id) or whose repo:tag or digest equals the ref's, so
+// python:3.12 covers docker.io/library/python:3.12.
+func imageNamedForRefs(image buildahStoredImage, refs []string) bool {
+	for _, ref := range refs {
+		if ref == "" {
+			continue
+		}
+		for _, name := range image.Names {
+			if strings.Contains(name, ref) || imageRefTail(name) == imageRefTail(ref) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// imageRefTail is the last path element of an image reference with its tag or
+// digest: repo:tag, or repo@sha256:... .
+func imageRefTail(ref string) string {
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		ref = ref[i+1:]
+	}
+	return ref
+}
+
+func buildahStoredImageIDs(graphroot, driver string) (map[string]struct{}, error) {
+	var images []buildahStoredImage
+	if err := readBuildahStoreJSON(graphroot, driver, "images", "images.json", &images); err != nil {
+		return nil, err
+	}
+	ids := make(map[string]struct{}, len(images))
+	for _, image := range images {
+		ids[image.ID] = struct{}{}
 	}
 	return ids, nil
 }

--- a/pkg/worker/image_build_cache_test.go
+++ b/pkg/worker/image_build_cache_test.go
@@ -54,7 +54,7 @@ func TestOldestRemovableBuildahImagesOrdersByLocalAddTime(t *testing.T) {
 	})
 	writeBuildahStoreJSON(t, graphroot, "images", "images.json", []buildahStoredImage{
 		{ID: "base", Layer: "base-top", Created: time.Date(2023, 11, 10, 0, 0, 0, 0, time.UTC), Names: []string{"docker.io/library/python:3.12"}},
-		{ID: "old-build", Layer: "old-build-top", Created: now.Add(-24 * time.Hour)},
+		{ID: "old-build", Layer: "old-build-top", Created: now.Add(-24 * time.Hour), Names: []string{"registry.localhost:5000/beta9-users:old-build"}},
 		{ID: "new-build", Layer: "new-build-top", Created: now.Add(-time.Hour)},
 		{ID: "busy", Layer: "busy-top", Created: now.Add(-60 * 24 * time.Hour)},
 		{ID: "no-layer-record", Layer: "missing", Created: now.Add(-14 * 24 * time.Hour)},
@@ -63,7 +63,8 @@ func TestOldestRemovableBuildahImagesOrdersByLocalAddTime(t *testing.T) {
 		{ID: "working", ImageID: "busy"},
 	})
 
-	ids, err := oldestRemovableBuildahImages(graphroot, "overlay", nil, 10)
+	all := trimExclusions{minAdded: now}
+	ids, err := oldestRemovableBuildahImages(graphroot, "overlay", all, 10)
 	require.NoError(t, err)
 	// busy is excluded (a working container is built from it); the rest are
 	// oldest-added first, falling back to the image's own created when the
@@ -71,9 +72,76 @@ func TestOldestRemovableBuildahImagesOrdersByLocalAddTime(t *testing.T) {
 	require.Equal(t, []string{"old-build", "no-layer-record", "base", "new-build"}, ids)
 
 	// limit and skip narrow the batch.
-	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", map[string]struct{}{"old-build": {}}, 2)
+	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{skip: map[string]struct{}{"old-build": {}}, minAdded: now}, 2)
 	require.NoError(t, err)
 	require.Equal(t, []string{"no-layer-record", "base"}, ids)
+
+	// Anything added within the minimum age stays: a base a starting build
+	// just pulled, an image a finishing build committed but has not pushed.
+	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{minAdded: now.Add(-buildLayerCacheMinAge)}, 10)
+	require.NoError(t, err)
+	require.Equal(t, []string{"old-build", "no-layer-record", "base"}, ids)
+
+	// Images named for a build in flight stay: by build id inside the name,
+	// or by repo:tag regardless of registry prefix.
+	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{minAdded: now, protectedRefs: []string{"python:3.12", "old-build"}}, 10)
+	require.NoError(t, err)
+	require.Equal(t, []string{"no-layer-record", "new-build"}, ids)
+}
+
+func TestOldestRemovableBuildahImagesRefusesUnknownLiveness(t *testing.T) {
+	graphroot := t.TempDir()
+	writeBuildahStoreJSON(t, graphroot, "images", "images.json", []buildahStoredImage{{ID: "img", Layer: "l"}})
+	dir := filepath.Join(graphroot, "overlay-containers")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "containers.json"), []byte("{not json"), 0o644))
+
+	_, err := oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{minAdded: time.Now()}, 10)
+	require.Error(t, err, "a corrupt container index must stop the trim, not read as no containers")
+}
+
+func TestImageNamedForRefs(t *testing.T) {
+	img := buildahStoredImage{Names: []string{
+		"187248174200.dkr.ecr.us-east-1.amazonaws.com/prod/beta9-users:6ec9ea3006729fb8",
+		"docker.io/library/python:3.12",
+		"public.ecr.aws/n4e0e1y0/beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5",
+	}}
+	require.True(t, imageNamedForRefs(img, []string{"6ec9ea3006729fb8"}), "build id inside a tag")
+	require.True(t, imageNamedForRefs(img, []string{"python:3.12"}), "bare repo:tag matches the fully qualified name")
+	require.True(t, imageNamedForRefs(img, []string{"beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5"}))
+	require.False(t, imageNamedForRefs(img, []string{"python:3.11", "", "other-build"}))
+	require.False(t, imageNamedForRefs(buildahStoredImage{}, []string{"python:3.12"}), "intermediate images have no names")
+}
+
+func TestBuildLayerCacheTrimmerProtectsInFlightBuilds(t *testing.T) {
+	tr := &buildLayerCacheTrimmer{inFlight: map[string][]string{}}
+	require.Empty(t, tr.protectedRefs())
+	done := tr.protectBuildImages("build-1", "build-1", "python:3.12")
+	require.ElementsMatch(t, []string{"build-1", "python:3.12"}, tr.protectedRefs())
+	done()
+	require.Empty(t, tr.protectedRefs())
+}
+
+func TestTrimBuildLayerCacheInBackgroundCoalesces(t *testing.T) {
+	c := &ImageClient{} // cap disabled: each trim returns at once
+	tr := buildLayerCacheTrims
+	tr.mu.Lock()
+	tr.running, tr.pending = true, false // hold the trimmer as if a trim were underway
+	tr.mu.Unlock()
+
+	c.trimBuildLayerCacheInBackground(t.TempDir(), "overlay")
+	tr.mu.Lock()
+	require.True(t, tr.pending, "a request during a trim is remembered, not dropped")
+	tr.running = false // let go of the fake trim
+	tr.mu.Unlock()
+
+	// The next request runs, and consumes the pending mark.
+	c.trimBuildLayerCacheInBackground(t.TempDir(), "overlay")
+	require.Eventually(t, func() bool {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		return !tr.running && !tr.pending
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestBuildLayerCacheMaxBytesDisabledByZeroOrWholeDisk(t *testing.T) {

--- a/pkg/worker/image_build_cache_test.go
+++ b/pkg/worker/image_build_cache_test.go
@@ -82,9 +82,9 @@ func TestOldestRemovableBuildahImagesOrdersByLocalAddTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"old-build", "no-layer-record", "base"}, ids)
 
-	// Images named for a build in flight stay: by build id inside the name,
-	// or by repo:tag regardless of registry prefix.
-	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{minAdded: now, protectedRefs: []string{"python:3.12", "old-build"}}, 10)
+	// Images named for a build in flight stay: the build's own image by id,
+	// its base by repo:tag regardless of registry prefix.
+	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{minAdded: now, inFlight: []inFlightBuild{{imageID: "old-build", baseImage: "python:3.12"}}}, 10)
 	require.NoError(t, err)
 	require.Equal(t, []string{"no-layer-record", "new-build"}, ids)
 }
@@ -100,30 +100,42 @@ func TestOldestRemovableBuildahImagesRefusesUnknownLiveness(t *testing.T) {
 	require.Error(t, err, "a corrupt container index must stop the trim, not read as no containers")
 }
 
-func TestImageNamedForRefs(t *testing.T) {
-	img := buildahStoredImage{Names: []string{
+func TestImageNamedForBuilds(t *testing.T) {
+	named := func(names ...string) buildahStoredImage { return buildahStoredImage{Names: names} }
+	img := named(
 		"187248174200.dkr.ecr.us-east-1.amazonaws.com/prod/beta9-users:6ec9ea3006729fb8",
 		"docker.io/library/python:3.12",
 		"public.ecr.aws/n4e0e1y0/beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5",
-	}}
-	require.True(t, imageNamedForRefs(img, []string{"6ec9ea3006729fb8"}), "build id as the tag")
-	require.True(t, imageNamedForRefs(buildahStoredImage{Names: []string{"6ec9ea3006729fb8:latest"}}, []string{"6ec9ea3006729fb8"}), "build id as the repo (bud path)")
-	require.True(t, imageNamedForRefs(img, []string{"python:3.12"}), "bare repo:tag matches the fully qualified name")
-	require.True(t, imageNamedForRefs(img, []string{"docker.io/library/python:3.12"}))
-	require.True(t, imageNamedForRefs(img, []string{"beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5"}))
-	require.False(t, imageNamedForRefs(img, []string{"python:3.11", "", "other-build"}))
-	require.False(t, imageNamedForRefs(img, []string{"python", "beta9", "6ec9ea30"}), "a bare repo (python means python:latest) or a substring protects nothing here")
-	require.True(t, imageNamedForRefs(buildahStoredImage{Names: []string{"docker.io/library/python:latest"}}, []string{"python"}))
-	require.False(t, imageNamedForRefs(buildahStoredImage{}, []string{"python:3.12"}), "intermediate images have no names")
+	)
+	build := func(id, base string) []inFlightBuild { return []inFlightBuild{{imageID: id, baseImage: base}} }
+
+	// The build's own image, by id.
+	require.True(t, imageNamedForBuilds(img, build("6ec9ea3006729fb8", "")), "build id as the tag")
+	require.True(t, imageNamedForBuilds(named("6ec9ea3006729fb8:latest"), build("6ec9ea3006729fb8", "")), "build id as the repo (bud path)")
+	require.False(t, imageNamedForBuilds(img, build("6ec9ea30", "")), "a prefix of the id is not the id")
+	require.False(t, imageNamedForBuilds(named("6ec9ea3006729fb8-x:latest", "x:6ec9ea3006729fb8x"), build("6ec9ea3006729fb8", "")), "the id must be the whole repo or tag")
+
+	// The build's base image, by repo:tag with :latest implicit.
+	require.True(t, imageNamedForBuilds(img, build("", "python:3.12")), "bare repo:tag matches the fully qualified name")
+	require.True(t, imageNamedForBuilds(img, build("", "docker.io/library/python:3.12")))
+	require.True(t, imageNamedForBuilds(img, build("", "beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5")))
+	require.True(t, imageNamedForBuilds(named("docker.io/library/python:latest"), build("", "python")))
+	require.True(t, imageNamedForBuilds(named("docker.io/library/python:latest"), build("", "docker.io/library/python")))
+	require.False(t, imageNamedForBuilds(img, build("", "python")), "python is python:latest, not python:3.12")
+	require.False(t, imageNamedForBuilds(named("other:python"), build("", "python")), "a base never matches as a tag")
+	require.False(t, imageNamedForBuilds(img, build("", "python:3.11")))
+	require.False(t, imageNamedForBuilds(img, build("other-build", "beta9")))
+	require.False(t, imageNamedForBuilds(buildahStoredImage{}, build("x", "python:3.12")), "intermediate images have no names")
+	require.False(t, imageNamedForBuilds(img, nil))
 }
 
 func TestBuildLayerCacheTrimmerProtectsInFlightBuilds(t *testing.T) {
-	tr := &buildLayerCacheTrimmer{inFlight: map[string][]string{}}
-	require.Empty(t, tr.protectedRefs())
-	done := tr.protectBuildImages("build-1", "build-1", "python:3.12")
-	require.ElementsMatch(t, []string{"build-1", "python:3.12"}, tr.protectedRefs())
+	tr := &buildLayerCacheTrimmer{inFlight: map[string]inFlightBuild{}}
+	require.Empty(t, tr.inFlightBuilds())
+	done := tr.protectBuildImages("build-1", "python:3.12")
+	require.Equal(t, []inFlightBuild{{imageID: "build-1", baseImage: "python:3.12"}}, tr.inFlightBuilds())
 	done()
-	require.Empty(t, tr.protectedRefs())
+	require.Empty(t, tr.inFlightBuilds())
 }
 
 func TestTrimBuildLayerCacheInBackgroundCoalesces(t *testing.T) {

--- a/pkg/worker/image_build_cache_test.go
+++ b/pkg/worker/image_build_cache_test.go
@@ -106,10 +106,14 @@ func TestImageNamedForRefs(t *testing.T) {
 		"docker.io/library/python:3.12",
 		"public.ecr.aws/n4e0e1y0/beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5",
 	}}
-	require.True(t, imageNamedForRefs(img, []string{"6ec9ea3006729fb8"}), "build id inside a tag")
+	require.True(t, imageNamedForRefs(img, []string{"6ec9ea3006729fb8"}), "build id as the tag")
+	require.True(t, imageNamedForRefs(buildahStoredImage{Names: []string{"6ec9ea3006729fb8:latest"}}, []string{"6ec9ea3006729fb8"}), "build id as the repo (bud path)")
 	require.True(t, imageNamedForRefs(img, []string{"python:3.12"}), "bare repo:tag matches the fully qualified name")
+	require.True(t, imageNamedForRefs(img, []string{"docker.io/library/python:3.12"}))
 	require.True(t, imageNamedForRefs(img, []string{"beta9-runner@sha256:9ad4225de28a135f30a83dd7711d38bce0c3ead4b2167c3cc9fd485b07a00af5"}))
 	require.False(t, imageNamedForRefs(img, []string{"python:3.11", "", "other-build"}))
+	require.False(t, imageNamedForRefs(img, []string{"python", "beta9", "6ec9ea30"}), "a bare repo (python means python:latest) or a substring protects nothing here")
+	require.True(t, imageNamedForRefs(buildahStoredImage{Names: []string{"docker.io/library/python:latest"}}, []string{"python"}))
 	require.False(t, imageNamedForRefs(buildahStoredImage{}, []string{"python:3.12"}), "intermediate images have no names")
 }
 

--- a/pkg/worker/image_build_cache_test.go
+++ b/pkg/worker/image_build_cache_test.go
@@ -1,0 +1,98 @@
+package worker
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func writeBuildahStoreJSON(t *testing.T, graphroot, kind, name string, v any) {
+	t.Helper()
+	dir := filepath.Join(graphroot, "overlay-"+kind)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), data, 0o644))
+}
+
+func TestBuildLayerStoreBytesSumsRecordedLayerSizes(t *testing.T) {
+	graphroot := t.TempDir()
+
+	// An empty store (files not written yet) is zero, not an error.
+	size, err := buildLayerStoreBytes(graphroot, "overlay")
+	require.NoError(t, err)
+	require.Zero(t, size)
+
+	writeBuildahStoreJSON(t, graphroot, "layers", "layers.json", []buildahStoredLayer{
+		{ID: "a", DiffSize: 100},
+		{ID: "b", Parent: "a", DiffSize: 250},
+		{ID: "c", DiffSize: -1}, // size unknown: not counted, not an error
+	})
+	size, err = buildLayerStoreBytes(graphroot, "overlay")
+	require.NoError(t, err)
+	require.Equal(t, int64(350), size)
+}
+
+// TestOldestRemovableBuildahImagesOrdersByLocalAddTime mirrors the prod store:
+// a base image whose upstream created date is 2023 was pulled last week, while
+// a build image created yesterday has been here longer. The pull time (its top
+// layer's created) decides, so the popular base is not the first to go.
+func TestOldestRemovableBuildahImagesOrdersByLocalAddTime(t *testing.T) {
+	graphroot := t.TempDir()
+	now := time.Now().UTC()
+	writeBuildahStoreJSON(t, graphroot, "layers", "layers.json", []buildahStoredLayer{
+		{ID: "base-top", Created: now.Add(-7 * 24 * time.Hour), DiffSize: 10},
+		{ID: "old-build-top", Created: now.Add(-30 * 24 * time.Hour), DiffSize: 10},
+		{ID: "new-build-top", Created: now.Add(-time.Hour), DiffSize: 10},
+		{ID: "busy-top", Created: now.Add(-60 * 24 * time.Hour), DiffSize: 10},
+	})
+	writeBuildahStoreJSON(t, graphroot, "images", "images.json", []buildahStoredImage{
+		{ID: "base", Layer: "base-top", Created: time.Date(2023, 11, 10, 0, 0, 0, 0, time.UTC), Names: []string{"docker.io/library/python:3.12"}},
+		{ID: "old-build", Layer: "old-build-top", Created: now.Add(-24 * time.Hour)},
+		{ID: "new-build", Layer: "new-build-top", Created: now.Add(-time.Hour)},
+		{ID: "busy", Layer: "busy-top", Created: now.Add(-60 * 24 * time.Hour)},
+		{ID: "no-layer-record", Layer: "missing", Created: now.Add(-14 * 24 * time.Hour)},
+	})
+	writeBuildahStoreJSON(t, graphroot, "containers", "containers.json", []buildahStoredContainer{
+		{ID: "working", ImageID: "busy"},
+	})
+
+	ids, err := oldestRemovableBuildahImages(graphroot, "overlay", nil, 10)
+	require.NoError(t, err)
+	// busy is excluded (a working container is built from it); the rest are
+	// oldest-added first, falling back to the image's own created when the
+	// top layer has no record.
+	require.Equal(t, []string{"old-build", "no-layer-record", "base", "new-build"}, ids)
+
+	// limit and skip narrow the batch.
+	ids, err = oldestRemovableBuildahImages(graphroot, "overlay", map[string]struct{}{"old-build": {}}, 2)
+	require.NoError(t, err)
+	require.Equal(t, []string{"no-layer-record", "base"}, ids)
+}
+
+func TestBuildLayerCacheMaxBytesDisabledByZeroOrWholeDisk(t *testing.T) {
+	c := &ImageClient{}
+	c.config.ImageService.BuildLayerCacheMaxPct = 0
+	require.Zero(t, c.buildLayerCacheMaxBytes(t.TempDir()))
+	c.config.ImageService.BuildLayerCacheMaxPct = 1
+	require.Zero(t, c.buildLayerCacheMaxBytes(t.TempDir()))
+
+	c.config.ImageService.BuildLayerCacheMaxPct = 0.2
+	usage, err := fastDiskUsage(t.TempDir())
+	require.NoError(t, err)
+	require.Equal(t, int64(0.2*float64(usage.TotalBytes)), c.buildLayerCacheMaxBytes(t.TempDir()))
+}
+
+func TestBuildLayerCacheMaxPctDefault(t *testing.T) {
+	t.Setenv("CONFIG_PATH", "")
+	t.Setenv("CONFIG_JSON", "")
+	cm, err := common.NewConfigManager[types.AppConfig]()
+	require.NoError(t, err)
+	require.Equal(t, 0.20, cm.GetConfig().ImageService.BuildLayerCacheMaxPct)
+}


### PR DESCRIPTION
## Problem

The buildah graphroot under `/var/lib/beta9/cache/buildah` keeps every layer a build on the node produced or pulled, forever — nothing in buildah expires them. On prod build nodes it had reached **163–211 GB** (oldest image from 2023) on the same volume as the content cache, which is a large part of why those cache servers sat above the eviction watermark with nothing evictable (see #1872, #1873 for the accounting side). Layered builds (`imageService.layeredBuilds`) would make it grow faster.

## Fix

After each build on a persistent store, trim it to `imageService.buildLayerCacheMaxPct` of its filesystem (default `0.20`, `0` disables) until it is under 90% of the cap.

- **Oldest first by local add time**: age is when the image's top layer was added to *this* store (`layers.json` `created`), not the image's upstream created date — a popular base pulled last week is not evicted first because it was published in 2023.
- **Cheap measure**: store size is the sum of `layers.json` `diff-size` (verified equal to `du` on staging, 168 GB known on prod). Walking a 200 GB overlay tree on gp3 would take minutes of IOPS.
- **Safe alongside builds**: images a working container is built from are skipped up front; buildah refuses to remove layers a newer image or in-flight build still depends on, and the loop re-measures after each batch rather than trusting estimates. One trim runs at a time, in the background, off the build's critical path.

## Tests

Store sizing (unknown sizes, missing files), candidate ordering (upstream-old base pulled recently sorts after a locally-old build image; in-use image excluded; skip/limit), cap disabled at 0/1, default value.

Staging validation plan: temporarily set `buildLayerCacheMaxPct` low on staging, run a build, confirm `trimmed build layer cache` log and `du` drop, then restore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the persistent buildah layer store from growing without bound: after each build it is trimmed to `imageService.buildLayerCacheMaxPct` (default 0.20) of its filesystem, oldest images first.

- Trimming runs in the background and skips images a build in flight or working container depends on, plus anything added within the last hour. In-flight images are matched by final repo:tag or repo@digest, so a base like `python` only protects `python:latest`, not unrelated names.
- A trim request arriving mid-trim makes the trim run once more; a corrupt container index stops the trim.
- The cap can be disabled by setting `buildLayerCacheMaxPct` to 0.
- Store size is read from buildah's layer index, so the trim doesn't walk the overlay tree.

<sup>Written for commit 504571304bd79893cb4e51e1906c1502322902fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

