### PR TITLE
volume: prevent S3 path traversal outside volume root

### DIFF
--- a/pkg/abstractions/volume/multipart.go
+++ b/pkg/abstractions/volume/multipart.go
@@ -5,7 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"path/filepath"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -42,12 +43,13 @@ func (s *GlobalVolumeService) getS3Client() *s3.Client {
 	})
 }
 
-func joinCleanPath(parts ...string) string {
-	for i, part := range parts {
-		parts[i] = filepath.Clean(part)
+func buildVolumeObjectKey(rootPrefix, volumePath string) (string, error) {
+	key := path.Join(rootPrefix, volumePath)
+	if key != rootPrefix && !strings.HasPrefix(key, rootPrefix+"/") {
+		return "", errors.New("invalid volume path: outside volume root")
 	}
 
-	return filepath.Join(parts...)
+	return key, nil
 }
 
 func (s *GlobalVolumeService) GetFileServiceInfo(ctx context.Context, in *pb.GetFileServiceInfoRequest) (*pb.GetFileServiceInfoResponse, error) {
@@ -68,10 +70,21 @@ func (s *GlobalVolumeService) CreatePresignedURL(ctx context.Context, in *pb.Cre
 		}, nil
 	}
 
+	rootPrefix := path.Join(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId)
+	if authInfo.Workspace.StorageAvailable() {
+		rootPrefix = path.Join(types.DefaultVolumesPrefix, volume.ExternalId)
+	}
+
+	key, err := buildVolumeObjectKey(rootPrefix, in.VolumePath)
+	if err != nil {
+		return &pb.CreatePresignedURLResponse{
+			Ok:     false,
+			ErrMsg: err.Error(),
+		}, nil
+	}
+
 	var s3Client *s3.Client
 	var presignClient *s3.PresignClient
-
-	key := joinCleanPath(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId, in.VolumePath)
 	bucket := s.config.BucketName
 
 	if authInfo.Workspace.StorageAvailable() {
@@ -85,7 +98,6 @@ func (s *GlobalVolumeService) CreatePresignedURL(ctx context.Context, in *pb.Cre
 
 		s3Client = storageClient.S3Client()
 		presignClient = storageClient.PresignClient()
-		key = joinCleanPath(types.DefaultVolumesPrefix, volume.ExternalId, in.VolumePath)
 		bucket = storageClient.BucketName()
 	} else {
 		s3Client = s.getS3Client()
@@ -175,9 +187,21 @@ func (s *GlobalVolumeService) CreateMultipartUpload(ctx context.Context, in *pb.
 		}, nil
 	}
 
+	rootPrefix := path.Join(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId)
+	if authInfo.Workspace.StorageAvailable() {
+		rootPrefix = path.Join(types.DefaultVolumesPrefix, volume.ExternalId)
+	}
+
+	key, err := buildVolumeObjectKey(rootPrefix, in.VolumePath)
+	if err != nil {
+		return &pb.CreateMultipartUploadResponse{
+			Ok:     false,
+			ErrMsg: err.Error(),
+		}, nil
+	}
+
 	var s3Client *s3.Client
 	bucket := s.config.BucketName
-	key := joinCleanPath(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId, in.VolumePath)
 
 	if authInfo.Workspace.StorageAvailable() {
 		storageClient, err := clients.NewWorkspaceStorageClient(ctx, authInfo.Workspace.Name, authInfo.Workspace.Storage)
@@ -190,7 +214,6 @@ func (s *GlobalVolumeService) CreateMultipartUpload(ctx context.Context, in *pb.
 
 		s3Client = storageClient.S3Client()
 		bucket = storageClient.BucketName()
-		key = joinCleanPath(types.DefaultVolumesPrefix, volume.ExternalId, in.VolumePath)
 	} else {
 		s3Client = s.getS3Client()
 	}
@@ -265,10 +288,21 @@ func (s *GlobalVolumeService) CompleteMultipartUpload(ctx context.Context, in *p
 		}, nil
 	}
 
-	var s3Client *s3.Client
+	rootPrefix := path.Join(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId)
+	if authInfo.Workspace.StorageAvailable() {
+		rootPrefix = path.Join(types.DefaultVolumesPrefix, volume.ExternalId)
+	}
 
+	key, err := buildVolumeObjectKey(rootPrefix, in.VolumePath)
+	if err != nil {
+		return &pb.CompleteMultipartUploadResponse{
+			Ok:     false,
+			ErrMsg: err.Error(),
+		}, nil
+	}
+
+	var s3Client *s3.Client
 	bucket := s.config.BucketName
-	key := joinCleanPath(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId, in.VolumePath)
 
 	if authInfo.Workspace.StorageAvailable() {
 		storageClient, err := clients.NewWorkspaceStorageClient(ctx, authInfo.Workspace.Name, authInfo.Workspace.Storage)
@@ -281,7 +315,6 @@ func (s *GlobalVolumeService) CompleteMultipartUpload(ctx context.Context, in *p
 
 		s3Client = storageClient.S3Client()
 		bucket = storageClient.BucketName()
-		key = joinCleanPath(types.DefaultVolumesPrefix, volume.ExternalId, in.VolumePath)
 	} else {
 		s3Client = s.getS3Client()
 	}
@@ -327,10 +360,21 @@ func (s *GlobalVolumeService) AbortMultipartUpload(ctx context.Context, in *pb.A
 		}, nil
 	}
 
-	var s3Client *s3.Client
+	rootPrefix := path.Join(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId)
+	if authInfo.Workspace.StorageAvailable() {
+		rootPrefix = path.Join(types.DefaultVolumesPrefix, volume.ExternalId)
+	}
 
+	key, err := buildVolumeObjectKey(rootPrefix, in.VolumePath)
+	if err != nil {
+		return &pb.AbortMultipartUploadResponse{
+			Ok:     false,
+			ErrMsg: err.Error(),
+		}, nil
+	}
+
+	var s3Client *s3.Client
 	bucket := s.config.BucketName
-	key := joinCleanPath(types.DefaultVolumesPrefix, authInfo.Workspace.Name, volume.ExternalId, in.VolumePath)
 
 	if authInfo.Workspace.StorageAvailable() {
 		storageClient, err := clients.NewWorkspaceStorageClient(ctx, authInfo.Workspace.Name, authInfo.Workspace.Storage)
@@ -343,7 +387,6 @@ func (s *GlobalVolumeService) AbortMultipartUpload(ctx context.Context, in *pb.A
 
 		s3Client = storageClient.S3Client()
 		bucket = storageClient.BucketName()
-		key = joinCleanPath(types.DefaultVolumesPrefix, volume.ExternalId, in.VolumePath)
 	} else {
 		s3Client = s.getS3Client()
 	}

--- a/pkg/abstractions/volume/multipart_test.go
+++ b/pkg/abstractions/volume/multipart_test.go
@@ -1,0 +1,354 @@
+package volume
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/beam-cloud/beta9/pkg/auth"
+	"github.com/beam-cloud/beta9/pkg/repository"
+	"github.com/beam-cloud/beta9/pkg/types"
+	pb "github.com/beam-cloud/beta9/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockBackendRepoForMultipart struct {
+	repository.BackendRepository
+	getVolumeFunc func(ctx context.Context, workspaceId uint, volumeName string) (*types.Volume, error)
+}
+
+func (m *mockBackendRepoForMultipart) GetVolume(ctx context.Context, workspaceId uint, volumeName string) (*types.Volume, error) {
+	if m.getVolumeFunc != nil {
+		return m.getVolumeFunc(ctx, workspaceId, volumeName)
+	}
+	return nil, nil
+}
+
+func TestBuildVolumeObjectKey_SecurityInvariant(t *testing.T) {
+	sharedRoot := path.Join(types.DefaultVolumesPrefix, "ws-A", "vol-A")
+	dedicatedRoot := path.Join(types.DefaultVolumesPrefix, "vol-A")
+
+	tests := []struct {
+		name        string
+		rootPrefix  string
+		volumePath  string
+		expectedKey string
+		wantErr     bool
+	}{
+		{
+			name:        "valid normal path",
+			rootPrefix:  sharedRoot,
+			volumePath:  "models/model.bin",
+			expectedKey: "volumes/ws-A/vol-A/models/model.bin",
+			wantErr:     false,
+		},
+		{
+			name:        "internal non-escaping traversal",
+			rootPrefix:  sharedRoot,
+			volumePath:  "models/v1/../v2/weights.bin",
+			expectedKey: "volumes/ws-A/vol-A/models/v2/weights.bin",
+			wantErr:     false,
+		},
+		{
+			name:        "leading slash",
+			rootPrefix:  sharedRoot,
+			volumePath:  "/models/model.bin",
+			expectedKey: "volumes/ws-A/vol-A/models/model.bin",
+			wantErr:     false,
+		},
+		{
+			name:        "redundant separators",
+			rootPrefix:  sharedRoot,
+			volumePath:  "models//v1/model.bin",
+			expectedKey: "volumes/ws-A/vol-A/models/v1/model.bin",
+			wantErr:     false,
+		},
+		{
+			name:        "empty path resolves to root prefix",
+			rootPrefix:  sharedRoot,
+			volumePath:  "",
+			expectedKey: "volumes/ws-A/vol-A",
+			wantErr:     false,
+		},
+		{
+			name:        "same-volume boundary escape rejected",
+			rootPrefix:  sharedRoot,
+			volumePath:  "../other/file",
+			expectedKey: "",
+			wantErr:     true,
+		},
+		{
+			name:        "cross-workspace traversal rejected",
+			rootPrefix:  sharedRoot,
+			volumePath:  "../../ws-B/vol-B/compromise.txt",
+			expectedKey: "",
+			wantErr:     true,
+		},
+		{
+			name:        "root escape rejected",
+			rootPrefix:  sharedRoot,
+			volumePath:  "../../../escape.txt",
+			expectedKey: "",
+			wantErr:     true,
+		},
+		{
+			name:        "prefix collision attempt rejected",
+			rootPrefix:  sharedRoot,
+			volumePath:  "../vol-A-suffix/file",
+			expectedKey: "",
+			wantErr:     true,
+		},
+		{
+			name:        "dedicated storage valid path",
+			rootPrefix:  dedicatedRoot,
+			volumePath:  "models/model.bin",
+			expectedKey: "volumes/vol-A/models/model.bin",
+			wantErr:     false,
+		},
+		{
+			name:        "dedicated storage traversal rejected",
+			rootPrefix:  dedicatedRoot,
+			volumePath:  "../other-vol/data.bin",
+			expectedKey: "",
+			wantErr:     true,
+		},
+		{
+			name:        "dedicated storage prefix collision rejected",
+			rootPrefix:  dedicatedRoot,
+			volumePath:  "../vol-A-suffix/file",
+			expectedKey: "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualKey, err := buildVolumeObjectKey(tt.rootPrefix, tt.volumePath)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, "invalid volume path: outside volume root")
+				assert.Empty(t, actualKey)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedKey, actualKey)
+				// Invariant check
+				contained := actualKey == tt.rootPrefix || len(actualKey) > len(tt.rootPrefix) && actualKey[:len(tt.rootPrefix)+1] == tt.rootPrefix+"/"
+				assert.True(t, contained, "Key %q must remain within root prefix %q", actualKey, tt.rootPrefix)
+			}
+		})
+	}
+}
+
+func TestCreatePresignedURL_SecurityBoundary_RejectsTraversal(t *testing.T) {
+	wsId := uint(101)
+	workspace := &types.Workspace{
+		Id:   wsId,
+		Name: "ws-A",
+	}
+
+	authInfo := &auth.AuthInfo{
+		Workspace: workspace,
+		Token: &types.Token{
+			Key:         "test-token",
+			TokenType:   types.TokenTypeWorkspace,
+			WorkspaceId: &wsId,
+		},
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), authInfo)
+
+	service := &GlobalVolumeService{
+		config: types.FileServiceConfig{
+			Enabled:     true,
+			BucketName:  "test-bucket",
+			EndpointURL: "https://s3.us-east-1.amazonaws.com",
+			Region:      "us-east-1",
+			AccessKey:   "fake-access-key",
+			SecretKey:   "fake-secret-key",
+		},
+		backendRepo: &mockBackendRepoForMultipart{
+			getVolumeFunc: func(ctx context.Context, wid uint, volName string) (*types.Volume, error) {
+				return &types.Volume{
+					Id:          202,
+					ExternalId:  "vol-A",
+					Name:        volName,
+					WorkspaceId: wid,
+				}, nil
+			},
+		},
+	}
+
+	req := &pb.CreatePresignedURLRequest{
+		VolumeName: "my-vol",
+		VolumePath: "../../ws-B/vol-B/compromise.txt",
+		Method:     pb.PresignedURLMethod_GetObject,
+	}
+
+	resp, err := service.CreatePresignedURL(ctx, req)
+	require.NoError(t, err)
+
+	assert.False(t, resp.Ok, "CreatePresignedURL must reject out-of-bounds traversal with Ok=false")
+	assert.Equal(t, "invalid volume path: outside volume root", resp.ErrMsg)
+	assert.Empty(t, resp.Url, "No presigned URL must be returned for an out-of-bounds path")
+}
+
+func TestCreatePresignedURL_DedicatedStorage_RejectsTraversal(t *testing.T) {
+	wsId := uint(101)
+	storageId := uint(55)
+	workspace := &types.Workspace{
+		Id:   wsId,
+		Name: "ws-A",
+		Storage: &types.WorkspaceStorage{
+			Id: &storageId,
+		},
+	}
+
+	authInfo := &auth.AuthInfo{
+		Workspace: workspace,
+		Token: &types.Token{
+			Key:         "test-token",
+			TokenType:   types.TokenTypeWorkspace,
+			WorkspaceId: &wsId,
+		},
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), authInfo)
+
+	service := &GlobalVolumeService{
+		config: types.FileServiceConfig{
+			Enabled:     true,
+			BucketName:  "shared-bucket",
+			EndpointURL: "https://s3.us-east-1.amazonaws.com",
+			Region:      "us-east-1",
+			AccessKey:   "fake-access-key",
+			SecretKey:   "fake-secret-key",
+		},
+		backendRepo: &mockBackendRepoForMultipart{
+			getVolumeFunc: func(ctx context.Context, wid uint, volName string) (*types.Volume, error) {
+				return &types.Volume{
+					Id:          202,
+					ExternalId:  "vol-A",
+					Name:        volName,
+					WorkspaceId: wid,
+				}, nil
+			},
+		},
+	}
+
+	req := &pb.CreatePresignedURLRequest{
+		VolumeName: "my-vol",
+		VolumePath: "../other-vol/data.bin",
+		Method:     pb.PresignedURLMethod_GetObject,
+	}
+
+	resp, err := service.CreatePresignedURL(ctx, req)
+	require.NoError(t, err)
+
+	assert.False(t, resp.Ok, "Dedicated storage must reject out-of-bounds traversal with Ok=false")
+	assert.Equal(t, "invalid volume path: outside volume root", resp.ErrMsg)
+	assert.Empty(t, resp.Url)
+}
+
+func TestCreateMultipartUpload_SecurityBoundary_RejectsTraversal(t *testing.T) {
+	wsId := uint(101)
+	workspace := &types.Workspace{
+		Id:   wsId,
+		Name: "ws-A",
+	}
+
+	authInfo := &auth.AuthInfo{
+		Workspace: workspace,
+		Token: &types.Token{
+			Key:         "test-token",
+			TokenType:   types.TokenTypeWorkspace,
+			WorkspaceId: &wsId,
+		},
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), authInfo)
+
+	service := &GlobalVolumeService{
+		config: types.FileServiceConfig{
+			Enabled:     true,
+			BucketName:  "test-bucket",
+			EndpointURL: "https://s3.us-east-1.amazonaws.com",
+			Region:      "us-east-1",
+			AccessKey:   "fake-access-key",
+			SecretKey:   "fake-secret-key",
+		},
+		backendRepo: &mockBackendRepoForMultipart{
+			getVolumeFunc: func(ctx context.Context, wid uint, volName string) (*types.Volume, error) {
+				return &types.Volume{
+					Id:          202,
+					ExternalId:  "vol-A",
+					Name:        volName,
+					WorkspaceId: wid,
+				}, nil
+			},
+		},
+	}
+
+	req := &pb.CreateMultipartUploadRequest{
+		VolumeName: "my-vol",
+		VolumePath: "../../ws-B/vol-B/compromise.txt",
+		ChunkSize:  5 * 1024 * 1024,
+		FileSize:   10 * 1024 * 1024,
+	}
+
+	resp, err := service.CreateMultipartUpload(ctx, req)
+	require.NoError(t, err)
+
+	assert.False(t, resp.Ok, "CreateMultipartUpload must reject out-of-bounds traversal with Ok=false")
+	assert.Equal(t, "invalid volume path: outside volume root", resp.ErrMsg)
+	assert.Empty(t, resp.UploadId)
+}
+
+func TestCreatePresignedURL_ValidPath_GeneratesCorrectKey(t *testing.T) {
+	wsId := uint(101)
+	workspace := &types.Workspace{
+		Id:   wsId,
+		Name: "ws-A",
+	}
+
+	authInfo := &auth.AuthInfo{
+		Workspace: workspace,
+		Token: &types.Token{
+			Key:         "test-token",
+			TokenType:   types.TokenTypeWorkspace,
+			WorkspaceId: &wsId,
+		},
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), authInfo)
+
+	service := &GlobalVolumeService{
+		config: types.FileServiceConfig{
+			Enabled:     true,
+			BucketName:  "test-bucket",
+			EndpointURL: "https://s3.us-east-1.amazonaws.com",
+			Region:      "us-east-1",
+			AccessKey:   "fake-access-key",
+			SecretKey:   "fake-secret-key",
+		},
+		backendRepo: &mockBackendRepoForMultipart{
+			getVolumeFunc: func(ctx context.Context, wid uint, volName string) (*types.Volume, error) {
+				return &types.Volume{
+					Id:          202,
+					ExternalId:  "vol-A",
+					Name:        volName,
+					WorkspaceId: wid,
+				}, nil
+			},
+		},
+	}
+
+	req := &pb.CreatePresignedURLRequest{
+		VolumeName: "my-vol",
+		VolumePath: "models/model.bin",
+		Method:     pb.PresignedURLMethod_GetObject,
+	}
+
+	resp, err := service.CreatePresignedURL(ctx, req)
+	require.NoError(t, err)
+
+	assert.True(t, resp.Ok, "CreatePresignedURL must succeed for valid path with Ok=true")
+	assert.Empty(t, resp.ErrMsg)
+	assert.Contains(t, resp.Url, "volumes/ws-A/vol-A/models/model.bin")
+}


