### PR TITLE
storage: volume writes visible on fsync, remote volume reads prefetch over the wire, cache hosts survive transient raw-transport errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -317,7 +317,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260907142041-05899ece51a7
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260907155448-03ce641cb6d6
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.mod
+++ b/go.mod
@@ -317,7 +317,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260905013400-dd4457d0f23f
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260907142041-05899ece51a7
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20240319100328-84253e514e02/go.mod h1:k08r
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec h1:zcr7+ud507kcRJBHotXr4hcUzEoqfPEgjtcMW6eCZwo=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec/go.mod h1:uymwDNMk1qoxElmDSlPzwYqZDriHDnW5VVyfK3YNuz8=
-github.com/beam-cloud/geesefs v0.0.0-20260907142041-05899ece51a7 h1:2/bglvvI53cyEAYMvN3BckcDx8W4LyYscta2m0Wmejk=
-github.com/beam-cloud/geesefs v0.0.0-20260907142041-05899ece51a7/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260907155448-03ce641cb6d6 h1:5dx5YTFYCl27hIrSBcrLJk2kWEMaYhMZ9aNnYfrIlDo=
+github.com/beam-cloud/geesefs v0.0.0-20260907155448-03ce641cb6d6/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20240319100328-84253e514e02/go.mod h1:k08r
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec h1:zcr7+ud507kcRJBHotXr4hcUzEoqfPEgjtcMW6eCZwo=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec/go.mod h1:uymwDNMk1qoxElmDSlPzwYqZDriHDnW5VVyfK3YNuz8=
-github.com/beam-cloud/geesefs v0.0.0-20260905013400-dd4457d0f23f h1:t0Io0sAKHczywN/tj9wW5DSUxdnaVjCmUfotqPUj5uE=
-github.com/beam-cloud/geesefs v0.0.0-20260905013400-dd4457d0f23f/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260907142041-05899ece51a7 h1:2/bglvvI53cyEAYMvN3BckcDx8W4LyYscta2m0Wmejk=
+github.com/beam-cloud/geesefs v0.0.0-20260907142041-05899ece51a7/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -45,15 +45,21 @@ func NewAppGroup(g *echo.Group, backendRepo repository.BackendRepository, config
 
 type AppWithLatestStubOrDeployment struct {
 	types.App
-	Stub              *types.StubWithRelated       `json:"stub,omitempty" serializer:"stub"`
-	Deployment        *types.DeploymentWithRelated `json:"deployment,omitempty" serializer:"deployment"`
-	URL               string                       `json:"url,omitempty" serializer:"url,omitempty"`
-	InvokeURL         string                       `json:"invoke_url,omitempty" serializer:"invoke_url,omitempty"`
-	ConnectionURL     string                       `json:"connection_url,omitempty" serializer:"connection_url,omitempty"`
-	PoolName          string                       `json:"pool_name" serializer:"pool_name"`
-	RunningContainers int                          `json:"running_containers" serializer:"running_containers"`
-	IsService         bool                         `json:"is_service" serializer:"is_service"`
-	Serving           *types.ServingConfig         `json:"serving,omitempty" serializer:"serving"`
+	Stub          *types.StubWithRelated       `json:"stub,omitempty" serializer:"stub"`
+	Deployment    *types.DeploymentWithRelated `json:"deployment,omitempty" serializer:"deployment"`
+	URL           string                       `json:"url,omitempty" serializer:"url,omitempty"`
+	InvokeURL     string                       `json:"invoke_url,omitempty" serializer:"invoke_url,omitempty"`
+	ConnectionURL string                       `json:"connection_url,omitempty" serializer:"connection_url,omitempty"`
+	PoolName      string                       `json:"pool_name" serializer:"pool_name"`
+	// RunningContainers counts running containers across every stub in the
+	// app, not just the latest one, so multi-function and multi-config apps
+	// read as live whenever any of them is doing work.
+	RunningContainers int `json:"running_containers" serializer:"running_containers"`
+	// ActiveDeployments counts deployments in the app that are currently
+	// active (deployed and not stopped), across all of its functions.
+	ActiveDeployments int                  `json:"active_deployments" serializer:"active_deployments"`
+	IsService         bool                 `json:"is_service" serializer:"is_service"`
+	Serving           *types.ServingConfig `json:"serving,omitempty" serializer:"serving"`
 }
 
 func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
@@ -106,16 +112,20 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		return HTTPBadRequest("Failed to get apps")
 	}
 
