### PR TITLE
api: app liveness spans every stub and deployment in the app

### DIFF
--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -577,6 +577,14 @@ func (s *GenericPodService) run(ctx context.Context, authInfo *auth.AuthInfo, st
 		&stub.Stub,
 	)
 
+	// Sandboxes never create task records, so the dashboard's 24h activity
+	// strip reads this O(1) hourly counter instead of replaying event history.
+	if stub.Type == types.StubType(types.StubTypeSandbox) && appId != "" && s.containerRepo != nil {
+		if err := s.containerRepo.RecordSandboxCreated(workspace.ExternalId, appId, time.Now()); err != nil {
+			log.Warn().Err(err).Str("app_id", appId).Msg("failed to record sandbox activity")
+		}
+	}
+
 	return containerId, nil
 }
 

--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -3,7 +3,9 @@ package apiv1
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
@@ -14,6 +16,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/types/serializer"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
 )
 
 type AppGroup struct {
@@ -36,6 +39,7 @@ func NewAppGroup(g *echo.Group, backendRepo repository.BackendRepository, config
 	}
 
 	g.GET("/:workspaceId/latest", auth.WithWorkspaceAuth(group.ListAppWithLatestActivity))
+	g.GET("/:workspaceId/activity", auth.WithWorkspaceAuth(group.GetAppActivity))
 	g.GET("/:workspaceId", auth.WithWorkspaceAuth(group.ListApps))
 	g.GET("/:workspaceId/:appId", auth.WithWorkspaceAuth(group.RetrieveApp))
 	g.DELETE("/:workspaceId/:appId", auth.WithStrictWorkspaceAuth(group.DeleteApp))
@@ -57,9 +61,123 @@ type AppWithLatestStubOrDeployment struct {
 	RunningContainers int `json:"running_containers" serializer:"running_containers"`
 	// ActiveDeployments counts deployments in the app that are currently
 	// active (deployed and not stopped), across all of its functions.
-	ActiveDeployments int                  `json:"active_deployments" serializer:"active_deployments"`
-	IsService         bool                 `json:"is_service" serializer:"is_service"`
-	Serving           *types.ServingConfig `json:"serving,omitempty" serializer:"serving"`
+	ActiveDeployments int `json:"active_deployments" serializer:"active_deployments"`
+	// State is derived from the two counts above: running > idle > stopped.
+	// Only the list endpoint knows running containers, so only it sets this.
+	State     types.AppState       `json:"state,omitempty" serializer:"state,omitempty"`
+	IsService bool                 `json:"is_service" serializer:"is_service"`
+	Serving   *types.ServingConfig `json:"serving,omitempty" serializer:"serving"`
+}
+
+// AppListResponse is a page of apps plus workspace-wide state counts, so the
+// dashboard's Running / Idle / Stopped tabs describe the whole workspace and
+// not just the page that happens to be loaded.
+type AppListResponse struct {
+	repoCommon.CursorPaginationInfo[AppWithLatestStubOrDeployment]
+	StateCounts types.AppStateCounts `json:"state_counts" serializer:"state_counts"`
+}
+
+func appStateFor(runningContainers, activeDeployments int) types.AppState {
+	switch {
+	case runningContainers > 0:
+		return types.AppStateRunning
+	case activeDeployments > 0:
+		return types.AppStateIdle
+	default:
+		return types.AppStateStopped
+	}
+}
+
+// workspaceAppState is everything needed to classify every app in a workspace:
+// running containers per app (Redis) and active deployments per app (Postgres).
+// Apps in neither map are stopped.
+type workspaceAppState struct {
+	runningByApp map[string]int
+	activeByApp  map[string]int
+	totalApps    int
+}
+
+func (w workspaceAppState) counts() types.AppStateCounts {
+	counts := types.AppStateCounts{All: w.totalApps}
+	for appID := range w.runningByApp {
+		if w.runningByApp[appID] > 0 {
+			counts.Running++
+		}
+	}
+	for appID, active := range w.activeByApp {
+		if active > 0 && w.runningByApp[appID] == 0 {
+			counts.Idle++
+		}
+	}
+	counts.Stopped = counts.All - counts.Running - counts.Idle
+	if counts.Stopped < 0 {
+		counts.Stopped = 0
+	}
+	return counts
+}
+
+// scope narrows an AppFilter to the apps in the requested state. Running and
+// idle are finite id sets; stopped is everything else.
+func (w workspaceAppState) scope(filters *types.AppFilter, state types.AppState) {
+	running := make([]string, 0, len(w.runningByApp))
+	for appID, n := range w.runningByApp {
+		if n > 0 {
+			running = append(running, appID)
+		}
+	}
+	idle := make([]string, 0, len(w.activeByApp))
+	for appID, n := range w.activeByApp {
+		if n > 0 && w.runningByApp[appID] == 0 {
+			idle = append(idle, appID)
+		}
+	}
+	switch state {
+	case types.AppStateRunning:
+		filters.IncludeExternalIds = running
+	case types.AppStateIdle:
+		filters.IncludeExternalIds = idle
+	case types.AppStateStopped:
+		filters.ExcludeExternalIds = append(running, idle...)
+	}
+}
+
+// loadWorkspaceAppState fans out the three independent reads in parallel.
+func (a *AppGroup) loadWorkspaceAppState(ctx context.Context, workspace *types.Workspace) (workspaceAppState, error) {
+	state := workspaceAppState{runningByApp: map[string]int{}, activeByApp: map[string]int{}}
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		if a.containerRepo == nil {
+			return nil
+		}
+		running, err := countRunningContainersForApps(gctx, a.containerRepo, a.backendRepo, workspace.ExternalId)
+		if err != nil {
+			return err
+		}
+		state.runningByApp = running
+		return nil
+	})
+	g.Go(func() error {
+		active, err := a.backendRepo.CountActiveDeploymentsByApp(gctx, workspace.Id, nil)
+		if err != nil {
+			return err
+		}
+		state.activeByApp = active
+		return nil
+	})
+	g.Go(func() error {
+		total, err := a.backendRepo.CountApps(gctx, workspace.Id)
+		if err != nil {
+			return err
+		}
+		state.totalApps = total
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return workspaceAppState{}, err
+	}
+	return state, nil
 }
 
 func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
@@ -79,15 +197,34 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 	if err := ctx.Bind(&filters); err != nil {
 		return HTTPBadRequest("Failed to decode query parameters")
 	}
+	stateFilter, ok := types.ParseAppState(filters.State)
+	if !ok {
+		return HTTPBadRequest("Invalid state filter; expected running, idle or stopped")
+	}
 
-	apps, err := a.backendRepo.ListAppsPaginated(ctx.Request().Context(), workspace.Id, filters)
+	reqCtx := ctx.Request().Context()
+
+	// Live state for the whole workspace comes first: it drives both the tab
+	// counts and, when a state filter is set, which apps the page may contain.
+	appState, err := a.loadWorkspaceAppState(reqCtx, &workspace)
+	if err != nil {
+		return HTTPInternalServerError("Failed to get app state")
+	}
+	if stateFilter != "" {
+		appState.scope(&filters, stateFilter)
+	}
+
+	apps, err := a.backendRepo.ListAppsPaginated(reqCtx, workspace.Id, filters)
 	if err != nil {
 		return err
 	}
 
