### PR TITLE
api: return the workspace ID needed by live app state

### DIFF
--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -212,7 +212,7 @@ func (r *PostgresBackendRepository) CreateWorkspace(ctx context.Context) (types.
 func (r *PostgresBackendRepository) GetWorkspaceByExternalId(ctx context.Context, externalId string) (types.Workspace, error) {
 	var workspace types.Workspace
 
-	query := `SELECT id, name, created_at, updated_at, concurrency_limit_id, volume_cache_enabled, multi_gpu_enabled, storage_id FROM workspace WHERE external_id = $1;`
+	query := `SELECT id, external_id, name, created_at, updated_at, concurrency_limit_id, volume_cache_enabled, multi_gpu_enabled, storage_id FROM workspace WHERE external_id = $1;`
 	err := r.client.GetContext(ctx, &workspace, query, externalId)
 	if err != nil {
 		return types.Workspace{}, err


### PR DESCRIPTION
Live sandbox validation of #1879 found that Running stayed at zero while the container endpoint correctly returned RUNNING containers and their app IDs. GetWorkspaceByExternalId omitted external_id from its SELECT, so loadWorkspaceAppState queried the Redis workspace index with an empty ID.

Return external_id with the workspace row. This is a one-line query correction with no added lines or queries. The existing mocked app tests pre-populated ExternalId and could not expose the real database behavior; validation uses live staging sandboxes and their app/activity responses.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live app state sandbox validation by returning `external_id` from `GetWorkspaceByExternalId` so the Redis workspace index is queried with the actual ID instead of an empty string.

<sup>Written for commit f105b7b6c2fd953ed645a65a555ba290c272a2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