-	latestStubIndexes := map[string][]int{}
+	activeDeploymentsByApp, err := a.backendRepo.CountActiveDeploymentsByAppIDs(ctx.Request().Context(), workspace.Id, appIDs)
+	if err != nil {
+		return HTTPBadRequest("Failed to get apps")
+	}
+
+	appIndexes := make(map[string]int, len(apps.Data))
 	for i := range apps.Data {
 		appsWithLatest.Data[i].App = apps.Data[i]
+		appsWithLatest.Data[i].ActiveDeployments = activeDeploymentsByApp[apps.Data[i].ExternalId]
+		appIndexes[apps.Data[i].ExternalId] = i
 
 		if deployment, ok := deploymentsByApp[apps.Data[i].ExternalId]; ok {
 			deploymentCopy := deployment
 			a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment, false)
-			if deploymentCopy.Stub.ExternalId != "" {
-				latestStubIndexes[deploymentCopy.Stub.ExternalId] = append(latestStubIndexes[deploymentCopy.Stub.ExternalId], i)
-			}
 			deploymentCopy.URL = appsWithLatest.Data[i].URL
 			deploymentCopy.InvokeURL = appsWithLatest.Data[i].InvokeURL
 			if err := sanitizeDeploymentWithRelated(&deploymentCopy); err != nil {
@@ -132,24 +142,21 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 
 		stubCopy := stub
 		a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &stubCopy.Stub, nil, false)
-		if stubCopy.Stub.ExternalId != "" {
-			latestStubIndexes[stubCopy.Stub.ExternalId] = append(latestStubIndexes[stubCopy.Stub.ExternalId], i)
-		}
 		appsWithLatest.Data[i].Stub = &stubCopy
 		if err := sanitizeStubWithRelated(appsWithLatest.Data[i].Stub); err != nil {
 			return HTTPInternalServerError("Failed to sanitize stub config")
 		}
 	}
 
