### PR TITLE
deps: clip parallel-pulls every layer >= 32 MiB and resumes starved ranges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.75.3
-	github.com/beam-cloud/clip v0.0.0-20260905132617-5e80513d073d
+	github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec
 	github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1
 	github.com/beam-cloud/goproc v0.1.12
 	github.com/beam-cloud/redislock v0.0.0-20250201162619-1b534b3be324

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqx
 github.com/axiomhq/hyperloglog v0.0.0-20240319100328-84253e514e02 h1:bXAPYSbdYbS5VTy92NIUbeDI1qyggi+JYh5op9IFlcQ=
 github.com/axiomhq/hyperloglog v0.0.0-20240319100328-84253e514e02/go.mod h1:k08r+Yj1PRAmuayFiRK6MYuR5Ve4IuZtTfxErMIh0+c=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/beam-cloud/clip v0.0.0-20260905132617-5e80513d073d h1:9hxCxmPQpy+6k4obmU9fi6MvEhhVEFSUrXm6jRvH5yo=
-github.com/beam-cloud/clip v0.0.0-20260905132617-5e80513d073d/go.mod h1:uymwDNMk1qoxElmDSlPzwYqZDriHDnW5VVyfK3YNuz8=
+github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec h1:zcr7+ud507kcRJBHotXr4hcUzEoqfPEgjtcMW6eCZwo=
+github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec/go.mod h1:uymwDNMk1qoxElmDSlPzwYqZDriHDnW5VVyfK3YNuz8=
 github.com/beam-cloud/geesefs v0.0.0-20260905013400-dd4457d0f23f h1:t0Io0sAKHczywN/tj9wW5DSUxdnaVjCmUfotqPUj5uE=
 github.com/beam-cloud/geesefs v0.0.0-20260905013400-dd4457d0f23f/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=


### PR DESCRIPTION
## Why

GPU cold starts on the skynet RTX 4090 pool were 187–263 s end to end for the first container of an image on a machine. Worker logs showed the cause: layers pulled from ECR us-east-1 to Chicago were bounded by whichever S3 front-end a single TCP flow landed on. Some front-ends deliver 1–3 MiB/s while others deliver 60+ from the same host at the same moment.

- The 3 GiB model layer already used the parallel transport (>= 1 GiB, 256 MiB parts) but had no straggler handling, so one starved 256 MiB part held the layer for **180 s**.
- The 400 MiB torch layer was under the 1 GiB threshold, single-streamed, and took **249 s** (`import torch` = 249 s in the probe).

## What

Bumps `beam-cloud/clip` to [9420edd](https://github.com/beam-cloud/clip/commit/9420edd6f9ecdcdf78970f8c5839439530079498) (`storage: parallel-pull every layer >= 32 MiB and abandon starved ranges`):

- Threshold 1 GiB → 32 MiB, parts 256 → 32 MiB, 8 per layer, 24 total across layers on a worker.
- Straggler monitor: a range past a grace period that is below an absolute floor and far below the median of its peers / recent completions is cancelled and **resumed from the bytes already written** on a new connection. In the tail (nothing left to hand out) any range well below the reference rate is resumed.
- Front-ends that starved a range are avoided for 2 min via a custom dialer that spreads connections over resolved addresses; pooled connections are dropped so keep-alive does not hand the next range the same starved one.
- Info summary per layer (`parallel registry blob prefetch complete`: duration, MiB/s, straggler_aborts, retries). Disk-headroom skip is now a warning (was debug, which is why the old transport's behaviour was invisible in prod logs).

## Measured on a skynet worker (prod ECR, 3 interleaved rounds)

| layer | new parallel | single stream |
|---|---|---|
| 2.9 GiB model | 17.3 / 14.6 / 15.1 s (170–201 MiB/s) | 473 / 47 / 37 s |
| 383 MiB torch | 4.9 / 5.7 / 3.8 s | 108 / 42 / 5.1 s |

Straggler aborts per layer: 1–4, each resumed on a fresh connection (visible in debug logs with the remote IP and rate).

## Tests

clip: `TestStragglerRule`, `TestSlowEndpointSetExpires`, `TestParallelBlobTransportAbandonsStragglersAndRefetches` (starving server; byte-exact reassembly across resume, slow front-end marked, no single-stream fallback), plus the existing parallel-pull suite under `-race`.

Follow-up (not in this PR): cross-locality content cache reads so skynet/OVH workers can take decompressed layers from the AWS cache instead of ECR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github.com/beam-cloud/clip` to a version that parallel-pulls every layer >= 32 MiB (previously 1 GiB) and resumes starved ranges. This cuts GPU cold start times on remote workers from minutes to seconds.

- Parallel pull threshold lowered from 1 GiB to 32 MiB with 32 MiB parts, up to 8 per layer and 24 per worker.
- Ranges that fall behind peers are cancelled and resumed on new connections; starved S3 front-ends are avoided for 2 minutes.
- Adds per-layer info summaries and makes disk-headroom skip a warning.
- On a skynet worker, the 2.9 GiB model layer dropped from 180 s to ~15 s and the 400 MiB torch layer from 249 s to ~5 s.
- Tests cover straggler rule, slow endpoint expiry, and byte-exact resume across resumption.

<sup>Written for commit a4c9ced508595000feb1c6620f46b26d0cb4e8a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


