### PR TITLE
Fix prepared sandbox cache persistence

### DIFF
--- a/pkg/abstractions/pod/pod.go
+++ b/pkg/abstractions/pod/pod.go
@@ -733,18 +733,47 @@ func (s *GenericPodService) CreatePod(ctx context.Context, in *pb.CreatePodReque
 
 func (s *GenericPodService) preparedStubID(ctx context.Context, workspaceID string) string {
 	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok || s.rdb == nil {
+	if !ok {
 		return ""
 	}
 	cacheKeys := md.Get(common.PreparedStubCacheMetadata)
-	if len(cacheKeys) == 0 {
+	if len(cacheKeys) == 0 || cacheKeys[0] == "" {
 		return ""
 	}
-	stubID, _ := s.rdb.GetEx(
-		ctx,
-		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKeys[0]),
-		common.PreparedStubCacheTTL,
-	).Result()
+	cacheKey := cacheKeys[0]
+
+	if s.rdb != nil {
+		stubID, _ := s.rdb.GetEx(
+			ctx,
+			common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKey),
+			common.PreparedStubCacheTTL,
+		).Result()
+		if stubID != "" {
+			return stubID
+		}
+	}
+
+	if s.backendRepo == nil {
+		return ""
+	}
+	stubs, err := s.backendRepo.ListStubs(ctx, types.StubFilter{
+		WorkspaceID:         workspaceID,
+		StubTypes:           types.StringSlice{string(types.StubTypeSandbox)},
+		PreparationCacheKey: cacheKey,
+	})
+	if err != nil || len(stubs) == 0 {
+		return ""
+	}
+
+	stubID := stubs[0].ExternalId
+	if s.rdb != nil {
+		_ = s.rdb.SetEx(
+			ctx,
+			common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKey),
+			stubID,
+			common.PreparedStubCacheTTL,
+		).Err()
+	}
 	return stubID
 }
 

--- a/pkg/abstractions/pod/sandbox_test.go
+++ b/pkg/abstractions/pod/sandbox_test.go
@@ -45,6 +45,52 @@ func TestPreparedStubID(t *testing.T) {
 	}
 }
 