-	if a.containerRepo != nil && len(latestStubIndexes) > 0 {
-		runningByStubID, err := countRunningContainersForStubs(a.containerRepo, workspaceID, latestStubIndexes)
+	if a.containerRepo != nil && len(appIndexes) > 0 {
+		runningByAppID, err := countRunningContainersForApps(ctx.Request().Context(), a.containerRepo, a.backendRepo, workspaceID)
 		if err != nil {
 			return HTTPInternalServerError("Failed to get running containers")
 		}
 
-		for stubID, indexes := range latestStubIndexes {
-			for _, index := range indexes {
-				appsWithLatest.Data[index].RunningContainers = runningByStubID[stubID]
+		for appID, count := range runningByAppID {
+			if index, ok := appIndexes[appID]; ok {
+				appsWithLatest.Data[index].RunningContainers = count
 			}
 		}
 	}
@@ -165,23 +172,45 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 	)
 }
 
-func countRunningContainersForStubs(containerRepo repository.ContainerRepository, workspaceID string, latestStubIndexes map[string][]int) (map[string]int, error) {
-	runningByStubID := make(map[string]int, len(latestStubIndexes))
+// countRunningContainersForApps counts running containers per app across all
+// of the workspace's active containers, resolving each container's stub to its
+// app so containers from older stubs and other functions are included.
+func countRunningContainersForApps(ctx context.Context, containerRepo repository.ContainerRepository, backendRepo repository.BackendRepository, workspaceID string) (map[string]int, error) {
 	containers, err := containerRepo.GetActiveContainersByWorkspaceId(workspaceID)
 	if err != nil {
 		return nil, err
 	}
 
+	runningByStubID := map[string]int{}
 	for _, container := range containers {
-		if container.Status != types.ContainerStatusRunning {
+		if container.Status != types.ContainerStatusRunning || container.StubId == "" {
 			continue
 		}
-		if _, ok := latestStubIndexes[container.StubId]; ok {
-			runningByStubID[container.StubId]++
+		runningByStubID[container.StubId]++
+	}
+
+	runningByAppID := make(map[string]int, len(runningByStubID))
+	if len(runningByStubID) == 0 {
+		return runningByAppID, nil
+	}
+
+	stubIDs := make([]string, 0, len(runningByStubID))
+	for stubID := range runningByStubID {
+		stubIDs = append(stubIDs, stubID)
+	}
+
+	appIDsByStub, err := backendRepo.ListAppIDsByStubExternalIDs(ctx, workspaceID, stubIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	for stubID, count := range runningByStubID {
+		if appID, ok := appIDsByStub[stubID]; ok && appID != "" {
+			runningByAppID[appID] += count
 		}
 	}
 
-	return runningByStubID, nil
+	return runningByAppID, nil
 }
 
 func (a *AppGroup) enrichAppWithStubConfig(app *AppWithLatestStubOrDeployment, stub *types.Stub, deployment *types.Deployment, includeDatabaseSecretNames bool) {
@@ -292,6 +321,12 @@ func (a *AppGroup) hydrateDatabaseConnectionURL(ctx context.Context, workspace *
 
 func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace *types.Workspace, app types.App) (AppWithLatestStubOrDeployment, error) {
 	appWithLatest := AppWithLatestStubOrDeployment{App: app}
+
+	activeDeploymentsByApp, err := a.backendRepo.CountActiveDeploymentsByAppIDs(ctx, workspace.Id, []string{app.ExternalId})
+	if err != nil {
+		return appWithLatest, err
+	}
+	appWithLatest.ActiveDeployments = activeDeploymentsByApp[app.ExternalId]
 
 	deploymentsByApp, err := a.backendRepo.ListLatestDeploymentsByAppIDs(ctx, workspace.Id, []string{app.ExternalId})
 	if err != nil {

--- a/pkg/api/v1/app_test.go
+++ b/pkg/api/v1/app_test.go
@@ -25,6 +25,9 @@ type appBackendRepo struct {
 	stubsByApp       map[string][]types.StubWithRelated
 	secrets          map[string]string
 	secretLookups    int
+	// extraStubApps maps stub external IDs that aren't any app's latest stub
+	// to the app they belong to.
+	extraStubApps map[string]string
 }
 
 type appContainerRepo struct {
@@ -74,6 +77,45 @@ func (r *appBackendRepo) ListLatestDeploymentsByAppIDs(_ context.Context, _ uint
 		}
 	}
 	return deployments, nil
+}
+
+func (r *appBackendRepo) CountActiveDeploymentsByAppIDs(_ context.Context, _ uint, appExternalIDs []string) (map[string]int, error) {
+	counts := map[string]int{}
+	for _, appID := range appExternalIDs {
+		for _, deployment := range r.deploymentsByApp[appID] {
+			if deployment.Active {
+				counts[appID]++
+			}
+		}
+	}
+	return counts, nil
+}
+
+// ListAppIDsByStubExternalIDs resolves stubs through both the deployment and
+// stub fixtures, plus any explicit extra mappings (e.g. older stubs that are
+// no longer the app's latest).
+func (r *appBackendRepo) ListAppIDsByStubExternalIDs(_ context.Context, _ string, stubExternalIDs []string) (map[string]string, error) {
+	known := map[string]string{}
+	for appID, deployments := range r.deploymentsByApp {
+		for _, deployment := range deployments {
+			known[deployment.Stub.ExternalId] = appID
+		}
+	}
+	for appID, stubs := range r.stubsByApp {
+		for _, stub := range stubs {
+			known[stub.ExternalId] = appID
+		}
+	}
+	for stubID, appID := range r.extraStubApps {
+		known[stubID] = appID
+	}
+	result := map[string]string{}
+	for _, stubID := range stubExternalIDs {
+		if appID, ok := known[stubID]; ok {
+			result[stubID] = appID
+		}
+	}
+	return result, nil
 }
 
 func (r *appBackendRepo) ListStubs(_ context.Context, filters types.StubFilter) ([]types.StubWithRelated, error) {
@@ -181,12 +223,16 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 				Data: []types.App{appWithDeployment, appWithStub},
 				Next: "",
 			},
+			extraStubApps: map[string]string{"old-stub": appWithDeployment.ExternalId},
 			deploymentsByApp: map[string][]types.DeploymentWithRelated{
 				appWithDeployment.ExternalId: {
 					{
+						// Latest deployment is stopped; an older function in
+						// the same app is still deployed (below).
 						Deployment: types.Deployment{
 							ExternalId:  "deployment-1",
 							Name:        "Deployment 1",
+							Active:      false,
 							WorkspaceId: workspace.Id,
 							AppId:       appWithDeployment.Id,
 						},
@@ -196,6 +242,26 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 							Name:        "Stub Deploy",
 							Type:        types.StubType(types.StubTypePodDeployment),
 							Config:      `{"pool":{"name":"gpu-pool"},"is_service":true,"serving":{"app_kind":"llm_model","serving_protocol":"openai","llm":{"model_id":"Qwen/Qwen2.5-0.5B-Instruct","engine":"vllm","served_model_name":"qwen-test","context_length":4096,"metrics_path":"/metrics","slo_tier":"standard"}}}`,
+							WorkspaceId: workspace.Id,
+							AppId:       appWithDeployment.Id,
+						},
+						Workspace: *workspace,
+						App:       appWithDeployment,
+					},
+					{
+						Deployment: types.Deployment{
+							ExternalId:  "deployment-0",
+							Name:        "Deployment 0",
+							Active:      true,
+							WorkspaceId: workspace.Id,
+							AppId:       appWithDeployment.Id,
+						},
+						Stub: types.Stub{
+							Id:          3,
+							ExternalId:  "stub-older-fn",
+							Name:        "Older Function",
+							Type:        types.StubType(types.StubTypeEndpointDeployment),
+							Config:      "{}",
 							WorkspaceId: workspace.Id,
 							AppId:       appWithDeployment.Id,
 						},
@@ -228,7 +294,10 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 				{StubId: "stub-deploy", Status: types.ContainerStatusRunning},
 				{StubId: "stub-deploy", Status: types.ContainerStatusPending},
 				{StubId: "stub-latest", Status: types.ContainerStatusRunning},
+				// An older stub of the deployment app: still counts for the app.
 				{StubId: "old-stub", Status: types.ContainerStatusRunning},
+				// Not in any listed app: ignored.
+				{StubId: "unknown-stub", Status: types.ContainerStatusRunning},
 			},
 		},
 	}
@@ -260,6 +329,7 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 			ID                string `json:"id"`
 			PoolName          string `json:"pool_name"`
 			RunningContainers int    `json:"running_containers"`
+			ActiveDeployments int    `json:"active_deployments"`
 			IsService         bool   `json:"is_service"`
 			Serving           struct {
 				AppKind         string `json:"app_kind"`
@@ -295,6 +365,7 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 	byID := map[string]struct {
 		PoolName          string
 		RunningContainers int
+		ActiveDeployments int
 		IsService         bool
 		Serving           struct {
 			AppKind         string `json:"app_kind"`
@@ -313,6 +384,7 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 		byID[app.ID] = struct {
 			PoolName          string
 			RunningContainers int
+			ActiveDeployments int
 			IsService         bool
 			Serving           struct {
 				AppKind         string `json:"app_kind"`
@@ -329,21 +401,25 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 		}{
 			PoolName:          app.PoolName,
 			RunningContainers: app.RunningContainers,
+			ActiveDeployments: app.ActiveDeployments,
 			IsService:         app.IsService,
 			Serving:           app.Serving,
 		}
 	}
 
 	deploymentApp := byID[appWithDeployment.ExternalId]
-	if deploymentApp.PoolName != "gpu-pool" || deploymentApp.RunningContainers != 2 || !deploymentApp.IsService {
+	if deploymentApp.PoolName != "gpu-pool" || deploymentApp.RunningContainers != 3 || !deploymentApp.IsService {
 		t.Fatalf("unexpected deployment app enrichment: %+v", deploymentApp)
+	}
+	if deploymentApp.ActiveDeployments != 1 {
+		t.Fatalf("expected the older active deployment to count, got %+v", deploymentApp)
 	}
 	if deploymentApp.Serving.AppKind != "llm_model" || deploymentApp.Serving.ServingProtocol != "openai" || deploymentApp.Serving.LLM.ModelID != "Qwen/Qwen2.5-0.5B-Instruct" || deploymentApp.Serving.LLM.ContextLength != 4096 {
 		t.Fatalf("unexpected deployment app llm enrichment: %+v", deploymentApp)
 	}
 
 	stubApp := byID[appWithStub.ExternalId]
-	if stubApp.PoolName != "cpu-pool" || stubApp.RunningContainers != 1 || !stubApp.IsService {
+	if stubApp.PoolName != "cpu-pool" || stubApp.RunningContainers != 1 || stubApp.ActiveDeployments != 0 || !stubApp.IsService {
 		t.Fatalf("unexpected stub app enrichment: %+v", stubApp)
 	}
 }

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -622,6 +622,9 @@ func (c *Client) recordHostMonitorResult(host *Host, failures *int) bool {
 func (c *Client) checkHostEndpoint(host *Host) bool {
 	err := c.hostEndpointHealth(host)
 	if err != nil {
+		if !errors.Is(err, ErrHostNotFound) {
+			Logger.Infof("cache host endpoint probe failed @ %s (PrivateAddr=%s): %v", host.HostId, host.PrivateAddr, err)
+		}
 		c.removeHost(host)
 		return false
 	}
@@ -636,7 +639,7 @@ func (c *Client) hostEndpointHealth(host *Host) error {
 	c.mu.RLock()
 	client, exists := c.grpcClients[host.HostId]
 	c.mu.RUnlock()
-	if !exists {
+	if !exists || client == nil {
 		return ErrHostNotFound
 	}
 
@@ -1931,8 +1934,11 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hostIn
 			return 0, err
 		}
 		if errors.Is(err, ErrUnableToReachHost) {
-			c.removeHost(host)
-			return 0, ErrSelectedHostUnavailable
+			// A stale pooled connection or a slow dial is not a dead host.
+			// Probe before deactivating; if the host is up, use gRPC.
+			if !c.checkHostEndpoint(host) {
+				return 0, ErrSelectedHostUnavailable
+			}
 		}
 		if err != nil {
 			cacheReadRawFallbackTotal.Inc()

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -623,7 +623,7 @@ func (c *Client) checkHostEndpoint(host *Host) bool {
 	err := c.hostEndpointHealth(host)
 	if err != nil {
 		if !errors.Is(err, ErrHostNotFound) {
-			Logger.Infof("cache host endpoint probe failed @ %s (PrivateAddr=%s): %v", host.HostId, host.PrivateAddr, err)
+			Logger.Debugf("cache host endpoint probe failed @ %s (PrivateAddr=%s): %v", host.HostId, host.PrivateAddr, err)
 		}
 		c.removeHost(host)
 		return false

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -859,6 +860,80 @@ func TestReadContentIntoSkipsGRPCWhenRawHostUnreachable(t *testing.T) {
 	require.Equal(t, "raw", trace.Attempts[0].Source)
 	require.Equal(t, "unavailable", trace.Attempts[0].Result)
 	require.Equal(t, ErrUnableToReachHost.Error(), trace.Attempts[0].Error)
+}
+
+// A raw read on a stale pooled connection must fall back to gRPC and leave a
+// healthy host's endpoint active.
+func TestReadContentIntoStaleRawConnectionKeepsHealthyHost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Server: ServerConfig{
+			DiskCacheDir:         t.TempDir(),
+			DiskCacheMaxUsagePct: 90,
+			PageSizeBytes:        4,
+			ObjectTtlS:           300,
+			ReadTransport:        ServerReadTransportConfig{Enabled: true, Sendfile: true},
+		},
+		Client: ClientConfig{
+			NTopHosts:     1,
+			ReadTransport: ClientReadTransportConfig{Enabled: true, MaxActiveConnsPerHost: 2, MaxIdleConnsPerHost: 1},
+		},
+		Global: GlobalConfig{GRPCMessageSizeBytes: 1024 * 1024, GRPCDialTimeoutS: 1},
+	}
+	server, err := NewServerWithOptions(ctx, cfg, "test", WithServerMetadataStore(NewMockCacheMetadataStore()), WithServerHostID("remote-host"))
+	require.NoError(t, err)
+	addr, err := server.Serve("127.0.0.1:0", "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, server.Close()) }()
+
+	content := []byte("served-over-grpc-after-raw-fails")
+	hash, _, err := server.cas.AddReader(ctx, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	host := server.Host()
+	require.NotNil(t, host)
+	host.Addr = addr
+	host.PrivateAddr = addr
+
+	client := &Client{
+		ctx:                   ctx,
+		locality:              "test",
+		clientConfig:          cfg.Client,
+		globalConfig:          cfg.Global,
+		grpcClients:           make(map[string]proto.CacheClient),
+		grpcConns:             make(map[string]*grpc.ClientConn),
+		localServers:          make(map[string]*Server),
+		rawReadPools:          make(map[string]*rawReadConnPool),
+		localHostCache:        make(map[localHostCacheKey]*localClientCache),
+		hasher:                &orderedTestHasher{hosts: []*Host{host}},
+		maxGetContentAttempts: 1,
+	}
+	client.hostMap = NewHostMap(cfg.Global, client.addHost)
+	client.hostMap.Set(host)
+	defer client.Cleanup()
+
+	// Seed the pool with a connection the peer has already closed.
+	dead, peer := net.Pipe()
+	require.NoError(t, peer.Close())
+	pool := newRawReadConnPool(addr, cfg.Client.ReadTransport.MaxActiveConnsPerHost, cfg.Client.ReadTransport.MaxIdleConnsPerHost)
+	require.NoError(t, pool.acquire(ctx))
+	pool.put(dead)
+	client.mu.Lock()
+	client.rawReadPools[host.HostId] = pool
+	client.mu.Unlock()
+
+	readCtx, readCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer readCancel()
+	dst := make([]byte, len(content))
+	n, trace, err := client.ReadContentIntoWithTrace(readCtx, hash, 0, dst, ClientOptions{RoutingKey: hash})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
+	require.Equal(t, "raw", trace.Attempts[0].Source)
+	require.Equal(t, "unavailable", trace.Attempts[0].Result)
+	require.True(t, client.hostMap.Get(host.HostId).HasEndpoint())
 }
 
 func TestReadContentIntoUsesSelectedLocalServer(t *testing.T) {

--- a/pkg/cache/raw_transport.go
+++ b/pkg/cache/raw_transport.go
@@ -40,6 +40,9 @@ const (
 	// buffer, and a short wait here is far cheaper than the client's fallback.
 	rawReadAdmissionWait               = 250 * time.Millisecond
 	defaultRawReadWriteProgressTimeout = 30 * time.Second
+	// A connection burst can lose a SYN; TCP retransmits it after 1s, so a
+	// shorter dial timeout turns one dropped packet into a failed read.
+	rawReadDialTimeout = 3 * time.Second
 )
 
 type cacheMuxListener struct {
@@ -582,8 +585,10 @@ func newRawReadConnPool(addr string, maxActive int, maxIdle int) *rawReadConnPoo
 	if maxActive <= 0 {
 		maxActive = 64
 	}
+	// Connections above the idle cap are closed, so every burst redials;
+	// an idle connection costs nothing, so default to keeping them all.
 	if maxIdle <= 0 {
-		maxIdle = 16
+		maxIdle = maxActive
 	}
 	return &rawReadConnPool{
 		addr:     addr,
@@ -621,7 +626,7 @@ func (p *rawReadConnPool) get(ctx context.Context) (net.Conn, error) {
 	}
 	p.mu.Unlock()
 
-	dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+	dialCtx, cancel := context.WithTimeout(ctx, rawReadDialTimeout)
 	defer cancel()
 	dialer := &net.Dialer{}
 	conn, err := dialer.DialContext(dialCtx, "tcp", p.addr)

--- a/pkg/cache/raw_transport.go
+++ b/pkg/cache/raw_transport.go
@@ -43,6 +43,7 @@ const (
 	// A connection burst can lose a SYN; TCP retransmits it after 1s, so a
 	// shorter dial timeout turns one dropped packet into a failed read.
 	rawReadDialTimeout = 3 * time.Second
+	rawReadIdleTimeout = time.Minute
 )
 
 type cacheMuxListener struct {
@@ -571,31 +572,73 @@ func (cs *Server) rawReadPageRegions(req rawReadRequest) ([]rawReadPageRegion, i
 }
 
 type rawReadConnPool struct {
-	addr     string
-	maxIdle  int
-	mu       sync.Mutex
-	idle     []net.Conn
-	active   map[net.Conn]struct{}
-	tokens   chan struct{}
-	closed   bool
-	closedCh chan struct{}
+	addr        string
+	maxIdle     int
+	idleTimeout time.Duration
+	mu          sync.Mutex
+	idle        []rawReadIdleConn
+	active      map[net.Conn]struct{}
+	tokens      chan struct{}
+	closed      bool
+	closedCh    chan struct{}
+}
+
+type rawReadIdleConn struct {
+	conn  net.Conn
+	since time.Time
 }
 
 func newRawReadConnPool(addr string, maxActive int, maxIdle int) *rawReadConnPool {
 	if maxActive <= 0 {
 		maxActive = 64
 	}
-	// Connections above the idle cap are closed, so every burst redials;
-	// an idle connection costs nothing, so default to keeping them all.
+	// Connections above the idle cap are closed, so every burst redials.
+	// Keep them all; the reaper closes the ones a quiet host stops using.
 	if maxIdle <= 0 {
 		maxIdle = maxActive
 	}
-	return &rawReadConnPool{
-		addr:     addr,
-		maxIdle:  maxIdle,
-		active:   make(map[net.Conn]struct{}),
-		tokens:   make(chan struct{}, maxActive),
-		closedCh: make(chan struct{}),
+	p := &rawReadConnPool{
+		addr:        addr,
+		maxIdle:     maxIdle,
+		idleTimeout: rawReadIdleTimeout,
+		active:      make(map[net.Conn]struct{}),
+		tokens:      make(chan struct{}, maxActive),
+		closedCh:    make(chan struct{}),
+	}
+	go p.reapLoop()
+	return p
+}
+
+func (p *rawReadConnPool) reapLoop() {
+	ticker := time.NewTicker(p.idleTimeout / 2)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.closedCh:
+			return
+		case now := <-ticker.C:
+			p.reapIdle(now)
+		}
+	}
+}
+
+// reapIdle closes connections idle past the timeout; the server holds no
+// deadline on an accepted connection, so this is what ends them on both sides.
+func (p *rawReadConnPool) reapIdle(now time.Time) {
+	p.mu.Lock()
+	kept := p.idle[:0]
+	var expired []net.Conn
+	for _, entry := range p.idle {
+		if now.Sub(entry.since) >= p.idleTimeout {
+			expired = append(expired, entry.conn)
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	p.idle = kept
+	p.mu.Unlock()
+	for _, conn := range expired {
+		_ = conn.Close()
 	}
 }
 
@@ -612,7 +655,7 @@ func (p *rawReadConnPool) get(ctx context.Context) (net.Conn, error) {
 	}
 	last := len(p.idle) - 1
 	if last >= 0 {
-		conn := p.idle[last]
+		conn := p.idle[last].conn
 		p.idle = p.idle[:last]
 		if err := ctx.Err(); err != nil {
 			p.mu.Unlock()
@@ -709,7 +752,7 @@ func (p *rawReadConnPool) put(conn net.Conn) {
 		p.release()
 		return
 	}
-	p.idle = append(p.idle, conn)
+	p.idle = append(p.idle, rawReadIdleConn{conn: conn, since: time.Now()})
 	p.release()
 }
 
@@ -732,7 +775,9 @@ func (p *rawReadConnPool) close() {
 	p.closed = true
 	close(p.closedCh)
 	conns := make([]net.Conn, 0, len(p.idle)+len(p.active))
-	conns = append(conns, p.idle...)
+	for _, entry := range p.idle {
+		conns = append(conns, entry.conn)
+	}
 	for conn := range p.active {
 		conns = append(conns, conn)
 	}

--- a/pkg/cache/raw_transport_test.go
+++ b/pkg/cache/raw_transport_test.go
@@ -358,3 +358,29 @@ func TestReadContentIntoSurvivesSaturatedRawReadAdmission(t *testing.T) {
 	require.Equal(t, rawReadBusyRetries+1, raw, "raw attempts: %+v", trace.Attempts)
 	require.Equal(t, 1, grpcHits)
 }
+
+func TestRawReadConnPoolReapsIdleConnections(t *testing.T) {
+	pool := newRawReadConnPool("127.0.0.1:0", 4, 4)
+	defer pool.close()
+
+	fresh, freshPeer := net.Pipe()
+	stale, stalePeer := net.Pipe()
+	defer freshPeer.Close()
+	defer stalePeer.Close()
+	for _, conn := range []net.Conn{fresh, stale} {
+		require.NoError(t, pool.acquire(context.Background()))
+		pool.put(conn)
+	}
+	pool.mu.Lock()
+	pool.idle[1].since = time.Now().Add(-2 * pool.idleTimeout)
+	pool.mu.Unlock()
+
+	pool.reapIdle(time.Now())
+
+	pool.mu.Lock()
+	require.Len(t, pool.idle, 1)
+	require.Same(t, fresh, pool.idle[0].conn)
+	pool.mu.Unlock()
+	_, err := stale.Write([]byte{0})
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}

--- a/pkg/disk/spare_test.go
+++ b/pkg/disk/spare_test.go
@@ -208,7 +208,7 @@ func TestAttachWithoutSpareBuildsFreshVolume(t *testing.T) {
 		}
 	}
 	if created != 1 {
-		t.Fatalf("fresh attach formats exactly once: %v", host.commands)
+		t.Fatalf("fresh attach creates the volume image exactly once: %v", host.commands)
 	}
 	waitForSpares(t, manager, testSpareSize, spareTarget)
 	if err := manager.Close(ctx); err != nil {

--- a/pkg/disk/spare_test.go
+++ b/pkg/disk/spare_test.go
@@ -200,7 +200,14 @@ func TestAttachWithoutSpareBuildsFreshVolume(t *testing.T) {
 	if volume.dir != manager.volumeDir("disk") || !volume.state.Formatted {
 		t.Fatalf("fresh attach must build in place, got %+v", volume.state)
 	}
-	if len(host.ran("mkfs.ext4")) != 1 {
+	// Spare replenishment runs mkfs concurrently, so count the disk's own image.
+	created := 0
+	for _, command := range host.ran("qemu-img create") {
+		if strings.Contains(command, manager.volumeDir("disk")) {
+			created++
+		}
+	}
+	if created != 1 {
 		t.Fatalf("fresh attach formats exactly once: %v", host.commands)
 	}
 	waitForSpares(t, manager, testSpareSize, spareTarget)

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1728,6 +1728,41 @@ func (c *PostgresBackendRepository) ListLatestDeploymentsByAppIDs(ctx context.Co
 	return deploymentsByApp, nil
 }
 
+type activeDeploymentCountRow struct {
+	AppExternalID string `db:"app_external_id"`
+	Count         int    `db:"count"`
+}
+
+// CountActiveDeploymentsByAppIDs returns, per app, how many of its deployments
+// are currently active. Unlike ListLatestDeploymentsByAppIDs this considers
+// every deployment in the app, so an app whose newest deployment was stopped
+// while an older function is still deployed reports as live.
+func (c *PostgresBackendRepository) CountActiveDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]int, error) {
+	counts := make(map[string]int, len(appExternalIDs))
+	if workspaceID == 0 || len(appExternalIDs) == 0 {
+		return counts, nil
+	}
+
+	query := `
+		SELECT a.external_id AS app_external_id, COUNT(d.id) AS count
+		FROM app a
+		JOIN deployment d ON d.app_id = a.id AND d.deleted_at IS NULL AND d.active = true
+		WHERE a.workspace_id = $1
+		  AND a.deleted_at IS NULL
+		  AND a.external_id = ANY($2)
+		GROUP BY a.external_id;
+	`
+
+	var rows []activeDeploymentCountRow
+	if err := c.client.SelectContext(ctx, &rows, query, workspaceID, pq.Array(appExternalIDs)); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		counts[row.AppExternalID] = row.Count
+	}
+	return counts, nil
+}
+
 func (c *PostgresBackendRepository) ListDeploymentsPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error) {
 	qb := c.listDeploymentsQueryBuilder(filters)
 

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -221,6 +221,7 @@ type BackendRepository interface {
 	ListVolumesWithRelated(ctx context.Context, workspaceId uint) ([]types.VolumeWithRelated, error)
 	ListDeploymentsWithRelated(ctx context.Context, filters types.DeploymentFilter) ([]types.DeploymentWithRelated, error)
 	ListLatestDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]types.DeploymentWithRelated, error)
+	CountActiveDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]int, error)
 	ListLatestDeploymentsWithRelatedPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
 	ListDeploymentsPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
 	GetLatestDeploymentByName(ctx context.Context, workspaceId uint, name string, stubType string, filterDeleted bool) (*types.DeploymentWithRelated, error)


### PR DESCRIPTION
## Summary
Three fixes on the volume / CAS read-write path, plus the app-liveness change for app listing.

- **geesefs [05899ec](https://github.com/beam-cloud/geesefs/commit/05899ece51a7ad787a272b2cca40e2cf14d2788c)** — `fsync` on a staged file waits for the outstanding remote rename (the huggingface_hub `.incomplete` → final pattern); `sync(2)`/`syncfs(2)` wait for in-flight staged uploads. "fsync/sync returned" now means another container can read it.
- **geesefs [03ce641](https://github.com/beam-cloud/geesefs/commit/03ce641)** — with FD reads enabled (prod), prefetch only ever hinted local page files, so content that lived on another cache host was fetched one 512 KiB FUSE request at a time with no read-ahead. Remote content is now pulled in 64 MiB windows, 8 in flight, and foreground reads wait for the window covering them. Local content keeps the page-cache hint path.
- **cache client** — a raw-transport read error (stale pooled connection, a dial that lost one SYN) deactivated the host; every reader then scanned the ring and refreshed hosts, discovery re-added it a second later, and the loop repeated ~1/s. The client now probes the endpoint first and falls back to gRPC when the host is healthy. Raw dial timeout allows a SYN retransmit (3 s); the idle pool defaults to the active cap so bursts stop redialing.
- **api** — app liveness spans every stub and deployment in the app (folded in for the gateway release).

## Measured (staging, custom worker `vol-cas-563c040c`)
Cold read of 3 × 1 GiB volume files from a sandbox on a node that has none of the content (reader node cordoned away from the writer's node):

| | before | after |
|---|---|---|
| cold, over the wire | 229–300 MiB/s (512 KiB per FUSE read, no read-ahead) | **976–1192 MiB/s** (~9 Gbps on a 12.5 Gbps m7i link) |
| warm, same node (fd/splice) | 4.7 GiB/s | 2.8–6.4 GiB/s |
| page cache | ~6 GiB/s | 6–7 GiB/s |
| host deactivations during the read | up to 10/10 s (OVH) | 0 |

## Test plan
- geesefs: `TestSyncStagedFileWaitsForRemoteRename`, `TestSyncTreeWaitsForStagedUpload`, `TestExternalCacheFDRemoteContentPrefetchesDataWindows` (all fail on the previous commit); full Go-style `core` suite green in docker.
- beta9: `TestReadContentIntoStaleRawConnectionKeepsHealthyHost` (raw read on a dead pooled conn falls back to gRPC and leaves the host active); `go test ./pkg/cache/... ./pkg/api/...`.
- Staging: two-node volume writer/reader harness above; no `Deactivated cache host endpoint` in worker logs during 6 GiB of cold reads.

Made with [Cursor](https://cursor.com)