### PR TITLE
worker: reap leaked buildah stage containers; read the volatile container index

### DIFF
--- a/pkg/worker/image_build_cache.go
+++ b/pkg/worker/image_build_cache.go
@@ -194,7 +194,7 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 	env := c.buildahEnv(runroot, tmpdir, storageConf)
 
 	// Leaked containers first: they hold unsized layers and pin images.
-	if stale, err := staleBuildahContainers(graphroot, driver, time.Now().Add(-buildLayerCacheStaleContainerAge)); err != nil {
+	if stale, err := staleBuildahContainers(graphroot, driver, time.Now().Add(-buildLayerCacheStaleContainerAge), buildLayerCacheTrims.inFlightBuilds()); err != nil {
 		log.Warn().Err(err).Msg("build layer cache trim: cannot list working containers")
 	} else if len(stale) > 0 {
 		var out strings.Builder
@@ -458,17 +458,35 @@ func readBuildahStoredContainers(graphroot, driver string) ([]buildahStoredConta
 }
 
 // staleBuildahContainers returns the ids of working containers created before
-// cutoff, sorted for deterministic removal.
-func staleBuildahContainers(graphroot, driver string, cutoff time.Time) ([]string, error) {
+// cutoff, sorted for deterministic removal. Containers created from an image
+// named for a build in flight are kept whatever their age, as the rmi path
+// keeps the images themselves.
+func staleBuildahContainers(graphroot, driver string, cutoff time.Time, inFlight []inFlightBuild) ([]string, error) {
 	containers, err := readBuildahStoredContainers(graphroot, driver)
 	if err != nil {
 		return nil, err
 	}
+	protected := map[string]struct{}{}
+	if len(inFlight) > 0 {
+		var images []buildahStoredImage
+		if err := readBuildahStoreJSON(graphroot, driver, "images", "images.json", &images); err != nil {
+			return nil, err
+		}
+		for _, image := range images {
+			if imageNamedForBuilds(image, inFlight) {
+				protected[image.ID] = struct{}{}
+			}
+		}
+	}
 	var stale []string
 	for _, container := range containers {
-		if !container.Created.IsZero() && container.Created.Before(cutoff) {
-			stale = append(stale, container.ID)
+		if container.Created.IsZero() || !container.Created.Before(cutoff) {
+			continue
 		}
+		if _, ok := protected[container.ImageID]; ok {
+			continue
+		}
+		stale = append(stale, container.ID)
 	}
 	sort.Strings(stale)
 	return stale, nil

--- a/pkg/worker/image_build_cache.go
+++ b/pkg/worker/image_build_cache.go
@@ -30,6 +30,13 @@ import (
 //   - images a working container is built from are left alone;
 //   - buildah itself refuses to remove a layer another image or container
 //     still builds on, so a stale view of the store fails safe.
+//
+// bud's stage containers are volatile, so they and their read-write layers
+// are indexed in volatile-containers.json and volatile-layers.json, not the
+// non-volatile files. A build killed mid-way (the gateway's build timeout,
+// a worker exit) leaves them behind: their layers hold gigabytes the layer
+// index does not size, and they pin their images so rmi refuses them. Every
+// trim removes working containers older than any build can run.
 
 // buildLayerCacheTrimHysteresis is the fraction of the cap the trim aims for,
 // so a store just over the cap is not trimmed again after every build.
@@ -43,6 +50,12 @@ const buildLayerCacheMinAge = time.Hour
 // buildLayerCacheTrimBatch is how many images one buildah rmi removes before
 // the store is re-measured.
 const buildLayerCacheTrimBatch = 16
+
+// buildLayerCacheStaleContainerAge: a working container older than this
+// belongs to a build that is gone. Dockerfile builds are stopped by the
+// gateway after an hour (dockerfileContainerSpinupTimeout); the other bud
+// paths run for minutes.
+const buildLayerCacheStaleContainerAge = 3 * time.Hour
 
 const buildLayerCacheTrimTimeout = 30 * time.Minute
 
@@ -85,10 +98,11 @@ type buildahStoredImage struct {
 }
 
 // buildahStoredContainer is a working-container record from
-// overlay-containers/containers.json.
+// overlay-containers/containers.json or volatile-containers.json.
 type buildahStoredContainer struct {
-	ID      string `json:"id"`
-	ImageID string `json:"image"`
+	ID      string    `json:"id"`
+	ImageID string    `json:"image"`
+	Created time.Time `json:"created"`
 }
 
 // buildLayerCacheMaxBytes is the store's cap on the filesystem holding
@@ -165,15 +179,6 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 	if maxBytes <= 0 {
 		return
 	}
-	size, err := buildLayerStoreBytes(graphroot, driver)
-	if err != nil {
-		log.Warn().Err(err).Str("graphroot", graphroot).Msg("build layer cache trim skipped: cannot size the store")
-		return
-	}
-	if size <= maxBytes {
-		return
-	}
-	target := int64(float64(maxBytes) * buildLayerCacheTrimHysteresis)
 
 	runroot := mustMkdirTempBuildahDir("buildah-trim-run-")
 	defer os.RemoveAll(runroot)
@@ -187,6 +192,27 @@ func (c *ImageClient) trimBuildLayerCache(ctx context.Context, graphroot, driver
 	defer os.Remove(storageConf)
 	store := &buildahStore{graphroot: graphroot, runroot: runroot, tmpdir: tmpdir, driver: driver, conf: storageConf}
 	env := c.buildahEnv(runroot, tmpdir, storageConf)
+
+	// Leaked containers first: they hold unsized layers and pin images.
+	if stale, err := staleBuildahContainers(graphroot, driver, time.Now().Add(-buildLayerCacheStaleContainerAge)); err != nil {
+		log.Warn().Err(err).Msg("build layer cache trim: cannot list working containers")
+	} else if len(stale) > 0 {
+		var out strings.Builder
+		args := append(store.args("rm"), stale...)
+		err := newBuildahCommand(ctx, args, env, &out, &out).Run()
+		log.Info().Err(err).Int("containers", len(stale)).Str("output", strings.TrimSpace(out.String())).
+			Msg("removed stale build containers")
+	}
+
+	size, err := buildLayerStoreBytes(graphroot, driver)
+	if err != nil {
+		log.Warn().Err(err).Str("graphroot", graphroot).Msg("build layer cache trim skipped: cannot size the store")
+		return
+	}
+	if size <= maxBytes {
+		return
+	}
+	target := int64(float64(maxBytes) * buildLayerCacheTrimHysteresis)
 
 	started := time.Now()
 	startBytes := size
@@ -305,8 +331,8 @@ func oldestRemovableBuildahImages(graphroot, driver string, excl trimExclusions,
 	}
 	// An unreadable container index means unknown liveness: nothing is
 	// removable rather than everything.
-	var containers []buildahStoredContainer
-	if err := readBuildahStoreJSON(graphroot, driver, "containers", "containers.json", &containers); err != nil {
+	containers, err := readBuildahStoredContainers(graphroot, driver)
+	if err != nil {
 		return nil, err
 	}
 	inUse := map[string]struct{}{}
@@ -415,6 +441,37 @@ func buildahStoredImageIDs(graphroot, driver string) (map[string]struct{}, error
 		ids[image.ID] = struct{}{}
 	}
 	return ids, nil
+}
+
+// readBuildahStoredContainers returns every working container in the store,
+// volatile (bud's stage containers) and not.
+func readBuildahStoredContainers(graphroot, driver string) ([]buildahStoredContainer, error) {
+	var containers []buildahStoredContainer
+	for _, name := range []string{"containers.json", "volatile-containers.json"} {
+		var part []buildahStoredContainer
+		if err := readBuildahStoreJSON(graphroot, driver, "containers", name, &part); err != nil {
+			return nil, err
+		}
+		containers = append(containers, part...)
+	}
+	return containers, nil
+}
+
+// staleBuildahContainers returns the ids of working containers created before
+// cutoff, sorted for deterministic removal.
+func staleBuildahContainers(graphroot, driver string, cutoff time.Time) ([]string, error) {
+	containers, err := readBuildahStoredContainers(graphroot, driver)
+	if err != nil {
+		return nil, err
+	}
+	var stale []string
+	for _, container := range containers {
+		if !container.Created.IsZero() && container.Created.Before(cutoff) {
+			stale = append(stale, container.ID)
+		}
+	}
+	sort.Strings(stale)
+	return stale, nil
 }
 
 func readBuildahStoredLayers(graphroot, driver string) ([]buildahStoredLayer, error) {

--- a/pkg/worker/image_build_cache_test.go
+++ b/pkg/worker/image_build_cache_test.go
@@ -118,13 +118,22 @@ func TestStaleBuildahContainersSpansBothIndexes(t *testing.T) {
 		{ID: "undated", ImageID: "e"},
 	})
 
-	stale, err := staleBuildahContainers(graphroot, "overlay", now.Add(-buildLayerCacheStaleContainerAge))
+	stale, err := staleBuildahContainers(graphroot, "overlay", now.Add(-buildLayerCacheStaleContainerAge), nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"durable-old", "killed-this-morning", "killed-yesterday"}, stale,
 		"older than any build can run, from both indexes; a container with no created date is never assumed dead")
 
+	// A container built from an image named for a build in flight stays, as
+	// the image itself does on the rmi path.
+	writeBuildahStoreJSON(t, graphroot, "images", "images.json", []buildahStoredImage{
+		{ID: "c", Names: []string{"docker.io/library/python:3.12"}},
+	})
+	stale, err = staleBuildahContainers(graphroot, "overlay", now.Add(-buildLayerCacheStaleContainerAge), []inFlightBuild{{imageID: "abc", baseImage: "python:3.12"}})
+	require.NoError(t, err)
+	require.Equal(t, []string{"durable-old", "killed-yesterday"}, stale)
+
 	// An empty store has nothing stale and is not an error.
-	stale, err = staleBuildahContainers(t.TempDir(), "overlay", now)
+	stale, err = staleBuildahContainers(t.TempDir(), "overlay", now, nil)
 	require.NoError(t, err)
 	require.Empty(t, stale)
 }

--- a/pkg/worker/image_build_cache_test.go
+++ b/pkg/worker/image_build_cache_test.go
@@ -59,7 +59,8 @@ func TestOldestRemovableBuildahImagesOrdersByLocalAddTime(t *testing.T) {
 		{ID: "busy", Layer: "busy-top", Created: now.Add(-60 * 24 * time.Hour)},
 		{ID: "no-layer-record", Layer: "missing", Created: now.Add(-14 * 24 * time.Hour)},
 	})
-	writeBuildahStoreJSON(t, graphroot, "containers", "containers.json", []buildahStoredContainer{
+	// bud's stage containers are volatile and indexed apart from the rest.
+	writeBuildahStoreJSON(t, graphroot, "containers", "volatile-containers.json", []buildahStoredContainer{
 		{ID: "working", ImageID: "busy"},
 	})
 
@@ -98,6 +99,34 @@ func TestOldestRemovableBuildahImagesRefusesUnknownLiveness(t *testing.T) {
 
 	_, err := oldestRemovableBuildahImages(graphroot, "overlay", trimExclusions{minAdded: time.Now()}, 10)
 	require.Error(t, err, "a corrupt container index must stop the trim, not read as no containers")
+}
+
+// TestStaleBuildahContainersSpansBothIndexes mirrors a prod build node: 26
+// stage containers from builds killed hours ago sat in
+// volatile-containers.json holding 40 GB of unsized layers and pinning their
+// images, invisible to a reader of containers.json alone.
+func TestStaleBuildahContainersSpansBothIndexes(t *testing.T) {
+	graphroot := t.TempDir()
+	now := time.Now().UTC()
+	writeBuildahStoreJSON(t, graphroot, "containers", "volatile-containers.json", []buildahStoredContainer{
+		{ID: "killed-yesterday", ImageID: "a", Created: now.Add(-21 * time.Hour)},
+		{ID: "live-stage", ImageID: "b", Created: now.Add(-time.Minute)},
+		{ID: "killed-this-morning", ImageID: "c", Created: now.Add(-8 * time.Hour)},
+	})
+	writeBuildahStoreJSON(t, graphroot, "containers", "containers.json", []buildahStoredContainer{
+		{ID: "durable-old", ImageID: "d", Created: now.Add(-2 * 24 * time.Hour)},
+		{ID: "undated", ImageID: "e"},
+	})
+
+	stale, err := staleBuildahContainers(graphroot, "overlay", now.Add(-buildLayerCacheStaleContainerAge))
+	require.NoError(t, err)
+	require.Equal(t, []string{"durable-old", "killed-this-morning", "killed-yesterday"}, stale,
+		"older than any build can run, from both indexes; a container with no created date is never assumed dead")
+
+	// An empty store has nothing stale and is not an error.
+	stale, err = staleBuildahContainers(t.TempDir(), "overlay", now)
+	require.NoError(t, err)
+	require.Empty(t, stale)
 }
 
 func TestImageNamedForBuilds(t *testing.T) {


### PR DESCRIPTION
## Problem
Follow-up to #1874. `buildah bud` creates its stage containers as **volatile**, so they and their read-write layers are indexed in `overlay-containers/volatile-containers.json` and `overlay-layers/volatile-layers.json`. The trim only read `containers.json`, which does not exist on a bud-only store.

On prod build node `ip-10-110-66-87` right after the 0.1.743 rollout:
- 26 stage containers in `volatile-containers.json`, created 8–21 h earlier by builds that were killed (gateway build timeout / worker exit) — buildah never gets to remove them;
- their RW layers held **~40 GB** (`du` of the graphroot 75 GB vs 39 GB recorded in `layers.json`), invisible to `buildLayerStoreBytes`;
- they pinned their images, so the trim logged `attempted=112 removed=28`.

## Fix
- `readBuildahStoredContainers` reads both index files for the liveness check.
- Every trim first runs `buildah rm` on working containers older than `buildLayerCacheStaleContainerAge` (3 h; Dockerfile builds are stopped by the gateway at 1 h, other bud paths run for minutes), then sizes and trims images as before. Containers without a created date are never assumed dead.

## Tests
`TestStaleBuildahContainersSpansBothIndexes`; the ordering test now places the in-use container in the volatile index as bud does.