+type preparedStubBackendRepository struct {
+	repository.BackendRepository
+	stubs   []types.StubWithRelated
+	filters types.StubFilter
+}
+
+func (r *preparedStubBackendRepository) ListStubs(_ context.Context, filters types.StubFilter) ([]types.StubWithRelated, error) {
+	r.filters = filters
+	return r.stubs, nil
+}
+
+func TestPreparedStubIDFallsBackToPersistentStub(t *testing.T) {
+	rdb, err := repository.NewRedisClientForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	repo := &preparedStubBackendRepository{
+		stubs: []types.StubWithRelated{{Stub: types.Stub{ExternalId: "stub-persistent"}}},
+	}
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs(common.PreparedStubCacheMetadata, "cache-key"),
+	)
+
+	got := (&GenericPodService{rdb: rdb, backendRepo: repo}).preparedStubID(ctx, "workspace-1")
+	if got != "stub-persistent" {
+		t.Fatalf("preparedStubID() = %q, want stub-persistent", got)
+	}
+	if repo.filters.WorkspaceID != "workspace-1" || repo.filters.PreparationCacheKey != "cache-key" {
+		t.Fatalf("ListStubs filters = %#v", repo.filters)
+	}
+	if len(repo.filters.StubTypes) != 1 || repo.filters.StubTypes[0] != string(types.StubTypeSandbox) {
+		t.Fatalf("ListStubs stub types = %#v, want sandbox", repo.filters.StubTypes)
+	}
+
+	stubID, err := rdb.Get(
+		context.Background(),
+		common.RedisKeys.GatewayPreparedStub("workspace-1", "cache-key"),
+	).Result()
+	if err != nil || stubID != "stub-persistent" {
+		t.Fatalf("repopulated prepared stub = %q, %v", stubID, err)
+	}
+}
+
 func TestSandboxConnectErrorMessageDoesNotLeakDetails(t *testing.T) {
 	got := sandboxConnectErrorMessage(errors.New("container state not found: sandbox-123 on worker 10.0.0.12"))
 	if got != "Failed to connect to sandbox" {

--- a/pkg/gateway/services/stub.go
+++ b/pkg/gateway/services/stub.go
@@ -163,6 +163,7 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 		Disks:              in.Disks,
 		ManagedEndpoint:    managedEndpoint,
 	}
+	stubConfig.PreparationCacheKey = preparedStubCacheKey(ctx)
 
 	// A persistent root is shorthand for a qcow machine-root disk: the
 	// container's overlay upper layer lives on the volume, so disk snapshots
@@ -386,20 +387,31 @@ func (gws *GatewayService) GetOrCreateStub(ctx context.Context, in *pb.GetOrCrea
 }
 
 func (gws *GatewayService) cachePreparedStub(ctx context.Context, workspaceID, stubID string) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok || gws.redisClient == nil {
+	if gws.redisClient == nil {
 		return
 	}
-	cacheKeys := md.Get(common.PreparedStubCacheMetadata)
-	if len(cacheKeys) == 0 || cacheKeys[0] == "" {
+	cacheKey := preparedStubCacheKey(ctx)
+	if cacheKey == "" {
 		return
 	}
 	_ = gws.redisClient.SetEx(
 		ctx,
-		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKeys[0]),
+		common.RedisKeys.GatewayPreparedStub(workspaceID, cacheKey),
 		stubID,
 		common.PreparedStubCacheTTL,
 	).Err()
+}
+
+func preparedStubCacheKey(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	cacheKeys := md.Get(common.PreparedStubCacheMetadata)
+	if len(cacheKeys) == 0 {
+		return ""
+	}
+	return cacheKeys[0]
 }
 
 type stubCapacityVerdict struct {

--- a/pkg/gateway/services/stub_test.go
+++ b/pkg/gateway/services/stub_test.go
@@ -62,6 +62,15 @@ func TestCachePreparedStub(t *testing.T) {
 	require.Equal(t, "stub-1", stubID)
 }
 
+func TestPreparedStubCacheKey(t *testing.T) {
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs(common.PreparedStubCacheMetadata, "cache-key"),
+	)
+	require.Equal(t, "cache-key", preparedStubCacheKey(ctx))
+	require.Empty(t, preparedStubCacheKey(context.Background()))
+}
+
 func TestGetOrCreateStubReportsMissingSecret(t *testing.T) {
 	service := &GatewayService{
 		appConfig:   types.AppConfig{GatewayService: types.GatewayServiceConfig{StubLimits: types.StubLimits{Cpu: 2, Memory: 2}}},

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -1790,6 +1790,13 @@ func (c *PostgresBackendRepository) listStubsQueryBuilder(filters types.StubFilt
 		qb = qb.Where(squirrel.Eq{"s.type": filters.StubTypes})
 	}
 
+	if filters.PreparationCacheKey != "" {
+		qb = qb.
+			Where("s.config->>'preparation_cache_key' = ?", filters.PreparationCacheKey).
+			OrderBy("s.updated_at DESC", "s.id DESC").
+			Limit(1)
+	}
+
 	if filters.AppId != "" {
 		qb = qb.Where(squirrel.Eq{"a.external_id": filters.AppId})
 		qb = qb.Where("a.deleted_at IS NULL")

--- a/pkg/repository/backend_postgres_migrations/052_add_prepared_stub_cache_index.go
+++ b/pkg/repository/backend_postgres_migrations/052_add_prepared_stub_cache_index.go
@@ -1,0 +1,26 @@
+package backend_postgres_migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(upAddPreparedStubCacheIndex, downAddPreparedStubCacheIndex)
+}
+
+func upAddPreparedStubCacheIndex(ctx context.Context, db *sql.DB) error {
+	return createIndexConcurrently(
+		ctx,
+		db,
+		"idx_stub_preparation_cache_key",
+		"ON stub (workspace_id, type, (config->>'preparation_cache_key'), updated_at DESC, id DESC) WHERE config->>'preparation_cache_key' IS NOT NULL",
+	)
+}
+
+func downAddPreparedStubCacheIndex(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS idx_stub_preparation_cache_key")
+	return err
+}

--- a/pkg/repository/backend_postgres_test.go
+++ b/pkg/repository/backend_postgres_test.go
@@ -30,6 +30,16 @@ func TestGenerateDSNSSLMode(t *testing.T) {
 	})
 }
 
+func TestListStubsQueryBuilderFiltersPreparationCacheKey(t *testing.T) {
+	query, args, err := (&PostgresBackendRepository{}).listStubsQueryBuilder(types.StubFilter{
+		PreparationCacheKey: "cache-key",
+	}).ToSql()
+	require.NoError(t, err)
+	require.Contains(t, query, "s.config->>'preparation_cache_key' = $1")
+	require.Contains(t, query, "ORDER BY s.updated_at DESC, s.id DESC LIMIT 1")
+	require.Equal(t, []interface{}{"cache-key"}, args)
+}
+
 func TestListTaskWithRelated(t *testing.T) {
 	// Remove this skip if you are testing on local data
 	t.Skip()

--- a/pkg/types/backend.go
+++ b/pkg/types/backend.go
@@ -561,6 +561,8 @@ type StubConfigV1 struct {
 	// ManagedEndpoint carries the platform endpoint/service spec for
 	// managed_endpoint/* and managed_service/* stubs.
 	ManagedEndpoint *ManagedEndpointStubConfig `json:"managed_endpoint,omitempty"`
+
+	PreparationCacheKey string `json:"preparation_cache_key,omitempty"`
 }
 
 const (

--- a/pkg/types/filters.go
+++ b/pkg/types/filters.go
@@ -70,6 +70,8 @@ type StubFilter struct {
 	Pagination  bool        `query:"pagination"`
 	AppId       string      `query:"app_id"`
 	Limit       uint32      `query:"limit"`
+
+	PreparationCacheKey string `query:"-"`
 }
 
 // AppState is how an app reads in the dashboard. It is derived, not stored:


### PR DESCRIPTION
## Summary
- persist the SDK preparation cache key with sandbox stub configuration
- fall back to an indexed workspace-scoped stub lookup after the Redis entry expires
- repopulate Redis after a persistent-cache hit

This keeps the existing Redis fast path and avoids provider-specific preparation in the benchmark harness.

## Validation
- go test ./pkg/...
- go test ./pkg/repository/backend_postgres_migrations ./pkg/gateway/services ./pkg/abstractions/pod ./pkg/repository
- git diff --check

No production resources were changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prepared sandbox cache persistence so expired Redis entries no longer break sandbox stub lookups. The preparation cache key is now stored with the stub config, and lookups fall back to the database when Redis misses.

- Persists the cache key on `StubConfigV1` when the stub is created.
- Adds a Postgres index for the fallback lookup by workspace, stub type, and cache key.
- Repopulates Redis from a database hit to keep the fast path.

<sup>Written for commit 5120776f3f54e9ce2c0388c6ae16651f11d61bdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