-	appsWithLatest := repoCommon.CursorPaginationInfo[AppWithLatestStubOrDeployment]{
-		Data: make([]AppWithLatestStubOrDeployment, len(apps.Data)),
-		Next: apps.Next,
+	response := AppListResponse{
+		CursorPaginationInfo: repoCommon.CursorPaginationInfo[AppWithLatestStubOrDeployment]{
+			Data: make([]AppWithLatestStubOrDeployment, len(apps.Data)),
+			Next: apps.Next,
+		},
+		StateCounts: appState.counts(),
 	}
 
 	appIDs := make([]string, 0, len(apps.Data))
@@ -95,7 +232,7 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		appIDs = append(appIDs, apps.Data[i].ExternalId)
 	}
 
-	deploymentsByApp, err := a.backendRepo.ListLatestDeploymentsByAppIDs(ctx.Request().Context(), workspace.Id, appIDs)
+	deploymentsByApp, err := a.backendRepo.ListLatestDeploymentsByAppIDs(reqCtx, workspace.Id, appIDs)
 	if err != nil {
 		return HTTPBadRequest("Failed to get apps")
 	}
@@ -107,31 +244,27 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		}
 	}
 
-	stubsByApp, err := a.backendRepo.ListLatestStubsByAppIDs(ctx.Request().Context(), workspace.Id, appIDsWithoutDeployment)
+	stubsByApp, err := a.backendRepo.ListLatestStubsByAppIDs(reqCtx, workspace.Id, appIDsWithoutDeployment)
 	if err != nil {
 		return HTTPBadRequest("Failed to get apps")
 	}
 
-	activeDeploymentsByApp, err := a.backendRepo.CountActiveDeploymentsByAppIDs(ctx.Request().Context(), workspace.Id, appIDs)
-	if err != nil {
-		return HTTPBadRequest("Failed to get apps")
-	}
-
-	appIndexes := make(map[string]int, len(apps.Data))
 	for i := range apps.Data {
-		appsWithLatest.Data[i].App = apps.Data[i]
-		appsWithLatest.Data[i].ActiveDeployments = activeDeploymentsByApp[apps.Data[i].ExternalId]
-		appIndexes[apps.Data[i].ExternalId] = i
+		app := &response.Data[i]
+		app.App = apps.Data[i]
+		app.RunningContainers = appState.runningByApp[apps.Data[i].ExternalId]
+		app.ActiveDeployments = appState.activeByApp[apps.Data[i].ExternalId]
+		app.State = appStateFor(app.RunningContainers, app.ActiveDeployments)
 
 		if deployment, ok := deploymentsByApp[apps.Data[i].ExternalId]; ok {
 			deploymentCopy := deployment
-			a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &deploymentCopy.Stub, &deploymentCopy.Deployment, false)
-			deploymentCopy.URL = appsWithLatest.Data[i].URL
-			deploymentCopy.InvokeURL = appsWithLatest.Data[i].InvokeURL
+			a.enrichAppWithStubConfig(app, &deploymentCopy.Stub, &deploymentCopy.Deployment, false)
+			deploymentCopy.URL = app.URL
+			deploymentCopy.InvokeURL = app.InvokeURL
 			if err := sanitizeDeploymentWithRelated(&deploymentCopy); err != nil {
 				return HTTPInternalServerError("Failed to sanitize stub config")
 			}
-			appsWithLatest.Data[i].Deployment = &deploymentCopy
+			app.Deployment = &deploymentCopy
 			continue
 		}
 
@@ -141,35 +274,115 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 		}
 
 		stubCopy := stub
-		a.enrichAppWithStubConfig(&appsWithLatest.Data[i], &stubCopy.Stub, nil, false)
-		appsWithLatest.Data[i].Stub = &stubCopy
-		if err := sanitizeStubWithRelated(appsWithLatest.Data[i].Stub); err != nil {
+		a.enrichAppWithStubConfig(app, &stubCopy.Stub, nil, false)
+		app.Stub = &stubCopy
+		if err := sanitizeStubWithRelated(app.Stub); err != nil {
 			return HTTPInternalServerError("Failed to sanitize stub config")
 		}
 	}
 
-	if a.containerRepo != nil && len(appIndexes) > 0 {
-		runningByAppID, err := countRunningContainersForApps(ctx.Request().Context(), a.containerRepo, a.backendRepo, workspaceID)
-		if err != nil {
-			return HTTPInternalServerError("Failed to get running containers")
-		}
-
-		for appID, count := range runningByAppID {
-			if index, ok := appIndexes[appID]; ok {
-				appsWithLatest.Data[index].RunningContainers = count
-			}
-		}
-	}
-
-	serializedAppsWithLatest, err := serializer.Serialize(appsWithLatest)
+	serialized, err := serializer.Serialize(response)
 	if err != nil {
 		return HTTPInternalServerError("Failed to serialize response")
 	}
 
