### PR TITLE
worker: fail a lazy OCI mount whose registry refuses the image

### DIFF
--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -33,6 +33,10 @@ import (
 	"github.com/beam-cloud/clip/pkg/clip"
 	clipCommon "github.com/beam-cloud/clip/pkg/common"
 	clipStorage "github.com/beam-cloud/clip/pkg/storage"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/opencontainers/umoci"
 	"github.com/opencontainers/umoci/oci/cas/dir"
@@ -311,6 +315,9 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 
 	mountOptions := c.lazyMountOptions(ctx, request, archive)
 	if archive.usesOCIStorage() {
+		if err := c.verifyImageSource(ctx, mountOptions); err != nil {
+			return time.Since(startTime), err
+		}
 		c.scheduleImageLayerPrepare(context.WithoutCancel(ctx), request, mountOptions)
 	}
 
@@ -364,11 +371,7 @@ func (c *ImageClient) scheduleImageLayerPrepare(ctx context.Context, request *ty
 	if !ok {
 		return
 	}
-	localComplete := func(string) bool { return false }
-	if c.cacheClient != nil {
-		localComplete = c.cacheClient.LocalContentComplete
-	}
-	remaining := layersToPrepare(ociInfo, localComplete)
+	remaining := c.remoteLayers(ociInfo, options.CachePath)
 	if len(remaining) == 0 {
 		return
 	}
@@ -384,7 +387,52 @@ func (c *ImageClient) scheduleImageLayerPrepare(ctx context.Context, request *ty
 	})
 }
 