### PR DESCRIPTION
## Problem

`VolumePath` is client-controlled input used to construct S3 object keys for volume operations. The previous implementation used `filepath.Clean` / `filepath.Join` without enforcing that the resulting key remained inside the authenticated volume's root prefix.

A path containing parent-directory traversal could therefore resolve outside the intended volume boundary. Because the resulting key is passed to S3 presigning and multipart operations, this can enable access to other object keys when the service's configured S3 credentials permit that access.

## Root Cause

`joinCleanPath` used OS filesystem path semantics for S3 object keys and performed no volume-boundary validation after resolving `..` components.

For example, with:

`volumes/ws-A/vol-A`

and:

`../../ws-B/vol-B/compromise.txt`

the existing implementation could construct:

`volumes/ws-B/vol-B/compromise.txt`

## Fix

- Replace filesystem-specific path handling with POSIX `path` semantics for S3 object keys.
- Centralize key construction and enforce strict containment:
  `key == rootPrefix || strings.HasPrefix(key, rootPrefix + "/")`
- Reject out-of-boundary paths before any S3 or presigning operation.
- Apply the validation consistently to `CreatePresignedURL`, `CreateMultipartUpload`, `CompleteMultipartUpload`, and `AbortMultipartUpload`.
- Preserve legitimate existing path normalization behavior.

