### PR TITLE
cache: evict freshly stored content last

### DIFF
--- a/pkg/cache/storage_eviction.go
+++ b/pkg/cache/storage_eviction.go
@@ -37,6 +37,10 @@ const (
 	// evictionRecentAccessGuard preserves hot content during normal eviction.
 	// Hard disk pressure may still evict it to keep the node healthy.
 	evictionRecentAccessGuard = 10 * time.Minute
+	// evictionRecentStoreGuard orders content written this recently last in
+	// every pass: a volume write is read minutes later by another container,
+	// and until then it looks colder than anything a running one just read.
+	evictionRecentStoreGuard = 30 * time.Minute
 	// evictionIncompleteContentGrace keeps in-flight writes out of eviction,
 	// while allowing abandoned marker-less v2 dirs to be reclaimed.
 	evictionIncompleteContentGrace = 30 * time.Minute
@@ -46,10 +50,11 @@ const (
 )
 
 type evictionCandidate struct {
-	hash       string
-	dir        string
-	lastAccess time.Time
-	sizeBytes  int64
+	hash        string
+	dir         string
+	lastAccess  time.Time
+	completedAt time.Time
+	sizeBytes   int64
 }
 
 // contentEntry is one object as the index knows it. complete mirrors the
@@ -152,7 +157,7 @@ func (idx *contentIndex) candidates(now time.Time) []evictionCandidate {
 		if !entry.complete && now.Sub(entry.lastAccess) < evictionIncompleteContentGrace {
 			continue
 		}
-		out = append(out, evictionCandidate{hash: hash, dir: entry.dir, lastAccess: entry.lastAccess, sizeBytes: entry.size})
+		out = append(out, evictionCandidate{hash: hash, dir: entry.dir, lastAccess: entry.lastAccess, completedAt: entry.completedAt, sizeBytes: entry.size})
 	}
 	return out
 }
@@ -403,7 +408,11 @@ func (cas *Store) evictLRUWithProtected(bytesToFree int64, protected map[string]
 	}
 
 	candidates := cas.evictionCandidates()
+	storeCutoff := time.Now().Add(-evictionRecentStoreGuard)
 	sort.Slice(candidates, func(i, j int) bool {
+		if fresh, other := candidates[i].completedAt.After(storeCutoff), candidates[j].completedAt.After(storeCutoff); fresh != other {
+			return other
+		}
 		return candidates[i].lastAccess.Before(candidates[j].lastAccess)
 	})
 
@@ -419,7 +428,7 @@ func (cas *Store) evictLRUWithProtected(bytesToFree int64, protected map[string]
 		}
 		// Oldest-first order: once we reach recently-read content, nothing
 		// after it is evictable either.
-		if !allowRecent && candidate.lastAccess.After(cutoff) {
+		if !allowRecent && (candidate.lastAccess.After(cutoff) || candidate.completedAt.After(storeCutoff)) {
 			break
 		}
 		if err := cas.removeContent(candidate); err != nil {

--- a/pkg/cache/storage_eviction_test.go
+++ b/pkg/cache/storage_eviction_test.go
@@ -23,6 +23,7 @@ func addEvictionTestContent(t *testing.T, store *Store, content string, lastAcce
 	entry, ok := store.index.get(hash)
 	require.True(t, ok)
 	entry.lastAccess = lastAccess
+	entry.completedAt = lastAccess
 	store.index.put(hash, entry)
 	return hash
 }
@@ -84,6 +85,40 @@ func TestEvictLRUNeverRemovesRecentlyReadContent(t *testing.T) {
 	require.Zero(t, evicted)
 	require.Zero(t, freed)
 	require.True(t, store.Exists(hash))
+}
+
+func TestEvictLRUEvictsFreshlyStoredContentLast(t *testing.T) {
+	store := newTestStore(t, 5)
+
+	now := time.Now()
+	cold := addEvictionTestContent(t, store, "cold-content", now.Add(-2*time.Hour))
+	// Stored long ago, read a minute ago.
+	hot := addEvictionTestContent(t, store, "hot-content!", now.Add(-2*time.Hour))
+	entry, ok := store.index.get(hot)
+	require.True(t, ok)
+	entry.lastAccess = now.Add(-time.Minute)
+	store.index.put(hot, entry)
+	// Written two minutes ago and not read yet: colder than hot by access
+	// time, but the write is what a container is about to read.
+	fresh, _, err := store.AddReader(context.Background(), bytes.NewReader([]byte("fresh-content")))
+	require.NoError(t, err)
+	entry, ok = store.index.get(fresh)
+	require.True(t, ok)
+	entry.lastAccess = now.Add(-2 * time.Minute)
+	entry.completedAt = entry.lastAccess
+	store.index.put(fresh, entry)
+
+	// Normal pass: fresh content is guarded like recently-read content.
+	evicted, _ := store.evictLRUWithProtected(1<<30, nil, false)
+	require.Equal(t, 1, evicted)
+	require.False(t, store.Exists(cold))
+	require.True(t, store.Exists(fresh))
+
+	// Under pressure the recently-read object goes before the fresh write.
+	evicted, _ = store.evictLRUWithProtected(int64(len("hot-content!")), nil, true)
+	require.Equal(t, 1, evicted)
+	require.False(t, store.Exists(hot))
+	require.True(t, store.Exists(fresh))
 }
 
 func TestEvictWatermarkPctAcceptsWholePercent(t *testing.T) {


### PR DESCRIPTION
## Summary
Under disk pressure the cache server evicted content that had just been stored — before content that was old but recently read — because a fresh store's only access is the store itself. On staging, three 1 GiB volume files written by one container were evicted within 1–3 minutes (\`disk cache evicted protected content under critical pressure\`, then a 35 GB LRU pass), so the container that read them a minute later fell through to Tigris at 240 MiB/s instead of the CAS at ~1 GiB/s.

Content completed in the last 30 minutes now sorts after everything else in every eviction pass (normal, recent, and critical), and the normal pass stops at it the way it stops at recently-read content. Disk pressure can still take it when nothing else is left.

## Test plan
- `TestEvictLRUEvictsFreshlyStoredContentLast`: the normal pass evicts cold content and keeps the fresh write; under pressure the recently-read object goes before the fresh write.
- Existing eviction tests pass (helper now backdates `completedAt` alongside `lastAccess`, matching a restart-rebuilt index).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops disk-pressure eviction from deleting freshly stored content before older content that was just read.

- Content completed in the last 30 minutes now sorts after everything else in every eviction pass.
- The normal eviction pass stops at it like it stops at recently-read content.
- Disk pressure can still evict it when nothing else is left.

**Test plan**
- `TestEvictLRUEvictsFreshlyStoredContentLast` covers the new ordering; existing eviction tests still pass.

<sup>Written for commit 4368a127db28c58a2d871a53f5bd81fb33cf5313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

