### PR TITLE
cache: preserve fresh volume content with fewer eviction passes

### DIFF
--- a/pkg/api/v1/app.go
+++ b/pkg/api/v1/app.go
@@ -197,7 +197,7 @@ func (a *AppGroup) ListAppWithLatestActivity(ctx echo.Context) error {
 	if err := ctx.Bind(&filters); err != nil {
 		return HTTPBadRequest("Failed to decode query parameters")
 	}
-	stateFilter, ok := types.ParseAppState(filters.State)
+	stateFilter, ok := types.ParseAppState(ctx.QueryParam("state"))
 	if !ok {
 		return HTTPBadRequest("Invalid state filter; expected running, idle or stopped")
 	}

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -619,18 +619,6 @@ func (c *Client) recordHostMonitorResult(host *Host, failures *int) bool {
 	return false
 }
 
-func (c *Client) checkHostEndpoint(host *Host) bool {
-	err := c.hostEndpointHealth(host)
-	if err != nil {
-		if !errors.Is(err, ErrHostNotFound) {
-			Logger.Debugf("cache host endpoint probe failed @ %s (PrivateAddr=%s): %v", host.HostId, host.PrivateAddr, err)
-		}
-		c.removeHost(host)
-		return false
-	}
-	return true
-}
-
 func (c *Client) hostEndpointHealth(host *Host) error {
 	if !c.isCurrentHostEndpoint(host) {
 		return ErrHostNotFound
@@ -1933,13 +1921,8 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hostIn
 			c.removeLocalHostCache(hash)
 			return 0, err
 		}
-		if errors.Is(err, ErrUnableToReachHost) {
-			// A stale pooled connection or a slow dial is not a dead host.
-			// Probe before deactivating; if the host is up, use gRPC.
-			if !c.checkHostEndpoint(host) {
-				return 0, ErrSelectedHostUnavailable
-			}
-		}
+		// A raw connection failure is not a dead host. Let the gRPC read
+		// below check reachability and fetch the bytes in one request.
 		if err != nil {
 			cacheReadRawFallbackTotal.Inc()
 		}
@@ -1951,7 +1934,7 @@ func (c *Client) readContentIntoFromHost(ctx context.Context, host *Host, hostIn
 	c.mu.RLock()
 	client, exists := c.grpcClients[host.HostId]
 	c.mu.RUnlock()
-	if !exists {
+	if !exists || client == nil {
 		trace.addAttempt(hostIndex, host, "grpc_client", "unavailable", 0, 0, ErrSelectedHostUnavailable)
 		c.removeLocalHostCache(hash)
 		return 0, ErrSelectedHostUnavailable

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -817,6 +817,9 @@ func TestReadContentIntoHandlesMissingGRPCClientAfterRawFailure(t *testing.T) {
 	require.Equal(t, "raw", trace.Attempts[0].Source)
 	require.Equal(t, "unavailable", trace.Attempts[0].Result)
 	require.Equal(t, ErrUnableToReachHost.Error(), trace.Attempts[0].Error)
+	require.Equal(t, "grpc_client", trace.Attempts[1].Source)
+	require.Equal(t, "unavailable", trace.Attempts[1].Result)
+	require.Equal(t, ErrSelectedHostUnavailable.Error(), trace.Attempts[1].Error)
 }
 
 // A raw read on a stale pooled connection must fall back to gRPC and leave a

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -355,49 +355,6 @@ func TestClientEndpointFailureKeepsLogicalHostInHRW(t *testing.T) {
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestCheckHostEndpointPrunesUnreachableEndpoint(t *testing.T) {
-	host := &Host{
-		HostId:         "cache-host-default-node-a-path",
-		RegistrationID: "worker-a",
-		NodeID:         "node-a",
-		CachePathID:    "path",
-		PrivateAddr:    "10.0.0.1:2049",
-	}
-	hostMap := NewHostMap(GlobalConfig{}, nil)
-	hostMap.Set(host)
-
-	client := &Client{
-		ctx:            context.Background(),
-		clientConfig:   ClientConfig{NTopHosts: 1},
-		hostMap:        hostMap,
-		grpcClients:    map[string]proto.CacheClient{host.HostId: &fakeStoreCacheClient{stateErr: errors.New("connection refused")}},
-		grpcConns:      make(map[string]*grpc.ClientConn),
-		localServers:   make(map[string]*Server),
-		rawReadPools:   make(map[string]*rawReadConnPool),
-		localHostCache: make(map[localHostCacheKey]*localClientCache),
-		hasher:         &orderedTestHasher{hosts: []*Host{host}},
-	}
-
-	require.False(t, client.checkHostEndpoint(host))
-
-	deactivated := hostMap.Get(host.HostId)
-	require.NotNil(t, deactivated)
-	require.False(t, deactivated.HasEndpoint())
-
-	selected, err := client.getHostForRequest(&ClientRequest{
-		rt:        ClientRequestTypeRetrieval,
-		hash:      "hash",
-		key:       "hash",
-		hostIndex: 0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, host.HostId, selected.HostId)
-	require.False(t, selected.HasEndpoint())
-
-	_, _, err = client.getGRPCClientForHostIndex(context.Background(), ClientRequestTypeRetrieval, "hash", "hash", 0)
-	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
-}
-
 func TestHostMonitorRequiresConsecutiveFailuresBeforePruningEndpoint(t *testing.T) {
 	host := &Host{
 		HostId:         "cache-host-default-node-a-path",
@@ -832,7 +789,7 @@ func TestReadContentIntoDoesNotRefreshHostsOnContentMiss(t *testing.T) {
 	require.Equal(t, "miss", trace.Result)
 }
 
-func TestReadContentIntoSkipsGRPCWhenRawHostUnreachable(t *testing.T) {
+func TestReadContentIntoHandlesMissingGRPCClientAfterRawFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -856,7 +813,7 @@ func TestReadContentIntoSkipsGRPCWhenRawHostUnreachable(t *testing.T) {
 	dst := make([]byte, 16)
 	_, trace, err := client.ReadContentIntoWithTrace(ctx, strings.Repeat("a", sha256.Size*2), 0, dst, ClientOptions{})
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
-	require.Len(t, trace.Attempts, 1)
+	require.Len(t, trace.Attempts, 2)
 	require.Equal(t, "raw", trace.Attempts[0].Source)
 	require.Equal(t, "unavailable", trace.Attempts[0].Result)
 	require.Equal(t, ErrUnableToReachHost.Error(), trace.Attempts[0].Error)

--- a/pkg/cache/storage_eviction.go
+++ b/pkg/cache/storage_eviction.go
@@ -177,8 +177,13 @@ func (idx *contentIndex) replace(scanned map[string]contentEntry, since time.Tim
 		switch {
 		case completedDuringWalk && (!ok || !entry.complete):
 			scanned[hash] = current
-		case ok && current.lastAccess.After(entry.lastAccess):
-			entry.lastAccess = current.lastAccess
+		case ok:
+			if entry.complete {
+				entry.completedAt = current.completedAt
+			}
+			if current.lastAccess.After(entry.lastAccess) {
+				entry.lastAccess = current.lastAccess
+			}
 			scanned[hash] = entry
 		}
 	}
@@ -446,6 +451,7 @@ func (cas *Store) evictLRUWithProtected(bytesToFree int64, protected map[string]
 func (cas *Store) evictionCandidateStats(protected map[string]struct{}) (int, int, int, int) {
 	candidates := cas.evictionCandidates()
 	cutoff := time.Now().Add(-evictionRecentAccessGuard)
+	storeCutoff := time.Now().Add(-evictionRecentStoreGuard)
 	protectedCount := 0
 	recentCount := 0
 	evictableCount := 0
@@ -454,7 +460,7 @@ func (cas *Store) evictionCandidateStats(protected map[string]struct{}) (int, in
 			protectedCount++
 			continue
 		}
-		if candidate.lastAccess.After(cutoff) {
+		if candidate.lastAccess.After(cutoff) || candidate.completedAt.After(storeCutoff) {
 			recentCount++
 			continue
 		}

--- a/pkg/cache/storage_eviction.go
+++ b/pkg/cache/storage_eviction.go
@@ -313,12 +313,7 @@ func (cas *Store) maybeEvictDiskCache(snapshot diskUsageSnapshot) bool {
 
 	started := time.Now()
 	protected := cas.protectedContentSnapshot()
-	evicted, freed := cas.evictLRUWithProtected(bytesToFree, protected, false)
-	if freed < bytesToFree {
-		moreEvicted, moreFreed := cas.evictLRUWithProtected(bytesToFree-freed, protected, true)
-		evicted += moreEvicted
-		freed += moreFreed
-	}
+	evicted, freed := cas.evictLRUWithProtected(bytesToFree, protected, true)
 	protectedEvicted := 0
 	var protectedFreed int64
 	if criticalBytes := cas.criticalDiskPressureBytesToFree(snapshot, freed); criticalBytes > 0 {
@@ -431,6 +426,11 @@ func (cas *Store) evictLRUWithProtected(bytesToFree int64, protected map[string]
 		if _, ok := protected[candidate.hash]; ok {
 			continue
 		}
+		// A non-nil protection set also guards fresh writes. Only the
+		// critical pass (nil) may evict them, after older protected content.
+		if protected != nil && candidate.completedAt.After(storeCutoff) {
+			break
+		}
 		// Oldest-first order: once we reach recently-read content, nothing
 		// after it is evictable either.
 		if !allowRecent && (candidate.lastAccess.After(cutoff) || candidate.completedAt.After(storeCutoff)) {
@@ -524,9 +524,6 @@ func (cas *Store) protectedContentSnapshot() map[string]struct{} {
 	}
 	cas.protectedMu.RLock()
 	defer cas.protectedMu.RUnlock()
-	if len(cas.protectedContent) == 0 {
-		return nil
-	}
 	out := make(map[string]struct{}, len(cas.protectedContent))
 	for hash := range cas.protectedContent {
 		out[hash] = struct{}{}

--- a/pkg/cache/storage_eviction_test.go
+++ b/pkg/cache/storage_eviction_test.go
@@ -98,15 +98,10 @@ func TestEvictLRUEvictsFreshlyStoredContentLast(t *testing.T) {
 	require.True(t, ok)
 	entry.lastAccess = now.Add(-time.Minute)
 	store.index.put(hot, entry)
-	// Written two minutes ago and not read yet: colder than hot by access
+	// Written twenty minutes ago and not read yet: colder than hot by access
 	// time, but the write is what a container is about to read.
-	fresh, _, err := store.AddReader(context.Background(), bytes.NewReader([]byte("fresh-content")))
-	require.NoError(t, err)
-	entry, ok = store.index.get(fresh)
-	require.True(t, ok)
-	entry.lastAccess = now.Add(-2 * time.Minute)
-	entry.completedAt = entry.lastAccess
-	store.index.put(fresh, entry)
+	fresh := addEvictionTestContent(t, store, "fresh-content", now.Add(-20*time.Minute))
+	store.rebuildContentIndex()
 
 	// Normal pass: fresh content is guarded like recently-read content.
 	evicted, _ := store.evictLRUWithProtected(1<<30, nil, false)

--- a/pkg/cache/storage_eviction_test.go
+++ b/pkg/cache/storage_eviction_test.go
@@ -114,6 +114,8 @@ func TestEvictLRUEvictsFreshlyStoredContentLast(t *testing.T) {
 	require.Equal(t, 1, evicted)
 	require.False(t, store.Exists(hot))
 	require.True(t, store.Exists(fresh))
+	evicted, _ = store.evictLRUWithProtected(1<<30, map[string]struct{}{}, true)
+	require.Zero(t, evicted, "fresh writes survive normal pressure without any stub protection")
 }
 
 func TestEvictWatermarkPctAcceptsWholePercent(t *testing.T) {
@@ -133,7 +135,8 @@ func TestMaybeEvictDiskCacheEvictsRecentUnprotectedBeforeProtectedContent(t *tes
 
 	now := time.Now()
 	protected := addEvictionTestContent(t, store, "protected-hot-content", now.Add(-2*time.Minute))
-	unprotected := addEvictionTestContent(t, store, "unprotected-hot-content", now.Add(-time.Minute))
+	unprotected := addEvictionTestContent(t, store, "unprotected-hot-content", now.Add(-time.Hour))
+	store.touchContentAccess(unprotected)
 	store.SetProtectedContent(map[string]struct{}{protected: struct{}{}})
 
 	evicted := store.maybeEvictDiskCache(diskUsageSnapshot{
@@ -164,7 +167,8 @@ func TestMaybeEvictDiskCachePreservesProtectedContentAboveSoftWatermark(t *testi
 		events = append(events, event)
 	})
 
-	protected := addEvictionTestContent(t, store, "protected-hot-content", time.Now().Add(-time.Minute))
+	protected := addEvictionTestContent(t, store, "protected-hot-content", time.Now().Add(-time.Hour))
+	fresh := addEvictionTestContent(t, store, "fresh-volume-content", time.Now().Add(-20*time.Minute))
 	store.SetProtectedContent(map[string]struct{}{protected: struct{}{}})
 
 	evicted := store.maybeEvictDiskCache(diskUsageSnapshot{
@@ -176,9 +180,11 @@ func TestMaybeEvictDiskCachePreservesProtectedContentAboveSoftWatermark(t *testi
 
 	require.False(t, evicted)
 	require.True(t, store.Exists(protected))
+	require.True(t, store.Exists(fresh))
 	require.Len(t, events, 1)
 	require.Equal(t, CacheChurnStatusNothingEvictable, events[0].Status)
 	require.Equal(t, 1, events[0].ProtectedCandidates)
+	require.Equal(t, 1, events[0].RecentCandidates)
 }
 
 func TestMaybeEvictDiskCacheEvictsProtectedContentToClearHardReserve(t *testing.T) {
@@ -191,7 +197,8 @@ func TestMaybeEvictDiskCacheEvictsProtectedContentToClearHardReserve(t *testing.
 		events = append(events, event)
 	})
 
-	protected := addEvictionTestContent(t, store, "protected-hot-content", time.Now().Add(-time.Minute))
+	protected := addEvictionTestContent(t, store, "protected-hot-content", time.Now().Add(-time.Hour))
+	fresh := addEvictionTestContent(t, store, "fresh-volume-content", time.Now().Add(-20*time.Minute))
 	store.SetProtectedContent(map[string]struct{}{protected: struct{}{}})
 
 	evicted := store.maybeEvictDiskCache(diskUsageSnapshot{
@@ -203,9 +210,10 @@ func TestMaybeEvictDiskCacheEvictsProtectedContentToClearHardReserve(t *testing.
 
 	require.True(t, evicted)
 	require.False(t, store.Exists(protected))
+	require.False(t, store.Exists(fresh))
 	require.Len(t, events, 1)
 	require.Equal(t, CacheChurnStatusProtectedEvicted, events[0].Status)
-	require.Equal(t, 1, events[0].ProtectedObjects)
+	require.Equal(t, 2, events[0].ProtectedObjects)
 	require.Positive(t, events[0].ProtectedFreedBytes)
 }
 

--- a/pkg/types/filters.go
+++ b/pkg/types/filters.go
@@ -99,7 +99,6 @@ func ParseAppState(s string) (AppState, bool) {
 
 type AppFilter struct {
 	Name   string `query:"name"`
-	State  string `query:"state"`
 	Cursor string `query:"cursor"`
 	Limit  uint32 `query:"limit"`
 


### PR DESCRIPTION
Fresh volume content could lose its 30-minute eviction guard on every disk rescan, and soft-pressure eviction could delete it anyway when older objects were stub-protected. Preserve store completion times during rescans and keep fresh stores protected until critical pressure. The normal pass now performs one sorted scan instead of two.

Raw transport failures fall through directly to the existing gRPC read, which both checks reachability and retrieves the data. Remove the separate health probe and its duplicate test while retaining the real stale-connection integration case. Keep #1879's state query local to the endpoint that implements it, resolving its shared-filter review concern.

Net change: 55 fewer lines. Existing eviction tests cover rescans, empty protection sets, soft pressure, and critical pressure. Cache race suites passed on macOS and Linux; the exact pinned geesefs core Go tests passed on Linux. GitHub's full package, SDK, and protobuf checks passed before the two-line API cleanup; combined checks are required before merge.

Staging reproduced premature deletion of two freshly stored 1 GiB files below the hard reserve on worker 0.1.747 and the first audit build. Final release validation will verify remote CAS ownership, retention across eviction/rescan cycles, full-file checksums, sync/rename visibility, and concurrent reads on the two m7i.8xlarge nodes, followed by a normal Helm rollout of gateway and workers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the 30-minute eviction guard for fresh volume content across disk rescans and keeps those stores protected until critical pressure, so soft-pressure eviction no longer deletes recently written files when older objects are stub-protected. The normal eviction pass now does one sorted scan instead of two, and raw transport failures fall through to the existing gRPC read instead of a separate health probe.

**Bug Fixes**
- Completion times now survive disk rescans, so fresh content keeps its eviction guard.
- Fresh stores are skipped by soft-pressure eviction; only the critical pass may evict them, after older protected content.
- Existing eviction tests cover rescans, empty protection sets, soft pressure, and critical pressure.

**Refactors**
- Removed the redundant host endpoint probe and its duplicate test; the stale-connection integration case remains.
- The gRPC client lookup now treats a nil client as unavailable, with test coverage for the fallthrough trace after a raw failure.
- Removed the `State` field from the shared `AppFilter`; the activity endpoint reads the `state` query parameter directly.

<sup>Written for commit c53c0ec304492a46228853ed4e01aad20c7a1cf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

