### PR TITLE
migrations: strip \u0000 escapes from stub.config before indexing preparation_cache_key

### DIFF
--- a/pkg/repository/backend_postgres_migrations/052_add_prepared_stub_cache_index.go
+++ b/pkg/repository/backend_postgres_migrations/052_add_prepared_stub_cache_index.go
@@ -1,8 +1,12 @@
 package backend_postgres_migrations
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/pressly/goose/v3"
 )
@@ -12,12 +16,82 @@ func init() {
 }
 
 func upAddPreparedStubCacheIndex(ctx context.Context, db *sql.DB) error {
+	if err := stripStubConfigNulls(ctx, db); err != nil {
+		return err
+	}
 	return createIndexConcurrently(
 		ctx,
 		db,
 		"idx_stub_preparation_cache_key",
 		"ON stub (workspace_id, type, (config->>'preparation_cache_key'), updated_at DESC, id DESC) WHERE config->>'preparation_cache_key' IS NOT NULL",
 	)
+}
+
+// stub.config is json, so Postgres re-parses it on every ->> and rejects any
+// \u0000 escape the application happily stored. The index build evaluates the
+// expression over every row, so rewrite those configs without the NULs first.
+func stripStubConfigNulls(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, `SELECT id, config::text FROM stub WHERE position('\u0000' in config::text) > 0`)
+	if err != nil {
+		return fmt.Errorf("find stub configs with NUL escapes: %w", err)
+	}
+	defer rows.Close()
+
+	cleaned := map[uint][]byte{}
+	for rows.Next() {
+		var id uint
+		var raw string
+		if err := rows.Scan(&id, &raw); err != nil {
+			return err
+		}
+		config, err := withoutNulls(raw)
+		if err != nil {
+			return fmt.Errorf("rewrite stub %d config: %w", id, err)
+		}
+		cleaned[id] = config
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for id, config := range cleaned {
+		if _, err := db.ExecContext(ctx, `UPDATE stub SET config = $1 WHERE id = $2`, config, id); err != nil {
+			return fmt.Errorf("update stub %d config: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func withoutNulls(raw string) ([]byte, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	encoder := json.NewEncoder(&out)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(stripNulls(value)); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(out.Bytes()), nil
+}
+
+func stripNulls(value any) any {
+	switch v := value.(type) {
+	case string:
+		return strings.ReplaceAll(v, "\x00", "")
+	case []any:
+		for i := range v {
+			v[i] = stripNulls(v[i])
+		}
+	case map[string]any:
+		for k, e := range v {
+			v[k] = stripNulls(e)
+		}
+	}
+	return value
 }
 
 func downAddPreparedStubCacheIndex(ctx context.Context, db *sql.DB) error {


### PR DESCRIPTION
## Why

Production gateway 0.1.774 crash-looped at startup:

```
ERROR go migration no tx: "052_add_prepared_stub_cache_index.go": create index idx_stub_preparation_cache_key: pq: unsupported Unicode escape sequence
```

`stub.config` is `json` (not `jsonb`), so `config->>'preparation_cache_key'` re-parses the stored text on every evaluation. Postgres refuses `\u0000` escapes in that path, while the application (Go `encoding/json`) stores them happily. Three `pod/run` stubs in prod had a shell command containing `\u0000`; building the expression index evaluates every row, so the whole migration failed.

Prod was unblocked by rewriting those three rows by hand (backup in `stub_config_backup_20260911`). This makes the migration do that itself so staging/self-hosted/other databases with the same rows don't hit it.

## What

`052` now selects configs whose text contains `\u0000`, decodes them (`UseNumber` so large ints survive), strips NUL characters from every string value, re-encodes, and updates the row before calling `createIndexConcurrently`. Escaped-backslash sequences (`\\u0000`) are untouched because they decode to a literal `\u0000` text, not a NUL.

## Verification

Against a local `postgres:16-alpine` with a `stub` table containing a `\u0000` row: the raw `CREATE INDEX` reproduces `pq: unsupported Unicode escape sequence`; `upAddPreparedStubCacheIndex` rewrites the row, builds a valid index, is a no-op on rerun, and `down` drops it.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `052` migration so gateway startup no longer crash-loops when `stub.config` rows contain `\u0000` Unicode escapes, which Postgres rejects when evaluating the `preparation_cache_key` index expression. The migration now rewrites affected configs (removing NUL characters from all string values) before creating the index concurrently.

**Notes**

- Only rows whose `config` text contains `\u0000` are rewritten; all other rows are untouched.
- The decode step uses `UseNumber` so large integers survive re-encoding unchanged.
- Escaped-backslash sequences like `\\u0000` are left alone because they decode to literal text, not a NUL.
- The migration is still idempotent on rerun, and the down migration is unchanged.

<sup>Written for commit 3a98eea039826f85184fede4607f39dbf9420c76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

