### PR TITLE
image: resolve registry credentials from workspace secrets

### DIFF
--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"sort"
 
 	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
@@ -119,21 +120,27 @@ func (is *ContainerImageService) BuildImage(in *pb.BuildImageRequest, stream pb.
 		return err
 	}
 
+	buildOptions := verifyResult.opts
+	if buildOptions == nil {
+		return errors.New("missing image build options")
+	}
+	buildOptions.ExistingImageCreds, err = is.resolveImageCreds(stream.Context(), in.ExistingImageCreds)
+	if err != nil {
+		return err
+	}
+
 	if verifyResult.exists {
+		// The runtime pulls an unmodified image with whatever this deploy
+		// supplied, so a rotated credential must replace the stored one.
+		if err := is.createCredentialSecretIfNeeded(stream.Context(), verifyResult.imageID, buildOptions); err != nil {
+			log.Error().Err(err).Msg("failed to refresh credential secret")
+		}
 		_ = stream.Send(&pb.BuildImageResponse{Msg: "Image already exists\n", Done: false, Success: true, ImageId: verifyResult.imageID})
 		_ = stream.Send(&pb.BuildImageResponse{Msg: "Build completed successfully\n", Done: true, Success: true, ImageId: verifyResult.imageID})
 		return nil
 	}
 
 	clipVersion := is.config.ImageService.ClipVersion
-
-	// Set ExistingImageCreds for credential processing
-	buildOptions := verifyResult.opts
-	if buildOptions == nil {
-		return errors.New("missing image build options")
-	}
-
-	buildOptions.ExistingImageCreds = in.ExistingImageCreds
 	buildOptions.ClipVersion = clipVersion
 
 	// Process credentials for custom base image (if provided)
@@ -234,6 +241,40 @@ func streamImageBuildOutput(ctx context.Context, outputChan <-chan common.Output
 			return lastMessage, ctx.Err()
 		}
 	}
+}
+
+// resolveImageCreds fills in registry credentials the client named without a
+// value from the workspace secrets of the same name, so a deploy does not have
+// to carry them in its environment.
+func (is *ContainerImageService) resolveImageCreds(ctx context.Context, creds map[string]string) (map[string]string, error) {
+	var missing []string
+	for name, value := range creds {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return creds, nil
+	}
+	authInfo, ok := auth.AuthInfoFromContext(ctx)
+	if !ok || authInfo.Workspace == nil {
+		return nil, errors.New("no workspace found in context")
+	}
+	secrets, err := is.backendRepo.GetSecretsByNameDecrypted(ctx, authInfo.Workspace, missing)
+	if err != nil {
+		return nil, err
+	}
+	resolved := maps.Clone(creds)
+	for _, secret := range secrets {
+		resolved[secret.Name] = secret.Value
+	}
+	sort.Strings(missing)
+	for _, name := range missing {
+		if resolved[name] == "" {
+			return nil, fmt.Errorf("registry credential %s is neither set in the environment nor a workspace secret", name)
+		}
+	}
+	return resolved, nil
 }
 
 func (is *ContainerImageService) retrieveBuildSecrets(ctx context.Context, secrets []string, authInfo *auth.AuthInfo) ([]string, error) {

--- a/pkg/abstractions/image/image_test.go
+++ b/pkg/abstractions/image/image_test.go
@@ -50,6 +50,27 @@ func TestRetrieveBuildSecretsSortsByName(t *testing.T) {
 	}, buildSecrets)
 }
 
