### PR TITLE
Recover cache reads after host departure and reduce prefetch latency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -317,7 +317,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260907155448-03ce641cb6d6
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260907234040-91217aec652c
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20240319100328-84253e514e02/go.mod h1:k08r
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec h1:zcr7+ud507kcRJBHotXr4hcUzEoqfPEgjtcMW6eCZwo=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec/go.mod h1:uymwDNMk1qoxElmDSlPzwYqZDriHDnW5VVyfK3YNuz8=
-github.com/beam-cloud/geesefs v0.0.0-20260907155448-03ce641cb6d6 h1:5dx5YTFYCl27hIrSBcrLJk2kWEMaYhMZ9aNnYfrIlDo=
-github.com/beam-cloud/geesefs v0.0.0-20260907155448-03ce641cb6d6/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260907234040-91217aec652c h1:UVEqAacpxJFQjZP7xuZeR5eW84BrhmhlYCUqrnT9jyY=
+github.com/beam-cloud/geesefs v0.0.0-20260907234040-91217aec652c/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1780,17 +1780,15 @@ func (c *Client) tryReadContentIntoKnownHosts(ctx context.Context, hash string, 
 	// top-N, and the content is then on a host we have not asked. Every other
 	// host is one cheap round trip away; the alternative is the caller falling
 	// back to the registry for a whole layer.
-	if contentMissing || (lastErr != nil && !primaryUnavailable) {
-		for _, host := range c.remainingHostsForRequest(checked) {
-			if err := ctx.Err(); err != nil {
-				return 0, err
-			}
-			n, err := c.readContentIntoFromHost(ctx, host, len(checked), hash, offset, dst, trace)
-			if err == nil && n == length {
-				c.rememberHostForContent(hash, opts.RoutingKey, host)
-				Logger.Debugf("cache read-into found content off-ring: hash=%s host=%s", hash, host.HostId)
-				return n, nil
-			}
+	for _, host := range c.remainingHostsForRequest(checked) {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		n, err := c.readContentIntoFromHost(ctx, host, len(checked), hash, offset, dst, trace)
+		if err == nil && n == length {
+			c.rememberHostForContent(hash, opts.RoutingKey, host)
+			Logger.Debugf("cache read-into found content off-ring: hash=%s host=%s", hash, host.HostId)
+			return n, nil
 		}
 	}
 

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -479,7 +479,7 @@ func TestLogicalOnlyHostStaysInHRWButHasNoEndpoint(t *testing.T) {
 	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
 }
 
-func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {
+func TestReadContentIntoRecoversFromUnavailablePrimaryWithLocalReplica(t *testing.T) {
 	store := newTestStore(t, 5)
 	content := []byte("local-cache-content")
 	hash, _, err := store.AddReader(context.Background(), bytes.NewReader(content))
@@ -504,10 +504,11 @@ func TestReadContentIntoDoesNotUseNonSelectedLocalReplica(t *testing.T) {
 
 	dst := make([]byte, len(content))
 	_, err = client.ReadContentInto(context.Background(), hash, 0, dst, ClientOptions{})
-	require.ErrorIs(t, err, ErrSelectedHostUnavailable)
+	require.NoError(t, err)
+	require.Equal(t, content, dst)
 
 	_, err = client.ClientLocalPageFileViews(hash, 3, 6, ClientOptions{})
-	require.ErrorIs(t, err, ErrContentNotFound)
+	require.NoError(t, err)
 }
 
 func TestReadContentIntoDoesNotMaskSelectedHostMissWithDifferentHost(t *testing.T) {

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -2563,4 +2563,14 @@ func TestReadsFindContentOnHostOutsideTopN(t *testing.T) {
 		streamed = append(streamed, chunk...)
 	}
 	require.Equal(t, content, streamed)
+
+	// A departed primary must not hide a surviving off-ring copy either.
+	require.NoError(t, servers[0].Close())
+	client.removeLocalHostCache(hash)
+	client.maxGetContentAttempts = 1
+	clear(dst)
+	n, err = client.ReadContentInto(ctx, hash, 0, dst, ClientOptions{RoutingKey: hash})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), n)
+	require.Equal(t, content, dst)
 }


### PR DESCRIPTION
Cold volume reads can fall back to object storage even when a healthy cache host has the bytes: when the preferred host departs, the read path skipped hosts outside its top-N. Always scan the remaining registered hosts before reporting failure, and remember the surviving copy. Existing real-server coverage now closes the primary and verifies recovery; the prior code fails that case. The full cache race suite passes.

Pin geesefs #21, which reduces external-cache windows from 64 MiB to 16 MiB with eight concurrent fetches. Direct remote CAS sustains approximately 1.4 GiB/s with either size, but smaller requests complete within the 250 ms foreground wait more consistently. On two staging m7i.8xlarge nodes with cold reader mounts and warm source pages, the final candidate reached 1,136 / 1,407 / 1,368 MiB/s, compared with 990 / 1,307 / 1,154 MiB/s at 64 MiB. Captured prefetch wait timeouts fell from 240 to zero; both runs had zero cloud requests and read-into misses. Local-cache FUSE reads were approximately 2.3–2.7 GiB/s and page-cache rereads approximately 6–6.7 GiB/s. These are software-path measurements, not claims about cold gp3 disks, smaller AWS NICs, or GPU model loading.

The staging audit also verified immediate cross-mount visibility after rename/fsync/sync, full 1 GiB checksums, range/EOF reads, fresh-store retention under soft disk pressure, and six concurrent remote readers without errors. Six concurrent readers on the final candidate completed 6 GiB in 8.67 seconds with correct checksums and zero errors; placement included a smaller AWS node, so this is a correctness check rather than a throughput ceiling. All package, SDK, protobuf, and automated-review checks passed. The clean release will be rolled and verified through staging Helmfile before production is prepared.

This follow-up adds nine lines including regression assertions; combined with #1881, the audit removes 43 lines. The geesefs constant change adds no lines. No new configuration knobs are introduced.