-	return ctx.JSON(
-		http.StatusOK,
-		serializedAppsWithLatest,
-	)
+	return ctx.JSON(http.StatusOK, serialized)
+}
+
+const (
+	appActivityWindow  = 24 * time.Hour
+	maxActivityAppIDs  = 100
+	activityBucketSize = time.Hour
+)
+
+// GetAppActivity returns the last 24h of hourly activity for a set of apps in
+// one call: tasks created (and failed) from Postgres, sandboxes created from
+// the Redis counters bumped at creation. Every app gets a full, zero-filled
+// series so the client never has to align buckets itself.
+func (a *AppGroup) GetAppActivity(ctx echo.Context) error {
+	cc, _ := ctx.(*auth.HttpAuthContext)
+	workspaceID := ctx.Param("workspaceId")
+
+	if cc.AuthInfo.Workspace.ExternalId != workspaceID && cc.AuthInfo.Token.TokenType != types.TokenTypeClusterAdmin {
+		return HTTPNotFound()
+	}
+
+	workspace, err := a.backendRepo.GetWorkspaceByExternalId(ctx.Request().Context(), workspaceID)
+	if err != nil {
+		return HTTPBadRequest("Failed to retrieve workspace")
+	}
+
+	appIDs := uniqueNonEmpty(strings.Split(ctx.QueryParam("app_ids"), ","))
+	if len(appIDs) == 0 {
+		return HTTPBadRequest("app_ids is required")
+	}
+	if len(appIDs) > maxActivityAppIDs {
+		return HTTPBadRequest("Too many app_ids")
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-appActivityWindow).Truncate(activityBucketSize)
+
+	var tasks, sandboxes map[string][]types.AppActivityBucket
+	g, gctx := errgroup.WithContext(ctx.Request().Context())
+	g.Go(func() error {
+		var err error
+		tasks, err = a.backendRepo.AggregateTaskActivityByApp(gctx, workspace.Id, appIDs, since)
+		return err
+	})
+	g.Go(func() error {
+		if a.containerRepo == nil {
+			return nil
+		}
+		var err error
+		sandboxes, err = a.containerRepo.GetSandboxActivity(workspaceID, appIDs, since)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return HTTPInternalServerError("Failed to get app activity")
+	}
+
+	bucketCount := int(appActivityWindow/activityBucketSize) + 1
+	response := make(map[string][]types.AppActivityBucket, len(appIDs))
+	for _, appID := range appIDs {
+		byHour := make(map[int64]*types.AppActivityBucket, bucketCount)
+		series := make([]types.AppActivityBucket, 0, bucketCount)
+		for t := since; !t.After(now); t = t.Add(activityBucketSize) {
+			series = append(series, types.AppActivityBucket{Time: t})
+		}
+		for i := range series {
+			byHour[series[i].Time.Unix()] = &series[i]
+		}
+		for _, source := range [][]types.AppActivityBucket{tasks[appID], sandboxes[appID]} {
+			for _, b := range source {
+				if target, ok := byHour[b.Time.UTC().Truncate(activityBucketSize).Unix()]; ok {
+					target.Total += b.Total
+					target.Failed += b.Failed
+				}
+			}
+		}
+		response[appID] = series
+	}
+
+	return ctx.JSON(http.StatusOK, response)
+}
+
+func uniqueNonEmpty(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // countRunningContainersForApps counts running containers per app across all
@@ -322,7 +535,7 @@ func (a *AppGroup) hydrateDatabaseConnectionURL(ctx context.Context, workspace *
 func (a *AppGroup) appWithLatestStubOrDeployment(ctx context.Context, workspace *types.Workspace, app types.App) (AppWithLatestStubOrDeployment, error) {
 	appWithLatest := AppWithLatestStubOrDeployment{App: app}
 
-	activeDeploymentsByApp, err := a.backendRepo.CountActiveDeploymentsByAppIDs(ctx, workspace.Id, []string{app.ExternalId})
+	activeDeploymentsByApp, err := a.backendRepo.CountActiveDeploymentsByApp(ctx, workspace.Id, []string{app.ExternalId})
 	if err != nil {
 		return appWithLatest, err
 	}

--- a/pkg/api/v1/app_test.go
+++ b/pkg/api/v1/app_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/beam-cloud/beta9/pkg/auth"
 	"github.com/beam-cloud/beta9/pkg/common"
@@ -28,15 +29,28 @@ type appBackendRepo struct {
 	// extraStubApps maps stub external IDs that aren't any app's latest stub
 	// to the app they belong to.
 	extraStubApps map[string]string
+	taskActivity  map[string][]types.AppActivityBucket
+	lastFilters   types.AppFilter
 }
 
 type appContainerRepo struct {
 	repository.ContainerRepository
-	states []types.ContainerState
+	states          []types.ContainerState
+	sandboxActivity map[string][]types.AppActivityBucket
 }
 
 func (r *appContainerRepo) GetActiveContainersByWorkspaceId(_ string) ([]types.ContainerState, error) {
 	return r.states, nil
+}
+
+func (r *appContainerRepo) GetSandboxActivity(_ string, appIds []string, _ time.Time) (map[string][]types.AppActivityBucket, error) {
+	out := map[string][]types.AppActivityBucket{}
+	for _, id := range appIds {
+		if b, ok := r.sandboxActivity[id]; ok {
+			out[id] = b
+		}
+	}
+	return out, nil
 }
 
 func (r *appBackendRepo) GetWorkspaceByExternalId(_ context.Context, externalId string) (types.Workspace, error) {
@@ -51,8 +65,49 @@ func (r *appBackendRepo) GetWorkspaceByExternalIdWithSigningKey(_ context.Contex
 	return r.GetWorkspaceByExternalId(context.Background(), externalId)
 }
 
-func (r *appBackendRepo) ListAppsPaginated(_ context.Context, _ uint, _ types.AppFilter) (repoCommon.CursorPaginationInfo[types.App], error) {
-	return r.apps, nil
+// ListAppsPaginated honours the include / exclude scoping the handler derives
+// from live state, the way the real query does.
+func (r *appBackendRepo) ListAppsPaginated(_ context.Context, _ uint, filters types.AppFilter) (repoCommon.CursorPaginationInfo[types.App], error) {
+	r.lastFilters = filters
+	page := repoCommon.CursorPaginationInfo[types.App]{Next: r.apps.Next}
+	for _, app := range r.apps.Data {
+		if filters.IncludeExternalIds != nil {
+			found := false
+			for _, id := range filters.IncludeExternalIds {
+				if id == app.ExternalId {
+					found = true
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		excluded := false
+		for _, id := range filters.ExcludeExternalIds {
+			if id == app.ExternalId {
+				excluded = true
+			}
+		}
+		if excluded {
+			continue
+		}
+		page.Data = append(page.Data, app)
+	}
+	return page, nil
+}
+
+func (r *appBackendRepo) CountApps(_ context.Context, _ uint) (int, error) {
+	return len(r.apps.Data), nil
+}
+
+func (r *appBackendRepo) AggregateTaskActivityByApp(_ context.Context, _ uint, appIDs []string, _ time.Time) (map[string][]types.AppActivityBucket, error) {
+	out := map[string][]types.AppActivityBucket{}
+	for _, id := range appIDs {
+		if b, ok := r.taskActivity[id]; ok {
+			out[id] = b
+		}
+	}
+	return out, nil
 }
 
 func (r *appBackendRepo) RetrieveApp(_ context.Context, workspaceID uint, appID string) (*types.App, error) {
@@ -79,7 +134,12 @@ func (r *appBackendRepo) ListLatestDeploymentsByAppIDs(_ context.Context, _ uint
 	return deployments, nil
 }
 
-func (r *appBackendRepo) CountActiveDeploymentsByAppIDs(_ context.Context, _ uint, appExternalIDs []string) (map[string]int, error) {
+func (r *appBackendRepo) CountActiveDeploymentsByApp(_ context.Context, _ uint, appExternalIDs []string) (map[string]int, error) {
+	if appExternalIDs == nil {
+		for appID := range r.deploymentsByApp {
+			appExternalIDs = append(appExternalIDs, appID)
+		}
+	}
 	counts := map[string]int{}
 	for _, appID := range appExternalIDs {
 		for _, deployment := range r.deploymentsByApp[appID] {
@@ -325,11 +385,13 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 	}
 
 	var response struct {
-		Data []struct {
+		StateCounts types.AppStateCounts `json:"state_counts"`
+		Data        []struct {
 			ID                string `json:"id"`
 			PoolName          string `json:"pool_name"`
 			RunningContainers int    `json:"running_containers"`
 			ActiveDeployments int    `json:"active_deployments"`
+			State             string `json:"state"`
 			IsService         bool   `json:"is_service"`
 			Serving           struct {
 				AppKind         string `json:"app_kind"`
@@ -413,6 +475,16 @@ func TestListAppWithLatestActivityIncludesCardEnrichment(t *testing.T) {
 	}
 	if deploymentApp.ActiveDeployments != 1 {
 		t.Fatalf("expected the older active deployment to count, got %+v", deploymentApp)
+	}
+	// Both apps have running containers, so both are running and nothing is idle
+	// or stopped, workspace-wide.
+	if response.StateCounts != (types.AppStateCounts{All: 2, Running: 2}) {
+		t.Fatalf("unexpected state counts: %+v", response.StateCounts)
+	}
+	for _, app := range response.Data {
+		if app.State != string(types.AppStateRunning) {
+			t.Fatalf("expected %s to be running, got %q", app.ID, app.State)
+		}
 	}
 	if deploymentApp.Serving.AppKind != "llm_model" || deploymentApp.Serving.ServingProtocol != "openai" || deploymentApp.Serving.LLM.ModelID != "Qwen/Qwen2.5-0.5B-Instruct" || deploymentApp.Serving.LLM.ContextLength != 4096 {
 		t.Fatalf("unexpected deployment app llm enrichment: %+v", deploymentApp)
@@ -626,5 +698,184 @@ func TestEnrichAppWithStubConfigHidesDefaultPool(t *testing.T) {
 	}
 	if !app.IsService {
 		t.Fatal("expected service metadata to remain populated")
+	}
+}
+
+// Three apps in three states. Counts must describe the whole workspace and the
+// state filter must scope the page server-side.
+func TestListAppWithLatestActivityStateFilterAndCounts(t *testing.T) {
+	workspace := &types.Workspace{Id: 1, ExternalId: "workspace-1", Name: "Workspace 1"}
+	running := types.App{Id: 1, ExternalId: "app-running", Name: "Running", WorkspaceId: workspace.Id}
+	idle := types.App{Id: 2, ExternalId: "app-idle", Name: "Idle", WorkspaceId: workspace.Id}
+	stopped := types.App{Id: 3, ExternalId: "app-stopped", Name: "Stopped", WorkspaceId: workspace.Id}
+
+	deployment := func(app types.App, stubID string, active bool) types.DeploymentWithRelated {
+		return types.DeploymentWithRelated{
+			Deployment: types.Deployment{ExternalId: "dep-" + app.ExternalId, Name: app.Name, Active: active, WorkspaceId: workspace.Id, AppId: app.Id},
+			Stub:       types.Stub{ExternalId: stubID, Name: app.Name, Type: types.StubType(types.StubTypeEndpointDeployment), Config: "{}", WorkspaceId: workspace.Id, AppId: app.Id},
+			Workspace:  *workspace,
+			App:        app,
+		}
+	}
+
+	repo := &appBackendRepo{
+		workspace: workspace,
+		apps:      repoCommon.CursorPaginationInfo[types.App]{Data: []types.App{running, idle, stopped}},
+		deploymentsByApp: map[string][]types.DeploymentWithRelated{
+			running.ExternalId: {deployment(running, "stub-running", true)},
+			idle.ExternalId:    {deployment(idle, "stub-idle", true)},
+			stopped.ExternalId: {deployment(stopped, "stub-stopped", false)},
+		},
+		stubsByApp: map[string][]types.StubWithRelated{},
+	}
+	appGroup := &AppGroup{
+		backendRepo: repo,
+		containerRepo: &appContainerRepo{states: []types.ContainerState{
+			{StubId: "stub-running", Status: types.ContainerStatusRunning},
+		}},
+	}
+
+	call := func(query string) (struct {
+		StateCounts types.AppStateCounts `json:"state_counts"`
+		Data        []struct {
+			ID    string `json:"id"`
+			State string `json:"state"`
+		} `json:"data"`
+	}, types.AppFilter) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/workspace-1/latest"+query, nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("workspaceId")
+		ctx.SetParamValues(workspace.ExternalId)
+		if err := appGroup.ListAppWithLatestActivity(&auth.HttpAuthContext{
+			Context:  ctx,
+			AuthInfo: &auth.AuthInfo{Workspace: workspace, Token: &types.Token{TokenType: types.TokenTypeWorkspacePrimary}},
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", rec.Code, rec.Body.String())
+		}
+		var out struct {
+			StateCounts types.AppStateCounts `json:"state_counts"`
+			Data        []struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return out, repo.lastFilters
+	}
+
+	all, _ := call("")
+	if all.StateCounts != (types.AppStateCounts{All: 3, Running: 1, Idle: 1, Stopped: 1}) {
+		t.Fatalf("unexpected counts: %+v", all.StateCounts)
+	}
+	states := map[string]string{}
+	for _, app := range all.Data {
+		states[app.ID] = app.State
+	}
+	if states[running.ExternalId] != "running" || states[idle.ExternalId] != "idle" || states[stopped.ExternalId] != "stopped" {
+		t.Fatalf("unexpected per-app states: %+v", states)
+	}
+
+	for _, tc := range []struct {
+		state string
+		want  string
+	}{{"running", running.ExternalId}, {"idle", idle.ExternalId}, {"stopped", stopped.ExternalId}} {
+		page, filters := call("?state=" + tc.state)
+		if len(page.Data) != 1 || page.Data[0].ID != tc.want {
+			t.Fatalf("state=%s: expected only %s, got %+v", tc.state, tc.want, page.Data)
+		}
+		// Counts stay workspace-wide regardless of the filter.
+		if page.StateCounts.All != 3 {
+			t.Fatalf("state=%s: counts should cover the workspace, got %+v", tc.state, page.StateCounts)
+		}
+		if tc.state == "stopped" && len(filters.ExcludeExternalIds) != 2 {
+			t.Fatalf("stopped should exclude running+idle, got %+v", filters)
+		}
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/workspace-1/latest?state=bogus", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("workspaceId")
+	ctx.SetParamValues(workspace.ExternalId)
+	err := appGroup.ListAppWithLatestActivity(&auth.HttpAuthContext{
+		Context:  ctx,
+		AuthInfo: &auth.AuthInfo{Workspace: workspace, Token: &types.Token{TokenType: types.TokenTypeWorkspacePrimary}},
+	})
+	if err == nil {
+		t.Fatalf("expected an error for an invalid state filter")
+	}
+}
+
+func TestGetAppActivityMergesTasksAndSandboxesIntoFullSeries(t *testing.T) {
+	workspace := &types.Workspace{Id: 1, ExternalId: "workspace-1", Name: "Workspace 1"}
+	now := time.Now().UTC().Truncate(time.Hour)
+	appGroup := &AppGroup{
+		backendRepo: &appBackendRepo{
+			workspace: workspace,
+			taskActivity: map[string][]types.AppActivityBucket{
+				"app-a": {{Time: now.Add(-2 * time.Hour), Total: 5, Failed: 1}, {Time: now, Total: 2}},
+			},
+		},
+		containerRepo: &appContainerRepo{sandboxActivity: map[string][]types.AppActivityBucket{
+			"app-a": {{Time: now, Total: 3}},
+			"app-b": {{Time: now.Add(-time.Hour), Total: 7}},
+		}},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/workspace-1/activity?app_ids=app-a,app-b,app-a,", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("workspaceId")
+	ctx.SetParamValues(workspace.ExternalId)
+	if err := appGroup.GetAppActivity(&auth.HttpAuthContext{
+		Context:  ctx,
+		AuthInfo: &auth.AuthInfo{Workspace: workspace, Token: &types.Token{TokenType: types.TokenTypeWorkspacePrimary}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var out map[string][]types.AppActivityBucket
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected two apps, got %d", len(out))
+	}
+	// 24h window + the current partial hour = 25 buckets, zero-filled.
+	if len(out["app-a"]) != 25 || len(out["app-b"]) != 25 {
+		t.Fatalf("expected 25 buckets per app, got %d / %d", len(out["app-a"]), len(out["app-b"]))
+	}
+	byTime := func(series []types.AppActivityBucket, at time.Time) types.AppActivityBucket {
+		for _, b := range series {
+			if b.Time.Equal(at) {
+				return b
+			}
+		}
+		t.Fatalf("missing bucket at %s", at)
+		return types.AppActivityBucket{}
+	}
+	if b := byTime(out["app-a"], now); b.Total != 5 || b.Failed != 0 {
+		t.Fatalf("expected tasks+sandboxes merged into the current hour, got %+v", b)
+	}
+	if b := byTime(out["app-a"], now.Add(-2*time.Hour)); b.Total != 5 || b.Failed != 1 {
+		t.Fatalf("unexpected older bucket: %+v", b)
+	}
+	if b := byTime(out["app-b"], now.Add(-time.Hour)); b.Total != 7 {
+		t.Fatalf("unexpected sandbox-only bucket: %+v", b)
+	}
+	if b := byTime(out["app-b"], now); b.Total != 0 {
+		t.Fatalf("expected zero-filled bucket, got %+v", b)
 	}
 }

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -37,6 +37,9 @@ var (
 	schedulerCheckpointState          string = "scheduler:checkpoint_state:%s:%s"
 	schedulerServeLock                string = "scheduler:serve:lock:%s:%s"
 	schedulerStubState                string = "scheduler:stub:state:%s"
+	// Hash of hour-epoch -> sandboxes created, per app. Cheap source for the
+	// dashboard's 24h activity strip; bumped on every sandbox creation.
+	schedulerAppSandboxActivity string = "scheduler:app:sandbox_activity:%s:%s"
 )
 
 var (
@@ -251,6 +254,10 @@ func (rk *redisKeys) SchedulerContainerWorkerIndex(workerId string) string {
 
 func (rk *redisKeys) SchedulerContainerWorkspaceIndex(workspaceId string) string {
 	return fmt.Sprintf(schedulerContainerWorkspaceIndex, workspaceId)
+}
+
+func (rk *redisKeys) SchedulerAppSandboxActivity(workspaceId, appId string) string {
+	return fmt.Sprintf(schedulerAppSandboxActivity, workspaceId, appId)
 }
 
 func (rk *redisKeys) SchedulerContainerAddress(containerId string) string {

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -915,6 +915,51 @@ func (c *PostgresBackendRepository) GetTaskCountPerDeployment(ctx context.Contex
 	return taskCounts, nil
 }
 
+type taskActivityRow struct {
+	AppExternalID string    `db:"app_external_id"`
+	Time          time.Time `db:"time"`
+	Total         int       `db:"total"`
+	Failed        int       `db:"failed"`
+}
+
+// AggregateTaskActivityByApp buckets tasks created since `since` by app and
+// hour, for a set of apps, in one query. Backs the dashboard's per-card
+// activity strips, replacing one aggregate request per card.
+func (c *PostgresBackendRepository) AggregateTaskActivityByApp(ctx context.Context, workspaceID uint, appExternalIDs []string, since time.Time) (map[string][]types.AppActivityBucket, error) {
+	result := make(map[string][]types.AppActivityBucket, len(appExternalIDs))
+	if workspaceID == 0 || len(appExternalIDs) == 0 {
+		return result, nil
+	}
+
+	query := `
+		SELECT a.external_id AS app_external_id,
+		       DATE_TRUNC('hour', t.created_at) AS time,
+		       COUNT(t.id) AS total,
+		       COUNT(t.id) FILTER (WHERE t.status = 'ERROR') AS failed
+		FROM task t
+		JOIN stub s ON s.id = t.stub_id
+		JOIN app a ON a.id = s.app_id
+		WHERE t.workspace_id = $1
+		  AND t.created_at >= $2
+		  AND a.external_id = ANY($3)
+		GROUP BY a.external_id, DATE_TRUNC('hour', t.created_at)
+		ORDER BY a.external_id, time;
+	`
+
+	var rows []taskActivityRow
+	if err := c.client.SelectContext(ctx, &rows, query, workspaceID, since, pq.Array(appExternalIDs)); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.AppExternalID] = append(result[row.AppExternalID], types.AppActivityBucket{
+			Time:   row.Time.UTC(),
+			Total:  row.Total,
+			Failed: row.Failed,
+		})
+	}
+	return result, nil
+}
+
 func (c *PostgresBackendRepository) AggregateTasksByTimeWindow(ctx context.Context, filters types.TaskFilter) ([]types.TaskCountByTime, error) {
 	interval := strings.ToLower(filters.Interval)
 	if interval == "" {
@@ -1733,28 +1778,36 @@ type activeDeploymentCountRow struct {
 	Count         int    `db:"count"`
 }
 
-// CountActiveDeploymentsByAppIDs returns, per app, how many of its deployments
+// CountActiveDeploymentsByApp returns, per app, how many of its deployments
 // are currently active. Unlike ListLatestDeploymentsByAppIDs this considers
 // every deployment in the app, so an app whose newest deployment was stopped
-// while an older function is still deployed reports as live.
-func (c *PostgresBackendRepository) CountActiveDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]int, error) {
+// while an older function is still deployed reports as idle rather than
+// stopped. A nil appExternalIDs covers every app in the workspace, which is
+// what the dashboard needs to compute workspace-wide state counts; apps with
+// no active deployment are simply absent from the result.
+func (c *PostgresBackendRepository) CountActiveDeploymentsByApp(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]int, error) {
 	counts := make(map[string]int, len(appExternalIDs))
-	if workspaceID == 0 || len(appExternalIDs) == 0 {
+	if workspaceID == 0 || (appExternalIDs != nil && len(appExternalIDs) == 0) {
 		return counts, nil
 	}
 
-	query := `
-		SELECT a.external_id AS app_external_id, COUNT(d.id) AS count
-		FROM app a
-		JOIN deployment d ON d.app_id = a.id AND d.deleted_at IS NULL AND d.active = true
-		WHERE a.workspace_id = $1
-		  AND a.deleted_at IS NULL
-		  AND a.external_id = ANY($2)
-		GROUP BY a.external_id;
-	`
+	qb := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Select("a.external_id AS app_external_id", "COUNT(d.id) AS count").
+		From("app a").
+		Join("deployment d ON d.app_id = a.id AND d.deleted_at IS NULL AND d.active = true").
+		Where(squirrel.Eq{"a.workspace_id": workspaceID}).
+		Where("a.deleted_at IS NULL").
+		GroupBy("a.external_id")
+	if appExternalIDs != nil {
+		qb = qb.Where(squirrel.Eq{"a.external_id": appExternalIDs})
+	}
+	query, args, err := qb.ToSql()
+	if err != nil {
+		return nil, err
+	}
 
 	var rows []activeDeploymentCountRow
-	if err := c.client.SelectContext(ctx, &rows, query, workspaceID, pq.Array(appExternalIDs)); err != nil {
+	if err := c.client.SelectContext(ctx, &rows, query, args...); err != nil {
 		return nil, err
 	}
 	for _, row := range rows {
@@ -2553,6 +2606,16 @@ func (r *PostgresBackendRepository) ListAppsPaginated(ctx context.Context, works
 		qb = qb.Where(squirrel.Like{"LOWER(a.name)": fmt.Sprintf("%%%s%%", strings.ToLower(filters.Name))})
 	}
 
+	// State filters arrive as explicit id sets (running / idle apps are known
+	// from Redis + deployments). An empty include set means "nothing matches";
+	// squirrel renders that as (1=0), which is what we want.
+	if filters.IncludeExternalIds != nil {
+		qb = qb.Where(squirrel.Eq{"a.external_id": filters.IncludeExternalIds})
+	}
+	if len(filters.ExcludeExternalIds) > 0 {
+		qb = qb.Where(squirrel.NotEq{"a.external_id": filters.ExcludeExternalIds})
+	}
+
 	page, err := common.Paginate(
 		common.SquirrelCursorPaginator[types.App]{
 			Client:          r.client,
@@ -2569,6 +2632,13 @@ func (r *PostgresBackendRepository) ListAppsPaginated(ctx context.Context, works
 	}
 
 	return *page, nil
+}
+
+// CountApps returns the number of live (non-deleted) apps in a workspace.
+func (r *PostgresBackendRepository) CountApps(ctx context.Context, workspaceId uint) (int, error) {
+	var count int
+	err := r.client.GetContext(ctx, &count, `SELECT COUNT(*) FROM app WHERE workspace_id = $1 AND deleted_at IS NULL;`, workspaceId)
+	return count, err
 }
 
 // Use to update the updated_at field of app when stub and deployment is created with app_id

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -81,6 +81,8 @@ type ContainerRepository interface {
 	ReserveContainerConcurrencyForPending(quota *types.ConcurrencyLimit, request *types.ContainerRequest) error
 	GetActiveContainersByStubId(stubId string) ([]types.ContainerState, error)
 	GetActiveContainersByWorkspaceId(workspaceId string) ([]types.ContainerState, error)
+	RecordSandboxCreated(workspaceId, appId string, at time.Time) error
+	GetSandboxActivity(workspaceId string, appIds []string, since time.Time) (map[string][]types.AppActivityBucket, error)
 	GetActiveContainersByWorkerId(workerId string) ([]types.ContainerState, error)
 	GetFailedContainersByStubId(stubId string) ([]string, error)
 	GetStubState(stubId string) (string, error)
@@ -221,7 +223,8 @@ type BackendRepository interface {
 	ListVolumesWithRelated(ctx context.Context, workspaceId uint) ([]types.VolumeWithRelated, error)
 	ListDeploymentsWithRelated(ctx context.Context, filters types.DeploymentFilter) ([]types.DeploymentWithRelated, error)
 	ListLatestDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]types.DeploymentWithRelated, error)
-	CountActiveDeploymentsByAppIDs(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]int, error)
+	CountActiveDeploymentsByApp(ctx context.Context, workspaceID uint, appExternalIDs []string) (map[string]int, error)
+	AggregateTaskActivityByApp(ctx context.Context, workspaceID uint, appExternalIDs []string, since time.Time) (map[string][]types.AppActivityBucket, error)
 	ListLatestDeploymentsWithRelatedPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
 	ListDeploymentsPaginated(ctx context.Context, filters types.DeploymentFilter) (common.CursorPaginationInfo[types.DeploymentWithRelated], error)
 	GetLatestDeploymentByName(ctx context.Context, workspaceId uint, name string, stubType string, filterDeleted bool) (*types.DeploymentWithRelated, error)
@@ -263,6 +266,7 @@ type BackendRepository interface {
 	RetrieveAppByStubExternalId(ctx context.Context, stubExternalId string) (*types.App, error)
 	ListApps(ctx context.Context, workspaceId uint) ([]types.App, error)
 	ListAppsPaginated(ctx context.Context, workspaceId uint, filters types.AppFilter) (common.CursorPaginationInfo[types.App], error)
+	CountApps(ctx context.Context, workspaceId uint) (int, error)
 	DeleteApp(ctx context.Context, appId string) error
 	GetImageClipVersion(ctx context.Context, imageId string) (uint32, error)
 	CreateImage(ctx context.Context, imageId string, clipVersion uint32) (uint32, error)

--- a/pkg/repository/container_redis.go
+++ b/pkg/repository/container_redis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -926,34 +927,37 @@ func (cr *ContainerRedisRepository) GetWorkerAddress(ctx context.Context, contai
 	}
 }
 
+// listContainerStateByIndex resolves the container state hashes behind an
+// index set. Everything is pipelined: one round-trip to read every hash, one
+// to check exit codes for the hashes that have expired, one to prune stale
+// index members. The previous per-key loop cost two serial round-trips per
+// container, which dominated the dashboard's list endpoints on busy workspaces.
 func (cr *ContainerRedisRepository) listContainerStateByIndex(indexKey string, keys []string) ([]types.ContainerState, error) {
-	containerStates := make([]types.ContainerState, 0)
+	containerStates := make([]types.ContainerState, 0, len(keys))
+	if len(keys) == 0 {
+		return containerStates, nil
+	}
+	ctx := context.TODO()
 
-	for _, key := range keys {
-		exists, err := cr.rdb.Exists(context.TODO(), key).Result()
+	// HGETALL on a missing key returns an empty map, so a single pass tells us
+	// both which states exist and what they contain.
+	pipe := cr.rdb.Pipeline()
+	hashCmds := make([]*redis.MapStringStringCmd, len(keys))
+	for i, key := range keys {
+		hashCmds[i] = pipe.HGetAll(ctx, key)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, fmt.Errorf("failed to read container states: %v", err)
+	}
+
+	missing := make([]string, 0)
+	for i, key := range keys {
+		res, err := hashCmds[i].Result()
 		if err != nil {
 			continue
 		}
-		if exists == 0 {
-			containerId := strings.Split(key, ":")[len(strings.Split(key, ":"))-1]
-			exitCodeKey := common.RedisKeys.SchedulerContainerExitCode(containerId)
-
-			exitCodeKeyExists, err := cr.rdb.Exists(context.TODO(), exitCodeKey).Result()
-			if err != nil {
-				continue
-			}
-
-			if exitCodeKeyExists > 0 {
-				continue
-			}
-
-			// We don't have an exit code, or a state key, remove key from set
-			cr.rdb.SRem(context.TODO(), indexKey, key)
-			continue
-		}
-
-		res, err := cr.rdb.HGetAll(context.TODO(), key).Result()
-		if err != nil {
+		if len(res) == 0 {
+			missing = append(missing, key)
 			continue
 		}
 
@@ -961,15 +965,128 @@ func (cr *ContainerRedisRepository) listContainerStateByIndex(indexKey string, k
 		if err = common.ToStruct(res, &state); err != nil {
 			continue
 		}
-
 		if state.ContainerId == "" {
 			continue
 		}
-
 		containerStates = append(containerStates, state)
 	}
 
+	if len(missing) == 0 {
+		return containerStates, nil
+	}
+
+	// A state hash that is gone but whose exit code is still around belongs to
+	// a container that just finished; leave the index entry for the reaper.
+	// Anything else is a dangling index member and gets pruned.
+	exitPipe := cr.rdb.Pipeline()
+	exitCmds := make([]*redis.IntCmd, len(missing))
+	for i, key := range missing {
+		parts := strings.Split(key, ":")
+		exitCmds[i] = exitPipe.Exists(ctx, common.RedisKeys.SchedulerContainerExitCode(parts[len(parts)-1]))
+	}
+	if _, err := exitPipe.Exec(ctx); err != nil && err != redis.Nil {
+		return containerStates, nil
+	}
+
+	stale := make([]interface{}, 0, len(missing))
+	for i, key := range missing {
+		if exists, err := exitCmds[i].Result(); err == nil && exists == 0 {
+			stale = append(stale, key)
+		}
+	}
+	if len(stale) > 0 {
+		cr.rdb.SRem(ctx, indexKey, stale...)
+	}
+
 	return containerStates, nil
+}
+
+// Sandbox activity is kept as one hash per app keyed by hour epoch. Buckets
+// older than the retention window are trimmed on write, so the hash stays at
+// most ~25 fields and reads are a single HGETALL per app.
+const sandboxActivityRetention = 26 * time.Hour
+
+func (cr *ContainerRedisRepository) RecordSandboxCreated(workspaceId, appId string, at time.Time) error {
+	if workspaceId == "" || appId == "" {
+		return nil
+	}
+	ctx := context.TODO()
+	key := common.RedisKeys.SchedulerAppSandboxActivity(workspaceId, appId)
+	hour := at.UTC().Truncate(time.Hour).Unix()
+
+	pipe := cr.rdb.Pipeline()
+	pipe.HIncrBy(ctx, key, strconv.FormatInt(hour, 10), 1)
+	pipe.Expire(ctx, key, sandboxActivityRetention)
+	fields := pipe.HKeys(ctx, key)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return err
+	}
+
+	// Trim relative to the newest bucket present, not this write's timestamp,
+	// so a late/out-of-order write can never resurrect old buckets.
+	epochs := make(map[string]int64, len(fields.Val()))
+	newest := hour
+	for _, field := range fields.Val() {
+		epoch, err := strconv.ParseInt(field, 10, 64)
+		if err != nil {
+			continue
+		}
+		epochs[field] = epoch
+		if epoch > newest {
+			newest = epoch
+		}
+	}
+	cutoff := newest - int64(sandboxActivityRetention/time.Second)
+	stale := make([]string, 0)
+	for field, epoch := range epochs {
+		if epoch < cutoff {
+			stale = append(stale, field)
+		}
+	}
+	if len(stale) > 0 {
+		cr.rdb.HDel(ctx, key, stale...)
+	}
+	return nil
+}
+
+func (cr *ContainerRedisRepository) GetSandboxActivity(workspaceId string, appIds []string, since time.Time) (map[string][]types.AppActivityBucket, error) {
+	result := make(map[string][]types.AppActivityBucket, len(appIds))
+	if workspaceId == "" || len(appIds) == 0 {
+		return result, nil
+	}
+	ctx := context.TODO()
+
+	pipe := cr.rdb.Pipeline()
+	cmds := make([]*redis.MapStringStringCmd, len(appIds))
+	for i, appId := range appIds {
+		cmds[i] = pipe.HGetAll(ctx, common.RedisKeys.SchedulerAppSandboxActivity(workspaceId, appId))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, err
+	}
+
+	cutoff := since.UTC().Truncate(time.Hour).Unix()
+	for i, appId := range appIds {
+		fields, err := cmds[i].Result()
+		if err != nil || len(fields) == 0 {
+			continue
+		}
+		buckets := make([]types.AppActivityBucket, 0, len(fields))
+		for field, raw := range fields {
+			epoch, err := strconv.ParseInt(field, 10, 64)
+			if err != nil || epoch < cutoff {
+				continue
+			}
+			count, err := strconv.Atoi(raw)
+			if err != nil || count == 0 {
+				continue
+			}
+			buckets = append(buckets, types.AppActivityBucket{Time: time.Unix(epoch, 0).UTC(), Total: count})
+		}
+		sort.Slice(buckets, func(a, b int) bool { return buckets[a].Time.Before(buckets[b].Time) })
+		result[appId] = buckets
+	}
+	return result, nil
 }
 
 func (cr *ContainerRedisRepository) GetActiveContainersByStubId(stubId string) ([]types.ContainerState, error) {

--- a/pkg/repository/container_redis_test.go
+++ b/pkg/repository/container_redis_test.go
@@ -1952,3 +1952,92 @@ func testContainerRequest(containerId, workspaceId string, cpu int64) *types.Con
 		},
 	}
 }
+
+// Stale index members (state hash gone, no exit code) must be pruned and live
+// ones returned, with the whole resolution pipelined rather than per-key.
+func TestListContainerStateByIndexPrunesStaleMembers(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := NewContainerRedisRepositoryForTest(rdb)
+	ctx := context.Background()
+
+	live := &types.ContainerState{ContainerId: "pod-live", StubId: "stub-a", WorkspaceId: "ws", Status: types.ContainerStatusRunning, ScheduledAt: time.Now().Unix()}
+	if err := repo.SetContainerState(live.ContainerId, live); err != nil {
+		t.Fatal(err)
+	}
+
+	indexKey := common.RedisKeys.SchedulerContainerWorkspaceIndex("ws")
+	// A container that exited: hash gone, exit code present → keep the index entry.
+	exitedKey := common.RedisKeys.SchedulerContainerState("pod-exited")
+	rdb.SAdd(ctx, indexKey, exitedKey)
+	rdb.Set(ctx, common.RedisKeys.SchedulerContainerExitCode("pod-exited"), 0, time.Minute)
+	// A dangling member: neither hash nor exit code → prune.
+	danglingKey := common.RedisKeys.SchedulerContainerState("pod-dangling")
+	rdb.SAdd(ctx, indexKey, danglingKey)
+
+	states, err := repo.GetActiveContainersByWorkspaceId("ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].ContainerId != live.ContainerId {
+		t.Fatalf("expected only the live container, got %+v", states)
+	}
+
+	members, _ := rdb.SMembers(ctx, indexKey).Result()
+	if len(members) != 2 {
+		t.Fatalf("expected live + exited members to remain, got %v", members)
+	}
+	for _, m := range members {
+		if m == danglingKey {
+			t.Fatalf("dangling member should have been pruned: %v", members)
+		}
+	}
+}
+
+func TestSandboxActivityCountersBucketByHour(t *testing.T) {
+	rdb, err := NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := NewContainerRedisRepositoryForTest(rdb)
+
+	now := time.Date(2026, 9, 7, 15, 20, 0, 0, time.UTC)
+	for _, at := range []time.Time{now, now.Add(-5 * time.Minute), now.Add(-3 * time.Hour), now.Add(-30 * time.Hour)} {
+		if err := repo.RecordSandboxCreated("ws", "app-a", at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := repo.RecordSandboxCreated("ws", "app-b", now); err != nil {
+		t.Fatal(err)
+	}
+
+	activity, err := repo.GetSandboxActivity("ws", []string{"app-a", "app-b", "app-none"}, now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := activity["app-a"]
+	if len(a) != 2 {
+		t.Fatalf("expected two buckets inside the window for app-a, got %+v", a)
+	}
+	if !a[0].Time.Equal(now.Add(-3*time.Hour).Truncate(time.Hour)) || a[0].Total != 1 {
+		t.Fatalf("unexpected first bucket: %+v", a[0])
+	}
+	if !a[1].Time.Equal(now.Truncate(time.Hour)) || a[1].Total != 2 {
+		t.Fatalf("expected two creations in the current hour, got %+v", a[1])
+	}
+	if len(activity["app-b"]) != 1 || activity["app-b"][0].Total != 1 {
+		t.Fatalf("unexpected app-b activity: %+v", activity["app-b"])
+	}
+	if _, ok := activity["app-none"]; ok {
+		t.Fatalf("apps with no activity should be absent")
+	}
+
+	// The 30h-old bucket is trimmed on write, so the hash never grows past the window.
+	fields, _ := rdb.HKeys(context.Background(), common.RedisKeys.SchedulerAppSandboxActivity("ws", "app-a")).Result()
+	if len(fields) != 2 {
+		t.Fatalf("expected stale bucket to be trimmed, got fields %v", fields)
+	}
+}

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -407,6 +407,22 @@ type TaskCountPerDeployment struct {
 	TaskCount      uint   `db:"task_count" json:"task_count"`
 }
 
+// AppActivityBucket is one hour of an app's 24h activity strip: tasks created
+// (task-based stubs) plus sandboxes created (sandbox stubs), and how many of
+// those tasks ended in error.
+type AppActivityBucket struct {
+	Time   time.Time `json:"time"`
+	Total  int       `json:"total"`
+	Failed int       `json:"failed"`
+}
+
+type AppStateCounts struct {
+	All     int `json:"all" serializer:"all"`
+	Running int `json:"running" serializer:"running"`
+	Idle    int `json:"idle" serializer:"idle"`
+	Stopped int `json:"stopped" serializer:"stopped"`
+}
+
 type TaskCountByTime struct {
 	Time         time.Time       `db:"time" json:"time"`
 	Count        uint            `count:"count" json:"count"`

--- a/pkg/types/filters.go
+++ b/pkg/types/filters.go
@@ -75,10 +75,38 @@ type StubFilter struct {
 	Limit       uint32      `query:"limit"`
 }
 
+// AppState is how an app reads in the dashboard. It is derived, not stored:
+// running containers live in Redis, deployments in Postgres.
+type AppState string
+
+const (
+	// AppStateRunning: at least one container is running for any stub in the app.
+	AppStateRunning AppState = "running"
+	// AppStateIdle: nothing running right now, but at least one deployment is
+	// active, so the app scales up on the next request.
+	AppStateIdle AppState = "idle"
+	// AppStateStopped: nothing deployed and nothing running.
+	AppStateStopped AppState = "stopped"
+)
+
+func ParseAppState(s string) (AppState, bool) {
+	switch AppState(s) {
+	case AppStateRunning, AppStateIdle, AppStateStopped:
+		return AppState(s), true
+	}
+	return "", s == ""
+}
+
 type AppFilter struct {
 	Name   string `query:"name"`
+	State  string `query:"state"`
 	Cursor string `query:"cursor"`
 	Limit  uint32 `query:"limit"`
+
+	// Scoping computed server-side from live state. Untagged on purpose so the
+	// query binder can never set them from the request.
+	IncludeExternalIds []string
+	ExcludeExternalIds []string
 }
 
 type StubGetURLFilter struct {


### PR DESCRIPTION
## Why

The dashboard's Live / Idle split for apps was wrong for any app with more than one function or sandbox config:

- `running_containers` only counted containers whose stub was the app's **latest** stub. Sandboxes from an older `Sandbox(...)` config, or a task queue running alongside a newer endpoint, didn't count → app showed as idle while it was doing work.
- Liveness also read `deployment.active` from the **latest** deployment only. Stop the newest function while an older one is still deployed → app showed as idle.

## What

- `running_containers` counts running containers across **all** stubs in the app. Active containers are resolved stub → app via the existing `ListAppIDsByStubExternalIDs`, then summed per app (one extra query per list call, no per-app fan-out).
- New `active_deployments` on the list + retrieve payloads: count of active deployments across the whole app (`CountActiveDeploymentsByAppIDs`, one grouped query).

Existing field semantics for the frontend are unchanged except that the counts are now app-wide. The frontend change that consumes `active_deployments` (with a fallback to `deployment.active` for older gateways) is in beam-cloud/beta9-frontend#808.

## Test

`TestListAppWithLatestActivityIncludesCardEnrichment` now covers an app whose latest deployment is stopped while an older one is active (→ `active_deployments = 1`) and a running container on a non-latest stub (→ counted), plus a container on an unknown stub (→ ignored).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard's Live/Idle split for apps with more than one function or sandbox config so they no longer show as idle while older stubs or deployments are still active, and computes app state workspace-wide on the gateway instead of from a single page of results.

- `running_containers` now counts running containers across every stub in the app, not just the latest one.
- New `active_deployments` field on list and retrieve payloads counts active deployments across the whole app, replacing reliance on the latest deployment's `active` flag.
- Apps now carry a `state` (running / idle / stopped) derived from those counts; the list endpoint accepts `?state=`, scopes the page server-side, and returns workspace-wide `state_counts` alongside the page.
- New `GET /:workspaceId/activity?app_ids=` returns 24h hourly task and sandbox activity for a page of apps in one call; sandbox activity comes from an O(1) Redis hourly counter bumped at sandbox creation.
- `listContainerStateByIndex` now uses pipelined Redis reads instead of per-container round-trips.
- Frontend consumes `active_deployments` with a fallback to `deployment.active` for older gateways (beam-cloud/beta9-frontend#808).

<sup>Written for commit 319173394df36c430e36cb837f7cb5ae6ff36b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

