### PR TITLE
image: registry credentials are workspace secrets named on the image

### DIFF
--- a/pkg/abstractions/image/image.go
+++ b/pkg/abstractions/image/image.go
@@ -2,8 +2,9 @@ package image
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 
 	abstractions "github.com/beam-cloud/beta9/pkg/abstractions/common"
@@ -119,21 +120,23 @@ func (is *ContainerImageService) BuildImage(in *pb.BuildImageRequest, stream pb.
 		return err
 	}
 
+	buildOptions := verifyResult.opts
+	if buildOptions == nil {
+		return errors.New("missing image build options")
+	}
+	buildOptions.ExistingImageCreds, err = is.registryCredentials(stream.Context(), in.ExistingImageCreds)
+	if err != nil {
+		return err
+	}
+
 	if verifyResult.exists {
+		is.setImageCredentialSecretNames(verifyResult.imageID, buildOptions)
 		_ = stream.Send(&pb.BuildImageResponse{Msg: "Image already exists\n", Done: false, Success: true, ImageId: verifyResult.imageID})
 		_ = stream.Send(&pb.BuildImageResponse{Msg: "Build completed successfully\n", Done: true, Success: true, ImageId: verifyResult.imageID})
 		return nil
 	}
 
 	clipVersion := is.config.ImageService.ClipVersion
-
-	// Set ExistingImageCreds for credential processing
-	buildOptions := verifyResult.opts
-	if buildOptions == nil {
-		return errors.New("missing image build options")
-	}
-
-	buildOptions.ExistingImageCreds = in.ExistingImageCreds
 	buildOptions.ClipVersion = clipVersion
 
 	// Process credentials for custom base image (if provided)
@@ -171,11 +174,7 @@ func (is *ContainerImageService) BuildImage(in *pb.BuildImageRequest, stream pb.
 		return errors.New("failed to create image record")
 	}
 
-	// Create credential secret ONLY for unmodified images (not pushed to build registry)
-	// Modified images use build registry credentials instead
-	if err := is.createCredentialSecretIfNeeded(stream.Context(), lastMessage.ImageId, buildOptions); err != nil {
-		log.Error().Err(err).Msg("failed to create credential secret")
-	}
+	is.setImageCredentialSecretNames(lastMessage.ImageId, buildOptions)
 
 	log.Info().Msg("build completed successfully")
 	return nil
@@ -268,94 +267,41 @@ func convertBuildSteps(buildSteps []*pb.BuildStep) []BuildStep {
 	return steps
 }
 
