### PR TITLE
Restore build progress colors and image loading timing

### DIFF
--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -941,19 +941,24 @@ func requiresPostBuildImageMaterialization(request *types.ContainerRequest, clip
 
 func (s *Worker) pullLazyWithMetrics(ctx context.Context, request *types.ContainerRequest, phase string, outputLogger *slog.Logger) (time.Duration, error) {
 	phaseStart := time.Now()
-	outputLogger.Info("Loading image metadata...\n")
-	stopHeartbeat := startSilentOutputHeartbeat(ctx, outputLogger, phaseStart, newActiveOutputWriter(outputLogger), "Loading image metadata...")
+	message := fmt.Sprintf("Loading image <%s>", request.ImageId)
+	// Fast runtime starts stay quiet; builds and slow loads retain progress.
+	if request.IsBuildRequest() {
+		outputLogger.Info(message + "...\n")
+	}
+	stopHeartbeat := startSilentOutputHeartbeat(ctx, outputLogger, phaseStart, newActiveOutputWriter(outputLogger), message)
 	elapsed, err := s.imageClient.PullLazy(ctx, request)
 	stopHeartbeat()
-	if err == nil {
-		outputLogger.Info("Image metadata loaded\n")
+	duration := time.Since(phaseStart)
+	if err == nil && (request.IsBuildRequest() || duration >= buildOutputHeartbeatInterval) {
+		outputLogger.Info(fmt.Sprintf("Loaded image <%s> in %s\n", request.ImageId, duration.Round(time.Millisecond)))
 	}
-	metrics.RecordWorkerStartupPhase(phase, time.Since(phaseStart), request, map[string]string{"success": fmt.Sprintf("%t", err == nil)})
+	metrics.RecordWorkerStartupPhase(phase, duration, request, map[string]string{"success": fmt.Sprintf("%t", err == nil)})
 	spanID := types.ContainerLifecycleImageLoad
 	if phase != "pull_lazy" && phase != "pull_lazy_after_build" {
 		spanID = types.ContainerLifecycleID("image." + phase)
 	}
-	s.recordContainerLifecycle(ctx, request, containerLifecycleFromDuration(spanID, request, phaseStart, time.Since(phaseStart), err == nil, map[string]string{
+	s.recordContainerLifecycle(ctx, request, containerLifecycleFromDuration(spanID, request, phaseStart, duration, err == nil, map[string]string{
 		types.EventAttrLifecycle: phase,
 		"image_id":               request.ImageId,
 		"elapsed_raw":            elapsed.String(),

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -617,7 +617,7 @@ class Image(BaseAbstraction):
 
         cache_key = self._cache_key()
         if cached_result := self._cached_build_result(cache_key):
-            terminal.detail(f"Using cached image {cached_result.image_id}", dim=False)
+            terminal.header("Using cached image", cached_result.image_id)
             self.image_id = cached_result.image_id
             self.python_version = cached_result.python_version
             return cached_result
@@ -625,7 +625,7 @@ class Image(BaseAbstraction):
         terminal.detail("Checking image cache...", dim=False)
         exists, exists_response = self._exists()
         if exists:
-            terminal.detail(f"Using cached image {exists_response.image_id}", dim=False)
+            terminal.header("Using cached image", exists_response.image_id)
             result = ImageBuildResult(
                 success=True,
                 image_id=exists_response.image_id,
@@ -640,6 +640,7 @@ class Image(BaseAbstraction):
             )
 
         with sdk_timing("image.build_stream"):
+            terminal.header("Building image")
             with terminal.progress("Building image"):
                 last_response = BuildImageResponse(success=False)
                 output = ""
@@ -674,7 +675,6 @@ class Image(BaseAbstraction):
                 success=False, error=output.rstrip() or "Build ended without a result"
             )
 
-        terminal.header("Image built")
         result = ImageBuildResult(
             success=True,
             image_id=last_response.image_id,

--- a/sdk/src/beta9/terminal.py
+++ b/sdk/src/beta9/terminal.py
@@ -4,7 +4,6 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
-from contextvars import ContextVar
 from dataclasses import dataclass
 from io import BytesIO
 from os import PathLike
@@ -48,14 +47,10 @@ _error_console = Console(stderr=True)
 _current_status = None
 _status_lock = threading.Lock()
 _status_count = 0
-_step_depth = ContextVar("beta9_step_depth", default=0)
 
 
 def header(text: str, subtext: str = "") -> None:
-    if _step_depth.get():
-        debug(text)
-        return
-    line = Text("◆ ", style=BRAND_COLOR).append(text, style="bold")
+    line = Text(f"◆ {text}", style=f"bold {BRAND_COLOR}")
     if subtext:
         line.append(f"  {subtext}", style="dim")
     _console.print(line)
@@ -138,7 +133,11 @@ def progress(task_name: str) -> Generator[rich.status.Status, None, None]:
 
     with _status_lock:
         if _current_status is None:
-            _current_status = _console.status(task_name, spinner="dots", spinner_style="white")
+            _current_status = _console.status(
+                Text(task_name, style=f"bold {BRAND_COLOR}"),
+                spinner="dots",
+                spinner_style=BRAND_COLOR,
+            )
             if not _console.is_terminal or _console.is_dumb_terminal:
                 _console.print(Text(f"{task_name}...", style="dim"))
             _current_status.start()
@@ -158,7 +157,7 @@ def update_progress(text: str) -> None:
     """Update the text of the currently active progress spinner, if any."""
     with _status_lock:
         if _current_status is not None:
-            _current_status.update(text)
+            _current_status.update(Text(text, style=f"bold {BRAND_COLOR}"))
 
 
 def progress_open(file: Union[str, PathLike, bytes], mode: str, **kwargs: Any) -> BytesIO:
@@ -497,7 +496,7 @@ class Step:
 
 
 class StepTracker:
-    """One transient status and one timed result per step; nested headings are diagnostic."""
+    """One transient status and one timed result per step."""
 
     def __init__(self, title: str = ""):
         self._started_at = time.monotonic()
@@ -508,7 +507,6 @@ class StepTracker:
     def step(self, name: str, done_name: str = ""):
         start = time.monotonic()
         handle = Step()
-        token = _step_depth.set(_step_depth.get() + 1)
         try:
             with progress(name):
                 yield handle
@@ -516,7 +514,6 @@ class StepTracker:
             handle.ok = False
             raise
         finally:
-            _step_depth.reset(token)
             self._finish(name, done_name, start, ok=handle.ok)
 
     def _finish(self, name: str, done_name: str, start: float, ok: bool) -> None:


### PR DESCRIPTION
The progress wrapper hid colored image-build headings, and every container start printed untimed image-metadata messages. Restore cyan headings and progress, retain the timed build result, and remove the duplicate completion heading. Builds show image-loading progress and elapsed completion; ordinary fast function starts stay quiet, while slow loads retain elapsed heartbeats.

Validated against a patched worker in local k3d using real terminal captures: fresh and cached images, function calls and map, preserved application ANSI colors, and live stdout/stderr. Both CLIs passed successful and failed builds, plain output, and JSON output; a silent build retained elapsed heartbeats, and JSON stayed valid while all 500 stdout and 500 stderr records streamed to stderr. Failed builds returned exit 1 with the remote error. Existing SDK checks passed (39 tests), along with targeted worker tests and formatting/lint checks.