-// layersToPrepare returns the layers not fully present in a local page store.
+// remoteLayers returns the layers this node holds neither as a file in the
+// layer cache nor completely in a local page store.
+func (c *ImageClient) remoteLayers(info *clipCommon.OCIStorageInfo, cachePath string) []string {
+	return layersToPrepare(info, func(hash string) bool {
+		if _, err := os.Stat(filepath.Join(cachePath, hash)); err == nil {
+			return true
+		}
+		return c.cacheClient != nil && c.cacheClient.LocalContentComplete(hash)
+	})
+}
+
+// verifyImageSource refuses a lazy mount whose registry refuses the image. A
+// dead credential then fails the container start with the registry's answer
+// instead of surfacing as EIO on a read the runtime cannot survive. Layers the
+// node already holds need no registry; other registry failures stay lazy.
+func (c *ImageClient) verifyImageSource(ctx context.Context, options clip.MountOptions) error {
+	info, ok := ociStorageInfo(options.Metadata)
+	if !ok || len(c.remoteLayers(info, options.CachePath)) == 0 {
+		return nil
+	}
+	ref, err := name.ParseReference(ociImageReference(info))
+	if err != nil {
+		return err
+	}
+	remoteOpts := []remote.Option{remote.WithContext(ctx)}
+	if provider, ok := options.RegistryCredProvider.(clipCommon.RegistryCredentialProvider); ok {
+		if auth, err := provider.GetCredentials(ctx, info.RegistryURL, info.Repository); err == nil && auth != nil {
+			remoteOpts = append(remoteOpts, remote.WithAuth(authn.FromConfig(*auth)))
+		}
+	}
+	_, err = remote.Head(ref, remoteOpts...)
+	var terr *transport.Error
+	if errors.As(err, &terr) && (terr.StatusCode == http.StatusUnauthorized || terr.StatusCode == http.StatusForbidden || terr.StatusCode == http.StatusNotFound) {
+		return fmt.Errorf("image source %s: %w", ref, err)
+	}
+	return nil
+}
+
+func ociImageReference(info *clipCommon.OCIStorageInfo) string {
+	if strings.HasPrefix(info.Reference, "sha256:") {
+		return fmt.Sprintf("%s/%s@%s", info.RegistryURL, info.Repository, info.Reference)
+	}
+	return fmt.Sprintf("%s/%s:%s", info.RegistryURL, info.Repository, info.Reference)
+}
+
+// layersToPrepare returns the layers localComplete does not vouch for.
 func layersToPrepare(info *clipCommon.OCIStorageInfo, localComplete func(hash string) bool) []string {
 	remaining := make([]string, 0, len(info.Layers))
 	for _, layer := range info.Layers {

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -389,59 +389,43 @@ func (c *ImageClient) scheduleImageLayerPrepare(ctx context.Context, request *ty
 
 // remoteLayers returns the layers this node holds neither as a file in the
 // layer cache nor completely in a local page store.
-func (c *ImageClient) remoteLayers(info *clipCommon.OCIStorageInfo, cachePath string) []string {
-	return layersToPrepare(info, func(hash string) bool {
-		if _, err := os.Stat(filepath.Join(cachePath, hash)); err == nil {
-			return true
+func (c *ImageClient) remoteLayers(info *clipCommon.OCIStorageInfo, cachePath string) (remaining []string) {
+	for _, layer := range info.Layers {
+		hash := info.DecompressedHashByLayer[layer]
+		_, err := os.Stat(filepath.Join(cachePath, hash))
+		if hash == "" || err != nil && !(c.cacheClient != nil && c.cacheClient.LocalContentComplete(hash)) {
+			remaining = append(remaining, layer)
 		}
-		return c.cacheClient != nil && c.cacheClient.LocalContentComplete(hash)
-	})
+	}
+	return remaining
 }
 
-// verifyImageSource refuses a lazy mount whose registry refuses the image. A
-// dead credential then fails the container start with the registry's answer
-// instead of surfacing as EIO on a read the runtime cannot survive. Layers the
-// node already holds need no registry; other registry failures stay lazy.
+// verifyImageSource fails a lazy mount whose registry refuses the image, so a dead
+// credential surfaces at container start instead of as an EIO the runtime cannot
+// survive. Layers the node already holds need no registry; other failures stay lazy.
 func (c *ImageClient) verifyImageSource(ctx context.Context, options clip.MountOptions) error {
 	info, ok := ociStorageInfo(options.Metadata)
 	if !ok || len(c.remoteLayers(info, options.CachePath)) == 0 {
 		return nil
 	}
-	ref, err := name.ParseReference(ociImageReference(info))
+	ref, err := name.ParseReference(strings.Replace(info.RegistryURL+"/"+info.Repository+":"+info.Reference, ":sha256:", "@sha256:", 1))
 	if err != nil {
 		return err
 	}
-	remoteOpts := []remote.Option{remote.WithContext(ctx)}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	opts := []remote.Option{remote.WithContext(ctx)}
 	if provider, ok := options.RegistryCredProvider.(clipCommon.RegistryCredentialProvider); ok {
 		if auth, err := provider.GetCredentials(ctx, info.RegistryURL, info.Repository); err == nil && auth != nil {
-			remoteOpts = append(remoteOpts, remote.WithAuth(authn.FromConfig(*auth)))
+			opts = append(opts, remote.WithAuth(authn.FromConfig(*auth)))
 		}
 	}
-	_, err = remote.Head(ref, remoteOpts...)
+	_, err = remote.Head(ref, opts...)
 	var terr *transport.Error
 	if errors.As(err, &terr) && (terr.StatusCode == http.StatusUnauthorized || terr.StatusCode == http.StatusForbidden || terr.StatusCode == http.StatusNotFound) {
 		return fmt.Errorf("image source %s: %w", ref, err)
 	}
 	return nil
-}
-
-func ociImageReference(info *clipCommon.OCIStorageInfo) string {
-	if strings.HasPrefix(info.Reference, "sha256:") {
-		return fmt.Sprintf("%s/%s@%s", info.RegistryURL, info.Repository, info.Reference)
-	}
-	return fmt.Sprintf("%s/%s:%s", info.RegistryURL, info.Repository, info.Reference)
-}
-
-// layersToPrepare returns the layers localComplete does not vouch for.
-func layersToPrepare(info *clipCommon.OCIStorageInfo, localComplete func(hash string) bool) []string {
-	remaining := make([]string, 0, len(info.Layers))
-	for _, layer := range info.Layers {
-		if hash := info.DecompressedHashByLayer[layer]; hash != "" && localComplete(hash) {
-			continue
-		}
-		remaining = append(remaining, layer)
-	}
-	return remaining
 }
 
 // prepareImageLayers materializes every OCI layer of the archive into the

--- a/pkg/worker/image_test.go
+++ b/pkg/worker/image_test.go
@@ -417,8 +417,7 @@ func TestTerminateImageProcessGroupKillsDescendants(t *testing.T) {
 }
 
 func TestVerifyImageSourceFailsOnlyWhenRegistryRefusesRemoteLayers(t *testing.T) {
-	status := http.StatusOK
-	requests := 0
+	status, requests := http.StatusOK, 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		w.WriteHeader(status)
@@ -426,38 +425,30 @@ func TestVerifyImageSourceFailsOnlyWhenRegistryRefusesRemoteLayers(t *testing.T)
 	defer server.Close()
 
 	cachePath := t.TempDir()
-	options := func(layers map[string]string) clip.MountOptions {
-		info := &clipCommon.OCIStorageInfo{
-			RegistryURL:             server.Listener.Addr().String(),
-			Repository:              "org/app",
-			Reference:               "sha256:" + strings.Repeat("a", 64),
-			DecompressedHashByLayer: layers,
-		}
-		for layer := range layers {
-			info.Layers = append(info.Layers, layer)
-		}
-		return clip.MountOptions{CachePath: cachePath, Metadata: &clipCommon.ClipArchiveMetadata{StorageInfo: info}}
-	}
+	options := clip.MountOptions{CachePath: cachePath, Metadata: &clipCommon.ClipArchiveMetadata{StorageInfo: &clipCommon.OCIStorageInfo{
+		RegistryURL:             server.Listener.Addr().String(),
+		Repository:              "org/app",
+		Reference:               "sha256:" + strings.Repeat("a", 64),
+		Layers:                  []string{"sha256:1"},
+		DecompressedHashByLayer: map[string]string{"sha256:1": "hash-1"},
+	}}}
 	c := &ImageClient{}
-	remote := map[string]string{"sha256:1": "hash-1"}
 
 	for _, status = range []int{http.StatusOK, http.StatusInternalServerError} {
-		require.NoError(t, c.verifyImageSource(context.Background(), options(remote)), status)
+		require.NoError(t, c.verifyImageSource(context.Background(), options), status)
 	}
 	for _, status = range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
-		err := c.verifyImageSource(context.Background(), options(remote))
-		require.ErrorContains(t, err, "image source "+server.Listener.Addr().String()+"/org/app@sha256:", status)
+		require.ErrorContains(t, c.verifyImageSource(context.Background(), options), "image source "+server.Listener.Addr().String()+"/org/app@sha256:", status)
 	}
 
 	// A layer already in the layer cache needs no registry at all.
 	require.NoError(t, os.WriteFile(filepath.Join(cachePath, "hash-1"), nil, 0o644))
 	requests = 0
-	status = http.StatusForbidden
-	require.NoError(t, c.verifyImageSource(context.Background(), options(remote)))
+	require.NoError(t, c.verifyImageSource(context.Background(), options))
 	require.Zero(t, requests)
 }
 
-func TestLayersToPrepareSkipsLocallyCompleteLayers(t *testing.T) {
+func TestRemoteLayersSkipsLayersHeldLocally(t *testing.T) {
 	info := &clipCommon.OCIStorageInfo{
 		Layers: []string{"sha256:a", "sha256:b", "sha256:c"},
 		DecompressedHashByLayer: map[string]string{
@@ -465,10 +456,9 @@ func TestLayersToPrepareSkipsLocallyCompleteLayers(t *testing.T) {
 			"sha256:b": "hash-b",
 		},
 	}
-	local := map[string]bool{"hash-a": true}
+	cachePath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cachePath, "hash-a"), nil, 0o644))
 
-	remaining := layersToPrepare(info, func(hash string) bool { return local[hash] })
-
-	// b is not local; c has no decompressed hash so it can never be local.
-	require.Equal(t, []string{"sha256:b", "sha256:c"}, remaining)
+	// b is not on disk; c has no decompressed hash so it can never be local.
+	require.Equal(t, []string{"sha256:b", "sha256:c"}, (&ImageClient{}).remoteLayers(info, cachePath))
 }

--- a/pkg/worker/image_test.go
+++ b/pkg/worker/image_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -411,6 +414,47 @@ func TestTerminateImageProcessGroupKillsDescendants(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("process group did not exit after termination")
 	}
+}
+
+func TestVerifyImageSourceFailsOnlyWhenRegistryRefusesRemoteLayers(t *testing.T) {
+	status := http.StatusOK
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(status)
+	}))
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	options := func(layers map[string]string) clip.MountOptions {
+		info := &clipCommon.OCIStorageInfo{
+			RegistryURL:             server.Listener.Addr().String(),
+			Repository:              "org/app",
+			Reference:               "sha256:" + strings.Repeat("a", 64),
+			DecompressedHashByLayer: layers,
+		}
+		for layer := range layers {
+			info.Layers = append(info.Layers, layer)
+		}
+		return clip.MountOptions{CachePath: cachePath, Metadata: &clipCommon.ClipArchiveMetadata{StorageInfo: info}}
+	}
+	c := &ImageClient{}
+	remote := map[string]string{"sha256:1": "hash-1"}
+
+	for _, status = range []int{http.StatusOK, http.StatusInternalServerError} {
+		require.NoError(t, c.verifyImageSource(context.Background(), options(remote)), status)
+	}
+	for _, status = range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		err := c.verifyImageSource(context.Background(), options(remote))
+		require.ErrorContains(t, err, "image source "+server.Listener.Addr().String()+"/org/app@sha256:", status)
+	}
+
+	// A layer already in the layer cache needs no registry at all.
+	require.NoError(t, os.WriteFile(filepath.Join(cachePath, "hash-1"), nil, 0o644))
+	requests = 0
+	status = http.StatusForbidden
+	require.NoError(t, c.verifyImageSource(context.Background(), options(remote)))
+	require.Zero(t, requests)
 }
 
 func TestLayersToPrepareSkipsLocallyCompleteLayers(t *testing.T) {

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -921,6 +921,7 @@ func (s *Worker) loadContainerImage(ctx context.Context, request *types.Containe
 
 	if !request.IsBuildRequest() {
 		log.Error().Str("container_id", request.ContainerId).Msgf("failed to pull image: %v", err)
+		outputLogger.Error(fmt.Sprintf("Failed to load image <%s>: %v\n", request.ImageId, err))
 		return elapsed, false, err
 	}
 


### PR DESCRIPTION
A lazy mount never talks to the registry until the runtime's first read
of a layer the node does not hold, so a dead credential surfaced as EIO
from FUSE, which nvidia-container-cli's ldconfig turned into SIGBUS, one
container after another. Now, when any layer must come from the registry,
the worker HEADs the manifest with the vended credentials before mounting
and fails the container start on 401/403/404 with the registry's answer,
also written to the container log. Layers already in the layer cache or a
local page store need no registry; other registry errors stay lazy.

Verified: `go test ./pkg/worker/` passes; `remote.Head` against `ghcr.io/beam-cloud/vllm-harness` with an expired token yields the same `403 DENIED` transport error this catches (anonymous: `401 UNAUTHORIZED`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails a lazy OCI mount when the registry refuses the image, so a dead credential now fails the container start with the registry's answer instead of surfacing as EIO from FUSE, which nvidia-container-cli's ldconfig turned into SIGBUS.

**Details**
- When any layer must come from the registry, the worker HEADs the manifest with vended credentials before mounting.
- 401/403/404 responses fail the container start; the registry's answer is also written to the container log.
- Layers already in the layer cache or a local page store skip the registry check; other registry errors stay lazy.

<sup>Written for commit dfd0ef58dd0f9e8d336f94dca67006980cd88f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

