### PR TITLE
scheduler: a cordoned worker never holds pool headroom

### DIFF
--- a/pkg/scheduler/pool_headroom.go
+++ b/pkg/scheduler/pool_headroom.go
@@ -28,8 +28,12 @@ import (
 // A failed worker lookup answers true: an idle worker that stays one keepalive
 // longer costs nothing, while one that leaves on a bad read leaves the pool
 // cold.
+//
+// A worker that is not available (cordoned, draining, or still pending) is
+// never headroom: the scheduler will not place on it, so keeping it changes
+// nothing for the pool and only pins a pod the operator asked to retire.
 func WorkerHoldsPoolHeadroom(workerRepo repository.WorkerRepository, config types.AppConfig, worker *types.Worker) bool {
-	if worker == nil || worker.PoolName == "" {
+	if worker == nil || worker.PoolName == "" || worker.Status != types.WorkerStatusAvailable {
 		return false
 	}
 	poolConfig, ok := config.Worker.Pools[worker.PoolName]

--- a/pkg/scheduler/pool_headroom_test.go
+++ b/pkg/scheduler/pool_headroom_test.go
@@ -67,6 +67,21 @@ func TestWorkerHoldsPoolHeadroom(t *testing.T) {
 	assert.True(t, WorkerHoldsPoolHeadroom(workerRepo, headroomTestConfig("12000m"), first))
 	assert.True(t, WorkerHoldsPoolHeadroom(workerRepo, headroomTestConfig("12000m"), second))
 
+	// A cordoned worker sorted ahead of the ready ones would otherwise be
+	// told it is headroom whenever they fall short, and sit idle forever.
+	// The scheduler will not place on it, so it never holds headroom; nor
+	// does a worker still pending.
+	cordoned := headroomTestWorker("0-cordoned", types.WorkerStatusDisabled, 10_000)
+	assert.Nil(t, workerRepo.AddWorker(cordoned))
+	assert.Nil(t, workerRepo.SetWorkerCordon(cordoned.Id, true))
+	cordoned, err = workerRepo.GetWorkerById(cordoned.Id)
+	assert.Nil(t, err)
+	assert.Equal(t, types.WorkerStatusDisabled, cordoned.Status)
+	assert.False(t, WorkerHoldsPoolHeadroom(workerRepo, headroomTestConfig("120000m"), cordoned))
+	assert.False(t, WorkerHoldsPoolHeadroom(workerRepo, headroomTestConfig("120000m"), pending))
+	// The ready workers behind it still hold the headroom themselves.
+	assert.True(t, WorkerHoldsPoolHeadroom(workerRepo, headroomTestConfig("120000m"), first))
+
 	// Unknown pool or nil worker: never headroom.
 	assert.False(t, WorkerHoldsPoolHeadroom(workerRepo, headroomTestConfig("4000m"), nil))
 	assert.False(t, WorkerHoldsPoolHeadroom(workerRepo, types.AppConfig{}, first))


### PR DESCRIPTION
## Why

`WorkerHoldsPoolHeadroom` decides whether an idle worker must stay to keep the pool's `minFree*` capacity, but it never looked at the worker's own status. A cordoned (disabled) worker whose id sorts ahead of the ready ones was told it held the headroom whenever those ready workers fell short, and `shouldExitIdle` then kept it up indefinitely.

Seen in prod tonight after the 0.1.745 rollout: `worker-build-11236716` and `worker-build-11f17d11` (0.1.744, `cordon_requested=1`, status `disabled`, zero containers) idle for 40+ minutes. The one ready build worker ahead of them in id order had `free_cpu=0`, so every keepalive answered `pool_headroom=true`.

## What

Only an available worker can hold headroom. A disabled or pending worker returns false before the pool scan: the scheduler will not place on it, so keeping it changes nothing for the pool and only pins a pod the operator asked to retire. Gateway-side only; no worker change.

## Tests

`TestWorkerHoldsPoolHeadroom`: a cordoned worker sorted first in a pool whose ready workers fall short of the minimum is not headroom (nor is a pending one), while the ready workers behind it still are.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `WorkerHoldsPoolHeadroom` to ignore non-available workers so cordoned workers no longer stay idle indefinitely. Previously, a disabled worker could be counted as holding headroom if it sorted ahead of ready workers, keeping it up forever. Now only available workers can hold headroom, and pending workers are also excluded.

<sup>Written for commit 1273d09f23e7e604893c679e622a2341772fade7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

