### PR TITLE
Recover volume fsync after lost multipart uploads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -317,7 +317,7 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
-replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260907234040-91217aec652c
+replace github.com/yandex-cloud/geesefs => github.com/beam-cloud/geesefs v0.0.0-20260908033220-4484605feb60
 
 replace github.com/aws/aws-sdk-go => github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f
 

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20240319100328-84253e514e02/go.mod h1:k08r
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec h1:zcr7+ud507kcRJBHotXr4hcUzEoqfPEgjtcMW6eCZwo=
 github.com/beam-cloud/clip v0.0.0-20260907023706-9420edd6f9ec/go.mod h1:uymwDNMk1qoxElmDSlPzwYqZDriHDnW5VVyfK3YNuz8=
-github.com/beam-cloud/geesefs v0.0.0-20260907234040-91217aec652c h1:UVEqAacpxJFQjZP7xuZeR5eW84BrhmhlYCUqrnT9jyY=
-github.com/beam-cloud/geesefs v0.0.0-20260907234040-91217aec652c/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
+github.com/beam-cloud/geesefs v0.0.0-20260908033220-4484605feb60 h1:fX/Z5XOjVKYsWJO/FIOyCdWgg038BNHEpvp6lsiH49g=
+github.com/beam-cloud/geesefs v0.0.0-20260908033220-4484605feb60/go.mod h1:q0qGsu0wiOzf/5m9JGLqZ7WteYDaaLGgBwNmstb3og0=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f h1:XzHOu+erxeBO6D3fKVbd5DAlipl+PYZ3u+Ywb8m7Ovk=
 github.com/beam-cloud/geesefs/s3ext v0.0.0-20250606164905-2f3593d03f4f/go.mod h1:YT41ScwaZw9hYfM0WbYZ64sQLNhPxWZFOXJOPug7O5M=
 github.com/beam-cloud/go-runc v0.0.0-20250911154456-bb45084abfe1 h1:EUB/gApGrZW0SzPdyk0jQILJk4Q8wUsWevTHGMkWU58=


### PR DESCRIPTION
Update geesefs to recover staged-volume fsync after the object store loses a multipart upload ID. The dependency change restarts the upload from retained staged bytes with bounded retries, preserves generation checks and fsync errors, and removes the unused buffered staged flusher (net 88 fewer lines including regression coverage).

Dependency change: https://github.com/beam-cloud/geesefs/pull/22

Validation: staging worker 0.1.748 reproduced both injected fsync ENOENT failures (1 GiB rename-before-fsync and 3 GiB direct write). The candidate passed 10/10 writes totaling 18 GiB, including four test-owned multipart-upload aborts across three fault cases. Every write passed full SHA-256 verification from a pre-mounted volume on another physical node, range/EOF checks, and a direct object-store GET. Worker logs showed four expected restarts, zero FUSE SyncFileOp errors, and zero failed staged flushes. Temporary volumes and sandboxes were cleaned up. The staging workspace uses Wasabi; the original production errors came from Tigris.

Beta9 Go lint/tests, SDK checks, protobuf verification, and automated review passed on head 44033263, including the already-merged worker shutdown fix from #1884. The candidate image was built at 9e12b969 before that independent main update. Published worker 0.1.750 passed the same 10/10 end-to-end staging cases, including all four injected upload losses and full cross-node/origin checksums. Staging workers/cache and both gateway configs are fully rolled and verified. Production remains unchanged. Release: https://github.com/beam-cloud/beta9/releases/tag/worker-0.1.750
