### PR TITLE
fix(worker): recover started containers stuck in FUSE after SIGKILL

### DIFF
--- a/pkg/storage/geese.go
+++ b/pkg/storage/geese.go
@@ -570,6 +570,12 @@ func (s *GeeseStorage) Unmount(localPath string) error {
 	return errs
 }
 
+// AbortPendingOperations releases processes stuck in FUSE calls even after
+// SIGKILL. Callers must first ensure no running container still uses this mount.
+func (s *GeeseStorage) AbortPendingOperations(localPath string) error {
+	return abortFuseConnection(localPath)
+}
+
 func abortFuseConnection(localPath string) error {
 	mountInfo, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -287,10 +287,10 @@ func (s *Worker) stopObservedContainer(containerID string, request *types.Contai
 		if stillRunning || (runtimeAbsent && stopSignalErr != nil) {
 			instance.StopEscalationStarted.Store(false)
 			log.Warn().Str("container_id", containerID).Msg("container termination is not confirmed; allowing the next status heartbeat to retry")
-			runtimeStarted, _ := instance.runtimeStartState()
-			if !runtimeStarted {
-				s.scheduleStuckWorkspaceMountRecovery(instance, request, stuckContainerAbortDelay)
-			}
+			// A started runtime can remain alive after SIGKILL while a process
+			// waits for a wedged FUSE request. Recover that mount too; the
+			// recovery rechecks that every container sharing it is stopping.
+			s.scheduleStuckWorkspaceMountRecovery(instance, request, stuckContainerAbortDelay)
 			return
 		}
 	}

--- a/pkg/worker/stuck_mount_recovery_test.go
+++ b/pkg/worker/stuck_mount_recovery_test.go
@@ -1,0 +1,100 @@
+package worker
+
+import (
+	"context"
+	"path"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/runtime"
+	"github.com/beam-cloud/beta9/pkg/storage"
+	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+type abortableTrackedStorage struct {
+	trackedStorage
+	abortPath string
+	calls     []string
+}
+
+func (s *abortableTrackedStorage) AbortPendingOperations(localPath string) error {
+	s.abortPath = localPath
+	s.calls = append(s.calls, "abort")
+	return nil
+}
+
+func (s *abortableTrackedStorage) Unmount(localPath string) error {
+	s.calls = append(s.calls, "unmount")
+	return s.trackedStorage.Unmount(localPath)
+}
+
+func TestStartedRuntimeStuckAfterKillSchedulesWorkspaceRecovery(t *testing.T) {
+	for _, force := range []bool{false, true} {
+		name := "stopping"
+		if force {
+			name = "orphaned"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			request := &types.ContainerRequest{
+				ContainerId: "stuck-container",
+				Workspace:   types.Workspace{Name: "stuck-workspace"},
+			}
+			rt := &shutdownSignalRuntime{mockRuntime: mockRuntime{
+				state: func(context.Context, string) (runtime.State, error) {
+					// SIGKILL succeeds, but a blocked filesystem operation keeps
+					// the runtime alive until its workspace mount is recovered.
+					return runtime.State{Status: types.RuncContainerStatusRunning}, nil
+				},
+			}}
+			instance := &ContainerInstance{
+				Id: request.ContainerId, ExitCode: -1, StopReason: types.StopContainerReasonUser,
+				Request: request, Runtime: rt,
+			}
+			instance.markRuntimeStarted(1234)
+			instance.StopEscalationStarted.Store(true)
+			instances := common.NewSafeMap[*ContainerInstance]()
+			instances.Set(instance.Id, instance)
+			mount := &abortableTrackedStorage{trackedStorage: trackedStorage{mode: storage.StorageModeGeese}}
+			otherMount := &abortableTrackedStorage{trackedStorage: trackedStorage{mode: storage.StorageModeGeese}}
+			manager := &WorkspaceStorageManager{
+				mounts: common.NewSafeMap[storage.Storage](), mountLastUsed: common.NewSafeMap[time.Time](),
+				containerInstances: instances, mountLocks: make(map[string]*sync.RWMutex),
+				poolConfig: types.WorkerPoolConfig{StorageMode: storage.StorageModeGeese},
+				config:     types.StorageConfig{WorkspaceStorage: types.WorkspaceStorageConfig{BaseMountPath: t.TempDir()}},
+			}
+			manager.mounts.Set(request.Workspace.Name, mount)
+			manager.mounts.Set("other-workspace", otherMount)
+			worker := &Worker{ctx: ctx, containerInstances: instances, storageManager: manager}
+
+			worker.stopObservedContainer(instance.Id, request, types.EventSourceWorkerStatusHeartbeat, force)
+
+			require.False(t, instance.StopEscalationStarted.Load(), "runtime stop must remain retryable")
+			require.True(t, instance.StuckMountRecoveryStarted.Load(), "a started runtime blocked after SIGKILL needs mount recovery")
+			expected := []syscall.Signal{syscall.SIGKILL}
+			if !force {
+				expected = append([]syscall.Signal{syscall.SIGTERM}, expected...)
+			}
+			require.Equal(t, expected, rt.recordedSignals())
+
+			// A new container can arrive before the recovery timer fires. The
+			// callback must recheck the shared workspace before unmounting it.
+			instances.Set("sibling", &ContainerInstance{ExitCode: -1, Request: request})
+			worker.abortStuckWorkspaceMount(request)
+			require.False(t, mount.unmounted, "a running sibling must keep its mount")
+			require.Empty(t, mount.calls, "a running sibling must protect pending operations too")
+			instances.Delete("sibling")
+			worker.abortStuckWorkspaceMount(request)
+			require.True(t, mount.unmounted, "a workspace with only stopping containers can recover")
+			require.Equal(t, []string{"abort", "unmount"}, mount.calls)
+			require.Equal(t, path.Join(manager.config.WorkspaceStorage.BaseMountPath, request.Workspace.Name), mount.abortPath)
+			require.False(t, otherMount.unmounted, "recovery must not touch another workspace")
+			require.Empty(t, otherMount.calls)
+		})
+	}
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -10,6 +10,7 @@ import (
 	_ "net/http/pprof" // Import for side effects
 	"os"
 	"os/signal"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -1351,6 +1352,16 @@ func (s *Worker) abortStuckWorkspaceMount(request *types.ContainerRequest) {
 	}
 
 	log.Warn().Str("container_id", request.ContainerId).Str("workspace", workspaceName).Msg("aborting stuck workspace mount after SIGKILL timeout")
+	if mount, ok := s.storageManager.mounts.Get(workspaceName); ok {
+		if aborter, ok := mount.(interface{ AbortPendingOperations(string) error }); ok {
+			// A lazy unmount alone does not release in-flight FUSE requests.
+			// Abort while holding the workspace lock, before detaching the mount.
+			localPath := path.Join(s.storageManager.config.WorkspaceStorage.BaseMountPath, workspaceName)
+			if err := aborter.AbortPendingOperations(localPath); err != nil {
+				log.Warn().Err(err).Str("workspace", workspaceName).Msg("failed to abort stuck workspace filesystem operations")
+			}
+		}
+	}
 	if err := s.storageManager.unmountLocked(workspaceName); err != nil {
 		log.Warn().Err(err).Str("workspace", workspaceName).Msg("stuck workspace mount recovery completed with errors")
 	}


### PR DESCRIPTION
A started container blocked in a FUSE request can survive SIGKILL while its worker continues emitting usage. The forced-stop retry path previously skipped mount recovery once the runtime had started, leaving the container stuck indefinitely even after its control-plane state disappeared.

Schedule the existing delayed recovery for unconfirmed forced stops, and explicitly abort the affected GeeseFS connection before unmounting. A lazy unmount alone does not release an in-flight FUSE request. The recovery retains the per-workspace lock and rechecks that every container sharing the mount is stopping, so a running sibling protects the mount.

Validation:

- The new regression fails on the original lifecycle code for both graceful-stop escalation and orphaned-container force-stop.
- An isolated Linux pod in staging passed 52 stop, heartbeat, and workspace-storage regression tests, including abort-before-unmount ordering and protection of same-workspace and other-workspace containers.
- A private FUSE mount in staging reproduced a real process in uninterruptible SETATTR after SIGKILL. Using the worker's production two-minute timer and FUSE-abort implementation, recovery released the process in 2m0.004s while the neighboring workspace remained mounted. The fixture used adapters for runtime status/signals and mount detachment; it did not run a customer workload.
- `git diff --check` and all repository CI jobs passed: Go package tests, Python SDK lint/tests, and protobuf generation verification ([run](https://github.com/beam-cloud/beta9/actions/runs/34182748531)).