-// createCredentialSecretIfNeeded creates a workspace secret for OCI registry credentials
-// ONLY for unmodified images that were not pushed to the build registry.
-// Modified images use build registry credentials instead.
-func (is *ContainerImageService) createCredentialSecretIfNeeded(ctx context.Context, imageId string, opts *BuildOpts) error {
-	if opts == nil {
-		return nil
+// registryCredentials reads the workspace secrets named by the keys of creds.
+// Values sent by the client are ignored; a secret is the only place they live.
+func (is *ContainerImageService) registryCredentials(ctx context.Context, creds map[string]string) (map[string]string, error) {
+	if len(creds) == 0 {
+		return nil, nil
 	}
-
-	// Check if this image was modified (built/pushed to build registry)
-	wasModified := is.builder.hasWorkToDo(opts) || opts.Dockerfile != ""
-	if wasModified {
-		log.Debug().
-			Str("image_id", imageId).
-			Msg("image was modified and pushed to build registry, skipping credential secret creation")
-		return nil
-	}
-
-	// Image was NOT modified - it's just an indexed base image in external registry
-	// Store credentials as secret for runtime access
-	log.Info().
-		Str("image_id", imageId).
-		Str("existing_image_uri", opts.ExistingImageUri).
-		Msg("unmodified image - storing credentials for runtime access")
-
-	// Only create secret if credentials were provided
-	if opts.ExistingImageCreds == nil || len(opts.ExistingImageCreds) == 0 {
-		return nil
-	}
-
-	if opts.ExistingImageUri == "" {
-		return nil
-	}
-
-	// Get structured credentials
-	registry, creds, err := reg.GetRegistryCredentialsForImage(opts.ExistingImageUri, opts.ExistingImageCreds)
-	if err != nil {
-		log.Warn().Err(err).Str("image_id", imageId).Msg("failed to get registry credentials")
-		return nil
-	}
-
-	credType := reg.DetectCredentialType(registry, creds)
-	if credType == reg.CredTypePublic || len(creds) == 0 {
-		return nil
-	}
-
-	secretValue, err := reg.MarshalCredentials(registry, credType, creds)
-	if err != nil {
-		return fmt.Errorf("failed to marshal credentials: %w", err)
-	}
-
-	// Get workspace context
 	authInfo, ok := auth.AuthInfoFromContext(ctx)
 	if !ok || authInfo.Workspace == nil {
-		return fmt.Errorf("no workspace found in context")
+		return nil, errors.New("no workspace found in context")
 	}
-
-	secretName := reg.CreateSecretName(registry)
-
-	secret, err := is.upsertSecret(context.Background(), authInfo, secretName, secretValue, registry)
+	names := slices.Sorted(maps.Keys(creds))
+	secrets, err := is.backendRepo.GetSecretsByNameDecrypted(ctx, authInfo.Workspace, names)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	if err := is.backendRepo.SetImageCredentialSecret(context.Background(), imageId, secretName, secret.ExternalId); err != nil {
-		return fmt.Errorf("failed to associate secret with image: %w", err)
+	resolved := make(map[string]string, len(secrets))
+	for _, secret := range secrets {
+		resolved[secret.Name] = secret.Value
 	}
-
-	log.Info().Str("image_id", imageId).Str("secret_name", secretName).Msg("stored credential secret")
-	return nil
+	for _, name := range names {
+		if resolved[name] == "" {
+			return nil, fmt.Errorf("registry credential %s is not a workspace secret; create it with `beta9 secret create %s <value>`", name, name)
+		}
+	}
+	return resolved, nil
 }
 
-func (is *ContainerImageService) upsertSecret(ctx context.Context, authInfo *auth.AuthInfo, secretName, secretValue, registry string) (*types.Secret, error) {
-	secret, err := is.backendRepo.GetSecretByName(ctx, authInfo.Workspace, secretName)
-	if err != nil && err != sql.ErrNoRows {
-		return nil, fmt.Errorf("failed to check for existing secret: %w", err)
+// setImageCredentialSecretNames records which workspace secrets the runtime
+// reads to pull an unmodified image. Modified images live in the build registry.
+func (is *ContainerImageService) setImageCredentialSecretNames(imageId string, opts *BuildOpts) {
+	if len(opts.ExistingImageCreds) == 0 || is.builder.hasWorkToDo(opts) || opts.Dockerfile != "" {
+		return
 	}
-
-	if secret != nil {
-		secret, err = is.backendRepo.UpdateSecret(ctx, authInfo.Workspace, authInfo.Token.Id, secretName, secretValue)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update secret: %w", err)
-		}
-	} else {
-		secret, err = is.backendRepo.CreateSecret(ctx, authInfo.Workspace, authInfo.Token.Id, secretName, secretValue, false)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create secret: %w", err)
-		}
+	names := slices.Sorted(maps.Keys(opts.ExistingImageCreds))
+	if err := is.backendRepo.SetImageCredentialSecretNames(context.Background(), imageId, names); err != nil {
+		log.Error().Err(err).Str("image_id", imageId).Msg("failed to store image credential secret names")
 	}
-
-	return secret, nil
 }

--- a/pkg/abstractions/image/image_test.go
+++ b/pkg/abstractions/image/image_test.go
@@ -50,6 +50,26 @@ func TestRetrieveBuildSecretsSortsByName(t *testing.T) {
 	}, buildSecrets)
 }
 
+func TestRegistryCredentialsComeFromWorkspaceSecretsOnly(t *testing.T) {
+	is := &ContainerImageService{
+		backendRepo: &unorderedBuildSecretsRepository{
+			secrets: []types.Secret{{Name: "GITHUB_TOKEN", Value: "from-workspace"}},
+		},
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{Workspace: &types.Workspace{}})
+
+	creds, err := is.registryCredentials(ctx, map[string]string{"GITHUB_TOKEN": "sent-by-client"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"GITHUB_TOKEN": "from-workspace"}, creds)
+
+	_, err = is.registryCredentials(ctx, map[string]string{"GITHUB_TOKEN": "", "GITHUB_USERNAME": ""})
+	assert.EqualError(t, err, "registry credential GITHUB_USERNAME is not a workspace secret; create it with `beta9 secret create GITHUB_USERNAME <value>`")
+
+	creds, err = is.registryCredentials(ctx, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, creds)
+}
+
 func TestStreamImageBuildOutputSendsTerminalFailureWhenBuildReturnsWithoutOutput(t *testing.T) {
 	outputChan := make(chan common.OutputMsg)
 	buildErrChan := make(chan error, 1)

--- a/pkg/gateway/services/repository/cache_coordinator_test.go
+++ b/pkg/gateway/services/repository/cache_coordinator_test.go
@@ -69,16 +69,11 @@ type originCredentialsBackendRepo struct {
 	repository.BackendRepository
 	workspace                 *types.Workspace
 	stub                      *types.StubWithRelated
-	secretName                string
 	secret                    *types.Secret
 	workspaceByExternalCalls  int
 	workspaceWithSigningCalls int
 	workspaceCalls            int
 	stubCalls                 int
-}
-
-func (r *originCredentialsBackendRepo) GetImageCredentialSecret(ctx context.Context, imageID string) (string, string, error) {
-	return r.secretName, "", nil
 }
 
 func (r *originCredentialsBackendRepo) GetWorkspaceByExternalId(ctx context.Context, externalID string) (types.Workspace, error) {
@@ -124,14 +119,11 @@ func (r *originCredentialsBackendRepo) GetStubByExternalId(ctx context.Context, 
 	}, nil
 }
 
-func (r *originCredentialsBackendRepo) GetSecretByNameDecrypted(ctx context.Context, workspace *types.Workspace, name string) (*types.Secret, error) {
-	if name != r.secretName {
-		return nil, nil
+func (r *originCredentialsBackendRepo) GetImageCredentials(ctx context.Context, workspace *types.Workspace, imageID string) (string, error) {
+	if r.secret == nil || workspace == nil || workspace.SigningKey == nil || *workspace.SigningKey == "" {
+		return "", nil
 	}
-	if workspace == nil || workspace.SigningKey == nil || *workspace.SigningKey == "" {
-		return nil, nil
-	}
-	return r.secret, nil
+	return r.secret.Value, nil
 }
 
 func TestAuthorizeCacheRepositoryRequestWithWorkerToken(t *testing.T) {
@@ -563,9 +555,8 @@ func TestPruneStaleCacheCheckpointsDefersDbPruneWhenOriginDeleteCannotRun(t *tes
 func TestGetCacheOriginCredentialsVendsImageRegistrySecret(t *testing.T) {
 	signingKey := "workspace-signing-key"
 	backendRepo := &originCredentialsBackendRepo{
-		workspace:  &types.Workspace{Id: 7, ExternalId: "workspace-id", SigningKey: &signingKey},
-		secretName: "registry-secret",
-		secret:     &types.Secret{Name: "registry-secret", Value: "registry-user:registry-pass"},
+		workspace: &types.Workspace{Id: 7, ExternalId: "workspace-id", SigningKey: &signingKey},
+		secret:    &types.Secret{Name: "registry-secret", Value: "registry-user:registry-pass"},
 	}
 	service := &WorkerRepositoryService{
 		backendRepo: backendRepo,
@@ -592,9 +583,8 @@ func TestGetCacheOriginCredentialsVendsImageRegistrySecret(t *testing.T) {
 func TestGetCacheOriginCredentialsDoesNotDecryptImageRegistrySecretWithoutSigningKey(t *testing.T) {
 	service := &WorkerRepositoryService{
 		backendRepo: &originCredentialsBackendRepo{
-			workspace:  &types.Workspace{Id: 7, ExternalId: "workspace-id"},
-			secretName: "registry-secret",
-			secret:     &types.Secret{Name: "registry-secret", Value: "registry-user:registry-pass"},
+			workspace: &types.Workspace{Id: 7, ExternalId: "workspace-id"},
+			secret:    &types.Secret{Name: "registry-secret", Value: "registry-user:registry-pass"},
 		},
 	}
 

--- a/pkg/gateway/services/repository/cache_metadata.go
+++ b/pkg/gateway/services/repository/cache_metadata.go
@@ -465,22 +465,12 @@ func (s *WorkerRepositoryService) imageRegistryCredentials(ctx context.Context, 
 	if s.backendRepo == nil || workspaceID == "" || imageID == "" {
 		return ""
 	}
-
-	secretName, _, err := s.backendRepo.GetImageCredentialSecret(ctx, imageID)
-	if err != nil || secretName == "" {
-		return ""
-	}
-
 	workspace, err := s.backendRepo.GetWorkspaceByExternalIdWithSigningKey(ctx, workspaceID)
-	if err != nil || workspace.SigningKey == nil || *workspace.SigningKey == "" {
+	if err != nil {
 		return ""
 	}
-
-	secret, err := s.backendRepo.GetSecretByNameDecrypted(ctx, &workspace, secretName)
-	if err != nil || secret == nil {
-		return ""
-	}
-	return secret.Value
+	credentials, _ := s.backendRepo.GetImageCredentials(ctx, &workspace, imageID)
+	return credentials
 }
 
 func derefString(s *string) string {

--- a/pkg/registry/credentials.go
+++ b/pkg/registry/credentials.go
@@ -189,18 +189,6 @@ func MarshalCredentials(registry string, credType CredType, creds map[string]str
 	return string(jsonBytes), nil
 }
 
-// CreateSecretName generates a consistent secret name for a registry
-// Format: "oci-registry-<normalized-registry-name>"
-func CreateSecretName(registry string) string {
-	// Normalize registry name for use in secret name
-	normalized := strings.ToLower(registry)
-	normalized = strings.ReplaceAll(normalized, ".", "-")
-	normalized = strings.ReplaceAll(normalized, ":", "-")
-	normalized = strings.ReplaceAll(normalized, "/", "-")
-
-	return fmt.Sprintf("oci-registry-%s", normalized)
-}
-
 // CreateProviderFromCredentials creates a CLIP-compatible credential provider from a credential map
 // This function creates an appropriate credential provider without setting environment variables
 // Returns common.RegistryCredentialProvider

--- a/pkg/registry/credentials_test.go
+++ b/pkg/registry/credentials_test.go
@@ -243,42 +243,6 @@ func TestMarshalCredentials(t *testing.T) {
 	assert.NotNil(t, parsed["credentials"])
 }
 
-func TestCreateSecretName(t *testing.T) {
-	tests := []struct {
-		name     string
-		registry string
-		expected string
-	}{
-		{
-			name:     "docker.io",
-			registry: "docker.io",
-			expected: "oci-registry-docker-io",
-		},
-		{
-			name:     "registry with port",
-			registry: "registry.example.com:5000",
-			expected: "oci-registry-registry-example-com-5000",
-		},
-		{
-			name:     "gcr.io",
-			registry: "gcr.io",
-			expected: "oci-registry-gcr-io",
-		},
-		{
-			name:     "ecr registry",
-			registry: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
-			expected: "oci-registry-123456789012-dkr-ecr-us-east-1-amazonaws-com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := CreateSecretName(tt.registry)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestCreateProviderFromEnv(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/repository/backend_postgres.go
+++ b/pkg/repository/backend_postgres.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pressly/goose/v3"
 
 	pkgCommon "github.com/beam-cloud/beta9/pkg/common"
+	"github.com/beam-cloud/beta9/pkg/registry"
 	_ "github.com/beam-cloud/beta9/pkg/repository/backend_postgres_migrations"
 	"github.com/beam-cloud/beta9/pkg/repository/common"
 	"github.com/beam-cloud/beta9/pkg/types"
@@ -2672,27 +2673,31 @@ func (r *PostgresBackendRepository) CreateImage(ctx context.Context, imageId str
 	return clipVersion, nil
 }
 
-func (r *PostgresBackendRepository) SetImageCredentialSecret(ctx context.Context, imageId string, secretName string, secretExternalId string) error {
-	query := `
-		UPDATE image 
-		SET credential_secret_name = $2, credential_secret_id = $3
-		WHERE image_id = $1;
-	`
-	_, err := r.client.ExecContext(ctx, query, imageId, secretName, secretExternalId)
+func (r *PostgresBackendRepository) SetImageCredentialSecretNames(ctx context.Context, imageId string, names []string) error {
+	query := `UPDATE image SET credential_secret_names = $2 WHERE image_id = $1;`
+	_, err := r.client.ExecContext(ctx, query, imageId, pq.Array(names))
 	return err
 }
 
-func (r *PostgresBackendRepository) GetImageCredentialSecret(ctx context.Context, imageId string) (string, string, error) {
-	var secretName sql.NullString
-	var secretId sql.NullString
-	query := `SELECT credential_secret_name, credential_secret_id FROM image WHERE image_id = $1;`
-
-	err := r.client.QueryRowContext(ctx, query, imageId).Scan(&secretName, &secretId)
-	if err != nil {
-		return "", "", err
+// GetImageCredentials returns the registry credentials for an image, read from
+// the workspace secrets it names, in the form the worker parses. Empty when the
+// image names none.
+func (r *PostgresBackendRepository) GetImageCredentials(ctx context.Context, workspace *types.Workspace, imageId string) (string, error) {
+	var names pq.StringArray
+	query := `SELECT credential_secret_names FROM image WHERE image_id = $1;`
+	if err := r.client.QueryRowContext(ctx, query, imageId).Scan(&names); err != nil || len(names) == 0 {
+		return "", err
 	}
 
-	return secretName.String, secretId.String, nil
+	secrets, err := r.GetSecretsByNameDecrypted(ctx, workspace, names)
+	if err != nil {
+		return "", err
+	}
+	creds := make(map[string]string, len(secrets))
+	for _, secret := range secrets {
+		creds[secret.Name] = secret.Value
+	}
+	return registry.MarshalCredentials("", registry.DetectCredentialType("", creds), creds)
 }
 
 func (r *PostgresBackendRepository) CreateCheckpoint(ctx context.Context, checkpoint *types.Checkpoint) (*types.Checkpoint, error) {

--- a/pkg/repository/backend_postgres_migrations/053_image_credential_secret_names.go
+++ b/pkg/repository/backend_postgres_migrations/053_image_credential_secret_names.go
@@ -1,0 +1,33 @@
+package backend_postgres_migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(upImageCredentialSecretNames, downImageCredentialSecretNames)
+}
+
+// An image names the workspace secrets holding its registry credentials.
+func upImageCredentialSecretNames(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+		DROP INDEX IF EXISTS idx_image_credential_secret_name;
+		ALTER TABLE image
+			DROP COLUMN IF EXISTS credential_secret_id,
+			DROP COLUMN IF EXISTS credential_secret_name,
+			ADD COLUMN IF NOT EXISTS credential_secret_names TEXT[];
+	`)
+	return err
+}
+
+func downImageCredentialSecretNames(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+		ALTER TABLE image
+			DROP COLUMN IF EXISTS credential_secret_names,
+			ADD COLUMN IF NOT EXISTS credential_secret_name VARCHAR(255),
+			ADD COLUMN IF NOT EXISTS credential_secret_id VARCHAR(36);
+	`)
+	return err
+}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -311,8 +311,8 @@ type BackendRepository interface {
 	DeleteApp(ctx context.Context, appId string) error
 	GetImageClipVersion(ctx context.Context, imageId string) (uint32, error)
 	CreateImage(ctx context.Context, imageId string, clipVersion uint32) (uint32, error)
-	SetImageCredentialSecret(ctx context.Context, imageId string, secretName string, secretExternalId string) error
-	GetImageCredentialSecret(ctx context.Context, imageId string) (string, string, error)
+	SetImageCredentialSecretNames(ctx context.Context, imageId string, names []string) error
+	GetImageCredentials(ctx context.Context, workspace *types.Workspace, imageId string) (string, error)
 	CreateCheckpoint(ctx context.Context, checkpoint *types.Checkpoint) (*types.Checkpoint, error)
 	UpdateCheckpoint(ctx context.Context, checkpoint *types.Checkpoint) (*types.Checkpoint, error)
 	ListCheckpoints(ctx context.Context, workspaceExternalId string) ([]types.Checkpoint, error)

--- a/pkg/repository/worker_redis.go
+++ b/pkg/repository/worker_redis.go
@@ -1716,6 +1716,9 @@ func (r *WorkerRedisRepository) ScheduleContainerRequests(worker *types.Worker, 
 			victims, err = r.selectEvictionVictims(ctx, worker.Id,
 				cpu-current.FreeCpu, memory-current.FreeMemory, gpu-int64(current.FreeGpuCount))
 			if err != nil {
+				if errors.Is(err, ErrInsufficientEvictableCapacity) && current.ResourceVersion != worker.ResourceVersion {
+					return errors.Join(ErrWorkerCapacityChanged, err)
+				}
 				return err
 			}
 		}

--- a/pkg/repository/worker_redis_evict.go
+++ b/pkg/repository/worker_redis_evict.go
@@ -14,6 +14,10 @@ import (
 // ErrEvictionVictimsChanged means the chosen victims changed before the placement committed.
 var ErrEvictionVictimsChanged = errors.New("eviction victims changed before placement committed")
 
+// ErrWorkerCapacityChanged means the worker's capacity changed after the
+// scheduler selected it and the request must be planned against a fresh view.
+var ErrWorkerCapacityChanged = errors.New("worker capacity changed after selection")
+
 var ErrInsufficientEvictableCapacity = errors.New("unable to schedule container, worker out of free and evictable capacity")
 
 // requestMayEvict reports whether a request may displace evictable containers.

--- a/pkg/repository/worker_redis_evict.go
+++ b/pkg/repository/worker_redis_evict.go
@@ -14,8 +14,7 @@ import (
 // ErrEvictionVictimsChanged means the chosen victims changed before the placement committed.
 var ErrEvictionVictimsChanged = errors.New("eviction victims changed before placement committed")
 
-// ErrWorkerCapacityChanged means the worker's capacity changed after the
-// scheduler selected it and the request must be planned against a fresh view.
+// ErrWorkerCapacityChanged means the scheduler selected the worker from a stale snapshot.
 var ErrWorkerCapacityChanged = errors.New("worker capacity changed after selection")
 
 var ErrInsufficientEvictableCapacity = errors.New("unable to schedule container, worker out of free and evictable capacity")

--- a/pkg/repository/worker_redis_test.go
+++ b/pkg/repository/worker_redis_test.go
@@ -1072,7 +1072,8 @@ func TestScheduleContainerRequestRejectsStaleWorkerReservation(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = repo.ScheduleContainerRequest(secondWorkerCopy, secondRequest)
-	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrWorkerCapacityChanged), err)
+	assert.True(t, errors.Is(err, ErrInsufficientEvictableCapacity), err)
 
 	updatedWorker, err := repo.GetWorkerById(worker.Id)
 	assert.Nil(t, err)

--- a/pkg/scheduler/batch.go
+++ b/pkg/scheduler/batch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/beam-cloud/beta9/pkg/metrics"
 	repo "github.com/beam-cloud/beta9/pkg/repository"
 	"github.com/beam-cloud/beta9/pkg/types"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -209,35 +210,25 @@ func (b *schedulingBatch) dispatchSchedules(schedules []plannedSchedule) {
 func (b *schedulingBatch) completeSchedule(schedule plannedSchedule, err error) {
 	attempt := newSchedulingAttempt(b.scheduler, schedule.request, b.workers)
 	if err != nil {
-		// A stale selection should be planned against a fresh worker snapshot
-		// immediately. It is expected when scheduler replicas race for the same
-		// best-fit worker and is not a fault of this request.
+		// A stale selection is expected when scheduler replicas race for the same
+		// worker: replan now against a fresh snapshot, keeping the request's place
+		// in line. Reclaimable capacity that moved is a capacity wait.
+		reason, level := "schedule_failed", zerolog.ErrorLevel
 		if errors.Is(err, repo.ErrWorkerCapacityChanged) {
-			attempt.recordBacklogWait(false, "worker_capacity_changed")
-			metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, "worker_capacity_changed")
-			workerLog(requestLog(log.Debug(), schedule.request), schedule.worker).
-				Msg("worker capacity changed after selection; replanning request")
-			if attempt.runnable() {
-				attempt.requeueForWorkerWaitNow("worker_capacity_changed")
-			}
-			return
+			reason, level = "worker_capacity_changed", zerolog.DebugLevel
 		}
-
-		attempt.recordBacklogWait(false, "schedule_failed")
-		metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, "schedule_failed")
-		workerLog(requestLog(log.Error(), schedule.request), schedule.worker).
-			Err(err).
-			Msg("unable to schedule planned request on worker")
-
-		// Reclaimable capacity that moved independently of the worker version is
-		// a capacity wait, not a fault of this request.
-		if errors.Is(err, repo.ErrEvictionVictimsChanged) || errors.Is(err, repo.ErrInsufficientEvictableCapacity) {
-			if attempt.runnable() {
-				attempt.requeueForWorkerWaitDelay(provisioningWorkerRequeueDelay, "reclaimable_capacity_changed")
-			}
-			return
+		attempt.recordBacklogWait(false, reason)
+		metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, reason)
+		workerLog(requestLog(log.WithLevel(level), schedule.request), schedule.worker).Err(err).Msg("unable to schedule planned request on worker")
+		switch {
+		case !attempt.runnable():
+		case errors.Is(err, repo.ErrWorkerCapacityChanged):
+			attempt.requeueForWorkerWaitDelay(0, reason)
+		case errors.Is(err, repo.ErrEvictionVictimsChanged) || errors.Is(err, repo.ErrInsufficientEvictableCapacity):
+			attempt.requeueForWorkerWaitDelay(provisioningWorkerRequeueDelay, "reclaimable_capacity_changed")
+		default:
+			attempt.retrySoon(reason)
 		}
-		attempt.retryIfRunnable("schedule_failed")
 		return
 	}
 

--- a/pkg/scheduler/batch.go
+++ b/pkg/scheduler/batch.go
@@ -209,14 +209,28 @@ func (b *schedulingBatch) dispatchSchedules(schedules []plannedSchedule) {
 func (b *schedulingBatch) completeSchedule(schedule plannedSchedule, err error) {
 	attempt := newSchedulingAttempt(b.scheduler, schedule.request, b.workers)
 	if err != nil {
+		// A stale selection should be planned against a fresh worker snapshot
+		// immediately. It is expected when scheduler replicas race for the same
+		// best-fit worker and is not a fault of this request.
+		if errors.Is(err, repo.ErrWorkerCapacityChanged) {
+			attempt.recordBacklogWait(false, "worker_capacity_changed")
+			metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, "worker_capacity_changed")
+			workerLog(requestLog(log.Debug(), schedule.request), schedule.worker).
+				Msg("worker capacity changed after selection; replanning request")
+			if attempt.runnable() {
+				attempt.requeueForWorkerWaitNow("worker_capacity_changed")
+			}
+			return
+		}
+
+		attempt.recordBacklogWait(false, "schedule_failed")
+		metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, "schedule_failed")
 		workerLog(requestLog(log.Error(), schedule.request), schedule.worker).
 			Err(err).
 			Msg("unable to schedule planned request on worker")
 
-		attempt.recordBacklogWait(false, "schedule_failed")
-		metrics.RecordSchedulerWorkerWait(time.Since(schedule.request.Timestamp), schedule.request, "schedule_failed")
-		// Reclaimable capacity that moved under us is a capacity wait, not a
-		// fault of this request.
+		// Reclaimable capacity that moved independently of the worker version is
+		// a capacity wait, not a fault of this request.
 		if errors.Is(err, repo.ErrEvictionVictimsChanged) || errors.Is(err, repo.ErrInsufficientEvictableCapacity) {
 			if attempt.runnable() {
 				attempt.requeueForWorkerWaitDelay(provisioningWorkerRequeueDelay, "reclaimable_capacity_changed")

--- a/pkg/scheduler/reserve.go
+++ b/pkg/scheduler/reserve.go
@@ -183,26 +183,10 @@ func (a *schedulingAttempt) requeueForWorkerWait() {
 	a.requeueForWorkerWaitDelay(provisioningWorkerRequeueDelay, "worker_capacity_wait")
 }
 
-func (a *schedulingAttempt) requeueForWorkerWaitNow(reason string) {
-	if time.Since(a.request.Timestamp) >= maxScheduleRetryDuration {
-		a.fail(types.ContainerSchedulingFailureWorkerCapacityTimeout)
-		return
-	}
-
-	if err := a.scheduler.pushBacklog(a.request, 0); err != nil {
-		requestLog(log.Error(), a.request).Err(err).Msg("failed to requeue request waiting for worker capacity")
-		a.fail(types.ContainerSchedulingFailureReason(reason + "_requeue_failed"))
-	}
-}
-
 func (a *schedulingAttempt) requeueForWorkerWaitDelay(delay time.Duration, reason string) {
 	if time.Since(a.request.Timestamp) >= maxScheduleRetryDuration {
 		a.fail(types.ContainerSchedulingFailureWorkerCapacityTimeout)
 		return
-	}
-
-	if delay < requestProcessingInterval {
-		delay = requestProcessingInterval
 	}
 
 	if err := a.scheduler.pushBacklog(a.request, delay); err != nil {

--- a/pkg/scheduler/reserve.go
+++ b/pkg/scheduler/reserve.go
@@ -183,6 +183,18 @@ func (a *schedulingAttempt) requeueForWorkerWait() {
 	a.requeueForWorkerWaitDelay(provisioningWorkerRequeueDelay, "worker_capacity_wait")
 }
 
+func (a *schedulingAttempt) requeueForWorkerWaitNow(reason string) {
+	if time.Since(a.request.Timestamp) >= maxScheduleRetryDuration {
+		a.fail(types.ContainerSchedulingFailureWorkerCapacityTimeout)
+		return
+	}
+
+	if err := a.scheduler.pushBacklog(a.request, 0); err != nil {
+		requestLog(log.Error(), a.request).Err(err).Msg("failed to requeue request waiting for worker capacity")
+		a.fail(types.ContainerSchedulingFailureReason(reason + "_requeue_failed"))
+	}
+}
+
 func (a *schedulingAttempt) requeueForWorkerWaitDelay(delay time.Duration, reason string) {
 	if time.Since(a.request.Timestamp) >= maxScheduleRetryDuration {
 		a.fail(types.ContainerSchedulingFailureWorkerCapacityTimeout)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -859,34 +859,15 @@ func (s *Scheduler) loadImageCredentials(request *types.ContainerRequest) (sched
 
 	cacheKey := imageCredentialCacheKey(request.WorkspaceId, request.ImageId)
 	credential, cacheHit, err := s.credentials.getOrLoad(cacheKey, schedulerImageCredentialTTL, func() (cachedSchedulerCredential, error) {
-		secretName, _, err := s.backendRepo.GetImageCredentialSecret(context.TODO(), request.ImageId)
-		if err != nil {
-			requestLog(log.Debug(), request).
-				Str("image_id", request.ImageId).
-				Err(err).
-				Msg("error getting image credential secret")
-			return cachedSchedulerCredential{}, err
-		}
-
-		if secretName == "" {
-			return cachedSchedulerCredential{exists: false}, nil
-		}
-
-		secret, err := s.backendRepo.GetSecretByNameDecrypted(context.TODO(), &request.Workspace, secretName)
+		value, err := s.backendRepo.GetImageCredentials(context.TODO(), &request.Workspace, request.ImageId)
 		if err != nil {
 			requestLog(log.Warn(), request).
 				Str("image_id", request.ImageId).
-				Str("secret_name", secretName).
 				Err(err).
-				Msg("failed to get secret by name")
+				Msg("error getting image credentials")
 			return cachedSchedulerCredential{}, err
 		}
-
-		return cachedSchedulerCredential{
-			value:  secret.Value,
-			source: secretName,
-			exists: true,
-		}, nil
+		return cachedSchedulerCredential{value: value, source: request.ImageId, exists: value != ""}, nil
 	})
 	if err != nil {
 		return schedulerCredentialAttachResult{cacheHit: cacheHit}, err
@@ -899,7 +880,6 @@ func (s *Scheduler) loadImageCredentials(request *types.ContainerRequest) (sched
 
 	requestLog(log.Debug(), request).
 		Str("image_id", request.ImageId).
-		Str("secret_name", credential.source).
 		Bool("cache_hit", cacheHit).
 		Int("credentials_length", len(credential.value)).
 		Msg("attached OCI credentials")

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1448,56 +1448,31 @@ func TestProcessRequestBatchDoesNotOverScheduleWorkerSnapshot(t *testing.T) {
 }
 
 func TestProcessRequestBatchImmediatelyReplansStaleCapacity(t *testing.T) {
-	firstScheduler, err := NewSchedulerForTest()
+	first, err := NewSchedulerForTest()
 	assert.NoError(t, err)
-	secondScheduler := schedulerReplicaForTest(firstScheduler)
-
-	packed := &types.Worker{
-		Id:          "packed",
-		Status:      types.WorkerStatusAvailable,
-		TotalCpu:    1000,
-		TotalMemory: 1250,
-		FreeCpu:     1000,
-		FreeMemory:  1250,
-		PoolName:    "beta9-cpu",
-	}
-	idle := &types.Worker{
-		Id:          "idle",
-		Status:      types.WorkerStatusAvailable,
-		TotalCpu:    2000,
-		TotalMemory: 2500,
-		FreeCpu:     2000,
-		FreeMemory:  2500,
-		PoolName:    "beta9-cpu",
-	}
-	assert.NoError(t, firstScheduler.workerRepo.AddWorker(packed))
-	assert.NoError(t, firstScheduler.workerRepo.AddWorker(idle))
-
-	firstWorkers, err := firstScheduler.workerRepo.GetAllWorkers()
+	second := schedulerReplicaForTest(first)
+	packed := &types.Worker{Id: "packed", Status: types.WorkerStatusAvailable, PoolName: "beta9-cpu", TotalCpu: 1000, TotalMemory: 1250, FreeCpu: 1000, FreeMemory: 1250}
+	idle := &types.Worker{Id: "idle", Status: types.WorkerStatusAvailable, PoolName: "beta9-cpu", TotalCpu: 2000, TotalMemory: 2500, FreeCpu: 2000, FreeMemory: 2500}
+	assert.NoError(t, first.workerRepo.AddWorker(packed))
+	assert.NoError(t, first.workerRepo.AddWorker(idle))
+	firstWorkers, err := first.workerRepo.GetAllWorkers()
 	assert.NoError(t, err)
-	staleWorkers, err := secondScheduler.workerRepo.GetAllWorkers()
+	staleWorkers, err := second.workerRepo.GetAllWorkers()
 	assert.NoError(t, err)
 
 	firstRequest := &types.ContainerRequest{ContainerId: "first", Cpu: 1000, Memory: 1000, Timestamp: time.Now()}
 	secondRequest := &types.ContainerRequest{ContainerId: "second", Cpu: 1000, Memory: 1000, Timestamp: time.Now()}
-	setPendingSchedulerRequests(t, firstScheduler, firstRequest, secondRequest)
+	setPendingSchedulerRequests(t, first, firstRequest, secondRequest)
+	first.processRequestBatch([]*types.ContainerRequest{firstRequest}, firstWorkers)
+	second.processRequestBatch([]*types.ContainerRequest{secondRequest}, staleWorkers)
 
-	firstScheduler.processRequestBatch([]*types.ContainerRequest{firstRequest}, firstWorkers)
-	secondScheduler.processRequestBatch([]*types.ContainerRequest{secondRequest}, staleWorkers)
-
-	requeued, err := firstScheduler.requestBacklog.Pop()
-	if err != nil {
-		t.Fatalf("stale capacity should be immediately ready to replan: %v", err)
-	}
-
-	currentWorkers, err := firstScheduler.workerRepo.GetAllWorkers()
+	// Both replicas best-fit "packed"; the loser is ready to replan at once and lands on "idle".
+	requeued, err := first.requestBacklog.Pop()
 	assert.NoError(t, err)
-	firstScheduler.processRequestBatch([]*types.ContainerRequest{requeued}, currentWorkers)
-
-	queued, err := firstScheduler.workerRepo.GetNextContainerRequest(packed.Id)
+	currentWorkers, err := first.workerRepo.GetAllWorkers()
 	assert.NoError(t, err)
-	assert.Equal(t, firstRequest.ContainerId, queued.ContainerId)
-	queued, err = firstScheduler.workerRepo.GetNextContainerRequest(idle.Id)
+	first.processRequestBatch([]*types.ContainerRequest{requeued}, currentWorkers)
+	queued, err := first.workerRepo.GetNextContainerRequest(idle.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, secondRequest.ContainerId, queued.ContainerId)
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1447,6 +1447,61 @@ func TestProcessRequestBatchDoesNotOverScheduleWorkerSnapshot(t *testing.T) {
 	assert.Equal(t, int64(2), updatedWorker.ResourceVersion)
 }
 
+func TestProcessRequestBatchImmediatelyReplansStaleCapacity(t *testing.T) {
+	firstScheduler, err := NewSchedulerForTest()
+	assert.NoError(t, err)
+	secondScheduler := schedulerReplicaForTest(firstScheduler)
+
+	packed := &types.Worker{
+		Id:          "packed",
+		Status:      types.WorkerStatusAvailable,
+		TotalCpu:    1000,
+		TotalMemory: 1250,
+		FreeCpu:     1000,
+		FreeMemory:  1250,
+		PoolName:    "beta9-cpu",
+	}
+	idle := &types.Worker{
+		Id:          "idle",
+		Status:      types.WorkerStatusAvailable,
+		TotalCpu:    2000,
+		TotalMemory: 2500,
+		FreeCpu:     2000,
+		FreeMemory:  2500,
+		PoolName:    "beta9-cpu",
+	}
+	assert.NoError(t, firstScheduler.workerRepo.AddWorker(packed))
+	assert.NoError(t, firstScheduler.workerRepo.AddWorker(idle))
+
+	firstWorkers, err := firstScheduler.workerRepo.GetAllWorkers()
+	assert.NoError(t, err)
+	staleWorkers, err := secondScheduler.workerRepo.GetAllWorkers()
+	assert.NoError(t, err)
+
+	firstRequest := &types.ContainerRequest{ContainerId: "first", Cpu: 1000, Memory: 1000, Timestamp: time.Now()}
+	secondRequest := &types.ContainerRequest{ContainerId: "second", Cpu: 1000, Memory: 1000, Timestamp: time.Now()}
+	setPendingSchedulerRequests(t, firstScheduler, firstRequest, secondRequest)
+
+	firstScheduler.processRequestBatch([]*types.ContainerRequest{firstRequest}, firstWorkers)
+	secondScheduler.processRequestBatch([]*types.ContainerRequest{secondRequest}, staleWorkers)
+
+	requeued, err := firstScheduler.requestBacklog.Pop()
+	if err != nil {
+		t.Fatalf("stale capacity should be immediately ready to replan: %v", err)
+	}
+
+	currentWorkers, err := firstScheduler.workerRepo.GetAllWorkers()
+	assert.NoError(t, err)
+	firstScheduler.processRequestBatch([]*types.ContainerRequest{requeued}, currentWorkers)
+
+	queued, err := firstScheduler.workerRepo.GetNextContainerRequest(packed.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, firstRequest.ContainerId, queued.ContainerId)
+	queued, err = firstScheduler.workerRepo.GetNextContainerRequest(idle.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, secondRequest.ContainerId, queued.ContainerId)
+}
+
 func TestProcessRequestBatchPacksOntoSingleWorker(t *testing.T) {
 	wb, err := NewSchedulerForTest()
 	assert.Nil(t, err)

--- a/pkg/worker/image.go
+++ b/pkg/worker/image.go
@@ -33,6 +33,10 @@ import (
 	"github.com/beam-cloud/clip/pkg/clip"
 	clipCommon "github.com/beam-cloud/clip/pkg/common"
 	clipStorage "github.com/beam-cloud/clip/pkg/storage"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/opencontainers/umoci"
 	"github.com/opencontainers/umoci/oci/cas/dir"
@@ -311,6 +315,9 @@ func (c *ImageClient) PullLazy(ctx context.Context, request *types.ContainerRequ
 
 	mountOptions := c.lazyMountOptions(ctx, request, archive)
 	if archive.usesOCIStorage() {
+		if err := c.verifyImageSource(ctx, request, mountOptions); err != nil {
+			return time.Since(startTime), err
+		}
 		c.scheduleImageLayerPrepare(context.WithoutCancel(ctx), request, mountOptions)
 	}
 
@@ -364,11 +371,7 @@ func (c *ImageClient) scheduleImageLayerPrepare(ctx context.Context, request *ty
 	if !ok {
 		return
 	}
-	localComplete := func(string) bool { return false }
-	if c.cacheClient != nil {
-		localComplete = c.cacheClient.LocalContentComplete
-	}
-	remaining := layersToPrepare(ociInfo, localComplete)
+	remaining := c.remoteLayers(ociInfo, options.CachePath)
 	if len(remaining) == 0 {
 		return
 	}
@@ -384,16 +387,51 @@ func (c *ImageClient) scheduleImageLayerPrepare(ctx context.Context, request *ty
 	})
 }
 
-// layersToPrepare returns the layers not fully present in a local page store.
-func layersToPrepare(info *clipCommon.OCIStorageInfo, localComplete func(hash string) bool) []string {
-	remaining := make([]string, 0, len(info.Layers))
+// remoteLayers returns the layers this node holds neither in the layer cache
+// nor completely in a local page store.
+func (c *ImageClient) remoteLayers(info *clipCommon.OCIStorageInfo, cachePath string) (remaining []string) {
 	for _, layer := range info.Layers {
-		if hash := info.DecompressedHashByLayer[layer]; hash != "" && localComplete(hash) {
-			continue
+		if hash := info.DecompressedHashByLayer[layer]; hash == "" || !c.holdsLayer(cachePath, hash) {
+			remaining = append(remaining, layer)
 		}
-		remaining = append(remaining, layer)
 	}
 	return remaining
+}
+
+func (c *ImageClient) holdsLayer(cachePath, hash string) bool {
+	if _, err := os.Stat(filepath.Join(cachePath, hash)); err == nil {
+		return true
+	}
+	return c.cacheClient != nil && c.cacheClient.LocalContentComplete(hash)
+}
+
+// verifyImageSource fails a lazy mount whose registry refuses the image, so a dead
+// credential surfaces at container start instead of as an EIO the runtime cannot
+// survive. Layers the node already holds need no registry; other failures stay lazy.
+func (c *ImageClient) verifyImageSource(ctx context.Context, request *types.ContainerRequest, options clip.MountOptions) error {
+	info, ok := ociStorageInfo(options.Metadata)
+	source, known := c.GetSourceImageRef(request.ImageId)
+	if !ok || !known || len(c.remoteLayers(info, options.CachePath)) == 0 {
+		return nil
+	}
+	ref, err := name.ParseReference(source)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	opts := []remote.Option{remote.WithContext(ctx)}
+	if provider, ok := options.RegistryCredProvider.(clipCommon.RegistryCredentialProvider); ok {
+		if auth, err := provider.GetCredentials(ctx, info.RegistryURL, info.Repository); err == nil && auth != nil {
+			opts = append(opts, remote.WithAuth(authn.FromConfig(*auth)))
+		}
+	}
+	_, err = remote.Head(ref, opts...)
+	var terr *transport.Error
+	if errors.As(err, &terr) && (terr.StatusCode == http.StatusUnauthorized || terr.StatusCode == http.StatusForbidden || terr.StatusCode == http.StatusNotFound) {
+		return fmt.Errorf("image source %s: %w", ref, err)
+	}
+	return nil
 }
 
 // prepareImageLayers materializes every OCI layer of the archive into the

--- a/pkg/worker/image_test.go
+++ b/pkg/worker/image_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -413,7 +415,39 @@ func TestTerminateImageProcessGroupKillsDescendants(t *testing.T) {
 	}
 }
 
-func TestLayersToPrepareSkipsLocallyCompleteLayers(t *testing.T) {
+func TestVerifyImageSourceFailsOnlyWhenRegistryRefusesRemoteLayers(t *testing.T) {
+	status, requests := http.StatusOK, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(status)
+	}))
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	source := server.Listener.Addr().String() + "/org/app:v1"
+	c := &ImageClient{v2ImageRefs: common.NewSafeMap[string]()}
+	c.v2ImageRefs.Set("img", source)
+	request := &types.ContainerRequest{ImageId: "img"}
+	options := clip.MountOptions{CachePath: cachePath, Metadata: &clipCommon.ClipArchiveMetadata{StorageInfo: &clipCommon.OCIStorageInfo{
+		Layers:                  []string{"sha256:1"},
+		DecompressedHashByLayer: map[string]string{"sha256:1": "hash-1"},
+	}}}
+
+	for _, status = range []int{http.StatusOK, http.StatusInternalServerError} {
+		require.NoError(t, c.verifyImageSource(context.Background(), request, options), status)
+	}
+	for _, status = range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		require.ErrorContains(t, c.verifyImageSource(context.Background(), request, options), "image source "+source, status)
+	}
+
+	// A layer already in the layer cache needs no registry at all.
+	require.NoError(t, os.WriteFile(filepath.Join(cachePath, "hash-1"), nil, 0o644))
+	requests = 0
+	require.NoError(t, c.verifyImageSource(context.Background(), request, options))
+	require.Zero(t, requests)
+}
+
+func TestRemoteLayersSkipsLayersHeldLocally(t *testing.T) {
 	info := &clipCommon.OCIStorageInfo{
 		Layers: []string{"sha256:a", "sha256:b", "sha256:c"},
 		DecompressedHashByLayer: map[string]string{
@@ -421,10 +455,9 @@ func TestLayersToPrepareSkipsLocallyCompleteLayers(t *testing.T) {
 			"sha256:b": "hash-b",
 		},
 	}
-	local := map[string]bool{"hash-a": true}
+	cachePath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cachePath, "hash-a"), nil, 0o644))
 
-	remaining := layersToPrepare(info, func(hash string) bool { return local[hash] })
-
-	// b is not local; c has no decompressed hash so it can never be local.
-	require.Equal(t, []string{"sha256:b", "sha256:c"}, remaining)
+	// b is not on disk; c has no decompressed hash so it can never be local.
+	require.Equal(t, []string{"sha256:b", "sha256:c"}, (&ImageClient{}).remoteLayers(info, cachePath))
 }

--- a/pkg/worker/lifecycle.go
+++ b/pkg/worker/lifecycle.go
@@ -921,6 +921,7 @@ func (s *Worker) loadContainerImage(ctx context.Context, request *types.Containe
 
 	if !request.IsBuildRequest() {
 		log.Error().Str("container_id", request.ContainerId).Msgf("failed to pull image: %v", err)
+		outputLogger.Error(fmt.Sprintf("Failed to load image <%s>: %v\n", request.ImageId, err))
 		return elapsed, false, err
 	}
 

--- a/sdk/src/beta9/abstractions/image.py
+++ b/sdk/src/beta9/abstractions/image.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Dict, List, Literal, NamedTuple, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Dict, List, Literal, NamedTuple, Optional, Sequence, Tuple, Union
 
 from beta9.clients.gateway import GatewayServiceStub
 from beta9.sync import FileSyncer
@@ -52,50 +52,6 @@ _image_build_cache = TTLCache(
 )
 
 
-class ImageCredentialValueNotFound(Exception):
-    def __init__(self, key_name: str, *args: object) -> None:
-        super().__init__(*args)
-        self.key_name = key_name
-
-    def __str__(self) -> str:
-        return f"Did not find the environment variable {self.key_name}. Did you forget to set it?"
-
-
-class AWSCredentials(TypedDict, total=False):
-    """Amazon Web Services credentials"""
-
-    AWS_ACCESS_KEY_ID: str
-    AWS_SECRET_ACCESS_KEY: str
-    AWS_SESSION_TOKEN: str
-    AWS_REGION: str
-
-
-class GCPCredentials(TypedDict, total=False):
-    """Google Cloud Platform credentials"""
-
-    GCP_ACCESS_TOKEN: str
-
-
-class DockerHubCredentials(TypedDict, total=False):
-    """Docker Hub credentials"""
-
-    DOCKERHUB_USERNAME: str
-    DOCKERHUB_PASSWORD: str
-
-
-class GHCRCredentials(TypedDict, total=False):
-    """GitHub Container Registry credentials"""
-
-    GITHUB_USERNAME: str
-    GITHUB_TOKEN: str
-
-
-class NGCCredentials(TypedDict, total=False):
-    """NVIDIA GPU Cloud credentials"""
-
-    NGC_API_KEY: str
-
-
 ImageCredentialKeys = Literal[
     "AWS_ACCESS_KEY_ID",
     "AWS_SECRET_ACCESS_KEY",
@@ -109,14 +65,7 @@ ImageCredentialKeys = Literal[
     "NGC_API_KEY",
 ]
 
-ImageCredentials = Union[
-    AWSCredentials,
-    DockerHubCredentials,
-    GCPCredentials,
-    NGCCredentials,
-    GHCRCredentials,
-    List[ImageCredentialKeys],
-]
+ImageCredentials = List[ImageCredentialKeys]
 
 
 def detected_python_version() -> PythonVersion:
@@ -172,10 +121,10 @@ class Image(BaseAbstraction):
                 `us-east4-docker.pkg.dev/my-project/my-repo/my-image:0.1.0`, and `nvcr.io/my-org/my-repo:0.1.0`.
                 Default is None.
             base_image_creds (Optional[ImageCredentials]):
-                A key/value pair or key list of environment variables that contain credentials to
-                a private registry. When provided as a dict, you must supply the correct keys and values.
-                When provided as a list, the keys are used to lookup the environment variable value
-                for you. Default is None.
+                Names of the workspace secrets holding the credentials for a private registry
+                (`beta9 secret create GITHUB_TOKEN ...`). Values are read from the workspace, at
+                build time and whenever the image is pulled, so rotating a secret needs no redeploy.
+                Default is None.
             env_vars (Optional[Union[str, List[str], Dict[str, str]]):
                 Adds environment variables to an image. These will be available when building the image
                 and when the container is running. This can be a string, a list of strings, or a
@@ -186,14 +135,14 @@ class Image(BaseAbstraction):
 
             Docker Hub
 
-            To use a private image from Docker Hub, export your Docker Hub credentials.
+            To use a private image from Docker Hub, store your Docker Hub credentials as workspace secrets.
 
             ```sh
-            export DOCKERHUB_USERNAME=user123
-            export DOCKERHUB_PASSWORD=pass123
+            beta9 secret create DOCKERHUB_USERNAME user123
+            beta9 secret create DOCKERHUB_PASSWORD pass123
             ```
 
-            Then configure the Image object with those environment variables.
+            Then name those secrets on the Image object.
 
             ```python
             image = Image(
@@ -209,14 +158,14 @@ class Image(BaseAbstraction):
 
             GitHub Container Registry (GHCR)
 
-            To use a private image from GitHub Container Registry, export your GitHub credentials.
+            To use a private image from GitHub Container Registry, store your GitHub credentials as workspace secrets.
 
             ```sh
-            export GITHUB_USERNAME=user123
-            export GITHUB_TOKEN=token123
+            beta9 secret create GITHUB_USERNAME user123
+            beta9 secret create GITHUB_TOKEN token123
             ```
 
-            Then configure the Image object with those environment variables.
+            Then name those secrets on the Image object.
 
             ```python
             image = Image(
@@ -232,8 +181,8 @@ class Image(BaseAbstraction):
 
             Amazon Elastic Container Registry (ECR)
 
-            To use a private image from Amazon ECR, export your AWS environment variables.
-            Then configure the Image object with those environment variables.
+            To use a private image from Amazon ECR, store your AWS keys as workspace secrets
+            and name them on the Image object.
 
             ```python
             image = Image(
@@ -249,13 +198,13 @@ class Image(BaseAbstraction):
 
             Google Artifact Registry (GAR)
 
-            To use a private image from Google Artifact Registry, export your access token.
+            To use a private image from Google Artifact Registry, store your access token as a workspace secret.
 
             ```sh
-            export GCP_ACCESS_TOKEN=$(gcloud auth print-access-token --project=my-project)
+            beta9 secret create GCP_ACCESS_TOKEN $(gcloud auth print-access-token --project=my-project)
             ```
 
-            Then configure the Image object to use the environment variable.
+            Then name that secret on the Image object.
 
             ```python
             image = Image(
@@ -270,13 +219,13 @@ class Image(BaseAbstraction):
 
             NVIDIA GPU Cloud (NGC)
 
-            To use a private image from NVIDIA GPU Cloud, export your API key.
+            To use a private image from NVIDIA GPU Cloud, store your API key as a workspace secret.
 
             ```sh
-            export NGC_API_KEY=abc123
+            beta9 secret create NGC_API_KEY abc123
             ```
 
-            Then configure the Image object to use the environment variable.
+            Then name that secret on the Image object.
 
             ```python
             image = Image(
@@ -347,7 +296,7 @@ class Image(BaseAbstraction):
         self.commands = commands
         self.build_steps = []
         self.base_image = base_image or ""
-        self.base_image_creds = base_image_creds or {}
+        self.base_image_creds = list(base_image_creds or [])
         self.env_vars = []
         self.secrets = []
         self._stub: Optional[ImageServiceStub] = None
@@ -523,8 +472,7 @@ class Image(BaseAbstraction):
                 - ECR: `111111111111.dkr.ecr.us-east-1.amazonaws.com/my-image:latest`
                 - GAR: `us-east4-docker.pkg.dev/my-project/my-repo/my-image:0.1.0`
                 - NGC: `nvcr.io/my-org/my-repo:0.1.0`
-            credentials: Optional credentials for private registry access.
-                Can be provided as a dict with key-value pairs or a list of environment variable keys.
+            credentials: Names of the workspace secrets holding the registry credentials.
 
         Returns:
             Image: The Image object configured with the registry image.
@@ -651,7 +599,7 @@ class Image(BaseAbstraction):
                         commands=self.commands,
                         build_steps=self.build_steps,
                         existing_image_uri=self.base_image,
-                        existing_image_creds=self.get_credentials_from_env(),
+                        existing_image_creds=dict.fromkeys(self.base_image_creds, ""),
                         env_vars=self.env_vars,
                         dockerfile=self.dockerfile,
                         build_ctx_object=self.build_ctx_object,
@@ -682,27 +630,6 @@ class Image(BaseAbstraction):
         )
         self._remember_build_result(cache_key, result)
         return result
-
-    def get_credentials_from_env(self) -> Dict[str, str]:
-        """Registry credentials named by base_image_creds, read from the environment.
-
-        Locally a missing key is an error the developer can fix in their shell. In a
-        container (whose environment carries the workspace's secrets) whatever is
-        present is sent and the build reports any registry failure.
-        """
-        keys = (
-            self.base_image_creds.keys()
-            if isinstance(self.base_image_creds, dict)
-            else self.base_image_creds
-        )
-
-        creds = {}
-        for key in keys:
-            if v := os.getenv(key):
-                creds[key] = v
-            elif env.is_local():
-                raise ImageCredentialValueNotFound(key)
-        return creds
 
     def micromamba(self) -> "Image":
         """

--- a/sdk/tests/test_image.py
+++ b/sdk/tests/test_image.py
@@ -1,8 +1,7 @@
 import os
-from contextlib import contextmanager
 from unittest import TestCase
 
-from beta9.abstractions.image import Image, ImageCredentialValueNotFound
+from beta9.abstractions.image import Image
 
 
 class TestImage(TestCase):
@@ -20,44 +19,11 @@ class TestImage(TestCase):
         assert image.build_steps[3].command == "numpy"
         assert image.build_steps[4].command == "pytorch"
 
-    def test_image_credentials(self):
-        env = {
-            "Key1": "1234",
-            "Key2": "5678",
-        }
-        with temp_env_vars(env):
-            image = Image(base_image_creds=env.keys())
-            creds = image.get_credentials_from_env()
-            self.assertTrue(creds == env)
-
-    def test_image_credentials_value_error(self):
-        env = {
-            "Key1": "1234",
-            "Key2": "",
-        }
-        with temp_env_vars(env):
-            image = Image(base_image_creds=list(env.keys()))
-
-            with self.assertRaises(ImageCredentialValueNotFound) as context:
-                image.get_credentials_from_env()
-
-            self.assertTrue("Did not find the environment variable Key2." in str(context.exception))
-
-    def test_image_credentials_in_container_sends_what_is_present(self):
-        # Inside a container the environment is the workspace's secrets; a
-        # missing key is left to the registry to report.
-        with temp_env_vars({"CONTAINER_ID": "c-1", "Key1": "1234", "Key2": ""}):
-            image = Image(base_image_creds=["Key1", "Key2"])
-            self.assertEqual(image.get_credentials_from_env(), {"Key1": "1234"})
-
-
-@contextmanager
-def temp_env_vars(d: dict):
-    for key, value in d.items():
-        os.environ[key] = value
-    yield
-    for key in d.keys():
-        os.environ.pop(key, None)
+    def test_image_credentials_are_workspace_secret_names(self):
+        # Only names travel; the gateway reads the values from workspace secrets.
+        image = Image(base_image_creds=["Key1", "Key2"])
+        self.assertEqual(image.base_image_creds, ["Key1", "Key2"])
+        self.assertEqual(Image().base_image_creds, [])
 
 
 class TestImageLocalFiles(TestCase):

--- a/sdk/tests/test_managed_endpoint.py
+++ b/sdk/tests/test_managed_endpoint.py
@@ -97,9 +97,7 @@ def test_deploy_rejects_mismatched_name():
     assert not ok
 
 
-def test_deploy_cached_private_image_without_registry_credentials(monkeypatch):
-    monkeypatch.delenv("GITHUB_USERNAME", raising=False)
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+def test_deploy_cached_private_image_skips_build():
     image = Image.from_registry(
         "ghcr.io/acme/model:pinned", credentials=["GITHUB_USERNAME", "GITHUB_TOKEN"]
     ).add_commands(["python -c 'import engine'"])
@@ -109,14 +107,12 @@ def test_deploy_cached_private_image_without_registry_credentials(monkeypatch):
         mock.patch.object(image, "_prepare_context"),
         mock.patch.object(image, "_cached_build_result", return_value=None),
         mock.patch.object(image, "_exists", return_value=(True, cached)) as exists,
-        mock.patch.object(image, "get_credentials_from_env") as credentials,
         mock.patch.object(ep, "prepare_runtime", side_effect=lambda **_: image.build().success),
         mock.patch.object(ep.gateway_stub, "deploy_stub", return_value=DeployStubResponse(ok=True)),
     ):
         _, ok = ep.deploy()
     assert ok
     exists.assert_called_once()
-    credentials.assert_not_called()
 
 
 def test_rollout_policy_is_explicit_and_validated():


### PR DESCRIPTION
## What

`Image.from_registry(uri, credentials=["GITHUB_USERNAME", "GITHUB_TOKEN"])` now names **workspace secrets**. Credential values never leave the client.

- Build: the gateway reads the named secrets (`GetSecretsByNameDecrypted`) and uses them exactly where the env-supplied values were used before (`GetRegistryTokenForImage` → skopeo/build worker). A name that is not a workspace secret fails the deploy with `registry credential X is not a workspace secret; create it with \`beta9 secret create X <value>\``.
- Unmodified images (the lazy-pulled v2 case) store the **names** on the image row (`image.credential_secret_names TEXT[]`, migration 053), on first build and again when the image already exists.
- Runtime: the scheduler (`attachImageCredentials`) and the worker credential broker (`imageRegistryCredentials`) call one repo method, `GetImageCredentials`, which reads the current secret values and marshals them in the form the worker already parses. Rotation is `beta9 secret modify NAME …`; it takes effect on the next pull (≤ 5 min scheduler cache), no redeploy.
- Removed: the gateway-written `oci-registry-<registry>` snapshot secret, `createCredentialSecretIfNeeded`/`upsertSecret`, `CreateSecretName`, the SDK env lookup (`get_credentials_from_env`, `ImageCredentialValueNotFound`, the credential `TypedDict`s). Net −195 lines.

The request still uses the existing `existing_image_creds` map (keys = names, values ignored), so older SDKs keep working as long as the secrets exist. No proto change.

## Why

The prod outage on the managed endpoints: the GitOps deploy ran with an Actions job token, the gateway snapshotted that value into `oci-registry-ghcr-io`, and every later lazy pull used the expired token (DENIED → EIO → SIGBUS). A credential must have one home that can be rotated without redeploying, and that home already exists: workspace secrets.

## Behaviour change

Users who relied on exporting env vars locally must create workspace secrets of the same names once. Images built under the old scheme keep their stale snapshot until redeployed, which is the redeploy they need anyway; the old `oci-registry-*` secrets are now inert and can be deleted.

## Verification

- `go test ./pkg/abstractions/image/ ./pkg/repository/ ./pkg/scheduler/ ./pkg/gateway/services/repository/ ./pkg/registry/`, SDK `pytest tests/test_image.py tests/test_managed_endpoint.py` (26 passed), ruff clean.
- End to end on the local k3d cluster with a private ECR image (`683656326989.dkr.ecr.us-east-1.amazonaws.com/beta9-e2e/private-alpine`), migration 053 applied by the gateway on start:
  1. no workspace secrets → build fails with the message above;
  2. `beta9 secret create AWS_*` → build pulls the private base image with those values, indexes it, and a Pod runs it; worker log: `using credentials … source="runtime secret"`, `creating ECR provider with AWS credentials access_key=ASIA…`, `fetched and cached ECR authorization token`, `has_password=true`;
  3. redeploy → `Image already exists`, names re-stored;
  4. `beta9 secret modify AWS_ACCESS_KEY_ID <marker>` with no redeploy → after the scheduler cache expires the next Pod's worker log shows the marker key.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registry credentials for private images now come from workspace secrets named on the image, instead of environment variables or a gateway-written snapshot secret; values are read at build time and on every pull, so rotating a secret takes effect without a redeploy. When a selected worker's capacity changes before placement, the scheduler now immediately replans against a fresh snapshot instead of requeueing with a delay. Lazy pulls of private images now fail fast when the registry refuses the image (401/403/404) instead of surfacing as an unrecoverable EIO.

**Migration**
- Create workspace secrets with the same names you previously exported as env vars; a name that is not a workspace secret fails the build with a clear message.
- Old `oci-registry-*` secrets are inert and can be deleted; images built under the old scheme keep their stale snapshot until redeployed.

<sup>Written for commit fd0da558d8ba5a61b50b340a1f507e4cdfced1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