+func TestResolveImageCredsFillsMissingValuesFromWorkspaceSecrets(t *testing.T) {
+	is := &ContainerImageService{
+		backendRepo: &unorderedBuildSecretsRepository{
+			secrets: []types.Secret{{Name: "GITHUB_TOKEN", Value: "ghp_durable"}},
+		},
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{Workspace: &types.Workspace{}})
+
+	creds, err := is.resolveImageCreds(ctx, map[string]string{"GITHUB_USERNAME": "bot", "GITHUB_TOKEN": ""})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"GITHUB_USERNAME": "bot", "GITHUB_TOKEN": "ghp_durable"}, creds)
+
+	// Values from the environment win; nothing is looked up.
+	creds, err = (&ContainerImageService{}).resolveImageCreds(context.Background(), map[string]string{"GITHUB_TOKEN": "ghp_env"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"GITHUB_TOKEN": "ghp_env"}, creds)
+
+	_, err = is.resolveImageCreds(ctx, map[string]string{"GITHUB_USERNAME": ""})
+	assert.EqualError(t, err, "registry credential GITHUB_USERNAME is neither set in the environment nor a workspace secret")
+}
+
 func TestStreamImageBuildOutputSendsTerminalFailureWhenBuildReturnsWithoutOutput(t *testing.T) {
 	outputChan := make(chan common.OutputMsg)
 	buildErrChan := make(chan error, 1)

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -52,15 +52,6 @@ _image_build_cache = TTLCache(
 )
 
 
-class ImageCredentialValueNotFound(Exception):
-    def __init__(self, key_name: str, *args: object) -> None:
-        super().__init__(*args)
-        self.key_name = key_name
-
-    def __str__(self) -> str:
-        return f"Did not find the environment variable {self.key_name}. Did you forget to set it?"
-
-
 class AWSCredentials(TypedDict, total=False):
     """Amazon Web Services credentials"""
 
@@ -175,7 +166,8 @@ class Image(BaseAbstraction):
                 A key/value pair or key list of environment variables that contain credentials to
                 a private registry. When provided as a dict, you must supply the correct keys and values.
                 When provided as a list, the keys are used to lookup the environment variable value
-                for you. Default is None.
+                for you; a key that is not set in the environment is read from the workspace secret
+                of the same name. Default is None.
             env_vars (Optional[Union[str, List[str], Dict[str, str]]):
                 Adds environment variables to an image. These will be available when building the image
                 and when the container is running. This can be a string, a list of strings, or a
@@ -684,25 +676,17 @@ class Image(BaseAbstraction):
         return result
 
     def get_credentials_from_env(self) -> Dict[str, str]:
-        """Registry credentials named by base_image_creds, read from the environment.
+        """Registry credentials named by base_image_creds.
 
-        Locally a missing key is an error the developer can fix in their shell. In a
-        container (whose environment carries the workspace's secrets) whatever is
-        present is sent and the build reports any registry failure.
+        Each name is read from the environment; a name that is not set is sent
+        empty, and the gateway fills it from the workspace secret of that name.
         """
         keys = (
             self.base_image_creds.keys()
             if isinstance(self.base_image_creds, dict)
             else self.base_image_creds
         )
-
-        creds = {}
-        for key in keys:
-            if v := os.getenv(key):
-                creds[key] = v
-            elif env.is_local():
-                raise ImageCredentialValueNotFound(key)
-        return creds
+        return {key: os.getenv(key, "") for key in keys}
 
     def micromamba(self) -> "Image":
         """

--- a/sdk/tests/test_image.py
+++ b/sdk/tests/test_image.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 from unittest import TestCase
 
-from beta9.abstractions.image import Image, ImageCredentialValueNotFound
+from beta9.abstractions.image import Image
 
 
 class TestImage(TestCase):
@@ -30,25 +30,11 @@ class TestImage(TestCase):
             creds = image.get_credentials_from_env()
             self.assertTrue(creds == env)
 
-    def test_image_credentials_value_error(self):
-        env = {
-            "Key1": "1234",
-            "Key2": "",
-        }
-        with temp_env_vars(env):
-            image = Image(base_image_creds=list(env.keys()))
-
-            with self.assertRaises(ImageCredentialValueNotFound) as context:
-                image.get_credentials_from_env()
-
-            self.assertTrue("Did not find the environment variable Key2." in str(context.exception))
-
-    def test_image_credentials_in_container_sends_what_is_present(self):
-        # Inside a container the environment is the workspace's secrets; a
-        # missing key is left to the registry to report.
-        with temp_env_vars({"CONTAINER_ID": "c-1", "Key1": "1234", "Key2": ""}):
+    def test_image_credentials_missing_key_is_sent_empty_for_workspace_secret(self):
+        # The gateway fills an empty value from the workspace secret of that name.
+        with temp_env_vars({"Key1": "1234", "Key2": ""}):
             image = Image(base_image_creds=["Key1", "Key2"])
-            self.assertEqual(image.get_credentials_from_env(), {"Key1": "1234"})
+            self.assertEqual(image.get_credentials_from_env(), {"Key1": "1234", "Key2": ""})
 
 
 @contextmanager


### PR DESCRIPTION
Image.from_registry(credentials=[...]) names environment variables, so a
deploy has to carry the registry credential itself, and a CI deploy hands
over whatever it has: for hosted-endpoints that was the GitHub Actions job
token, stored as the image's runtime credential and dead an hour later
(every replica of an unmodified image pulls with it).

A name the SDK cannot find in the environment is now sent empty and the
gateway fills it from the workspace secret of that name, so a long-lived
credential lives once, as a workspace secret, next to the token that
deploys. The gateway also refreshes the stored registry secret when the
image already exists, so a rotated credential reaches running deploys
instead of the first deploy's value persisting for the image's lifetime.

Tests: `go test ./pkg/abstractions/image/`, `pytest sdk/tests/test_image.py sdk/tests/test_managed_endpoint.py`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves registry credentials from workspace secrets so a long-lived credential can be stored once and rotated credentials reach running deploys.

**Changes**
- When a credential name is not set in the environment, the SDK sends an empty value and the gateway fills it from the workspace secret of the same name.
- The gateway refreshes the stored registry secret when the image already exists, so a rotated credential is used by running deploys.
- The SDK no longer raises `ImageCredentialValueNotFound` for missing environment variables; missing keys are left empty for the gateway to resolve.

<sup>Written for commit 360d089d4747b8678bff3130e946e17bc0366e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