## Tests

Added regression coverage for:
- valid paths;
- internal non-escaping `..`;
- leading/redundant separators;
- same-volume traversal;
- cross-workspace traversal;
- bucket-root escape;
- prefix-collision cases;
- shared and dedicated storage roots;
- service-level rejection before S3 presigning/upload operations.

Validation performed locally:

- `gofmt -d ...` — PASS
- `go test -v ./pkg/abstractions/volume/...` — PASS
- `go test -race ./pkg/abstractions/volume/...` — PASS
- `go vet ./pkg/abstractions/volume/...` — PASS

`go test ./pkg/...` was not run locally because full-repository compilation caused excessive CPU/RAM pressure in the WSL environment.

## Compatibility

Legitimate existing paths retain their previous normalized behavior. Inputs that attempt to escape the authenticated volume boundary are now rejected.

## Related Work

PR #1548 addresses the same general S3 object-key construction area but uses raw string concatenation and does not enforce volume-root containment. This PR takes a different approach by enforcing the actual volume-boundary invariant and adding regression coverage for traversal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents S3 path traversal by enforcing that volume paths stay inside the volume root. Previously, `..` sequences could resolve to object keys outside the authenticated volume, enabling access to other objects when the service's S3 credentials permit it.

**Key changes**
- Replace `filepath` with POSIX `path` for S3 key building.
- Enforce containment: key must equal root prefix or start with root prefix + "/".
- Apply validation to presigning and all multipart upload methods.
- Add regression tests covering valid paths, traversal attempts, and prefix collisions.

Legitimate paths keep their normalized behavior; only escapes from the volume boundary are rejected.

<sup>Written for commit bf2b7748e5df6d27e53ebcaf0fdfd0d7325007f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/beam-cloud/beta9/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

